### PR TITLE
Add offline mode and enforce gateway requirement

### DIFF
--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -32,11 +32,12 @@ class MyStrategy(Strategy):
 
 ## 실행 모드
 
-전략은 `Runner` 클래스로 실행합니다. 모드는 `backtest`, `dryrun`, `live` 세 가지가 있으며 CLI 또는 Python 코드에서 선택할 수 있습니다.
+전략은 `Runner` 클래스로 실행합니다. 모드는 `backtest`, `dryrun`, `live`, `offline` 네 가지가 있으며 CLI 또는 Python 코드에서 선택할 수 있습니다.
 
 ```bash
 # 커맨드라인 예시
 python -m qmtl.sdk tests.sample_strategy:SampleStrategy --mode backtest --start-time 2024-01-01 --end-time 2024-02-01
+python -m qmtl.sdk tests.sample_strategy:SampleStrategy --mode offline
 ```
 
 ```python

--- a/qmtl/proto/__init__.py
+++ b/qmtl/proto/__init__.py
@@ -1,0 +1,14 @@
+"""Protocol buffer generated modules."""
+
+from . import dagmanager_pb2
+import sys
+
+sys.modules.setdefault("dagmanager_pb2", dagmanager_pb2)
+
+from . import dagmanager_pb2_grpc
+sys.modules.setdefault("dagmanager_pb2_grpc", dagmanager_pb2_grpc)
+
+__all__ = [
+    "dagmanager_pb2",
+    "dagmanager_pb2_grpc",
+]

--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -7,11 +7,11 @@ from .runner import Runner
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run QMTL strategy")
     parser.add_argument("strategy", help="Import path as module:Class")
-    parser.add_argument("--mode", choices=["backtest", "dryrun", "live"], required=True)
+    parser.add_argument("--mode", choices=["backtest", "dryrun", "live", "offline"], required=True)
     parser.add_argument("--start-time")
     parser.add_argument("--end-time")
     parser.add_argument("--on-missing", default="skip")
-    parser.add_argument("--offline", action="store_true", help="Run without contacting the Gateway")
+    parser.add_argument("--gateway-url")
     args = parser.parse_args()
 
     module_name, class_name = args.strategy.split(":")
@@ -24,9 +24,11 @@ def main() -> None:
             start_time=args.start_time,
             end_time=args.end_time,
             on_missing=args.on_missing,
-            offline=args.offline,
+            gateway_url=args.gateway_url,
         )
     elif args.mode == "dryrun":
-        Runner.dryrun(strategy_cls, offline=args.offline)
+        Runner.dryrun(strategy_cls, gateway_url=args.gateway_url)
     elif args.mode == "live":
-        Runner.live(strategy_cls, offline=args.offline)
+        Runner.live(strategy_cls, gateway_url=args.gateway_url)
+    else:  # offline
+        Runner.offline(strategy_cls)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 import subprocess
 import sys
-from pathlib import Path
 
 STRATEGY_PATH = "tests.sample_strategy:SampleStrategy"
 
@@ -12,9 +11,17 @@ def test_cli_help():
 
 
 def test_cli_dryrun():
-    result = subprocess.run([sys.executable, "-m", "qmtl.sdk", STRATEGY_PATH, "--mode", "dryrun"], capture_output=True, text=True)
-    assert result.returncode == 0
-    assert "[DRYRUN] SampleStrategy" in result.stdout
+    result = subprocess.run([
+        sys.executable,
+        "-m",
+        "qmtl.sdk",
+        STRATEGY_PATH,
+        "--mode",
+        "dryrun",
+        "--gateway-url",
+        "http://gw",
+    ], capture_output=True, text=True)
+    assert result.returncode != 0
 
 
 def test_cli_offline():
@@ -24,8 +31,7 @@ def test_cli_offline():
         "qmtl.sdk",
         STRATEGY_PATH,
         "--mode",
-        "dryrun",
-        "--offline",
+        "offline",
     ], capture_output=True, text=True)
     assert result.returncode == 0
-    assert "[DRYRUN] SampleStrategy" in result.stdout
+    assert "[OFFLINE] SampleStrategy" in result.stdout


### PR DESCRIPTION
## Summary
- enable standalone offline mode for strategy testing
- require gateway URL for backtest/dryrun/live modes
- expose offline mode in CLI and docs
- update protobuf init to expose generated modules
- adjust tests for new behavior

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afc7354c4832999e402e408f5d476