### PR TITLE
Implement cache warmup logic in SDK

### DIFF
--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -1,6 +1,6 @@
 """QMTL strategy SDK."""
 
-from .node import Node, StreamInput, TagQueryNode
+from .node import Node, StreamInput, TagQueryNode, NodeCache
 from .strategy import Strategy
 from .runner import Runner
 from .cli import main as _cli
@@ -10,6 +10,7 @@ __all__ = [
     "Node",
     "StreamInput",
     "TagQueryNode",
+    "NodeCache",
     "Strategy",
     "Runner",
     "WebSocketClient",

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -54,6 +54,12 @@ class Runner:
                 node.execute = True
                 node.queue_topic = None
 
+    # ------------------------------------------------------------------
+    @staticmethod
+    def feed_queue_data(node, queue_id: str, interval: int, timestamp: int, payload) -> None:
+        """Insert queue data into a node's cache."""
+        node.feed(queue_id, interval, timestamp, payload)
+
     @staticmethod
     def backtest(
         strategy_cls: type[Strategy],

--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -1,0 +1,45 @@
+from qmtl.sdk import Node, StreamInput, Runner
+
+
+def test_cache_warmup_and_compute():
+    calls = []
+
+    def fn(cache):
+        calls.append(cache)
+
+    src = StreamInput(interval=60, period=2)
+    node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
+
+    Runner.feed_queue_data(node, "q1", 60, 1, {"v": 1})
+    assert node.pre_warmup
+    assert len(node.cache["q1"][60]) == 1
+    assert not calls
+
+    Runner.feed_queue_data(node, "q1", 60, 2, {"v": 2})
+    assert not node.pre_warmup
+    assert len(node.cache["q1"][60]) == 2
+    assert len(calls) == 1
+
+    Runner.feed_queue_data(node, "q1", 60, 3, {"v": 3})
+    assert len(node.cache["q1"][60]) == 2
+    assert len(calls) == 2
+
+
+def test_multiple_upstreams():
+    calls = []
+
+    def fn(cache):
+        calls.append(cache)
+
+    src = StreamInput(interval=60, period=2)
+    node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
+
+    Runner.feed_queue_data(node, "u1", 60, 1, {"v": 1})
+    Runner.feed_queue_data(node, "u2", 60, 1, {"v": 1})
+    assert node.pre_warmup
+    Runner.feed_queue_data(node, "u1", 60, 2, {"v": 2})
+    assert node.pre_warmup
+    Runner.feed_queue_data(node, "u2", 60, 2, {"v": 2})
+    assert not node.pre_warmup
+    assert len(calls) == 1
+


### PR DESCRIPTION
## Summary
- track FIFO caches per node and expose warmup status
- allow `Runner` to push queue items into node caches
- run compute functions only once caches are filled
- export `NodeCache` for external use
- test cache behaviour and warmup enforcement

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684555ae029c832987720bad15e7687e