### PR TITLE
Implement DAG-Manager hashing & schema setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "qmtl"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -1,0 +1,34 @@
+import hashlib
+from typing import Iterable
+
+
+def compute_node_id(
+    node_type: str,
+    code_hash: str,
+    config_hash: str,
+    schema_hash: str,
+    existing_ids: Iterable[str] | None = None,
+) -> str:
+    """Return deterministic node ID with SHA-256 and SHA-3 fallback.
+
+    Parameters
+    ----------
+    node_type, code_hash, config_hash, schema_hash : str
+        Components defining the node.
+    existing_ids : Iterable[str] | None
+        Previously generated IDs to detect collisions. If the computed SHA-256
+        hash already exists in this set, SHA-3-256 is used instead.
+    """
+    data = f"{node_type}:{code_hash}:{config_hash}:{schema_hash}".encode()
+    try:
+        sha = hashlib.sha256(data).hexdigest()
+    except Exception:  # pragma: no cover - unlikely
+        sha = hashlib.sha3_256(data).hexdigest()
+        return sha
+
+    if existing_ids and sha in set(existing_ids):
+        sha = hashlib.sha3_256(data).hexdigest()
+    return sha
+
+
+__all__ = ["compute_node_id"]

--- a/qmtl/dagmanager/neo4j_init.py
+++ b/qmtl/dagmanager/neo4j_init.py
@@ -1,0 +1,26 @@
+SCHEMA_QUERIES = [
+    "CREATE CONSTRAINT compute_pk IF NOT EXISTS ON (c:ComputeNode) ASSERT c.node_id IS UNIQUE",
+    "CREATE INDEX queue_topic IF NOT EXISTS FOR (q:Queue) ON (q.topic)",
+]
+
+
+def get_schema_queries() -> list[str]:
+    """Return Cypher statements needed to initialize Neo4j schema."""
+    return SCHEMA_QUERIES.copy()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    from neo4j import GraphDatabase
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Initialize Neo4j schema")
+    parser.add_argument("uri")
+    parser.add_argument("user")
+    parser.add_argument("password")
+    args = parser.parse_args()
+
+    driver = GraphDatabase.driver(args.uri, auth=(args.user, args.password))
+    with driver.session() as session:
+        for stmt in SCHEMA_QUERIES:
+            session.run(stmt)
+    driver.close()

--- a/tests/test_dagmanager.py
+++ b/tests/test_dagmanager.py
@@ -1,0 +1,25 @@
+from qmtl.dagmanager import compute_node_id
+from qmtl.dagmanager.neo4j_init import get_schema_queries
+import hashlib
+
+
+def test_compute_node_id_sha256():
+    node_id = compute_node_id("type", "code", "cfg", "schema")
+    expected = hashlib.sha256(b"type:code:cfg:schema").hexdigest()
+    assert node_id == expected
+
+
+def test_compute_node_id_sha3_fallback():
+    data = ("A", "B", "C", "D")
+    sha256_id = compute_node_id(*data)
+    # same components would normally yield the same sha256, but the existing id
+    # forces a fallback to sha3
+    second_id = compute_node_id(*data, existing_ids={sha256_id})
+    expected = hashlib.sha3_256(b"A:B:C:D").hexdigest()
+    assert second_id == expected
+
+
+def test_schema_queries():
+    queries = get_schema_queries()
+    assert "compute_pk" in queries[0]
+    assert "queue_topic" in queries[1]


### PR DESCRIPTION
## Summary
- add new `dagmanager` module
- implement `compute_node_id` with SHA-256 & SHA-3 fallback
- create Neo4j schema initialization script
- test hashing collisions and schema queries
- provide minimal `pyproject.toml`

## Testing
- `uv venv .venv`
- `uv pip install -e .[dev]`
- `uv run pip wheel .`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b07eb4188329844c466e74f573f8