### PR TITLE
Add GC tests and document S3 archive interface

### DIFF
--- a/dag-manager.md
+++ b/dag-manager.md
@@ -232,6 +232,6 @@ qmtl-dagm gc --sentinel v1.2.3
 
 > **TODO**
 >
-> * S3 archive module spec
+> * S3 archive integration (interface available via `S3ArchiveClient`)
 > * Neo4j schema DDL export script
 > * Canary rollout automation guide


### PR DESCRIPTION
## Summary
- extend GC unit tests to cover grace period handling and archiving
- add integration test for S3 archive path
- document S3ArchiveClient

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844997246f083299a87f417ecfcb74a