### PR TITLE
Add Ray option for compute execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dev = [
     "xstate",
 ]
 
+ray = ["ray"]
+
 [project.scripts]
 qmtl-dagm = "qmtl.dagmanager.cli:main"
 


### PR DESCRIPTION
## Summary
- support optional `ray` dependency
- run node compute functions via Ray when available
- fall back to sequential execution if Ray isn't installed
- test Runner with and without Ray using mocks

## Testing
- `uv venv`
- `uv pip install -e .[dev]`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458ddffd088329a09a713c85662ca9