### PR TITLE
Deprecate NodeCache snapshot

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- `NodeCache.snapshot()` has been deprecated in favor of the read-only
+  `CacheView` returned by `NodeCache.view()`. Strategy code should avoid
+  calling the snapshot helper.

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -52,3 +52,9 @@ CLI에 대한 전체 옵션은 다음 명령으로 확인할 수 있습니다.
 python -m qmtl.sdk --help
 ```
 
+## 캐시 조회
+
+`compute_fn`에는 `NodeCache.view()`가 반환하는 **읽기 전용 CacheView** 객체가
+전달됩니다. 이전 버전에서 사용하던 `NodeCache.snapshot()`은 내부 구현으로
+변경되었으므로 전략 코드에서 직접 호출하지 않아야 합니다.
+


### PR DESCRIPTION
## Summary
- hide `NodeCache.snapshot` behind private `_snapshot`
- build cache views directly from the tensor
- update Node documentation about CacheView
- mention snapshot deprecation in docs
- adjust tests to inspect caches without `snapshot`

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6849ec1b687083298dae5cb31cea2d06