### PR TITLE
Add gateway integration to Runner

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -27,6 +27,8 @@ class Node:
         self.tags = tags or []
         self.config = config or {}
         self.schema = schema or {}
+        self.execute = True
+        self.queue_topic: str | None = None
 
     def __repr__(self) -> str:  # pragma: no cover - simple repr
         return (

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -1,8 +1,40 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Optional
+
+import httpx
+
 from .strategy import Strategy
 
 
 class Runner:
     """Execute strategies in various modes."""
+
+    @staticmethod
+    def _post_gateway(
+        *,
+        gateway_url: str,
+        dag: dict,
+        meta: Optional[dict],
+        run_type: str,
+    ) -> dict:
+        url = gateway_url.rstrip("/") + "/strategies"
+        payload = {
+            "dag_json": base64.b64encode(json.dumps(dag).encode()).decode(),
+            "meta": meta,
+            "run_type": run_type,
+        }
+        resp = httpx.post(url, json=payload)
+        if resp.status_code == 202:
+            return resp.json().get("queue_map", {})
+        if resp.status_code == 409:
+            raise RuntimeError("duplicate strategy")
+        if resp.status_code == 422:
+            raise RuntimeError("invalid strategy payload")
+        resp.raise_for_status()
+        return {}
 
     @staticmethod
     def _prepare(strategy_cls: type[Strategy]) -> Strategy:
@@ -12,31 +44,78 @@ class Runner:
         return strategy
 
     @staticmethod
-    def backtest(strategy_cls: type[Strategy], start_time=None, end_time=None, on_missing="skip") -> Strategy:
+    def _apply_queue_map(strategy: Strategy, queue_map: dict[str, str]) -> None:
+        for node in strategy.nodes:
+            topic = queue_map.get(node.node_id)
+            if topic:
+                node.execute = False
+                node.queue_topic = topic
+            else:
+                node.execute = True
+                node.queue_topic = None
+
+    @staticmethod
+    def backtest(
+        strategy_cls: type[Strategy],
+        *,
+        start_time=None,
+        end_time=None,
+        on_missing="skip",
+        gateway_url: str | None = None,
+        meta: Optional[dict] = None,
+    ) -> Strategy:
         """Run strategy in backtest mode."""
         strategy = Runner._prepare(strategy_cls)
         print(f"[BACKTEST] {strategy_cls.__name__} from {start_time} to {end_time} on_missing={on_missing}")
         dag = strategy.serialize()
         print(f"Sending DAG to service: {[n['node_id'] for n in dag['nodes']]}")
+        if gateway_url:
+            queue_map = Runner._post_gateway(
+                gateway_url=gateway_url,
+                dag=dag,
+                meta=meta,
+                run_type="backtest",
+            )
+            Runner._apply_queue_map(strategy, queue_map)
         # Placeholder for backtest logic
         return strategy
 
     @staticmethod
-    def dryrun(strategy_cls: type[Strategy]) -> Strategy:
+    def dryrun(
+        strategy_cls: type[Strategy], *, gateway_url: str | None = None, meta: Optional[dict] = None
+    ) -> Strategy:
         """Run strategy in dry-run (paper trading) mode."""
         strategy = Runner._prepare(strategy_cls)
         print(f"[DRYRUN] {strategy_cls.__name__} starting")
         dag = strategy.serialize()
         print(f"Sending DAG to service: {[n['node_id'] for n in dag['nodes']]}")
+        if gateway_url:
+            queue_map = Runner._post_gateway(
+                gateway_url=gateway_url,
+                dag=dag,
+                meta=meta,
+                run_type="dry-run",
+            )
+            Runner._apply_queue_map(strategy, queue_map)
         # Placeholder for dry-run logic
         return strategy
 
     @staticmethod
-    def live(strategy_cls: type[Strategy]) -> Strategy:
+    def live(
+        strategy_cls: type[Strategy], *, gateway_url: str | None = None, meta: Optional[dict] = None
+    ) -> Strategy:
         """Run strategy in live trading mode."""
         strategy = Runner._prepare(strategy_cls)
         print(f"[LIVE] {strategy_cls.__name__} starting")
         dag = strategy.serialize()
         print(f"Sending DAG to service: {[n['node_id'] for n in dag['nodes']]}")
+        if gateway_url:
+            queue_map = Runner._post_gateway(
+                gateway_url=gateway_url,
+                dag=dag,
+                meta=meta,
+                run_type="live",
+            )
+            Runner._apply_queue_map(strategy, queue_map)
         # Placeholder for live trading logic
         return strategy

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,9 @@
 import sys
+import base64
+import json
+
+import httpx
+import pytest
 from qmtl.sdk.runner import Runner
 from tests.sample_strategy import SampleStrategy
 
@@ -22,3 +27,43 @@ def test_live(capsys):
     captured = capsys.readouterr().out
     assert "[LIVE] SampleStrategy" in captured
     assert isinstance(strategy, SampleStrategy)
+
+
+def test_gateway_queue_mapping(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode())
+        dag = json.loads(base64.b64decode(payload["dag_json"]).decode())
+        first_id = dag["nodes"][0]["node_id"]
+        return httpx.Response(
+            202,
+            json={"strategy_id": "s1", "queue_map": {first_id: "topic1"}},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def mock_post(url, json):
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, json=json)
+
+    monkeypatch.setattr(httpx, "post", mock_post)
+
+    strategy = Runner.dryrun(SampleStrategy, gateway_url="http://gw")
+    first_node = strategy.nodes[0]
+    assert first_node.queue_topic == "topic1"
+    assert not first_node.execute
+
+
+def test_gateway_error(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(409)
+
+    transport = httpx.MockTransport(handler)
+
+    def mock_post(url, json):
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, json=json)
+
+    monkeypatch.setattr(httpx, "post", mock_post)
+
+    with pytest.raises(RuntimeError):
+        Runner.dryrun(SampleStrategy, gateway_url="http://gw")


### PR DESCRIPTION
## Summary
- mark execution plan fields on nodes
- enable Runner to talk to gateway APIs
- adjust Node execution based on gateway response
- test new network integration and error handling

## Testing
- `PYTHONPATH=. uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b1e69bbc83299e0963503b01a019