### PR TITLE
Add backfill guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ uv run pytest -q tests
 For instructions on implementing strategies with the SDK, see
 [docs/sdk_tutorial.md](docs/sdk_tutorial.md).
 
+## Backfills
+
+Learn how to preload historical data using BackfillSource objects in
+[docs/backfill.md](docs/backfill.md).
+

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -1,0 +1,64 @@
+# Backfilling Historical Data
+
+This guide explains how to populate node caches with past values before a strategy starts processing live data.
+
+## Configuring a BackfillSource
+
+A `BackfillSource` provides historical data for a `(node_id, interval)` pair. It must implement the `fetch(start, end, *, node_id, interval)` method and return a `pandas.DataFrame` where each row contains a timestamp column `ts` and any payload fields.
+
+The SDK ships with `QuestDBSource` which reads from a QuestDB instance:
+
+```python
+from qmtl.sdk import QuestDBSource
+
+source = QuestDBSource("postgresql://user:pass@localhost:8812/qdb")
+```
+
+Custom sources can subclass `BackfillSource` or provide an object with the same interface.
+
+## Running a Backfill
+
+Backfills can be triggered when executing a strategy through the CLI or the `Runner` API. Provide the source specification along with the timestamp range:
+
+```bash
+python -m qmtl.sdk tests.sample_strategy:SampleStrategy \
+       --mode dryrun \
+       --gateway-url http://localhost:8000 \
+       --backfill-source questdb:postgresql://user:pass@localhost:8812/qdb \
+       --backfill-start 1700000000 --backfill-end 1700003600
+```
+
+The same operation via Python code:
+
+```python
+from qmtl.sdk import Runner
+from tests.sample_strategy import SampleStrategy
+
+Runner.dryrun(
+    SampleStrategy,
+    gateway_url="http://localhost:8000",
+    backfill_source="questdb:postgresql://user:pass@localhost:8812/qdb",
+    backfill_start=1700000000,
+    backfill_end=1700003600,
+)
+```
+
+## Monitoring Progress
+
+Backfill operations emit Prometheus metrics via `qmtl.sdk.metrics`:
+
+- `backfill_jobs_in_progress`: number of active jobs
+- `backfill_last_timestamp{node_id,interval}`: latest timestamp successfully backfilled
+- `backfill_retry_total{node_id,interval}`: retry attempts
+- `backfill_failure_total{node_id,interval}`: total failures
+
+Start the metrics server to scrape these values:
+
+```python
+from qmtl.sdk import metrics
+
+metrics.start_metrics_server(port=8000)
+```
+
+Access `http://localhost:8000/metrics` while a backfill is running to observe its progress.
+

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -59,3 +59,8 @@ python -m qmtl.sdk --help
 전달됩니다. 이전 버전에서 사용하던 `NodeCache.snapshot()`은 내부 구현으로
 변경되었으므로 전략 코드에서 직접 호출하지 않아야 합니다.
 
+## 백필 작업
+
+노드 캐시를 과거 데이터로 초기화하는 방법은
+[backfill.md](backfill.md) 문서를 참고하세요.
+


### PR DESCRIPTION
## Summary
- add a backfill guide under docs
- link backfill docs from README and SDK tutorial

## Testing
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684bb0e58f78832994bba0048e67f088