### PR TITLE
Add sentinel traffic metric support

### DIFF
--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import uuid
 import base64
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
@@ -19,6 +20,8 @@ from . import metrics as gw_metrics
 from .watch import QueueWatchHub
 from .ws import WebSocketHub
 _INITIAL_STATUS = "queued"
+
+logger = logging.getLogger(__name__)
 
 
 class StrategySubmit(BaseModel):
@@ -247,7 +250,15 @@ def create_app(
                 except (TypeError, ValueError):
                     weight = None
                 if weight is not None:
-                    await ws.send_sentinel_weight(sid, weight)
+                    if 0.0 <= weight <= 1.0:
+                        await ws.send_sentinel_weight(sid, weight)
+                        gw_metrics.set_sentinel_traffic_ratio(sid, weight)
+                    else:
+                        logger.warning(
+                            "Ignoring out-of-range sentinel weight %s for %s",
+                            weight,
+                            sid,
+                        )
         return {"ok": True}
 
     @app.get("/queues/by_tag")

--- a/tests/gateway/test_callbacks.py
+++ b/tests/gateway/test_callbacks.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 
 from qmtl.gateway.api import create_app
 from qmtl.gateway.ws import WebSocketHub
+from qmtl.gateway import metrics
 from qmtl.common.cloudevents import format_event
 
 
@@ -33,3 +34,51 @@ def test_dag_event_sentinel_weight():
     resp = client.post("/callbacks/dag-event", json=event)
     assert resp.status_code == 202
     assert hub.weights == [("v1", 0.7)]
+
+
+def test_dag_event_sentinel_weight_metric():
+    class DummyHub:
+        def __init__(self):
+            self.weights = []
+
+        async def send_sentinel_weight(self, sid: str, weight: float) -> None:
+            self.weights.append((sid, weight))
+
+    metrics.reset_metrics()
+    hub = DummyHub()
+    app = create_app(ws_hub=hub)
+    client = TestClient(app)
+    event = format_event(
+        "qmtl.dagmanager",
+        "sentinel_weight",
+        {"sentinel_id": "v2", "weight": 0.5},
+    )
+    resp = client.post("/callbacks/dag-event", json=event)
+    assert resp.status_code == 202
+    assert hub.weights == [("v2", 0.5)]
+    assert (
+        metrics.gateway_sentinel_traffic_ratio.labels("v2")._value.get() == 0.5
+    )
+
+
+def test_dag_event_sentinel_weight_invalid():
+    class DummyHub:
+        def __init__(self):
+            self.weights = []
+
+        async def send_sentinel_weight(self, sid: str, weight: float) -> None:
+            self.weights.append((sid, weight))
+
+    metrics.reset_metrics()
+    hub = DummyHub()
+    app = create_app(ws_hub=hub)
+    client = TestClient(app)
+    event = format_event(
+        "qmtl.dagmanager",
+        "sentinel_weight",
+        {"sentinel_id": "v3", "weight": 1.2},
+    )
+    resp = client.post("/callbacks/dag-event", json=event)
+    assert resp.status_code == 202
+    assert hub.weights == []
+    assert ("v3",) not in metrics.gateway_sentinel_traffic_ratio._metrics


### PR DESCRIPTION
## Summary
- record gateway sentinel weight as a gauge metric
- ignore invalid sentinel weight updates in callback route
- update sentinel metric when valid weight is processed
- add tests for sentinel weight metric handling

## Testing
- `uv pip install --system -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846eace21a88329bcf416eddd7d82d2