### PR TITLE
Add access logging to CacheView

### DIFF
--- a/qmtl/sdk/cache_view.py
+++ b/qmtl/sdk/cache_view.py
@@ -5,21 +5,45 @@ from typing import Any
 
 
 class CacheView:
-    """Simple hierarchical read-only view over a cache snapshot."""
+    """Simple hierarchical read-only view over a cache snapshot.
 
-    def __init__(self, data: Any) -> None:
+    When ``track_access`` is ``True`` every accessed ``(upstream_id, interval)``
+    pair is recorded and can be retrieved via :meth:`access_log`.
+    """
+
+    def __init__(
+        self,
+        data: Any,
+        *,
+        track_access: bool = False,
+        access_log: list[tuple[str, int]] | None = None,
+        path: tuple[Any, ...] = (),
+    ) -> None:
         self._data = data
+        self._track_access = track_access
+        self._access_log = access_log if access_log is not None else []
+        self._path = path
 
     def __getitem__(self, key: Any) -> Any:
         if isinstance(self._data, Mapping):
-            return CacheView(self._data[key])
+            new_path = self._path + (key,)
+            if self._track_access and len(new_path) == 2:
+                u, i = new_path
+                if isinstance(u, str) and isinstance(i, int):
+                    self._access_log.append((u, i))
+            return CacheView(
+                self._data[key],
+                track_access=self._track_access,
+                access_log=self._access_log,
+                path=new_path,
+            )
         if isinstance(self._data, Sequence):
             return self._data[key]
         raise TypeError("unsupported operation")
 
     def __getattr__(self, name: str) -> Any:
         if isinstance(self._data, Mapping) and name in self._data:
-            return CacheView(self._data[name])
+            return self.__getitem__(name)
         raise AttributeError(name)
 
     def latest(self) -> Any:
@@ -29,5 +53,10 @@ class CacheView:
 
     def __repr__(self) -> str:  # pragma: no cover - simple repr
         return f"CacheView({self._data!r})"
+
+    # ------------------------------------------------------------------
+    def access_log(self) -> list[tuple[str, int]]:
+        """Return list of accessed ``(upstream_id, interval)`` pairs."""
+        return list(self._access_log)
 
 

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -103,9 +103,13 @@ class NodeCache:
                 result[u][i] = [(int(t), v) for t, v in slice_ if t is not None]
         return result
 
-    def view(self) -> CacheView:
-        """Return a :class:`CacheView` built from :meth:`snapshot`."""
-        return CacheView(self.snapshot())
+    def view(self, *, track_access: bool = False) -> CacheView:
+        """Return a :class:`CacheView` built from :meth:`snapshot`.
+
+        When ``track_access`` is ``True`` every accessed ``(upstream_id, interval)``
+        pair is recorded and can be retrieved via :meth:`CacheView.access_log`.
+        """
+        return CacheView(self.snapshot(), track_access=track_access)
 
     def missing_flags(self) -> dict[str, dict[int, bool]]:
         """Return gap flags for all ``(u, interval)`` pairs."""

--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -155,3 +155,17 @@ def test_cache_view_access():
     with pytest.raises(AttributeError):
         _ = view.missing
 
+
+def test_cache_view_access_logging_and_reset():
+    cache = NodeCache(period=2)
+    cache.append("btc_price", 60, 1, {"v": 1})
+
+    view = cache.view(track_access=True)
+    _ = view["btc_price"][60].latest()
+    assert view.access_log() == [("btc_price", 60)]
+
+    view2 = cache.view(track_access=True)
+    assert view2.access_log() == []
+    _ = view2["btc_price"][60]
+    assert view2.access_log() == [("btc_price", 60)]
+


### PR DESCRIPTION
## Summary
- extend `CacheView` to support optional tracking of accessed upstream/interval pairs
- provide `NodeCache.view(track_access=True)` option
- expose `CacheView.access_log()` for retrieving access list
- test access logging and resetting between calls

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a2731a648329a3d7f2d727e63fbd