### PR TITLE
Add canary rollout documentation

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -48,6 +48,7 @@ Strategy SDK ──▶ Gateway ──▶ DAG-Manager ──▶ Graph DB (Neo4j)
    * 구성: `(node_type, code_hash, config_hash, schema_hash)`
    * 해시 알고리즘: SHA-256 → 충돌 감지 시 SHA-3 fallback
 2. **버전 감시 노드(Version Sentinel)** : Gateway가 DAG를 수신한 직후 **자동으로 1개의 메타 노드**를 삽입해 "버전 경계"를 표시한다. SDK·전략 작성자는 이를 직접 선언하거나 관리할 필요가 없으며, 오로지 **운영·배포 레이어**에서 롤백·카나리아 트래픽 분배, 큐 정합성 검증을 용이하게 하기 위한 인프라 내부 기능이다. Node‑hash만으로도 큐 재사용 판단은 가능하므로, 소규모·저빈도 배포 환경에서는 Sentinel 삽입을 비활성화(옵션)할 수 있다.
+   자세한 카나리아 트래픽 조절 방법은 [Canary Rollout Guide](docs/canary_rollout.md)에서 설명한다.
 3. **CloudEvents 기반 이벤트 스펙 도입** : 표준 이벤트 정의를 통해 시스템 확장성과 언어 독립성을 확보
 4. **상태 머신 기반 실행 제어(xState)** : 전략 상태 흐름을 Finite-State-Machine으로 모델링하여 이론 검증 가능성과 시각화 용이성 확보
 5. **Ray 기반 병렬 처리** : 병렬 실행 시 Python multiprocessing을 Ray로 대체하여 메모리 격리성과 클러스터 확장성을 보장

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -99,6 +99,7 @@ CREATE INDEX queue_topic IF NOT EXISTS FOR (q:Queue) ON (q.topic);
 | G→D | HTTP  | `/admin/gc-trigger`           | id              | 202                | 2 retry            | Manual GC        |
 | G→D | gRPC  | `AdminService.RedoDiff`       | sentinel\_id    | DiffResult         | manual             | 재Diff·롤백         |
 | D→G | HTTP  | `/callbacks/sentinel-traffic` | version, weight | 202                | 3×                 | 카나리아 비율 변경       |
+|     |       |                               |                 |     |                    | 자세한 절차는 [Canary Rollout Guide](docs/canary_rollout.md) 참조 |
 
 ---
 

--- a/docs/canary_rollout.md
+++ b/docs/canary_rollout.md
@@ -1,0 +1,26 @@
+# Canary Rollout Guide
+
+This document explains how to gradually shift traffic between strategy versions using the `DAG‑Mgr` callback endpoint `/callbacks/sentinel-traffic`.
+
+## Adjusting Weights
+
+1. Send an HTTP `POST` request to `/callbacks/sentinel-traffic` on the DAG‑Mgr.
+2. The payload must include the `version` identifier and a `weight` between `0` and `1`.
+3. On success, the DAG‑Mgr updates its routing table and notifies Gateway to route the specified percentage of traffic to the target version.
+
+Example:
+
+```bash
+curl -X POST \ 
+     -H 'Content-Type: application/json' \
+     -d '{"version": "v1.2.1", "weight": 0.25}' \
+     http://dagmgr.internal/callbacks/sentinel-traffic
+```
+
+## Monitoring Metrics
+
+* **Gateway metrics:** check `gateway_sentinel_traffic_ratio{version="v1.2.1"}` in Prometheus to confirm the live split.
+* **DAG‑Mgr metrics:** monitor `dagmgr_active_version_weight` for each version to ensure the new weight is applied.
+* **Alerts:** alert rules under `alert_rules.yml` trigger if traffic weight deviates from the configured value for more than 5 minutes.
+
+Review Grafana dashboards to visualize canary success rates and error budgets while gradually increasing the traffic weight.


### PR DESCRIPTION
## Summary
- document how to change traffic weights via `/callbacks/sentinel-traffic`
- cross-link the new doc from `architecture.md` and `dag-manager.md`

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684590c69ad4832999f43fdd2ce22be6