### PR TITLE
Switch compute_fn to CacheView

### DIFF
--- a/dag-manager.md
+++ b/dag-manager.md
@@ -15,7 +15,7 @@
 | **SRE Friendly**                    | gRPC/HTTP 인터페이스, 메트릭·로그·Alert 통합, Admin CLI          | §6, §10      |
 
 > **설계 철학:** “계산 그래프 + 메시징 큐”를 **불변 ID**로 연결해 재현성·롤백 가능성을 최우선. 모든 변형은 새 노드·큐로 분기하고, 레거시는 TTL+GC로 안전 제거.
-> SDK 측에서 실행되는 모든 `compute_fn`은 `NodeCache.snapshot()`이 반환하는 4‑D 캐시 스냅샷(dict) 하나만을 인자로 받는다.
+> SDK 측에서 실행되는 모든 `compute_fn`은 `NodeCache.view()`가 반환하는 read-only `CacheView` 한 개만을 인자로 받는다.
 
 ---
 

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -20,8 +20,8 @@ class MyStrategy(Strategy):
     def setup(self):
         price = StreamInput(interval=60, period=30)
 
-        def compute(cache):
-            return cache
+        def compute(view):
+            return view
 
         out = Node(input=price, compute_fn=compute, name="out")
         self.add_nodes([price, out])

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,14 +15,13 @@ python examples/cross_market_lag_strategy.py
 ```
 
 > **중요:**
-> - QMTL SDK의 모든 예제는 Node의 `compute_fn`이 반드시 4D cache snapshot(단일 dict/context 인자)만을 받도록 작성되어 있습니다.
-> - 예를 들어, multi-input node의 경우 `compute_fn(cache)` 형태로 호출되며, 필요한 입력 데이터는 cache에서 키로 조회해야 합니다.
+> - QMTL SDK의 모든 예제는 Node의 `compute_fn`이 반드시 read-only `CacheView`(단일 인자)만을 받도록 작성되어 있습니다.
+> - 예를 들어, multi-input node의 경우 `compute_fn(view)` 형태로 호출되며, 필요한 입력 데이터는 view에서 키로 조회해야 합니다.
 >   ```python
->   def lagged_corr(cache):
->       btc_price = cache["btc_price"]
->       mstr_price = cache["mstr_price"]
+>   def lagged_corr(view):
+>       btc = view[btc_price][60].latest()
+>       mstr = view[mstr_price][60].latest()
 >       ...
