### PR TITLE
Add health check endpoints

### DIFF
--- a/qmtl/dagmanager/api.py
+++ b/qmtl/dagmanager/api.py
@@ -23,6 +23,11 @@ def create_app(gc: GarbageCollector, *, callback_url: Optional[str] = None) -> F
     """Return a FastAPI app exposing admin routes."""
     app = FastAPI()
 
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        """Health check endpoint for e2e testing."""
+        return {"status": "ok"}
+
     @app.post("/admin/gc-trigger", status_code=status.HTTP_202_ACCEPTED)
     async def trigger_gc(payload: GcRequest) -> GcResponse:
         infos = gc.collect()

--- a/qmtl/dagmanager/http_server.py
+++ b/qmtl/dagmanager/http_server.py
@@ -26,6 +26,12 @@ def create_app(
     driver: "Driver" | None = None,
 ) -> FastAPI:
     app = FastAPI()
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        """Simple health probe used in CI pipelines."""
+        return {"status": "ok"}
+
     store = weights if weights is not None else {}
 
     @app.post("/callbacks/sentinel-traffic", status_code=status.HTTP_202_ACCEPTED)

--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -186,6 +186,11 @@ def create_app(
 ) -> FastAPI:
     app = FastAPI()
 
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        """Health check endpoint used for CI/e2e loops."""
+        return {"status": "ok"}
+
     r = redis_client or redis.Redis(host="localhost", port=6379, decode_responses=True)
     db = database or PostgresDatabase("postgresql://localhost/qmtl")
     fsm = StrategyFSM(redis=r, database=db)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from fastapi.testclient import TestClient
+
+from qmtl.gateway.api import create_app as gw_create_app
+from qmtl.dagmanager.http_server import create_app as dag_http_create_app
+from qmtl.dagmanager.api import create_app as dag_api_create_app
+from qmtl.dagmanager.gc import QueueInfo
+
+
+class DummyGC:
+    def collect(self):
+        return [QueueInfo("q", "raw", datetime.utcnow(), interval=60)]
+
+
+def test_gateway_health():
+    client = TestClient(gw_create_app())
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_dagmanager_http_health():
+    client = TestClient(dag_http_create_app())
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_dagmanager_api_health():
+    client = TestClient(dag_api_create_app(DummyGC()))
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- add /health endpoints to gateway and dag-manager HTTP apps
- verify health endpoints with unit tests

## Testing
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cdbdddc7083298df1bc869daa24c3