### PR TITLE
Clarify compute_fn cache contract

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -81,10 +81,10 @@ Strategy SDK ──▶ Gateway ──▶ DAG-Manager ──▶ Graph DB (Neo4j)
 
 1. **필수 `interval` 필드** — 모든 `Node` 메타 정의에 `interval`을 **필수 (primary key)** 로 포함한다. 예) `interval: 1m`, `5m`, `1h`.
 2. **업스트림 데이터 캐시** — 3‑D 맵 대신 4‑D Tensor `C[u,i,p,t]` 구조를 사용한다. 축 정의는 위 표를 참조하며, 큐 인서트는 벡터 단위·만료는 FIFO pop으로 수행된다.
-3. **프로세싱 함수(Compute‑Fn) 격리** — 노드의 계산 함수는 순수 함수로, `data_cache` 외부 상태를 읽거나 쓰지 않는다. I/O (큐 publish, DB write) 금지. 예시 시그니처:
+3. **프로세싱 함수(Compute-Fn) 규약** — 노드의 계산 함수는 순수 함수로, `data_cache` 외부 상태를 읽거나 쓰지 않는다. 모든 `compute_fn`은 `NodeCache.snapshot()`이 반환하는 **4‑D 캐시 스냅샷(dict)** 한 개만을 인자로 받으며, I/O(큐 publish, DB write) 역시 금지.
 
    ```python
-   def fn(cache_slice: pd.DataFrame) -> pd.DataFrame:
+   def fn(cache) -> pd.DataFrame:
        ...
    ```
 4. **Period 충족 조건** — 노드 트리거 공식: `∀ u ∈ upstreams : len(cache[u][interval]) ≥ period`.
@@ -220,7 +220,8 @@ from qmtl.sdk import Strategy, Node, StreamInput, Runner
 import pandas as pd
 
 # 사용자 정의 시그널 생성 함수
-def generate_signal(price: pd.DataFrame) -> pd.DataFrame:
+def generate_signal(cache) -> pd.DataFrame:
+    price = pd.DataFrame([v for _, v in cache[price_stream.node_id][60]])
     momentum = price["close"].pct_change().rolling(5).mean()
     signal = (momentum > 0).astype(int)
     return pd.DataFrame({"signal": signal})
@@ -265,7 +266,8 @@ from qmtl.sdk import Strategy, Node, TagQueryNode, run_strategy
 import pandas as pd
 
 # 사용자 정의 상관계수 계산 함수
-def calc_corr(indicator_df: pd.DataFrame) -> pd.DataFrame:
+def calc_corr(cache) -> pd.DataFrame:
+    indicator_df = pd.concat([pd.DataFrame([v for _, v in cache[u][3600]]) for u in cache], axis=1)
     # 컬럼 간 피어슨 상관계수 행렬 반환
     corr = indicator_df.corr(method="pearson")
     return corr
@@ -301,7 +303,7 @@ if __name__ == "__main__":
 
 1. Gateway는 (query\_tags, interval) 조건으로 글로벌 DAG를 탐색한다.
 2. 해당 조건에 부합하는 모든 큐들을 업스트림으로 설정한다.
-3. SDK는 각 큐의 데이터를 수집하여 compute\_fn에 직접 전달하며, 병합 방식은 사용자 정의 함수 내부에서 수행된다.
+3. SDK는 각 큐의 데이터를 수집해 **4‑D 캐시 스냅샷(dict)** 하나로 묶어 `compute_fn`에 전달한다. `compute_fn`은 반드시 이 스냅샷 **단일 인자**만을 받아야 하며, 병합 방식 역시 함수 내부에서 정의한다.
 4. 각 큐가 설정된 period를 만족하지 않으면 노드는 ‘pre-warmup’ 상태에 머물며, 충족 시점부터 연산을 시작한다. Gateway는 `(query_tags, interval)` 조건에 부합하는 신규 큐가 전역 DAG에 추가될 때마다 콜백 이벤트를 통해 TagQueryNode에 알리고, 해당 노드는 런타임 중에도 업스트림 큐 목록을 동적으로 확장할 수 있다.
 
 이 구조로 전략 작성자는 **큐 이름이나 위치를 몰라도 태그 기반으로 지표 집합을 참조**할 수 있으며, 지표가 추가될 때마다 전략 수정 없이 자동 반영된다.
@@ -316,8 +318,9 @@ if __name__ == "__main__":
 from qmtl.sdk import Strategy, Node, StreamInput, Runner
 import pandas as pd
 
-def lagged_corr(btc: pd.DataFrame, mstr: pd.DataFrame) -> pd.DataFrame:
-    # 90개(≈90분) 시차 상관계수 계산
+def lagged_corr(cache) -> pd.DataFrame:
+    btc = pd.DataFrame([v for _, v in cache[btc_price.node_id][60]])
+    mstr = pd.DataFrame([v for _, v in cache[mstr_price.node_id][60]])
     btc_shift = btc["close"].shift(90)
     corr = btc_shift.corr(mstr["close"])
     return pd.DataFrame({"lag_corr": [corr]})

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -15,6 +15,7 @@
 | **SRE Friendly**                    | gRPC/HTTP 인터페이스, 메트릭·로그·Alert 통합, Admin CLI          | §6, §10      |
 
 > **설계 철학:** “계산 그래프 + 메시징 큐”를 **불변 ID**로 연결해 재현성·롤백 가능성을 최우선. 모든 변형은 새 노드·큐로 분기하고, 레거시는 TTL+GC로 안전 제거.
