### PR TITLE
Refactor cache to tensor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.11"
 dependencies = [
     "prometheus-client",
     "boto3",
+    "xarray",
 ]
 
 [project.optional-dependencies]

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -75,7 +75,7 @@ class Runner:
     @staticmethod
     def feed_queue_data(node, queue_id: str, interval: int, timestamp: int, payload) -> None:
         """Insert queue data into ``node`` and trigger its ``compute_fn``."""
-        node.cache.append(queue_id, interval, (timestamp, payload))
+        node.cache.append(queue_id, interval, timestamp, payload)
         if node.pre_warmup and node.cache.ready():
             node.pre_warmup = False
         if not node.pre_warmup and node.compute_fn:


### PR DESCRIPTION
## Summary
- reimplement NodeCache using an xarray tensor
- adjust Runner.feed_queue_data for new cache API
- update tests for tensor-based cache and add simple memory check
- declare xarray as a dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459384e2308329bdab0fd9dbf9b955