### PR TITLE
Validate compute_fn signature

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -328,6 +328,26 @@ class Node:
         if period is None or period <= 0:
             raise ValueError("period must be positive")
 
+        if compute_fn is not None:
+            sig = inspect.signature(compute_fn)
+            positional = [
+                p
+                for p in sig.parameters.values()
+                if p.kind
+                in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                )
+            ]
+            has_var_positional = any(
+                p.kind == inspect.Parameter.VAR_POSITIONAL
+                for p in sig.parameters.values()
+            )
+            if len(positional) != 1 or has_var_positional:
+                raise TypeError(
+                    "compute_fn must accept exactly one positional argument"
+                )
+
         self.input = input
         self.inputs = self._normalize_inputs(input)
         self.compute_fn = compute_fn

--- a/tests/test_node_validation.py
+++ b/tests/test_node_validation.py
@@ -15,3 +15,16 @@ from qmtl.sdk.node import Node
 def test_invalid_node_parameters(interval, period):
     with pytest.raises(ValueError):
         Node(interval=interval, period=period)
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        lambda: None,
+        lambda a, b: None,
+        lambda a, *args: None,
+    ],
+)
+def test_invalid_compute_fn(fn):
+    with pytest.raises(TypeError):
+        Node(compute_fn=fn, interval=1, period=1)


### PR DESCRIPTION
## Summary
- enforce compute_fn signature with inspect
- ensure invalid compute_fn signatures raise TypeError

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c09206ca483299e3ea8f7646d7b0a