### PR TITLE
Add read-only DataArray view for NodeCache

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -119,6 +119,16 @@ class NodeCache:
                 result[u][i] = self._last_ts.get((u, i))
         return result
 
+    def as_xarray(self) -> xr.DataArray:
+        """Return a read-only ``xarray`` view of the internal tensor.
+
+        Callers must **not** mutate the returned :class:`xarray.DataArray`.
+        """
+        da = self._tensor.copy(deep=False)
+        da.data = da.data.view()
+        da.data.setflags(write=False)
+        return da
+
     # ------------------------------------------------------------------
     def latest(self, u: str, interval: int) -> tuple[int, Any] | None:
         """Return the most recent ``(timestamp, payload)`` for a pair."""


### PR DESCRIPTION
## Summary
- expose NodeCache.as_xarray() for read-only DataArray access
- note immutability in docstring
- test as_xarray behaviour and equality with snapshot

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684960988ec08329ae03badad19cb195