### PR TITLE
Validate node parameters

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -323,6 +323,11 @@ class Node:
         config: dict | None = None,
         schema: dict | None = None,
     ) -> None:
+        if interval is None or interval <= 0:
+            raise ValueError("interval must be positive")
+        if period is None or period <= 0:
+            raise ValueError("period must be positive")
+
         self.input = input
         self.inputs = self._normalize_inputs(input)
         self.compute_fn = compute_fn

--- a/tests/sample_strategy.py
+++ b/tests/sample_strategy.py
@@ -3,7 +3,7 @@ from qmtl.sdk import Strategy, Node, StreamInput
 class SampleStrategy(Strategy):
     def setup(self):
         src = StreamInput(interval=1, period=1)
-        node = Node(input=src, compute_fn=lambda df: df, name="out")
+        node = Node(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
         self.add_nodes([src, node])
 
     def define_execution(self):

--- a/tests/test_node_validation.py
+++ b/tests/test_node_validation.py
@@ -1,0 +1,17 @@
+import pytest
+from qmtl.sdk.node import Node
+
+@pytest.mark.parametrize(
+    "interval,period",
+    [
+        (None, 1),
+        (1, None),
+        (0, 1),
+        (1, 0),
+        (-1, 1),
+        (1, -1),
+    ],
+)
+def test_invalid_node_parameters(interval, period):
+    with pytest.raises(ValueError):
+        Node(interval=interval, period=period)


### PR DESCRIPTION
## Summary
- validate node interval and period
- update sample strategy with explicit interval/period
- test node parameter validation

## Testing
- `uv run -- pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c070c6c388329b52e2902c8aa9c3c