### PR TITLE
Add GC service with dynamic throttling

### DIFF
--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -33,6 +33,7 @@ def compute_node_id(
 
 from .topic import TopicConfig, topic_name, get_config
 from .kafka_admin import KafkaAdmin
+from .gc import GarbageCollector, DEFAULT_POLICY, S3ArchiveClient
 
 __all__ = [
     "compute_node_id",
@@ -40,4 +41,7 @@ __all__ = [
     "topic_name",
     "get_config",
     "KafkaAdmin",
+    "GarbageCollector",
+    "DEFAULT_POLICY",
+    "S3ArchiveClient",
 ]

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timedelta
+
+from qmtl.dagmanager.gc import GarbageCollector, QueueInfo
+
+
+class FakeStore:
+    def __init__(self, queues=None):
+        self.queues = queues or []
+        self.dropped = []
+
+    def list_orphan_queues(self):
+        return list(self.queues)
+
+    def drop_queue(self, name: str) -> None:
+        self.dropped.append(name)
+
+
+class FakeMetrics:
+    def __init__(self, value: float):
+        self.value = value
+
+    def messages_in_per_sec(self) -> float:
+        return self.value
+
+
+class FakeArchive:
+    def __init__(self):
+        self.archived = []
+
+    def archive(self, queue: str) -> None:
+        self.archived.append(queue)
+
+
+def test_gc_policy_drop_and_archive():
+    now = datetime.utcnow()
+    queues = [
+        QueueInfo("raw_q", "raw", now - timedelta(days=10)),
+        QueueInfo("sentinel_q", "sentinel", now - timedelta(days=220)),
+    ]
+    store = FakeStore(queues)
+    metrics = FakeMetrics(10)
+    archive = FakeArchive()
+    gc = GarbageCollector(store, metrics, archive=archive, batch_size=10)
+
+    processed = gc.collect(now)
+
+    assert processed == ["raw_q", "sentinel_q"]
+    assert store.dropped == ["raw_q", "sentinel_q"]
+    assert archive.archived == ["sentinel_q"]
+
+
+def test_gc_batch_halved_on_high_load():
+    now = datetime.utcnow()
+    queues = [
+        QueueInfo(f"q{i}", "raw", now - timedelta(days=10)) for i in range(4)
+    ]
+    store = FakeStore(queues)
+    metrics = FakeMetrics(85)
+    gc = GarbageCollector(store, metrics, batch_size=4)
+
+    gc.collect(now)
+
+    assert len(store.dropped) == 2

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timedelta
 
 import grpc
 import pytest
@@ -11,6 +12,7 @@ from qmtl.dagmanager.diff_service import (
     StreamSender,
 )
 from qmtl.dagmanager.grpc_server import serve
+from qmtl.dagmanager.gc import GarbageCollector, QueueInfo
 from qmtl.proto import dagmanager_pb2, dagmanager_pb2_grpc
 
 
@@ -43,3 +45,47 @@ async def test_grpc_diff():
         responses = [r async for r in stub.Diff(request)]
     await server.stop(None)
     assert responses[0].sentinel_id == "s-sentinel"
+
+
+class DummyStore:
+    def __init__(self, queues):
+        self.queues = queues
+        self.dropped = []
+
+    def list_orphan_queues(self):
+        return list(self.queues)
+
+    def drop_queue(self, name: str) -> None:
+        self.dropped.append(name)
+
+
+class DummyMetrics:
+    def __init__(self, val: float = 0) -> None:
+        self.val = val
+
+    def messages_in_per_sec(self) -> float:
+        return self.val
+
+
+class DummyArchive:
+    def __init__(self):
+        self.archived = []
+
+    def archive(self, queue: str) -> None:
+        self.archived.append(queue)
+
+
+@pytest.mark.asyncio
+async def test_grpc_cleanup_triggers_gc():
+    now = datetime.utcnow()
+    store = DummyStore([QueueInfo("q", "raw", now - timedelta(days=10))])
+    gc = GarbageCollector(store, DummyMetrics(), batch_size=1)
+
+    service = DiffService(FakeRepo(), FakeQueue(), FakeStream())
+    server, port = serve(service, host="127.0.0.1", port=0, gc=gc)
+    await server.start()
+    async with grpc.aio.insecure_channel(f"127.0.0.1:{port}") as channel:
+        stub = dagmanager_pb2_grpc.AdminServiceStub(channel)
+        await stub.Cleanup(dagmanager_pb2.CleanupRequest(strategy_id="s"))
+    await server.stop(None)
+    assert store.dropped == ["q"]


### PR DESCRIPTION
## Summary
- add `GarbageCollector` for orphan queue cleanup
- expose GC from dagmanager API server
- support optional S3 archive interface
- test cleanup logic and gRPC integration

## Testing
- `uv run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b7657dac83299e830858991823ce