### PR TITLE
Implement DiffService with stepwise diff algorithm

### DIFF
--- a/qmtl/dagmanager/diff_service.py
+++ b/qmtl/dagmanager/diff_service.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable, List, Dict
+
+
+@dataclass
+class DiffRequest:
+    strategy_id: str
+    dag_json: str
+
+
+@dataclass
+class DiffChunk:
+    queue_map: Dict[str, str]
+    sentinel_id: str
+
+
+@dataclass
+class NodeInfo:
+    node_id: str
+    code_hash: str
+    schema_hash: str
+
+
+@dataclass
+class NodeRecord(NodeInfo):
+    topic: str
+
+
+class NodeRepository:
+    """Interface to fetch nodes and insert sentinels."""
+
+    def get_nodes(self, node_ids: Iterable[str]) -> Dict[str, NodeRecord]:
+        raise NotImplementedError
+
+    def insert_sentinel(self, sentinel_id: str, node_ids: Iterable[str]) -> None:
+        raise NotImplementedError
+
+
+class QueueManager:
+    """Interface to create or update queues."""
+
+    def upsert(self, node_id: str) -> str:
+        raise NotImplementedError
+
+
+class StreamSender:
+    """Interface to send diff results as a stream."""
+
+    def send(self, chunk: DiffChunk) -> None:
+        raise NotImplementedError
+
+
+class DiffService:
+    """Process :class:`DiffRequest` following the documented steps."""
+
+    def __init__(
+        self,
+        node_repo: NodeRepository,
+        queue_manager: QueueManager,
+        stream_sender: StreamSender,
+    ) -> None:
+        self.node_repo = node_repo
+        self.queue_manager = queue_manager
+        self.stream_sender = stream_sender
+
+    # Step 1 ---------------------------------------------------------------
+    def _pre_scan(self, dag_json: str) -> List[NodeInfo]:
+        data = json.loads(dag_json)
+        nodes = []
+        for n in data.get("nodes", []):
+            nodes.append(
+                NodeInfo(
+                    node_id=n["node_id"],
+                    code_hash=n["code_hash"],
+                    schema_hash=n["schema_hash"],
+                )
+            )
+        return nodes
+
+    # Step 2 ---------------------------------------------------------------
+    def _db_fetch(self, node_ids: Iterable[str]) -> Dict[str, NodeRecord]:
+        return self.node_repo.get_nodes(node_ids)
+
+    # Step 3 ---------------------------------------------------------------
+    def _hash_compare(
+        self, nodes: Iterable[NodeInfo], existing: Dict[str, NodeRecord]
+    ) -> tuple[Dict[str, str], List[NodeInfo]]:
+        queue_map: Dict[str, str] = {}
+        new_nodes: List[NodeInfo] = []
+        for n in nodes:
+            rec = existing.get(n.node_id)
+            if rec and rec.code_hash == n.code_hash and rec.schema_hash == n.schema_hash:
+                queue_map[n.node_id] = rec.topic
+            else:
+                topic = self.queue_manager.upsert(n.node_id)
+                queue_map[n.node_id] = topic
+                new_nodes.append(n)
+        return queue_map, new_nodes
+
+    # Step 4 ---------------------------------------------------------------
+    def _insert_sentinel(self, sentinel_id: str, nodes: Iterable[NodeInfo]) -> None:
+        self.node_repo.insert_sentinel(sentinel_id, [n.node_id for n in nodes])
+
+    # Step 5 is handled inside _hash_compare via queue upsert --------------
+
+    # Step 6 ---------------------------------------------------------------
+    def _stream_send(self, queue_map: Dict[str, str], sentinel_id: str) -> None:
+        self.stream_sender.send(DiffChunk(queue_map=queue_map, sentinel_id=sentinel_id))
+
+    def diff(self, request: DiffRequest) -> DiffChunk:
+        nodes = self._pre_scan(request.dag_json)
+        existing = self._db_fetch([n.node_id for n in nodes])
+        queue_map, new_nodes = self._hash_compare(nodes, existing)
+        sentinel_id = f"{request.strategy_id}-sentinel"
+        self._insert_sentinel(sentinel_id, new_nodes)
+        self._stream_send(queue_map, sentinel_id)
+        return DiffChunk(queue_map=queue_map, sentinel_id=sentinel_id)

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -1,0 +1,98 @@
+import json
+from qmtl.dagmanager.diff_service import (
+    DiffService,
+    DiffRequest,
+    NodeRepository,
+    QueueManager,
+    StreamSender,
+    NodeRecord,
+)
+
+
+class FakeRepo(NodeRepository):
+    def __init__(self):
+        self.fetched = []
+        self.sentinels = []
+        self.records = {}
+
+    def get_nodes(self, node_ids):
+        self.fetched.append(list(node_ids))
+        return {nid: self.records[nid] for nid in node_ids if nid in self.records}
+
+    def insert_sentinel(self, sentinel_id, node_ids):
+        self.sentinels.append((sentinel_id, list(node_ids)))
+
+
+class FakeQueue(QueueManager):
+    def __init__(self):
+        self.calls = []
+
+    def upsert(self, node_id):
+        self.calls.append(node_id)
+        return f"topic_{node_id}"
+
+
+class FakeStream(StreamSender):
+    def __init__(self):
+        self.chunks = []
+
+    def send(self, chunk):
+        self.chunks.append(chunk)
+
+
+def _make_dag(nodes):
+    return json.dumps({"nodes": nodes})
+
+
+def test_pre_scan_and_db_fetch():
+    repo = FakeRepo()
+    queue = FakeQueue()
+    stream = FakeStream()
+    service = DiffService(repo, queue, stream)
+
+    dag = _make_dag([
+        {"node_id": "A", "code_hash": "c1", "schema_hash": "s1"},
+        {"node_id": "B", "code_hash": "c2", "schema_hash": "s2"},
+    ])
+    req = DiffRequest(strategy_id="s", dag_json=dag)
+
+    service.diff(req)
+    assert repo.fetched[0] == ["A", "B"]
+
+
+def test_hash_compare_and_queue_upsert():
+    repo = FakeRepo()
+    # existing node A
+    repo.records["A"] = NodeRecord("A", "c1", "s1", "topic_A")
+    queue = FakeQueue()
+    stream = FakeStream()
+    service = DiffService(repo, queue, stream)
+
+    dag = _make_dag([
+        {"node_id": "A", "code_hash": "c1", "schema_hash": "s1"},
+        {"node_id": "B", "code_hash": "c2", "schema_hash": "s2"},
+    ])
+    req = DiffRequest(strategy_id="s", dag_json=dag)
+
+    chunk = service.diff(req)
+    assert chunk.queue_map["A"] == "topic_A"
+    assert chunk.queue_map["B"] == "topic_B"
+    assert queue.calls == ["B"]
+
+
+def test_sentinel_insert_and_stream():
+    repo = FakeRepo()
+    queue = FakeQueue()
+    stream = FakeStream()
+    service = DiffService(repo, queue, stream)
+
+    dag = _make_dag([
+        {"node_id": "A", "code_hash": "c1", "schema_hash": "s1"},
+    ])
+    req = DiffRequest(strategy_id="strategy", dag_json=dag)
+
+    chunk = service.diff(req)
+
+    assert repo.sentinels == [("strategy-sentinel", ["A"])]
+    assert stream.chunks[0] == chunk
+    assert chunk.sentinel_id == "strategy-sentinel"


### PR DESCRIPTION
## Summary
- add `DiffService` with Node pre-scan, DB fetch, hash compare, sentinel insertion, queue upsert and stream send
- test `DiffService` to verify each algorithm stage

## Testing
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b1f4517c83298eaac19fdfc07dc4