### PR TITLE
Add BackfillEngine for concurrent backfills

### DIFF
--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -8,6 +8,7 @@ from .runner import Runner
 from .cli import main as _cli
 from .ws_client import WebSocketClient
 from .backfill import BackfillSource, QuestDBSource
+from .backfill_engine import BackfillEngine
 from . import metrics
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "WebSocketClient",
     "BackfillSource",
     "QuestDBSource",
+    "BackfillEngine",
     "metrics",
     "_cli",
 ]

--- a/qmtl/sdk/backfill_engine.py
+++ b/qmtl/sdk/backfill_engine.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Asynchronous engine for running backfill jobs."""
+
+import asyncio
+
+from .backfill import BackfillSource
+from .node import Node
+
+
+class BackfillEngine:
+    """Run backfill jobs concurrently using ``asyncio`` tasks."""
+
+    def __init__(self, source: BackfillSource, *, max_retries: int = 3) -> None:
+        self.source = source
+        self.max_retries = max_retries
+        self._tasks: set[asyncio.Task] = set()
+
+    # --------------------------------------------------------------
+    async def _run_job(self, node: Node, start: int, end: int) -> None:
+        attempts = 0
+        while True:
+            try:
+                df = await asyncio.to_thread(
+                    self.source.fetch,
+                    start,
+                    end,
+                    node_id=node.node_id,
+                    interval=node.interval,
+                )
+                if df is None:
+                    return
+                items = [
+                    (int(row.get("ts", 0)), row.to_dict())
+                    for _, row in df.iterrows()
+                ]
+                node.cache.backfill_bulk(node.node_id, node.interval, items)
+                return
+            except Exception:
+                attempts += 1
+                if attempts > self.max_retries:
+                    raise
+                await asyncio.sleep(0.1 * attempts)
+
+    # --------------------------------------------------------------
+    def submit(self, node: Node, start: int, end: int) -> asyncio.Task:
+        """Schedule a backfill job and return the created task."""
+        task = asyncio.create_task(self._run_job(node, start, end))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def wait(self) -> None:
+        """Wait for all scheduled backfill jobs to finish."""
+        if self._tasks:
+            await asyncio.gather(*self._tasks)

--- a/tests/test_backfill_engine.py
+++ b/tests/test_backfill_engine.py
@@ -1,0 +1,61 @@
+import asyncio
+import time
+import pandas as pd
+import pytest
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.backfill_engine import BackfillEngine
+
+
+class DummySource:
+    def __init__(self, df: pd.DataFrame, delay: float = 0.05, fail: int = 0) -> None:
+        self.df = df
+        self.delay = delay
+        self.fail = fail
+        self.calls = 0
+
+    def fetch(self, start: int, end: int, *, node_id: str, interval: int) -> pd.DataFrame:
+        self.calls += 1
+        if self.calls <= self.fail:
+            raise RuntimeError("fail")
+        time.sleep(self.delay)
+        return self.df
+
+
+@pytest.mark.asyncio
+async def test_concurrent_backfill_and_live_append():
+    node = Node(interval=60, period=5)
+    df = pd.DataFrame([
+        {"ts": 60, "value": 1},
+        {"ts": 120, "value": 2},
+        {"ts": 180, "value": 3},
+    ])
+    src = DummySource(df, delay=0.05)
+    engine = BackfillEngine(src)
+
+    engine.submit(node, 60, 180)
+    await asyncio.sleep(0)  # ensure task started
+    await asyncio.to_thread(node.feed, node.node_id, 60, 180, {"v": "live"})
+    await asyncio.to_thread(node.feed, node.node_id, 60, 240, {"v": "live2"})
+
+    await engine.wait()
+
+    assert node.cache.get_slice(node.node_id, 60, count=5) == [
+        (60, {"ts": 60, "value": 1}),
+        (120, {"ts": 120, "value": 2}),
+        (180, {"v": "live"}),
+        (240, {"v": "live2"}),
+    ]
+    assert node.cache.backfill_state.is_complete(node.node_id, 60, 60, 180)
+
+
+@pytest.mark.asyncio
+async def test_retry_logic():
+    node = Node(interval=60, period=2)
+    df = pd.DataFrame([{"ts": 60, "v": 1}])
+    src = DummySource(df, delay=0.01, fail=1)
+    engine = BackfillEngine(src, max_retries=2)
+    engine.submit(node, 60, 60)
+    await engine.wait()
+    assert src.calls == 2
+    assert node.cache.latest(node.node_id, 60) == (60, {"ts": 60, "v": 1})


### PR DESCRIPTION
## Summary
- implement `BackfillEngine` for running backfills concurrently via asyncio tasks
- expose the new engine from the SDK
- add regression tests verifying concurrent backfill execution and retry logic

## Testing
- `uv pip install --system -e .[dev]`
- `uv build --wheel .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba7ba72ec8329b5ca892328fcdd9a