### PR TITLE
Implement gap detection in NodeCache

### DIFF
--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -1,3 +1,4 @@
+import pytest
 from qmtl.sdk import Node, StreamInput, Runner, NodeCache
 
 
@@ -10,23 +11,23 @@ def test_cache_warmup_and_compute():
     src = StreamInput(interval=60, period=2)
     node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
 
-    Runner.feed_queue_data(node, "q1", 60, 1, {"v": 1})
+    Runner.feed_queue_data(node, "q1", 60, 60, {"v": 1})
     assert node.pre_warmup
-    assert node.cache.snapshot()["q1"][60] == [(1, {"v": 1})]
+    assert node.cache.snapshot()["q1"][60] == [(60, {"v": 1})]
     assert not calls
 
-    Runner.feed_queue_data(node, "q1", 60, 2, {"v": 2})
+    Runner.feed_queue_data(node, "q1", 60, 120, {"v": 2})
     assert not node.pre_warmup
     assert node.cache.snapshot()["q1"][60] == [
-        (1, {"v": 1}),
-        (2, {"v": 2}),
+        (60, {"v": 1}),
+        (120, {"v": 2}),
     ]
     assert len(calls) == 1
 
-    Runner.feed_queue_data(node, "q1", 60, 3, {"v": 3})
+    Runner.feed_queue_data(node, "q1", 60, 180, {"v": 3})
     assert node.cache.snapshot()["q1"][60] == [
-        (2, {"v": 2}),
-        (3, {"v": 3}),
+        (120, {"v": 2}),
+        (180, {"v": 3}),
     ]
     assert len(calls) == 2
 
@@ -40,17 +41,17 @@ def test_multiple_upstreams():
     src = StreamInput(interval=60, period=2)
     node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
 
-    Runner.feed_queue_data(node, "u1", 60, 1, {"v": 1})
-    Runner.feed_queue_data(node, "u2", 60, 1, {"v": 1})
+    Runner.feed_queue_data(node, "u1", 60, 60, {"v": 1})
+    Runner.feed_queue_data(node, "u2", 60, 60, {"v": 1})
     assert node.pre_warmup
-    Runner.feed_queue_data(node, "u1", 60, 2, {"v": 2})
+    Runner.feed_queue_data(node, "u1", 60, 120, {"v": 2})
     assert node.pre_warmup
-    Runner.feed_queue_data(node, "u2", 60, 2, {"v": 2})
+    Runner.feed_queue_data(node, "u2", 60, 120, {"v": 2})
     assert not node.pre_warmup
     assert len(calls) == 1
     snap = node.cache.snapshot()
-    assert snap["u1"][60][-1][0] == 2
-    assert snap["u2"][60][-1][0] == 2
+    assert snap["u1"][60][-1][0] == 120
+    assert snap["u2"][60][-1][0] == 120
 
 
 def test_tensor_memory():
@@ -58,4 +59,33 @@ def test_tensor_memory():
     cache.append("u1", 60, 1, {"v": 1})
     expected = 1 * 1 * 4 * 2 * 8
     assert cache._tensor.nbytes == expected
+
+
+def test_gap_detection():
+    cache = NodeCache(period=2)
+    cache.append("u1", 60, 1, {"v": 1})
+    assert not cache.missing_flags()["u1"][60]
+    cache.append("u1", 60, 3, {"v": 2})
+    assert cache.missing_flags()["u1"][60]
+
+
+def test_on_missing_policy_skip_and_fail():
+    calls = []
+
+    def fn(cache):
+        calls.append(cache)
+
+    src = StreamInput(interval=60, period=2)
+    node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
+
+    Runner.feed_queue_data(node, "q1", 60, 1, {"v": 1})
+    # Gap -> should skip
+    Runner.feed_queue_data(node, "q1", 60, 3, {"v": 2}, on_missing="skip")
+    assert node.cache.missing_flags()["q1"][60]
+    assert len(calls) == 0
+
+    node2 = Node(input=src, compute_fn=fn, name="n2", interval=60, period=2)
+    Runner.feed_queue_data(node2, "q1", 60, 1, {"v": 1})
+    with pytest.raises(RuntimeError):
+        Runner.feed_queue_data(node2, "q1", 60, 3, {"v": 2}, on_missing="fail")
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -161,8 +161,8 @@ def test_feed_queue_data_with_ray(monkeypatch):
     src = StreamInput(interval=60, period=2)
     node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
 
-    Runner.feed_queue_data(node, "q", 60, 1, {"v": 1})
-    Runner.feed_queue_data(node, "q", 60, 2, {"v": 2})
+    Runner.feed_queue_data(node, "q", 60, 60, {"v": 1})
+    Runner.feed_queue_data(node, "q", 60, 120, {"v": 2})
 
     assert len(dummy_ray.calls) == 1
     assert not calls
@@ -181,7 +181,7 @@ def test_feed_queue_data_without_ray(monkeypatch):
     src = StreamInput(interval=60, period=2)
     node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
 
-    Runner.feed_queue_data(node, "q", 60, 1, {"v": 1})
-    Runner.feed_queue_data(node, "q", 60, 2, {"v": 2})
+    Runner.feed_queue_data(node, "q", 60, 60, {"v": 1})
+    Runner.feed_queue_data(node, "q", 60, 120, {"v": 2})
 
     assert len(calls) == 1


### PR DESCRIPTION
## Summary
- track last timestamps and gaps in `NodeCache`
- allow `Runner.feed_queue_data` and `Node.feed` to skip or fail when gaps are detected
- add tests for cache gap handling and missing policies
- update existing tests to use realistic timestamps

## Testing
- `uv pip install --system -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845cfd31d208329b1fa45351b78fd56