### PR TITLE
Implement DAG monitor and alerting

### DIFF
--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -34,6 +34,8 @@ def compute_node_id(
 from .topic import TopicConfig, topic_name, get_config
 from .kafka_admin import KafkaAdmin
 from .gc import GarbageCollector, DEFAULT_POLICY, S3ArchiveClient
+from .alerts import PagerDutyClient, SlackClient, AlertManager
+from .monitor import Monitor
 
 __all__ = [
     "compute_node_id",
@@ -44,4 +46,8 @@ __all__ = [
     "GarbageCollector",
     "DEFAULT_POLICY",
     "S3ArchiveClient",
+    "PagerDutyClient",
+    "SlackClient",
+    "AlertManager",
+    "Monitor",
 ]

--- a/qmtl/dagmanager/alerts.py
+++ b/qmtl/dagmanager/alerts.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""Alerting helpers for PagerDuty and Slack."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import httpx
+
+
+class PagerDutySender(Protocol):
+    """Protocol for sending PagerDuty events."""
+
+    def send(self, message: str) -> None:
+        ...
+
+
+class SlackSender(Protocol):
+    """Protocol for sending Slack messages."""
+
+    def send(self, message: str) -> None:
+        ...
+
+
+@dataclass
+class PagerDutyClient:
+    url: str
+
+    def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
+        httpx.post(self.url, json={"text": message})
+
+
+@dataclass
+class SlackClient:
+    url: str
+
+    def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
+        httpx.post(self.url, json={"text": message})
+
+
+@dataclass
+class AlertManager:
+    pagerduty: PagerDutySender
+    slack: SlackSender
+
+    def send_pagerduty(self, message: str) -> None:
+        self.pagerduty.send(message)
+
+    def send_slack(self, message: str) -> None:
+        self.slack.send(message)
+
+
+__all__ = ["PagerDutyClient", "SlackClient", "AlertManager"]

--- a/qmtl/dagmanager/monitor.py
+++ b/qmtl/dagmanager/monitor.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Monitoring and recovery actions for DAG-Manager."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .alerts import AlertManager
+
+
+class MetricsBackend(Protocol):
+    """Expose system metrics used to detect failures."""
+
+    def neo4j_leader_is_null(self) -> bool:
+        ...
+
+    def kafka_zookeeper_disconnects(self) -> int:
+        ...
+
+    def diff_chunk_ack_timeout(self) -> bool:
+        ...
+
+
+class Neo4jCluster(Protocol):
+    """Control interface for Neo4j cluster."""
+
+    def elect_leader(self) -> None:
+        ...
+
+
+class KafkaSession(Protocol):
+    """Control interface for Kafka admin connection."""
+
+    def retry(self) -> None:
+        ...
+
+
+class DiffStream(Protocol):
+    """Interface to resume diff streams."""
+
+    def resume_from_last_offset(self) -> None:
+        ...
+
+
+@dataclass
+class Monitor:
+    metrics: MetricsBackend
+    neo4j: Neo4jCluster
+    kafka: KafkaSession
+    stream: DiffStream
+    alerts: AlertManager
+
+    def check_once(self) -> None:
+        """Inspect metrics once and trigger recovery/alerts."""
+        if self.metrics.neo4j_leader_is_null():
+            self.neo4j.elect_leader()
+            self.alerts.send_pagerduty("Neo4j leader down")
+
+        if self.metrics.kafka_zookeeper_disconnects() > 0:
+            self.kafka.retry()
+            self.alerts.send_slack("Kafka session lost")
+
+        if self.metrics.diff_chunk_ack_timeout():
+            self.stream.resume_from_last_offset()
+            self.alerts.send_slack("Diff stream stalled")
+
+
+__all__ = ["Monitor", "MetricsBackend", "Neo4jCluster", "KafkaSession", "DiffStream"]

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,23 @@
+import httpx
+from qmtl.dagmanager.alerts import PagerDutyClient, SlackClient
+
+
+def test_alert_clients(monkeypatch):
+    calls = []
+
+    def fake_post(url, json):
+        calls.append((url, json))
+        return httpx.Response(202)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    pd = PagerDutyClient("http://pd")
+    sl = SlackClient("http://slack")
+
+    pd.send("neo4j down")
+    sl.send("kafka lost")
+
+    assert calls == [
+        ("http://pd", {"text": "neo4j down"}),
+        ("http://slack", {"text": "kafka lost"}),
+    ]

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,78 @@
+from qmtl.dagmanager.monitor import Monitor, MetricsBackend, Neo4jCluster, KafkaSession, DiffStream
+from qmtl.dagmanager.alerts import AlertManager
+
+
+class FakeMetrics:
+    def __init__(self, leader=False, disconnects=0, stall=False):
+        self.leader = leader
+        self.disconnects = disconnects
+        self.stall = stall
+
+    def neo4j_leader_is_null(self) -> bool:
+        return self.leader
+
+    def kafka_zookeeper_disconnects(self) -> int:
+        return self.disconnects
+
+    def diff_chunk_ack_timeout(self) -> bool:
+        return self.stall
+
+
+class FakeCluster:
+    def __init__(self):
+        self.elected = 0
+
+    def elect_leader(self) -> None:
+        self.elected += 1
+
+
+class FakeKafka:
+    def __init__(self):
+        self.retried = 0
+
+    def retry(self) -> None:
+        self.retried += 1
+
+
+class FakeStream:
+    def __init__(self):
+        self.resumed = 0
+
+    def resume_from_last_offset(self) -> None:
+        self.resumed += 1
+
+
+class FakePagerDuty:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, msg: str) -> None:
+        self.sent.append(msg)
+
+
+class FakeSlack:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, msg: str) -> None:
+        self.sent.append(msg)
+
+
+def test_monitor_triggers_recovery_and_alerts():
+    metrics = FakeMetrics(leader=True, disconnects=1, stall=True)
+    cluster = FakeCluster()
+    kafka = FakeKafka()
+    stream = FakeStream()
+    pd = FakePagerDuty()
+    slack = FakeSlack()
+    manager = AlertManager(pd, slack)
+    monitor = Monitor(metrics, cluster, kafka, stream, manager)
+
+    monitor.check_once()
+
+    assert cluster.elected == 1
+    assert kafka.retried == 1
+    assert stream.resumed == 1
+    assert pd.sent == ["Neo4j leader down"]
+    assert "Kafka session lost" in slack.sent
+    assert "Diff stream stalled" in slack.sent


### PR DESCRIPTION
## Summary
- add monitor for service failures
- implement PagerDuty and Slack clients
- expose new modules in package
- test alert clients and monitoring logic

## Testing
- `./.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e81153e08329aaea9c3700a27118