### PR TITLE
Delegate node compute via Runner helper

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -13,6 +13,7 @@ import httpx
 
 from .cache_view import CacheView
 from .backfill_state import BackfillState
+from .runner import Runner
 
 from qmtl.dagmanager import compute_node_id
 
@@ -424,7 +425,7 @@ class Node:
             if on_missing == "skip":
                 return
         if not self.pre_warmup and self.compute_fn:
-            self.compute_fn(self.cache.view())
+            Runner._execute_compute_fn(self.compute_fn, self.cache.view())
 
     def to_dict(self) -> dict:
         return {

--- a/tests/test_node_feed.py
+++ b/tests/test_node_feed.py
@@ -1,0 +1,61 @@
+import qmtl.sdk.runner as rmod
+from qmtl.sdk import Node, StreamInput
+
+
+def test_node_feed_with_ray(monkeypatch):
+    class DummyRay:
+        def __init__(self):
+            self.calls = []
+            self.inited = False
+
+        def is_initialized(self):
+            return self.inited
+
+        def init(self, ignore_reinit_error=True):
+            self.inited = True
+
+        def remote(self, fn):
+            dummy = self
+
+            class Wrapper:
+                def remote(self, *args, **kwargs):
+                    dummy.calls.append((fn, args, kwargs))
+
+            return Wrapper()
+
+    dummy_ray = DummyRay()
+
+    monkeypatch.setattr(rmod, "ray", dummy_ray)
+    monkeypatch.setattr(rmod.Runner, "_ray_available", True)
+
+    calls = []
+
+    def compute(view):
+        calls.append(view)
+
+    src = StreamInput(interval=60, period=2)
+    node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
+
+    node.feed("q", 60, 60, {"v": 1})
+    node.feed("q", 60, 120, {"v": 2})
+
+    assert len(dummy_ray.calls) == 1
+    assert not calls
+
+
+def test_node_feed_without_ray(monkeypatch):
+    monkeypatch.setattr(rmod.Runner, "_ray_available", False)
+
+    calls = []
+
+    def compute(view):
+        calls.append(view)
+
+    src = StreamInput(interval=60, period=2)
+    node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
+
+    node.feed("q", 60, 60, {"v": 1})
+    node.feed("q", 60, 120, {"v": 2})
+
+    assert len(calls) == 1
+


### PR DESCRIPTION
## Summary
- run Node.compute functions via `Runner._execute_compute_fn`
- add tests ensuring Node.feed uses Ray when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0aa73d008329895642c65e17989d