### PR TITLE
Implement TagQuery in gateway

### DIFF
--- a/qmtl/proto/dagmanager.proto
+++ b/qmtl/proto/dagmanager.proto
@@ -15,6 +15,19 @@ service DiffService {
   rpc Diff(DiffRequest) returns (stream DiffChunk);
 }
 
+message TagQueryRequest {
+  repeated string tags = 1;
+  int64 interval = 2;
+}
+
+message TagQueryReply {
+  repeated string queues = 1;
+}
+
+service TagQuery {
+  rpc GetQueues(TagQueryRequest) returns (TagQueryReply);
+}
+
 message CleanupRequest {
   string strategy_id = 1;
 }

--- a/qmtl/proto/dagmanager_pb2.py
+++ b/qmtl/proto/dagmanager_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10\x64\x61gmanager.proto\x12\x0fqmtl.dagmanager\"4\n\x0b\x44iffRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\x8e\x01\n\tDiffChunk\x12;\n\tqueue_map\x18\x01 \x03(\x0b\x32(.qmtl.dagmanager.DiffChunk.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"%\n\x0e\x43leanupRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\"\x11\n\x0f\x43leanupResponse\"#\n\x11QueueStatsRequest\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\"q\n\nQueueStats\x12\x35\n\x05sizes\x18\x01 \x03(\x0b\x32&.qmtl.dagmanager.QueueStats.SizesEntry\x1a,\n\nSizesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"\r\n\x0bPingRequest\"\x0b\n\tPingReply2Q\n\x0b\x44iffService\x12\x42\n\x04\x44iff\x12\x1c.qmtl.dagmanager.DiffRequest\x1a\x1a.qmtl.dagmanager.DiffChunk0\x01\x32\xae\x01\n\x0c\x41\x64minService\x12L\n\x07\x43leanup\x12\x1f.qmtl.dagmanager.CleanupRequest\x1a .qmtl.dagmanager.CleanupResponse\x12P\n\rGetQueueStats\x12\".qmtl.dagmanager.QueueStatsRequest\x1a\x1b.qmtl.dagmanager.QueueStats2O\n\x0bHealthCheck\x12@\n\x04Ping\x12\x1c.qmtl.dagmanager.PingRequest\x1a\x1a.qmtl.dagmanager.PingReplyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10\x64\x61gmanager.proto\x12\x0fqmtl.dagmanager\"4\n\x0b\x44iffRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\x8e\x01\n\tDiffChunk\x12;\n\tqueue_map\x18\x01 \x03(\x0b\x32(.qmtl.dagmanager.DiffChunk.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"1\n\x0fTagQueryRequest\x12\x0c\n\x04tags\x18\x01 \x03(\t\x12\x10\n\x08interval\x18\x02 \x01(\x03\"\x1f\n\rTagQueryReply\x12\x0e\n\x06queues\x18\x01 \x03(\t\"%\n\x0e\x43leanupRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\"\x11\n\x0f\x43leanupResponse\"#\n\x11QueueStatsRequest\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\"q\n\nQueueStats\x12\x35\n\x05sizes\x18\x01 \x03(\x0b\x32&.qmtl.dagmanager.QueueStats.SizesEntry\x1a,\n\nSizesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"\r\n\x0bPingRequest\"\x0b\n\tPingReply2Q\n\x0b\x44iffService\x12\x42\n\x04\x44iff\x12\x1c.qmtl.dagmanager.DiffRequest\x1a\x1a.qmtl.dagmanager.DiffChunk0\x01\x32Y\n\x08TagQuery\x12M\n\tGetQueues\x12 .qmtl.dagmanager.TagQueryRequest\x1a\x1e.qmtl.dagmanager.TagQueryReply2\xae\x01\n\x0c\x41\x64minService\x12L\n\x07\x43leanup\x12\x1f.qmtl.dagmanager.CleanupRequest\x1a .qmtl.dagmanager.CleanupResponse\x12P\n\rGetQueueStats\x12\".qmtl.dagmanager.QueueStatsRequest\x1a\x1b.qmtl.dagmanager.QueueStats2O\n\x0bHealthCheck\x12@\n\x04Ping\x12\x1c.qmtl.dagmanager.PingRequest\x1a\x1a.qmtl.dagmanager.PingReplyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -41,24 +41,30 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_DIFFCHUNK']._serialized_end=234
   _globals['_DIFFCHUNK_QUEUEMAPENTRY']._serialized_start=187
   _globals['_DIFFCHUNK_QUEUEMAPENTRY']._serialized_end=234
-  _globals['_CLEANUPREQUEST']._serialized_start=236
-  _globals['_CLEANUPREQUEST']._serialized_end=273
-  _globals['_CLEANUPRESPONSE']._serialized_start=275
-  _globals['_CLEANUPRESPONSE']._serialized_end=292
-  _globals['_QUEUESTATSREQUEST']._serialized_start=294
-  _globals['_QUEUESTATSREQUEST']._serialized_end=329
-  _globals['_QUEUESTATS']._serialized_start=331
-  _globals['_QUEUESTATS']._serialized_end=444
-  _globals['_QUEUESTATS_SIZESENTRY']._serialized_start=400
-  _globals['_QUEUESTATS_SIZESENTRY']._serialized_end=444
-  _globals['_PINGREQUEST']._serialized_start=446
-  _globals['_PINGREQUEST']._serialized_end=459
-  _globals['_PINGREPLY']._serialized_start=461
-  _globals['_PINGREPLY']._serialized_end=472
-  _globals['_DIFFSERVICE']._serialized_start=474
-  _globals['_DIFFSERVICE']._serialized_end=555
-  _globals['_ADMINSERVICE']._serialized_start=558
-  _globals['_ADMINSERVICE']._serialized_end=732
-  _globals['_HEALTHCHECK']._serialized_start=734
-  _globals['_HEALTHCHECK']._serialized_end=813
+  _globals['_TAGQUERYREQUEST']._serialized_start=236
+  _globals['_TAGQUERYREQUEST']._serialized_end=285
+  _globals['_TAGQUERYREPLY']._serialized_start=287
+  _globals['_TAGQUERYREPLY']._serialized_end=318
+  _globals['_CLEANUPREQUEST']._serialized_start=320
+  _globals['_CLEANUPREQUEST']._serialized_end=357
+  _globals['_CLEANUPRESPONSE']._serialized_start=359
+  _globals['_CLEANUPRESPONSE']._serialized_end=376
+  _globals['_QUEUESTATSREQUEST']._serialized_start=378
+  _globals['_QUEUESTATSREQUEST']._serialized_end=413
+  _globals['_QUEUESTATS']._serialized_start=415
+  _globals['_QUEUESTATS']._serialized_end=528
+  _globals['_QUEUESTATS_SIZESENTRY']._serialized_start=484
+  _globals['_QUEUESTATS_SIZESENTRY']._serialized_end=528
+  _globals['_PINGREQUEST']._serialized_start=530
+  _globals['_PINGREQUEST']._serialized_end=543
+  _globals['_PINGREPLY']._serialized_start=545
+  _globals['_PINGREPLY']._serialized_end=556
+  _globals['_DIFFSERVICE']._serialized_start=558
+  _globals['_DIFFSERVICE']._serialized_end=639
+  _globals['_TAGQUERY']._serialized_start=641
+  _globals['_TAGQUERY']._serialized_end=730
+  _globals['_ADMINSERVICE']._serialized_start=733
+  _globals['_ADMINSERVICE']._serialized_end=907
+  _globals['_HEALTHCHECK']._serialized_start=909
+  _globals['_HEALTHCHECK']._serialized_end=988
 # @@protoc_insertion_point(module_scope)

--- a/qmtl/proto/dagmanager_pb2_grpc.py
+++ b/qmtl/proto/dagmanager_pb2_grpc.py
@@ -97,6 +97,78 @@ class DiffService(object):
             _registered_method=True)
 
 
+class TagQueryStub(object):
+    """Missing associated documentation comment in .proto file."""
+
+    def __init__(self, channel):
+        """Constructor.
+
+        Args:
+            channel: A grpc.Channel.
+        """
+        self.GetQueues = channel.unary_unary(
+                '/qmtl.dagmanager.TagQuery/GetQueues',
+                request_serializer=dagmanager__pb2.TagQueryRequest.SerializeToString,
+                response_deserializer=dagmanager__pb2.TagQueryReply.FromString,
+                _registered_method=True)
+
+
+class TagQueryServicer(object):
+    """Missing associated documentation comment in .proto file."""
+
+    def GetQueues(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+
+def add_TagQueryServicer_to_server(servicer, server):
+    rpc_method_handlers = {
+            'GetQueues': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetQueues,
+                    request_deserializer=dagmanager__pb2.TagQueryRequest.FromString,
+                    response_serializer=dagmanager__pb2.TagQueryReply.SerializeToString,
+            ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+            'qmtl.dagmanager.TagQuery', rpc_method_handlers)
+    server.add_generic_rpc_handlers((generic_handler,))
+    server.add_registered_method_handlers('qmtl.dagmanager.TagQuery', rpc_method_handlers)
+
+
+ # This class is part of an EXPERIMENTAL API.
+class TagQuery(object):
+    """Missing associated documentation comment in .proto file."""
+
+    @staticmethod
+    def GetQueues(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/qmtl.dagmanager.TagQuery/GetQueues',
+            dagmanager__pb2.TagQueryRequest.SerializeToString,
+            dagmanager__pb2.TagQueryReply.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+
 class AdminServiceStub(object):
     """Missing associated documentation comment in .proto file."""
 

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -1,0 +1,43 @@
+import pytest
+from fastapi.testclient import TestClient
+from fakeredis.aioredis import FakeRedis
+
+from qmtl.gateway.api import create_app, Database
+from qmtl.gateway.dagmanager_client import DagManagerClient
+
+
+class FakeDB(Database):
+    async def insert_strategy(self, strategy_id: str, meta=None):
+        pass
+
+    async def set_status(self, strategy_id: str, status: str) -> None:
+        pass
+
+    async def get_status(self, strategy_id: str):
+        return None
+
+
+class DummyDag(DagManagerClient):
+    def __init__(self):
+        super().__init__("dummy")
+        self.called_with = None
+
+    async def get_queues_by_tag(self, tags, interval):
+        self.called_with = (tags, interval)
+        return ["q1", "q2"]
+
+
+@pytest.fixture
+def client():
+    redis = FakeRedis(decode_responses=True)
+    dag = DummyDag()
+    app = create_app(redis_client=redis, database=FakeDB(), dag_client=dag)
+    return TestClient(app), dag
+
+
+def test_queues_by_tag_route(client):
+    c, dag = client
+    resp = c.get("/queues/by_tag", params={"tags": "t1,t2", "interval": "60"})
+    assert resp.status_code == 200
+    assert resp.json()["queues"] == ["q1", "q2"]
+    assert dag.called_with == (["t1", "t2"], 60)


### PR DESCRIPTION
## Summary
- extend `DagManagerClient` with `get_queues_by_tag`
- expose new `/queues/by_tag` gateway endpoint
- define TagQuery gRPC service
- tests for queue lookup route

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845077f4f6c83298b15914ea1310c63