### PR TITLE
Add sentinel traffic callback

### DIFF
--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -37,6 +37,7 @@ from .gc import GarbageCollector, DEFAULT_POLICY, S3ArchiveClient
 from .alerts import PagerDutyClient, SlackClient, AlertManager
 from .monitor import Monitor, MonitorLoop
 from .metrics import start_metrics_server
+from .http_server import create_app
 
 __all__ = [
     "compute_node_id",
@@ -53,4 +54,5 @@ __all__ = [
     "Monitor",
     "MonitorLoop",
     "start_metrics_server",
+    "create_app",
 ]

--- a/qmtl/dagmanager/http_server.py
+++ b/qmtl/dagmanager/http_server.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import FastAPI, status
+from pydantic import BaseModel, Field
+
+from .callbacks import post_with_backoff
+from ..common.cloudevents import format_event
+
+
+class WeightUpdate(BaseModel):
+    version: str = Field(..., description="Version identifier")
+    weight: float = Field(..., ge=0.0, le=1.0, description="Traffic weight")
+
+
+def create_app(
+    *,
+    weights: Optional[dict[str, float]] = None,
+    gateway_url: str | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    store = weights if weights is not None else {}
+
+    @app.post("/callbacks/sentinel-traffic", status_code=status.HTTP_202_ACCEPTED)
+    async def sentinel_traffic(update: WeightUpdate):
+        store[update.version] = update.weight
+        if gateway_url:
+            event = format_event(
+                "qmtl.dagmanager",
+                "sentinel_weight",
+                {"sentinel_id": update.version, "weight": update.weight},
+            )
+            await post_with_backoff(gateway_url, event)
+        return {"version": update.version, "weight": update.weight}
+
+    return app


### PR DESCRIPTION
## Summary
- implement a FastAPI app for `/callbacks/sentinel-traffic`
- expose `create_app` in dagmanager package
- send CloudEvents to Gateway when weights change
- test HTTP callback behaviour

## Testing
- `uv run -- pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684593796bb88329add876785d324887