### PR TITLE
Implement NodeID hashing and sentinel insertion

### DIFF
--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
+import base64
 from dataclasses import dataclass
 from typing import Optional
 
@@ -102,8 +103,24 @@ class StrategyManager:
 
     async def submit(self, payload: StrategySubmit) -> str:
         strategy_id = str(uuid.uuid4())
+
+        try:
+            dag_bytes = base64.b64decode(payload.dag_json)
+            dag_dict = json.loads(dag_bytes.decode())
+        except Exception:
+            dag_dict = json.loads(payload.dag_json)
+        sentinel = {
+            "node_type": "VersionSentinel",
+            "node_id": f"{strategy_id}-sentinel",
+        }
+        dag_dict.setdefault("nodes", []).append(sentinel)
+        encoded_dag = base64.b64encode(json.dumps(dag_dict).encode()).decode()
+
         await self.redis.rpush("strategy_queue", strategy_id)
-        await self.redis.hset(f"strategy:{strategy_id}", mapping={"status": _INITIAL_STATUS})
+        await self.redis.hset(
+            f"strategy:{strategy_id}",
+            mapping={"status": _INITIAL_STATUS, "dag": encoded_dag},
+        )
         await self.database.insert_strategy(strategy_id, payload.meta)
         return strategy_id
 

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -4,6 +4,8 @@ import hashlib
 import inspect
 import json
 
+from qmtl.dagmanager import compute_node_id
+
 
 class Node:
     """Represents a processing node in a strategy DAG."""
@@ -84,17 +86,12 @@ class Node:
 
     @property
     def node_id(self) -> str:
-        payload = "|".join(
-            [self.node_type, self.code_hash, self.config_hash, self.schema_hash]
-        ).encode()
-        try:
-            h = hashlib.sha256()
-            h.update(payload)
-            return h.hexdigest()
-        except Exception:  # pragma: no cover - unlikely
-            h = hashlib.sha3_256()
-            h.update(payload)
-            return h.hexdigest()
+        return compute_node_id(
+            self.node_type,
+            self.code_hash,
+            self.config_hash,
+            self.schema_hash,
+        )
 
     def to_dict(self) -> dict:
         return {

--- a/tests/gateway/test_nodeid.py
+++ b/tests/gateway/test_nodeid.py
@@ -1,0 +1,58 @@
+import base64
+import json
+import hashlib
+import pytest
+from fastapi.testclient import TestClient
+from fakeredis.aioredis import FakeRedis
+
+from qmtl.dagmanager import compute_node_id
+from qmtl.gateway.api import create_app, Database, StrategySubmit
+
+
+class FakeDB(Database):
+    def __init__(self) -> None:
+        self.records = {}
+
+    async def insert_strategy(self, strategy_id: str, meta=None) -> None:  # pragma: no cover - not used
+        self.records[strategy_id] = {"status": "queued", "meta": meta}
+
+    async def set_status(self, strategy_id: str, status: str) -> None:  # pragma: no cover - not used
+        self.records[strategy_id]["status"] = status
+
+    async def get_status(self, strategy_id: str) -> str | None:  # pragma: no cover - not used
+        rec = self.records.get(strategy_id)
+        return rec.get("status") if rec else None
+
+
+@pytest.fixture
+def client_and_redis():
+    redis = FakeRedis(decode_responses=True)
+    db = FakeDB()
+    app = create_app(redis_client=redis, database=db)
+    return TestClient(app), redis
+
+
+def test_compute_node_id_collision():
+    data = ("A", "B", "C", "D")
+    first = compute_node_id(*data)
+    second = compute_node_id(*data, existing_ids={first})
+    assert first != second
+    assert second == hashlib.sha3_256(b"A:B:C:D").hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_inserted(client_and_redis):
+    client, redis = client_and_redis
+    dag = {"nodes": []}
+    payload = StrategySubmit(
+        dag_json=base64.b64encode(json.dumps(dag).encode()).decode(),
+        meta=None,
+        run_type="dry-run",
+    )
+    resp = client.post("/strategies", json=payload.model_dump())
+    assert resp.status_code == 202
+    sid = resp.json()["strategy_id"]
+    encoded = await redis.hget(f"strategy:{sid}", "dag")
+    dag_saved = json.loads(base64.b64decode(encoded).decode())
+    assert any(n["node_type"] == "VersionSentinel" for n in dag_saved["nodes"])
+


### PR DESCRIPTION
## Summary
- use `compute_node_id` for deterministic IDs
- insert `VersionSentinel` node on strategy ingest
- test gateway NodeID behaviour and sentinel creation

## Testing
- `uv pip install -e .[dev]`
- `uv pip install fakeredis asyncpg fastapi uvicorn httpx xstate pytest-asyncio`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b3ad8f108329a2c9a879007898ec