### PR TITLE
Add SDK tutorial documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Run all unit and integration tests with:
 uv run pytest -q tests
 ```
 
+## SDK Tutorial
+
+For instructions on implementing strategies with the SDK, see
+[docs/sdk_tutorial.md](docs/sdk_tutorial.md).
+

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -1,0 +1,54 @@
+# SDK 사용 가이드
+
+본 문서는 QMTL SDK를 이용해 전략을 구현하고 실행하는 기본 절차를 소개합니다. 보다 상세한 아키텍처 설명과 예시는 `architecture.md`와 `examples/` 디렉터리를 참고하세요.
+
+## 설치
+
+```bash
+uv venv
+uv pip install -e .[dev]
+```
+
+## 기본 구조
+
+SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()`과 `define_execution()` 메서드를 구현합니다. 노드는 `StreamInput`, `Node`, `TagQueryNode` 등을 이용해 정의하며 모든 노드는 하나 이상의 업스트림을 가져야 합니다.
+
+```python
+from qmtl.sdk import Strategy, Node, StreamInput
+
+class MyStrategy(Strategy):
+    def setup(self):
+        price = StreamInput(interval=60, period=30)
+
+        def compute(cache):
+            return cache
+
+        out = Node(input=price, compute_fn=compute, name="out")
+        self.add_nodes([price, out])
+
+    def define_execution(self):
+        self.set_target("out")
+```
+
+## 실행 모드
+
+전략은 `Runner` 클래스로 실행합니다. 모드는 `backtest`, `dryrun`, `live` 세 가지가 있으며 CLI 또는 Python 코드에서 선택할 수 있습니다.
+
+```bash
+# 커맨드라인 예시
+python -m qmtl.sdk tests.sample_strategy:SampleStrategy --mode backtest --start-time 2024-01-01 --end-time 2024-02-01
+```
+
+```python
+from qmtl.sdk import Runner
+Runner.dryrun(MyStrategy)
+```
+
+## CLI 도움말
+
+CLI에 대한 전체 옵션은 다음 명령으로 확인할 수 있습니다.
+
+```bash
+python -m qmtl.sdk --help
+```
+


### PR DESCRIPTION
## Summary
- document how to set up the SDK and run strategies
- link the tutorial from the README

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684930686f788329836f0902cdcb672b