### PR TITLE
Support backfill options in Runner and CLI

### DIFF
--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -12,6 +12,9 @@ def main() -> None:
     parser.add_argument("--end-time")
     parser.add_argument("--on-missing", default="skip")
     parser.add_argument("--gateway-url")
+    parser.add_argument("--backfill-source")
+    parser.add_argument("--backfill-start", type=int)
+    parser.add_argument("--backfill-end", type=int)
     args = parser.parse_args()
 
     module_name, class_name = args.strategy.split(":")
@@ -25,10 +28,25 @@ def main() -> None:
             end_time=args.end_time,
             on_missing=args.on_missing,
             gateway_url=args.gateway_url,
+            backfill_source=args.backfill_source,
+            backfill_start=args.backfill_start,
+            backfill_end=args.backfill_end,
         )
     elif args.mode == "dryrun":
-        Runner.dryrun(strategy_cls, gateway_url=args.gateway_url)
+        Runner.dryrun(
+            strategy_cls,
+            gateway_url=args.gateway_url,
+            backfill_source=args.backfill_source,
+            backfill_start=args.backfill_start,
+            backfill_end=args.backfill_end,
+        )
     elif args.mode == "live":
-        Runner.live(strategy_cls, gateway_url=args.gateway_url)
+        Runner.live(
+            strategy_cls,
+            gateway_url=args.gateway_url,
+            backfill_source=args.backfill_source,
+            backfill_start=args.backfill_start,
+            backfill_end=args.backfill_end,
+        )
     else:  # offline
         Runner.offline(strategy_cls)


### PR DESCRIPTION
## Summary
- enable backfill in `Runner` with helper methods
- wire backfill options into CLI
- add tests for new functionality

## Testing
- `uv venv`
- `uv pip install -e .[dev]`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba626a7148329aace936a0b734339