### PR TITLE
Add Neo4j persistence for sentinel traffic

### DIFF
--- a/qmtl/dagmanager/http_server.py
+++ b/qmtl/dagmanager/http_server.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from fastapi import FastAPI, status
 from pydantic import BaseModel, Field
@@ -15,10 +15,15 @@ class WeightUpdate(BaseModel):
     weight: float = Field(..., ge=0.0, le=1.0, description="Traffic weight")
 
 
+if TYPE_CHECKING:  # pragma: no cover - optional import for typing
+    from neo4j import Driver
+
+
 def create_app(
     *,
     weights: Optional[dict[str, float]] = None,
     gateway_url: str | None = None,
+    driver: "Driver" | None = None,
 ) -> FastAPI:
     app = FastAPI()
     store = weights if weights is not None else {}
@@ -27,6 +32,14 @@ def create_app(
     async def sentinel_traffic(update: WeightUpdate):
         store[update.version] = update.weight
         metrics.set_active_version_weight(update.version, update.weight)
+        if driver:
+            with driver.session() as session:
+                session.run(
+                    "MERGE (s:VersionSentinel {version: $version}) "
+                    "SET s.traffic_weight = $weight",
+                    version=update.version,
+                    weight=update.weight,
+                )
         if gateway_url:
             event = format_event(
                 "qmtl.dagmanager",


### PR DESCRIPTION
## Summary
- allow DAG-Mgr HTTP server to receive a Neo4j driver
- persist `traffic_weight` on VersionSentinel when `/callbacks/sentinel-traffic` is posted
- verify the driver query in tests

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684ae86c9ca0832999a6c16b5bf893b4