### PR TITLE
Add end-to-end testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # qmtl
 
-See `docs/e2e_testing.md` for instructions on running the full stack locally.
+## End-to-End Testing
+
+For instructions on spinning up the entire stack and running the e2e suite, see [docs/e2e_testing.md](docs/e2e_testing.md).
+

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -1,12 +1,38 @@
 # End-to-End Testing
 
-This compose file spins up all required services for running the gateway and DAG-Manager together.
+This guide explains how to spin up the required services and execute the end-to-end test suite.
 
-## Usage
+## Prerequisites
+
+Make sure the following tools are installed and available on your `PATH`:
+
+- `docker`
+- `uv`
+
+## Installing dependencies
+
+Create the uv environment and install all development requirements:
+
+```bash
+uv venv
+uv pip install -e .[dev]
+```
+
+## Bringing up the stack
+
+Start all services using Docker Compose:
 
 ```bash
 docker compose -f tests/docker-compose.e2e.yml up -d
 ```
 
-Services include Redis, Postgres, Neo4j, Kafka, Zookeeper and containers running the `qmtl-gateway` and `qmtl-dagm` CLIs.  The gateway exposes port `8000` and the DAG-Manager gRPC endpoint is available on `50051`.
+This launches Redis, Postgres, Neo4j, Kafka, Zookeeper and the `qmtl-gateway` and `qmtl-dagm` containers. The gateway exposes port `8000` and the DAG‑Manager gRPC endpoint is available on `50051`.
+
+## Running the tests
+
+Execute the end-to-end tests within the uv environment:
+
+```bash
+uv run -- pytest tests/e2e
+```
 


### PR DESCRIPTION
## Summary
- document E2E testing prerequisites and workflow
- add short README section linking to docs

## Testing
- `uv pip install -e .[dev]`
- `uv run -- pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e7847c108329bb8f0682721dc10a