->   ```
-> - positional argument 방식(`def fn(a, b, ...)`)은 지원하지 않으니, 반드시 단일 인자(cache)만 사용하세요.
+> - positional argument 방식(`def fn(a, b, ...)`)은 지원하지 않으니, 반드시 단일 인자(CacheView)만 사용하세요.
 > - 최신 SDK에서는 ProcessingNode의 input으로 반드시 올바른 업스트림 노드(`StreamInput`, `TagQueryNode` 등)를 연결해야 하며, 필요시 별도의 SourceNode 추상화가 요구될 수 있습니다.
 > - 예제 실행 중 "ProcessingNode는 반드시 하나 이상의 업스트림을 가져야 합니다" 등의 에러가 발생할 경우, SDK의 input 연결 시그니처와 예제 코드를 반드시 확인하세요.

--- a/examples/correlation_strategy.py
+++ b/examples/correlation_strategy.py
@@ -9,9 +9,9 @@ class CorrelationStrategy(Strategy):
             period=24,
         )
 
-        def calc_corr(cache):
+        def calc_corr(view):
             df = pd.concat(
-                [pd.DataFrame([v for _, v in cache[u][3600]]) for u in cache],
+                [pd.DataFrame([v for _, v in view[u][3600]]) for u in view],
                 axis=1,
             )
             return df.corr(method="pearson")

--- a/examples/cross_market_lag_strategy.py
+++ b/examples/cross_market_lag_strategy.py
@@ -5,14 +5,12 @@ class CrossMarketLagStrategy(Strategy):
     def setup(self):
         btc_price = StreamInput(tags=["BTC", "price", "binance"], interval=60, period=120)
         mstr_price = StreamInput(tags=["MSTR", "price", "nasdaq"], interval=60, period=120)
-
-        def lagged_corr(cache):
-            btc = pd.DataFrame([v for _, v in cache[btc_price.node_id][60]])
-            mstr = pd.DataFrame([v for _, v in cache[mstr_price.node_id][60]])
+        def lagged_corr(view):
+            btc = pd.DataFrame([v for _, v in view[btc_price][60]])
+            mstr = pd.DataFrame([v for _, v in view[mstr_price][60]])
             btc_shift = btc["close"].shift(90)
             corr = btc_shift.corr(mstr["close"])
             return pd.DataFrame({"lag_corr": [corr]})
-
         corr_node = Node(
             input={"btc": btc_price, "mstr": mstr_price},
             compute_fn=lagged_corr,

--- a/examples/general_strategy.py
+++ b/examples/general_strategy.py
@@ -5,8 +5,8 @@ class GeneralStrategy(Strategy):
     def setup(self):
         price_stream = StreamInput(interval=60, period=30)
 
-        def generate_signal(cache):
-            price = pd.DataFrame([v for _, v in cache[price_stream.node_id][60]])
+        def generate_signal(view):
+            price = pd.DataFrame([v for _, v in view[price_stream][60]])
             momentum = price["close"].pct_change().rolling(5).mean()
             signal = (momentum > 0).astype(int)
             return pd.DataFrame({"signal": signal})

--- a/qmtl/sdk/cache_view.py
+++ b/qmtl/sdk/cache_view.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .node import Node
 
 from . import metrics as sdk_metrics
 
@@ -28,6 +31,10 @@ class CacheView:
 
     def __getitem__(self, key: Any) -> Any:
         if isinstance(self._data, Mapping):
+            from .node import Node  # local import to avoid circular dependency
+            if isinstance(key, Node):
+                key = key.node_id
+
             new_path = self._path + (key,)
             if self._track_access and len(new_path) == 2:
                 u, i = new_path

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -204,10 +204,7 @@ class NodeCache:
 class Node:
     """Represents a processing node in a strategy DAG.
 
-    ``compute_fn`` must accept exactly **one argument** – a snapshot of this
-    node's 4‑D cache returned by :pymeth:`NodeCache.snapshot`.  The snapshot is a
-    ``dict`` keyed by upstream node ID and interval.  Positional arguments other
-    than the cache snapshot are **not** supported.
+    ``compute_fn`` must accept exactly **one argument** – a :class:`CacheView` returned by :py:meth:`NodeCache.view`. The view provides read-only access to the cached data and mirrors the structure of :meth:`NodeCache.snapshot`. Positional arguments other than the cache view are **not** supported.
     """
 
     # ------------------------------------------------------------------
@@ -330,7 +327,7 @@ class Node:
             if on_missing == "skip":
                 return
         if not self.pre_warmup and self.compute_fn:
-            self.compute_fn(self.cache.snapshot())
+            self.compute_fn(self.cache.view())
 
     def to_dict(self) -> dict:
         return {

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -20,14 +20,14 @@ class Runner:
     _ray_available = ray is not None
 
     @staticmethod
-    def _execute_compute_fn(fn, cache_snapshot) -> None:
+    def _execute_compute_fn(fn, cache_view) -> None:
         """Run ``fn`` using Ray when available."""
         if Runner._ray_available:
             if not ray.is_initialized():  # type: ignore[attr-defined]
                 ray.init(ignore_reinit_error=True)  # type: ignore[attr-defined]
-            ray.remote(fn).remote(cache_snapshot)  # type: ignore[attr-defined]
+            ray.remote(fn).remote(cache_view)  # type: ignore[attr-defined]
         else:
-            fn(cache_snapshot)
+            fn(cache_view)
 
     @staticmethod
     def _post_gateway(
@@ -93,7 +93,7 @@ class Runner:
             if on_missing == "skip":
                 return
         if not node.pre_warmup and node.compute_fn:
-            Runner._execute_compute_fn(node.compute_fn, node.cache.snapshot())
+            Runner._execute_compute_fn(node.compute_fn, node.cache.view())
 
     @staticmethod
     def backtest(

--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -6,8 +6,8 @@ from qmtl.sdk import Node, StreamInput, Runner, NodeCache
 def test_cache_warmup_and_compute():
     calls = []
 
-    def fn(cache):
-        calls.append(cache)
+    def fn(view):
+        calls.append(view)
 
     src = StreamInput(interval=60, period=2)
     node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
@@ -36,8 +36,8 @@ def test_cache_warmup_and_compute():
 def test_multiple_upstreams():
     calls = []
 
-    def fn(cache):
-        calls.append(cache)
+    def fn(view):
+        calls.append(view)
 
     src = StreamInput(interval=60, period=2)
     node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
@@ -73,8 +73,8 @@ def test_gap_detection():
 def test_on_missing_policy_skip_and_fail():
     calls = []
 
-    def fn(cache):
-        calls.append(cache)
+    def fn(view):
+        calls.append(view)
 
     src = StreamInput(interval=60, period=2)
     node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
@@ -154,6 +154,16 @@ def test_cache_view_access():
         _ = view["missing"][60]
     with pytest.raises(AttributeError):
         _ = view.missing
+
+
+def test_cache_view_accepts_node_instance():
+    stream = StreamInput(interval=60, period=2)
+    cache = NodeCache(period=2)
+    cache.append(stream.node_id, 60, 1, {"v": 1})
+
+    view = cache.view()
+
+    assert view[stream][60].latest() == (1, {"v": 1})
 
 
 def test_cache_view_access_logging_and_reset():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -155,8 +155,8 @@ def test_feed_queue_data_with_ray(monkeypatch):
 
     calls = []
 
-    def compute(cache):
-        calls.append(cache)
+    def compute(view):
+        calls.append(view)
 
     src = StreamInput(interval=60, period=2)
     node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
@@ -175,8 +175,8 @@ def test_feed_queue_data_without_ray(monkeypatch):
 
     calls = []
 
-    def compute(cache):
-        calls.append(cache)
+    def compute(view):
+        calls.append(view)
 
     src = StreamInput(interval=60, period=2)
     node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)


### PR DESCRIPTION
## Summary
- pass CacheView to compute_fn
- update example strategies to use CacheView
- adjust docs to document CacheView usage
- align tests with new interface
- add support for Node keys in CacheView

## Testing
- `uv pip install -e .[dev]`
- `.venv/bin/pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849e0377dd08329b2532ac799e81e44