### PR TITLE
Add queue update CloudEvents and watch tests

### DIFF
--- a/qmtl/dagmanager/api.py
+++ b/qmtl/dagmanager/api.py
@@ -25,9 +25,14 @@ def create_app(gc: GarbageCollector, *, callback_url: Optional[str] = None) -> F
 
     @app.post("/admin/gc-trigger", status_code=status.HTTP_202_ACCEPTED)
     async def trigger_gc(payload: GcRequest) -> GcResponse:
-        processed = gc.collect()
+        infos = gc.collect()
+        processed = [q.name for q in infos]
         if callback_url:
-            event = format_event("qmtl.dagmanager", "gc", {"id": payload.id, "queues": processed})
+            event = format_event(
+                "qmtl.dagmanager",
+                "gc",
+                {"id": payload.id, "queues": processed},
+            )
             await post_with_backoff(callback_url, event)
         return GcResponse(processed=processed)
 

--- a/tests/gateway/test_queue_update_watch.py
+++ b/tests/gateway/test_queue_update_watch.py
@@ -1,0 +1,77 @@
+import asyncio
+import httpx
+import pytest
+import json
+
+from qmtl.gateway.api import create_app
+from qmtl.gateway.watch import QueueWatchHub
+from qmtl.sdk import TagQueryNode
+from qmtl.common.cloudevents import format_event
+
+class DummyDag:
+    async def get_queues_by_tag(self, tags, interval):
+        return []
+
+@pytest.mark.asyncio
+async def test_queue_update_reaches_subscriber(monkeypatch):
+    watch = QueueWatchHub()
+    gw_app = create_app(dag_client=DummyDag(), watch_hub=watch)
+    transport = httpx.ASGITransport(gw_app)
+
+    real_client = httpx.AsyncClient
+
+    class DummyStream:
+        def __init__(self, gen):
+            self._gen = gen
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            await self._gen.aclose()
+
+        async def aiter_lines(self):
+            async for queues in self._gen:
+                yield json.dumps({"queues": queues})
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = real_client(*a, **k)
+
+        async def __aenter__(self):
+            await self._client.__aenter__()
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            await self._client.__aexit__(exc_type, exc, tb)
+
+        def stream(self, method, url, params=None):
+            if url.endswith("/queues/watch"):
+                gen = watch.subscribe(["t1"], 60)
+                return DummyStream(gen)
+            return self._client.stream(method, url, params=params)
+
+        async def post(self, url, json=None):
+            return await self._client.post(url, json=json)
+
+    monkeypatch.setattr("qmtl.sdk.node.httpx.AsyncClient", DummyClient)
+
+    node = TagQueryNode(["t1"], interval=60, period=1)
+    task = asyncio.create_task(node.subscribe_updates("http://gw"))
+    await asyncio.sleep(0.2)
+
+    event = format_event(
+        "qmtl.dagmanager",
+        "queue_update",
+        {"tags": ["t1"], "interval": 60, "queues": ["q1"]},
+    )
+    async with httpx.AsyncClient(transport=transport, base_url="http://gw") as c:
+        resp = await c.post("/callbacks/dag-event", json=event)
+        assert resp.status_code == 202
+
+    await asyncio.sleep(0.1)
+    assert node.upstreams == ["q1"]
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -93,7 +93,15 @@ def test_pre_scan_and_db_fetch():
 def test_hash_compare_and_queue_upsert():
     repo = FakeRepo()
     # existing node A
-    repo.records["A"] = NodeRecord("A", "N", "c1", "s1", topic_name("asset", "N", "c1", "v1"))
+    repo.records["A"] = NodeRecord(
+        "A",
+        "N",
+        "c1",
+        "s1",
+        None,
+        [],
+        topic_name("asset", "N", "c1", "v1"),
+    )
     queue = FakeQueue()
     stream = FakeStream()
     service = DiffService(repo, queue, stream)
@@ -229,7 +237,15 @@ def test_integration_with_backends():
 def test_sentinel_gap_metric_increment():
     metrics.reset_metrics()
     repo = FakeRepo()
-    repo.records["A"] = NodeRecord("A", "N", "c1", "s1", topic_name("asset", "N", "c1", "v1"))
+    repo.records["A"] = NodeRecord(
+        "A",
+        "N",
+        "c1",
+        "s1",
+        None,
+        [],
+        topic_name("asset", "N", "c1", "v1"),
+    )
     queue = FakeQueue()
     stream = FakeStream()
     service = DiffService(repo, queue, stream)

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -44,7 +44,7 @@ def test_gc_policy_drop_and_archive():
 
     processed = gc.collect(now)
 
-    assert processed == ["raw_q", "sentinel_q"]
+    assert [q.name for q in processed] == ["raw_q", "sentinel_q"]
     assert store.dropped == ["raw_q", "sentinel_q"]
     assert archive.archived == ["sentinel_q"]
 
@@ -73,7 +73,7 @@ def test_gc_respects_grace_period():
 
     processed = gc.collect(now)
 
-    assert processed == []
+    assert [q.name for q in processed] == []
     assert store.dropped == []
 
 
@@ -87,7 +87,7 @@ def test_gc_archives_with_client():
 
     processed = gc.collect(now)
 
-    assert processed == ["s"]
+    assert [q.name for q in processed] == ["s"]
     assert store.dropped == ["s"]
     assert archive.archived == ["s"]
 

--- a/tests/test_gc_endpoint.py
+++ b/tests/test_gc_endpoint.py
@@ -2,6 +2,8 @@ from fastapi.testclient import TestClient
 import httpx
 
 from qmtl.dagmanager.api import create_app
+from qmtl.dagmanager.gc import QueueInfo
+from datetime import datetime
 
 
 class FakeGC:
@@ -10,7 +12,7 @@ class FakeGC:
 
     def collect(self):
         self.calls += 1
-        return ["q1"]
+        return [QueueInfo("q1", "raw", datetime.utcnow(), interval=60)]
 
 
 def test_gc_route_triggers_collect():


### PR DESCRIPTION
## Summary
- propagate node tags and interval in `DiffService`
- send `queue_update` events from gRPC Diff and GC services
- return processed QueueInfo from garbage collector
- adjust GC API and related tests
- add integration test verifying TagQueryNode receives `/queues/watch` updates

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae86d1e8c8329b76baa8dc63c4441