### PR TITLE
Implement Kafka topic utilities

### DIFF
--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -31,4 +31,13 @@ def compute_node_id(
     return sha
 
 
-__all__ = ["compute_node_id"]
+from .topic import TopicConfig, topic_name, get_config
+from .kafka_admin import KafkaAdmin
+
+__all__ = [
+    "compute_node_id",
+    "TopicConfig",
+    "topic_name",
+    "get_config",
+    "KafkaAdmin",
+]

--- a/qmtl/dagmanager/kafka_admin.py
+++ b/qmtl/dagmanager/kafka_admin.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Simple Kafka Admin wrapper for idempotent topic creation."""
+
+from dataclasses import dataclass
+from typing import Protocol, Mapping
+
+from .topic import TopicConfig
+
+
+class AdminClient(Protocol):
+    """Protocol describing minimal Kafka admin client methods."""
+
+    def list_topics(self) -> Mapping[str, dict]:
+        ...
+
+    def create_topic(
+        self,
+        name: str,
+        *,
+        num_partitions: int,
+        replication_factor: int,
+        config: Mapping[str, str] | None = None,
+    ) -> None:
+        ...
+
+
+@dataclass
+class KafkaAdmin:
+    client: AdminClient
+
+    def create_topic_if_needed(self, name: str, config: TopicConfig) -> None:
+        """Create topic if it does not exist."""
+        topics = self.client.list_topics()
+        if name in topics:
+            return
+        self.client.create_topic(
+            name,
+            num_partitions=config.partitions,
+            replication_factor=config.replication_factor,
+            config={"retention.ms": str(config.retention_ms)},
+        )
+
+
+__all__ = ["KafkaAdmin", "AdminClient"]

--- a/qmtl/dagmanager/topic.py
+++ b/qmtl/dagmanager/topic.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Utilities for Kafka topic naming and configuration."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TopicConfig:
+    partitions: int
+    replication_factor: int
+    retention_ms: int
+
+
+_QUEUE_CONFIG = {
+    "raw": TopicConfig(partitions=3, replication_factor=3, retention_ms=7 * 24 * 60 * 60 * 1000),
+    "indicator": TopicConfig(partitions=1, replication_factor=2, retention_ms=30 * 24 * 60 * 60 * 1000),
+    "trade_exec": TopicConfig(partitions=1, replication_factor=3, retention_ms=90 * 24 * 60 * 60 * 1000),
+}
+
+
+def topic_name(asset: str, node_type: str, code_hash: str, version: str, *, dryrun: bool = False) -> str:
+    """Return topic name following `{asset}_{node_type}_{short_hash}_{version}`."""
+    short_hash = code_hash[:6]
+    suffix = "_sim" if dryrun else ""
+    return f"{asset}_{node_type}_{short_hash}_{version}{suffix}"
+
+
+def get_config(queue_type: str) -> TopicConfig:
+    """Return :class:`TopicConfig` for the given ``queue_type``."""
+    try:
+        return _QUEUE_CONFIG[queue_type]
+    except KeyError:
+        raise ValueError(f"unknown queue type: {queue_type}")
+
+
+__all__ = ["TopicConfig", "topic_name", "get_config"]

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -1,0 +1,43 @@
+from qmtl.dagmanager.topic import topic_name, get_config, TopicConfig
+from qmtl.dagmanager.kafka_admin import KafkaAdmin
+
+
+class FakeAdmin:
+    def __init__(self, topics=None):
+        self.topics = topics or {}
+        self.created = []
+
+    def list_topics(self):
+        return self.topics
+
+    def create_topic(self, name, *, num_partitions, replication_factor, config=None):
+        self.created.append((name, num_partitions, replication_factor, config))
+        self.topics[name] = config or {}
+
+
+def test_topic_name_generation():
+    name = topic_name("btc", "Indicator", "abcdef123456", "v1")
+    assert name == "btc_Indicator_abcdef_v1"
+    sim = topic_name("btc", "Indicator", "abcdef123456", "v1", dryrun=True)
+    assert sim.endswith("_sim")
+
+
+def test_queue_config_values():
+    cfg = get_config("raw")
+    assert cfg == TopicConfig(partitions=3, replication_factor=3, retention_ms=7 * 24 * 60 * 60 * 1000)
+
+
+def test_idempotent_topic_creation():
+    admin = FakeAdmin({"exists": {}})
+    wrapper = KafkaAdmin(admin)
+
+    cfg = TopicConfig(1, 1, 1000)
+    wrapper.create_topic_if_needed("exists", cfg)
+    wrapper.create_topic_if_needed("new", cfg)
+
+    assert len(admin.created) == 1
+    name, parts, repl, conf = admin.created[0]
+    assert name == "new"
+    assert parts == 1
+    assert repl == 1
+    assert conf["retention.ms"] == "1000"


### PR DESCRIPTION
## Summary
- implement queue topic naming and config helpers
- add KafkaAdmin wrapper for idempotent topic creation
- expose utilities through `dagmanager` package
- test topic naming, configs, and idempotent creation

## Testing
- `uv venv`
- `uv pip install -e .[dev]`
- `.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b640b9dc8329b0bbf194d48a50de