### PR TITLE
Implement topic naming helper and update queue logic

### DIFF
--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -16,6 +16,7 @@ from .diff_service import (
     NodeRecord,
     StreamSender,
 )
+from .topic import topic_name
 from .neo4j_export import export_schema, connect
 from ..gateway.dagmanager_client import DagManagerClient
 from ..proto import dagmanager_pb2, dagmanager_pb2_grpc
@@ -40,11 +41,20 @@ class _MemQueue(QueueManager):
     def __init__(self) -> None:
         self.topics: Dict[str, str] = {}
 
-    def upsert(self, node_id: str) -> str:
-        topic = self.topics.get(node_id)
+    def upsert(
+        self,
+        asset: str,
+        node_type: str,
+        code_hash: str,
+        version: str,
+        *,
+        dryrun: bool = False,
+    ) -> str:
+        key = (asset, node_type, code_hash, version, dryrun)
+        topic = self.topics.get(key)
         if not topic:
-            topic = f"topic_{node_id}"
-            self.topics[node_id] = topic
+            topic = topic_name(asset, node_type, code_hash, version, dryrun=dryrun)
+            self.topics[key] = topic
         return topic
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,7 +2,14 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from qmtl.dagmanager.diff_service import DiffService, DiffRequest, NodeRepository, QueueManager, StreamSender
+from qmtl.dagmanager.diff_service import (
+    DiffService,
+    DiffRequest,
+    NodeRepository,
+    QueueManager,
+    StreamSender,
+)
+from qmtl.dagmanager.topic import topic_name
 from qmtl.dagmanager.gc import GarbageCollector, QueueInfo
 import httpx
 import time
@@ -21,12 +28,12 @@ class FakeRepo(NodeRepository):
 
 
 class FakeQueue(QueueManager):
-    def upsert(self, node_id):
-        return "topic"
+    def upsert(self, asset, node_type, code_hash, version, *, dryrun=False):
+        return topic_name(asset, node_type, code_hash, version, dryrun=dryrun)
 
 
 class FailingQueue(QueueManager):
-    def upsert(self, node_id):
+    def upsert(self, asset, node_type, code_hash, version, *, dryrun=False):
         raise RuntimeError("fail")
 
 
@@ -44,7 +51,11 @@ class DummyMetrics:
 
 
 def _make_dag():
-    return '{"nodes": [{"node_id": "A", "code_hash": "c", "schema_hash": "s"}]}'
+    return (
+        '{"nodes": ['
+        '{"node_id": "A", "node_type": "N", "code_hash": "c", "schema_hash": "s"}'
+        ']}'
+    )
 
 
 def test_metrics_exposed():

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -18,10 +18,23 @@ class FakeAdmin:
 
 
 def test_topic_name_generation():
-    name = topic_name("btc", "Indicator", "abcdef123456", "v1")
-    assert name == "btc_Indicator_abcdef_v1"
-    sim = topic_name("btc", "Indicator", "abcdef123456", "v1", dryrun=True)
-    assert sim.endswith("_dryrun")
+    existing = {"btc_Indicator_abcdef_v1"}
+    name = topic_name(
+        "btc",
+        "Indicator",
+        "abcdef123456",
+        "v1",
+        existing=existing,
+    )
+    assert name == "btc_Indicator_abcdef12_v1"
+    sim = topic_name(
+        "btc",
+        "Indicator",
+        "abcdef123456",
+        "v1",
+        dryrun=True,
+    )
+    assert sim.endswith("_sim")
 
 
 def test_queue_config_values():


### PR DESCRIPTION
## Summary
- add `topic_name` helper with collision handling
- generate topic names in `KafkaQueueManager.upsert`
- extend diff service to pass node metadata to queue manager
- adjust in-memory queue and affected unit tests

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad9bf719883298bf6f18f8d191a44