### PR TITLE
Implement TagQueryNode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "pytest-asyncio", "httpx", "fastapi", "fakeredis", "asyncpg", "xstate"]
 
 [build-system]
 requires = ["setuptools"]

--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -1,8 +1,8 @@
 """QMTL strategy SDK."""
 
-from .node import Node, StreamInput
+from .node import Node, StreamInput, TagQueryNode
 from .strategy import Strategy
 from .runner import Runner
 from .cli import main as _cli
 
-__all__ = ["Node", "StreamInput", "Strategy", "Runner", "_cli"]
+__all__ = ["Node", "StreamInput", "TagQueryNode", "Strategy", "Runner", "_cli"]

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import httpx
 
 
 class Node:
@@ -113,4 +114,55 @@ class StreamInput(Node):
 
     def __init__(self, tags: list[str] | None = None, interval: int | None = None, period: int | None = None) -> None:
         super().__init__(input=None, compute_fn=None, name="stream_input", interval=interval, period=period, tags=tags or [])
+
+
+class TagQueryNode(Node):
+    """Node that selects upstream queues by tag and interval."""
+
+    def __init__(
+        self,
+        query_tags: list[str],
+        *,
+        interval: int,
+        period: int,
+        compute_fn=None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(
+            input=None,
+            compute_fn=compute_fn,
+            name=name or "tag_query",
+            interval=interval,
+            period=period,
+            tags=list(query_tags),
+        )
+        self.query_tags = list(query_tags)
+        self.upstreams: list[str] = []
+
+    def resolve(self, gateway_url: str) -> list[str]:
+        """Fetch matching queues from ``gateway_url``."""
+        url = gateway_url.rstrip("/") + "/queues/by_tag"
+        params = {"tags": ",".join(self.query_tags), "interval": self.interval}
+        resp = httpx.get(url, params=params)
+        resp.raise_for_status()
+        queues = resp.json().get("queues", [])
+        self.upstreams = queues
+        return queues
+
+    async def subscribe_updates(self, gateway_url: str) -> None:
+        """Subscribe to queue updates via streaming endpoint."""
+        url = gateway_url.rstrip("/") + "/queues/watch"
+        params = {"tags": ",".join(self.query_tags), "interval": self.interval}
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream("GET", url, params=params) as resp:
+                async for line in resp.aiter_lines():
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    queues = data.get("queues")
+                    if queues is not None:
+                        self.upstreams = queues
 

--- a/tests/test_tag_query_node.py
+++ b/tests/test_tag_query_node.py
@@ -1,0 +1,61 @@
+import json
+import pytest
+import httpx
+
+from qmtl.sdk import TagQueryNode
+
+
+def test_resolve(monkeypatch):
+    node = TagQueryNode(["t1"], interval=60, period=2)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/queues/by_tag"
+        assert request.url.params["tags"] == "t1"
+        assert request.url.params["interval"] == "60"
+        return httpx.Response(200, json={"queues": ["q1", "q2"]})
+
+    transport = httpx.MockTransport(handler)
+
+    def mock_get(url, params=None):
+        with httpx.Client(transport=transport) as client:
+            return client.get(url, params=params)
+
+    monkeypatch.setattr(httpx, "get", mock_get)
+
+    node.resolve("http://gw")
+    assert node.upstreams == ["q1", "q2"]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_updates(monkeypatch):
+    node = TagQueryNode(["t1"], interval=60, period=2)
+
+    class DummyStream:
+        def __init__(self, lines):
+            self._lines = lines
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def aiter_lines(self):
+            for l in self._lines:
+                yield json.dumps(l)
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        def stream(self, method, url, params=None):
+            assert method == "GET"
+            assert url.endswith("/queues/watch")
+            assert params["tags"] == "t1"
+            assert params["interval"] == 60
+            return DummyStream([{"queues": ["q3"]}, {"queues": ["q4"]}])
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+
+    await node.subscribe_updates("http://gw")
+    assert node.upstreams == ["q4"]


### PR DESCRIPTION
## Summary
- add `TagQueryNode` for tag/interval queries
- expose `TagQueryNode` from `qmtl.sdk`
- support gateway interaction with HTTP and streaming updates
- include new dev dependencies for tests
- test queue lookup and streaming update logic

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b3fe3a888329a3c610deea26d558