### PR TITLE
Enhance determinism docs

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -21,14 +21,21 @@ receivers:
  groups:
    - name: qmtl
      rules:
-       - alert: DiffDurationHigh
-         expr: diff_duration_ms_p95 > 200
-         for: 5m
-         labels:
-           severity: warning
-         annotations:
-           summary: Diff processing slow
-       - alert: QueueCreateErrors
+      - alert: DiffDurationHigh
+        expr: diff_duration_ms_p95 > 200
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Diff processing slow
+      - alert: NodeCacheMemoryHigh
+        expr: nodecache_resident_bytes > 5e9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: NodeCache memory usage high
+      - alert: QueueCreateErrors
          expr: queue_create_error_total > 0
          for: 15m
          labels:

--- a/gateway.md
+++ b/gateway.md
@@ -131,3 +131,13 @@ Gateway persists its FSM in Redis with AOF enabled and mirrors crucial events in
 When resolving `TagQueryNode` dependencies, Gateway queries DAG-Manager for all queues matching `(tags, interval)` and returns the resulting mapping to the SDK so that only nodes lacking upstream queues execute locally.
 
 Gateway also listens for `sentinel_weight` CloudEvents emitted by DAG‑Manager. Upon receiving an update, the in-memory routing table is adjusted and the new weight broadcast to SDK clients via WebSocket. The effective ratio per version is exported as the Prometheus gauge `gateway_sentinel_traffic_ratio{version="<id>"}`.
+
+### S5 · Reliability Checklist
+
+* **NodeID CRC 파이프라인** – SDK가 전송한 `node_id`와 Gateway가 재계산한 값이
+  diff 요청 및 응답의 `crc32` 필드로 상호 검증된다.
+* **TagQueryNode 런타임 확장** – Gateway가 새 `(tags, interval)` 큐를 발견하면
+  `tagquery.upsert` CloudEvent를 발행해 SDK가 버퍼를 자동 초기화한다.
+* **Sentinel Traffic Δ 확인 루프** – `traffic_weight` 변경 후 Gateway 라우팅
+  테이블과 SDK 로컬 라우터가 5초 이내 동기화됐는지를 `sentinel_skew_seconds`
+  지표로 측정한다.


### PR DESCRIPTION
## Summary
- document NodeCache memory guardrail
- add end-to-end determinism checklist
- outline Gateway reliability checks
- detail topic retry workflow and CI gate
- track NodeCache memory via Prometheus rule

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c082fb0b883299ae2fe1be5a7358e