### PR TITLE
Implement MonitorLoop for periodic health checks

### DIFF
--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -35,7 +35,7 @@ from .topic import TopicConfig, topic_name, get_config
 from .kafka_admin import KafkaAdmin
 from .gc import GarbageCollector, DEFAULT_POLICY, S3ArchiveClient
 from .alerts import PagerDutyClient, SlackClient, AlertManager
-from .monitor import Monitor
+from .monitor import Monitor, MonitorLoop
 
 __all__ = [
     "compute_node_id",
@@ -50,4 +50,5 @@ __all__ = [
     "SlackClient",
     "AlertManager",
     "Monitor",
+    "MonitorLoop",
 ]

--- a/qmtl/dagmanager/monitor.py
+++ b/qmtl/dagmanager/monitor.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 """Monitoring and recovery actions for DAG-Manager."""
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, Optional
+import asyncio
 
 from .alerts import AlertManager
 
@@ -65,4 +66,42 @@ class Monitor:
             self.alerts.send_slack("Diff stream stalled")
 
 
-__all__ = ["Monitor", "MetricsBackend", "Neo4jCluster", "KafkaSession", "DiffStream"]
+@dataclass
+class MonitorLoop:
+    """Periodically run :class:`Monitor.check_once` in the background."""
+
+    monitor: Monitor
+    interval: float = 5.0
+    _task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Begin the monitoring loop."""
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                self.monitor.check_once()
+                await asyncio.sleep(self.interval)
+        except asyncio.CancelledError:  # pragma: no cover - background task
+            pass
+
+    async def stop(self) -> None:
+        """Cancel the running loop."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            finally:
+                self._task = None
+
+
+__all__ = [
+    "Monitor",
+    "MetricsBackend",
+    "Neo4jCluster",
+    "KafkaSession",
+    "DiffStream",
+    "MonitorLoop",
+]

--- a/tests/test_monitor_loop.py
+++ b/tests/test_monitor_loop.py
@@ -1,0 +1,22 @@
+import asyncio
+import pytest
+
+from qmtl.dagmanager.monitor import MonitorLoop
+
+
+class DummyMonitor:
+    def __init__(self):
+        self.called = 0
+
+    def check_once(self) -> None:
+        self.called += 1
+
+
+@pytest.mark.asyncio
+async def test_monitor_loop_runs_periodically():
+    mon = DummyMonitor()
+    loop = MonitorLoop(mon, interval=0.01)  # type: ignore[arg-type]
+    await loop.start()
+    await asyncio.sleep(0.03)
+    await loop.stop()
+    assert mon.called >= 2


### PR DESCRIPTION
## Summary
- monitor Neo4j, Kafka and Diff stream via MonitorLoop
- expose MonitorLoop in public API
- test periodic monitoring behaviour

## Testing
- `uv pip install -e .[dev]`
- `python -m pip wheel .`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449c655f088329ac14bd114b11d5e1