+> SDK 측에서 실행되는 모든 `compute_fn`은 `NodeCache.snapshot()`이 반환하는 4‑D 캐시 스냅샷(dict) 하나만을 인자로 받는다.
 
 ---
 

--- a/examples/correlation_strategy.py
+++ b/examples/correlation_strategy.py
@@ -1,0 +1,31 @@
+from qmtl.sdk import Strategy, Node, TagQueryNode, Runner
+import pandas as pd
+
+class CorrelationStrategy(Strategy):
+    def setup(self):
+        indicators = TagQueryNode(
+            query_tags=["ta-indicator"],
+            interval="1h",
+            period=24,
+        )
+
+        def calc_corr(cache):
+            df = pd.concat(
+                [pd.DataFrame([v for _, v in cache[u][3600]]) for u in cache],
+                axis=1,
+            )
+            return df.corr(method="pearson")
+
+        corr_node = Node(
+            input=indicators,
+            compute_fn=calc_corr,
+            name="indicator_corr",
+        )
+        self.add_nodes([indicators, corr_node])
+
+    def define_execution(self):
+        self.set_target("indicator_corr")
+
+
+if __name__ == "__main__":
+    Runner.live(CorrelationStrategy)

--- a/examples/cross_market_lag_strategy.py
+++ b/examples/cross_market_lag_strategy.py
@@ -1,0 +1,29 @@
+from qmtl.sdk import Strategy, Node, StreamInput, Runner
+import pandas as pd
+
+class CrossMarketLagStrategy(Strategy):
+    def setup(self):
+        btc_price = StreamInput(tags=["BTC", "price", "binance"], interval=60, period=120)
+        mstr_price = StreamInput(tags=["MSTR", "price", "nasdaq"], interval=60, period=120)
+
+        def lagged_corr(cache):
+            btc = pd.DataFrame([v for _, v in cache[btc_price.node_id][60]])
+            mstr = pd.DataFrame([v for _, v in cache[mstr_price.node_id][60]])
+            btc_shift = btc["close"].shift(90)
+            corr = btc_shift.corr(mstr["close"])
+            return pd.DataFrame({"lag_corr": [corr]})
+
+        corr_node = Node(
+            input={"btc": btc_price, "mstr": mstr_price},
+            compute_fn=lagged_corr,
+            name="btc_mstr_corr",
+        )
+
+        self.add_nodes([btc_price, mstr_price, corr_node])
+
+    def define_execution(self):
+        self.set_target("btc_mstr_corr")
+
+
+if __name__ == "__main__":
+    Runner.dryrun(CrossMarketLagStrategy)

--- a/examples/general_strategy.py
+++ b/examples/general_strategy.py
@@ -1,0 +1,31 @@
+from qmtl.sdk import Strategy, Node, StreamInput, Runner
+import pandas as pd
+
+class GeneralStrategy(Strategy):
+    def setup(self):
+        price_stream = StreamInput(interval=60, period=30)
+
+        def generate_signal(cache):
+            price = pd.DataFrame([v for _, v in cache[price_stream.node_id][60]])
+            momentum = price["close"].pct_change().rolling(5).mean()
+            signal = (momentum > 0).astype(int)
+            return pd.DataFrame({"signal": signal})
+
+        signal_node = Node(
+            input=price_stream,
+            compute_fn=generate_signal,
+            name="momentum_signal",
+        )
+        self.add_nodes([price_stream, signal_node])
+
+    def define_execution(self):
+        self.set_target("momentum_signal")
+
+
+if __name__ == "__main__":
+    Runner.backtest(
+        GeneralStrategy,
+        start_time="2024-01-01T00:00:00Z",
+        end_time="2024-02-01T00:00:00Z",
+        on_missing="skip",
+    )

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -101,7 +101,13 @@ class NodeCache:
 
 
 class Node:
-    """Represents a processing node in a strategy DAG."""
+    """Represents a processing node in a strategy DAG.
+
+    ``compute_fn`` must accept exactly **one argument** – a snapshot of this
+    node's 4‑D cache returned by :pymeth:`NodeCache.snapshot`.  The snapshot is a
+    ``dict`` keyed by upstream node ID and interval.  Positional arguments other
+    than the cache snapshot are **not** supported.
+    """
 
     # ------------------------------------------------------------------
     @staticmethod


### PR DESCRIPTION
## Summary
- document compute_fn single-argument rule in architecture and DAG Manager docs
- update example strategy snippets to use cache snapshots
- add SDK class docstring describing cache snapshot contract
- provide runnable examples demonstrating the pattern

## Testing
- `uv pip install --system -e .[dev]`
- `pytest -q`
- `python examples/general_strategy.py`
- `python examples/correlation_strategy.py`
- `python examples/cross_market_lag_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_6845ee5b38ec83299d2aed84a34b90fe