### PR TITLE
Require start/end time for backtest

### DIFF
--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -149,6 +149,8 @@ class Runner:
         backfill_end: int | None = None,
     ) -> Strategy:
         """Run strategy in backtest mode. Requires ``gateway_url``."""
+        if start_time is None or end_time is None:
+            raise ValueError("start_time and end_time are required")
         strategy = Runner._prepare(strategy_cls)
         print(f"[BACKTEST] {strategy_cls.__name__} from {start_time} to {end_time} on_missing={on_missing}")
         dag = strategy.serialize()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -31,6 +31,33 @@ def test_backtest(capsys, monkeypatch):
     assert isinstance(strategy, SampleStrategy)
 
 
+def test_backtest_requires_start_and_end(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(202, json={"strategy_id": "s"})
+
+    transport = httpx.MockTransport(handler)
+
+    def mock_post(url, json):
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, json=json)
+
+    monkeypatch.setattr(httpx, "post", mock_post)
+
+    with pytest.raises(ValueError):
+        Runner.backtest(
+            SampleStrategy,
+            gateway_url="http://gw",
+            end_time="e",
+        )
+
+    with pytest.raises(ValueError):
+        Runner.backtest(
+            SampleStrategy,
+            gateway_url="http://gw",
+            start_time="s",
+        )
+
+
 def test_dryrun(capsys, monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(202, json={"strategy_id": "s"})


### PR DESCRIPTION
## Summary
- enforce start_time and end_time in `Runner.backtest`
- cover the new failure mode

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0c4cc1b88329903c8d236895e716