### PR TITLE
Add e2e docker-compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ coverage.xml
 # Ignore compiled proto files
 *.pb2.py
 *.pb2_grpc.py
+uv.lock

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # qmtl
+
+See `docs/e2e_testing.md` for instructions on running the full stack locally.

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -1,0 +1,12 @@
+# End-to-End Testing
+
+This compose file spins up all required services for running the gateway and DAG-Manager together.
+
+## Usage
+
+```bash
+docker compose -f tests/docker-compose.e2e.yml up -d
+```
+
+Services include Redis, Postgres, Neo4j, Kafka, Zookeeper and containers running the `qmtl-gateway` and `qmtl-dagm` CLIs.  The gateway exposes port `8000` and the DAG-Manager gRPC endpoint is available on `50051`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "redis",
     "fakeredis",
     "grpcio",
+    "PyYAML",
     "grpcio-tools",
     "pytest-asyncio",
     "xstate",

--- a/tests/docker-compose.e2e.yml
+++ b/tests/docker-compose.e2e.yml
@@ -1,0 +1,57 @@
+version: '3'
+services:
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: example
+    ports:
+      - "5432:5432"
+
+  neo4j:
+    image: neo4j:latest
+    environment:
+      NEO4J_AUTH: neo4j/test
+    ports:
+      - "7687:7687"
+      - "7474:7474"
+
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: bitnami/kafka:latest
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+
+  dag-manager:
+    image: python:3
+    command: ["qmtl-dagm", "grpc-server"]
+    depends_on:
+      - kafka
+      - neo4j
+    ports:
+      - "50051:50051"
+
+  gateway:
+    image: python:3
+    command: ["qmtl-gateway", "serve"]
+    depends_on:
+      - dag-manager
+      - redis
+    ports:
+      - "8000:8000"

--- a/tests/test_docker_compose_e2e.py
+++ b/tests/test_docker_compose_e2e.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import yaml
+
+COMPOSE_FILE = Path(__file__).with_name("docker-compose.e2e.yml")
+
+
+def test_e2e_compose_services():
+    data = yaml.safe_load(COMPOSE_FILE.read_text())
+    services = data.get("services", {})
+    expected = {
+        "redis",
+        "postgres",
+        "neo4j",
+        "zookeeper",
+        "kafka",
+        "gateway",
+        "dag-manager",
+    }
+    assert expected.issubset(services.keys())
+


### PR DESCRIPTION
## Summary
- add an end-to-end docker compose environment
- document how to run it
- reference the docs from the README
- add pyyaml for tests
- test that the compose file defines expected services

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ddfb795c8329852d334e51eb5a3c