### PR TITLE
Fix websocket hub shutdown and multi-input tests

### DIFF
--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -37,6 +37,7 @@ class WebSocketHub:
 
     async def stop(self) -> None:
         """Stop the server and cleanup resources."""
+        await self._queue.join()
         self._stop_event.set()
         if self._server:
             self._server.close()

--- a/tests/gateway/test_ws.py
+++ b/tests/gateway/test_ws.py
@@ -19,11 +19,14 @@ async def test_hub_broadcasts_progress_and_queue_map():
     async def client():
         async with websockets.connect(url) as ws:
             while len(received) < 2:
-                msg = await ws.recv()
+                try:
+                    msg = await ws.recv()
+                except websockets.exceptions.ConnectionClosedOK:
+                    break
                 received.append(json.loads(msg))
 
     task = asyncio.create_task(client())
-    await asyncio.sleep(0.05)
+    await asyncio.sleep(0.1)
     await hub.send_progress("s1", "queued")
     await hub.send_queue_map("s1", {"n1": "t1"})
     await asyncio.sleep(0.1)
@@ -58,7 +61,7 @@ async def test_hub_line_rate_500_msgs_per_sec():
                 received += 1
 
     task = asyncio.create_task(client())
-    await asyncio.sleep(0.05)
+    await asyncio.sleep(0.1)
     start = time.perf_counter()
     for i in range(total):
         await hub.send_progress("s", str(i))

--- a/tests/test_multi_input_node.py
+++ b/tests/test_multi_input_node.py
@@ -1,0 +1,26 @@
+import pytest
+from qmtl.sdk import Node, StreamInput, TagQueryNode
+
+
+def test_multi_input_serialization_list():
+    s1 = StreamInput(interval=60, period=1)
+    s2 = StreamInput(interval=60, period=1)
+    node = Node(input=[s1, s2], compute_fn=lambda x: x, name="out", interval=60, period=1)
+    d = node.to_dict()
+    assert set(d["inputs"]) == {s1.node_id, s2.node_id}
+
+
+def test_multi_input_serialization_dict():
+    s1 = StreamInput(interval=60, period=1)
+    s2 = StreamInput(interval=60, period=1)
+    node = Node(input={"a": s1, "b": s2}, compute_fn=lambda x: x, name="out", interval=60, period=1)
+    d = node.to_dict()
+    assert set(d["inputs"]) == {s1.node_id, s2.node_id}
+
+
+def test_multi_input_with_tag_query():
+    tq = TagQueryNode(["t"], interval=60, period=1)
+    s = StreamInput(interval=60, period=1)
+    node = Node(input=[tq, s], compute_fn=lambda x: x, name="out", interval=60, period=1)
+    d = node.to_dict()
+    assert set(d["inputs"]) == {tq.node_id, s.node_id}


### PR DESCRIPTION
## Summary
- drain broadcast queue before shutting down WebSocketHub
- relax connection timing in websocket tests
- add multi-input test covering TagQueryNode

## Testing
- `uv run -m pytest tests/gateway/test_ws.py -q`
- `uv run -m pytest tests/test_multi_input_node.py -q`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e2303b088329ae688d85831618aa