### PR TITLE
Add gateway metrics and alerts

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -41,9 +41,22 @@ receivers:
            severity: warning
          annotations:
            summary: Missing diff sentinel detected
-       - alert: OrphanQueuesGrowing
-         expr: increase(orphan_queue_total[3h]) > 0
-         labels:
-           severity: warning
-         annotations:
-           summary: Orphan queue count rising
+      - alert: OrphanQueuesGrowing
+        expr: increase(orphan_queue_total[3h]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: Orphan queue count rising
+      - alert: GatewayLatencyHigh
+        expr: gateway_e2e_latency_p95 > 150
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Gateway end-to-end latency high
+      - alert: LostRequests
+        expr: increase(lost_requests_total[1m]) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: Diff submissions lost

--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Prometheus metrics for Gateway."""
+
+from collections import deque
+from typing import Deque
+import time
+
+from prometheus_client import Gauge, Counter, CollectorRegistry, generate_latest, start_http_server
+
+registry = CollectorRegistry()
+
+_e2e_samples: Deque[float] = deque(maxlen=100)
+
+gateway_e2e_latency_p95 = Gauge(
+    "gateway_e2e_latency_p95",
+    "95th percentile end-to-end latency in milliseconds",
+    registry=registry,
+)
+
+lost_requests_total = Counter(
+    "lost_requests_total",
+    "Total number of diff submissions lost due to queue errors",
+    registry=registry,
+)
+
+
+def observe_gateway_latency(duration_ms: float) -> None:
+    """Record a request latency and update the p95 gauge."""
+    _e2e_samples.append(duration_ms)
+    if not _e2e_samples:
+        return
+    ordered = sorted(_e2e_samples)
+    idx = max(0, int(len(ordered) * 0.95) - 1)
+    gateway_e2e_latency_p95.set(ordered[idx])
+    gateway_e2e_latency_p95._val = gateway_e2e_latency_p95._value.get()  # type: ignore[attr-defined]
+
+
+def start_metrics_server(port: int = 8000) -> None:
+    """Start an HTTP server to expose metrics."""
+    start_http_server(port, registry=registry)
+
+
+def collect_metrics() -> str:
+    """Return metrics in text exposition format."""
+    return generate_latest(registry).decode()
+
+
+def reset_metrics() -> None:
+    """Reset all metric values for tests."""
+    _e2e_samples.clear()
+    gateway_e2e_latency_p95.set(0)
+    gateway_e2e_latency_p95._val = 0  # type: ignore[attr-defined]
+    lost_requests_total._value.set(0)  # type: ignore[attr-defined]
+    lost_requests_total._val = 0  # type: ignore[attr-defined]

--- a/tests/gateway/test_metrics.py
+++ b/tests/gateway/test_metrics.py
@@ -1,0 +1,65 @@
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from fakeredis.aioredis import FakeRedis
+
+from qmtl.gateway.api import create_app, Database, StrategySubmit
+from qmtl.gateway import metrics
+
+
+class FakeDB(Database):
+    async def insert_strategy(self, strategy_id: str, meta):
+        pass
+
+    async def set_status(self, strategy_id: str, status: str):
+        pass
+
+    async def get_status(self, strategy_id: str):
+        return "queued"
+
+    async def append_event(self, strategy_id: str, event: str):
+        pass
+
+
+@pytest.fixture
+def app():
+    redis = FakeRedis(decode_responses=True)
+    db = FakeDB()
+    return create_app(redis_client=redis, database=db)
+
+
+def test_metrics_endpoint(app):
+    metrics.reset_metrics()
+    metrics.lost_requests_total.inc()
+    metrics.observe_gateway_latency(42)
+    client = TestClient(app)
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert "lost_requests_total" in resp.text
+    assert "gateway_e2e_latency_p95" in resp.text
+
+
+def test_latency_metric_recorded(app):
+    metrics.reset_metrics()
+    client = TestClient(app, raise_server_exceptions=False)
+    payload = StrategySubmit(dag_json="{}", meta=None, run_type="dry-run")
+    client.post("/strategies", json=payload.model_dump())
+    assert metrics.gateway_e2e_latency_p95._value.get() > 0
+
+
+def test_lost_requests_counter(monkeypatch):
+    metrics.reset_metrics()
+    redis = FakeRedis(decode_responses=True)
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(redis, "rpush", fail)
+    db = FakeDB()
+    app = create_app(redis_client=redis, database=db)
+    client = TestClient(app, raise_server_exceptions=False)
+    payload = StrategySubmit(dag_json="{}", meta=None, run_type="dry-run")
+    resp = client.post("/strategies", json=payload.model_dump())
+    assert resp.status_code == 500
+    assert metrics.lost_requests_total._value.get() == 1


### PR DESCRIPTION
## Summary
- instrument queue creation errors and lost requests
- track gateway e2e latency
- expose `/metrics` endpoint from gateway
- alert on new metrics
- cover metrics in gateway tests

## Testing
- `uv pip install --system -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454c49ee648329b977d0b3260a9ff3