### PR TITLE
Ensure offline mode behaves consistently

### DIFF
--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -71,6 +71,7 @@ class Runner:
         dag = strategy.serialize()
         print(f"Sending DAG to service: {[n['node_id'] for n in dag['nodes']]}")
         queue_map = {}
+        offline = offline or not gateway_url
         if gateway_url and not offline:
             try:
                 queue_map = Runner._post_gateway(
@@ -96,6 +97,7 @@ class Runner:
         dag = strategy.serialize()
         print(f"Sending DAG to service: {[n['node_id'] for n in dag['nodes']]}")
         queue_map = {}
+        offline = offline or not gateway_url
         if gateway_url and not offline:
             try:
                 queue_map = Runner._post_gateway(
@@ -120,6 +122,7 @@ class Runner:
         dag = strategy.serialize()
         print(f"Sending DAG to service: {[n['node_id'] for n in dag['nodes']]}")
         queue_map = {}
+        offline = offline or not gateway_url
         if gateway_url and not offline:
             try:
                 queue_map = Runner._post_gateway(


### PR DESCRIPTION
## Summary
- run in offline mode if no Gateway URL is provided
- preserve node IDs when the gateway is unavailable
- test node ID stability for missing or failing gateway connections

## Testing
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684490c860d4832981eae4f4108cba1e