### PR TITLE
Implement CacheView for NodeCache snapshots

### DIFF
--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -1,6 +1,7 @@
 """QMTL strategy SDK."""
 
 from .node import Node, StreamInput, TagQueryNode, NodeCache
+from .cache_view import CacheView
 from .strategy import Strategy
 from .runner import Runner
 from .cli import main as _cli
@@ -11,6 +12,7 @@ __all__ = [
     "StreamInput",
     "TagQueryNode",
     "NodeCache",
+    "CacheView",
     "Strategy",
     "Runner",
     "WebSocketClient",

--- a/qmtl/sdk/cache_view.py
+++ b/qmtl/sdk/cache_view.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+class CacheView:
+    """Simple hierarchical read-only view over a cache snapshot."""
+
+    def __init__(self, data: Any) -> None:
+        self._data = data
+
+    def __getitem__(self, key: Any) -> Any:
+        if isinstance(self._data, Mapping):
+            return CacheView(self._data[key])
+        if isinstance(self._data, Sequence):
+            return self._data[key]
+        raise TypeError("unsupported operation")
+
+    def __getattr__(self, name: str) -> Any:
+        if isinstance(self._data, Mapping) and name in self._data:
+            return CacheView(self._data[name])
+        raise AttributeError(name)
+
+    def latest(self) -> Any:
+        if isinstance(self._data, Sequence):
+            return self._data[-1] if self._data else None
+        raise AttributeError("latest")
+
+    def __repr__(self) -> str:  # pragma: no cover - simple repr
+        return f"CacheView({self._data!r})"
+
+

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -11,6 +11,8 @@ import numpy as np
 import xarray as xr
 import httpx
 
+from .cache_view import CacheView
+
 from qmtl.dagmanager import compute_node_id
 
 
@@ -100,6 +102,10 @@ class NodeCache:
                 slice_ = self._tensor.data[u_idx, i_idx]
                 result[u][i] = [(int(t), v) for t, v in slice_ if t is not None]
         return result
+
+    def view(self) -> CacheView:
+        """Return a :class:`CacheView` built from :meth:`snapshot`."""
+        return CacheView(self.snapshot())
 
     def missing_flags(self) -> dict[str, dict[int, bool]]:
         """Return gap flags for all ``(u, interval)`` pairs."""

--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -139,3 +139,19 @@ def test_as_xarray_view_is_read_only_and_matches_snapshot():
 
     assert cache.snapshot() == snap
 
+
+def test_cache_view_access():
+    cache = NodeCache(period=2)
+    cache.append("btc_price", 60, 1, {"v": 1})
+    cache.append("btc_price", 60, 2, {"v": 2})
+
+    view = cache.view()
+
+    assert view["btc_price"][60].latest() == (2, {"v": 2})
+    assert view.btc_price[60].latest() == (2, {"v": 2})
+
+    with pytest.raises(KeyError):
+        _ = view["missing"][60]
+    with pytest.raises(AttributeError):
+        _ = view.missing
+


### PR DESCRIPTION
## Summary
- add `CacheView` providing hierarchical access to cache snapshots
- export `CacheView` from sdk package
- expose `NodeCache.view()` returning a `CacheView`
- test CacheView attribute/key access

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684999b9a3cc83299939dbe470ea3577