### PR TITLE
Add docs for sentinel traffic updates

### DIFF
--- a/dag-manager.md
+++ b/dag-manager.md
@@ -102,6 +102,9 @@ CREATE INDEX queue_topic IF NOT EXISTS FOR (q:Queue) ON (q.topic);
 | D→G | HTTP  | `/callbacks/sentinel-traffic` | version, weight | 202                | 3×                 | 카나리아 비율 변경       |
 |     |       |                               |                 |     |                    | 자세한 절차는 [Canary Rollout Guide](docs/canary_rollout.md) 참조 |
 
+### 2-B. Sentinel Traffic API
+
+`/callbacks/sentinel-traffic`는 특정 `VersionSentinel`의 트래픽 가중치를 업데이트한다. 요청 본문은 `{"version": "v1.2.0", "weight": 0.25}` 형식이다. 수신 시 메모리 맵과 Neo4j 노드의 `traffic_weight` 속성에 값을 저장하고, 변경 사실을 `sentinel_weight` CloudEvent로 Gateway에 전달한다. 현재 적용된 값은 Prometheus 게이지 `dagmgr_active_version_weight{version="<id>"}`로 노출된다.
 ---
 
 ## 3. 큐 생성 & 명명 규칙 (확장)

--- a/docs/canary_rollout.md
+++ b/docs/canary_rollout.md
@@ -1,6 +1,6 @@
 # Canary Rollout Guide
 
-This document explains how to gradually shift traffic between strategy versions using the `DAG‑Mgr` callback endpoint `/callbacks/sentinel-traffic`.
+This document explains how to gradually shift traffic between strategy versions using the `DAG‑Mgr` callback endpoint `/callbacks/sentinel-traffic`. See [../dag-manager.md](../dag-manager.md) for the full API specification and [../gateway.md](../gateway.md) for how Gateway processes `sentinel_weight` events.
 
 ## Adjusting Weights
 

--- a/gateway.md
+++ b/gateway.md
@@ -129,3 +129,5 @@ Immediately after ingest, Gateway inserts a `VersionSentinel` node into the DAG 
 Gateway persists its FSM in Redis with AOF enabled and mirrors crucial events in PostgreSQL's Write-Ahead Log. This mitigates the Redis failure scenario described in the architecture (§2).
 
 When resolving `TagQueryNode` dependencies, Gateway queries DAG-Manager for all queues matching `(tags, interval)` and returns the resulting mapping to the SDK so that only nodes lacking upstream queues execute locally.
+
+Gateway also listens for `sentinel_weight` CloudEvents emitted by DAG‑Manager. Upon receiving an update, the in-memory routing table is adjusted and the new weight broadcast to SDK clients via WebSocket. The effective ratio per version is exported as the Prometheus gauge `gateway_sentinel_traffic_ratio{version="<id>"}`.


### PR DESCRIPTION
## Summary
- document Gateway `sentinel_weight` handling and metric
- describe DAG‑Mgr `/callbacks/sentinel-traffic` endpoint with metric
- cross-reference sentinel docs in canary rollout guide

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846eadeecc48329b74af4821462cabe