### PR TITLE
Add health check utilities

### DIFF
--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -134,6 +134,16 @@ class PostgresDatabase(Database):
         )
         return row["status"] if row else None
 
+    async def healthy(self) -> bool:
+        """Return ``True`` if the database connection is usable."""
+        if self._pool is None:
+            return False
+        try:
+            await self._pool.execute("SELECT 1")
+            return True
+        except Exception:
+            return False
+
 
 @dataclass
 class StrategyManager:

--- a/qmtl/gateway/dagmanager_client.py
+++ b/qmtl/gateway/dagmanager_client.py
@@ -14,6 +14,18 @@ class DagManagerClient:
     def __init__(self, target: str) -> None:
         self._target = target
 
+    async def ping(self) -> bool:
+        """Return ``True`` if the remote DAG manager responds to ``Ping``."""
+        channel = grpc.aio.insecure_channel(self._target)
+        stub = dagmanager_pb2_grpc.HealthCheckStub(channel)
+        try:
+            await stub.Ping(dagmanager_pb2.PingRequest())
+            return True
+        except Exception:
+            return False
+        finally:
+            await channel.close()
+
     async def diff(self, strategy_id: str, dag_json: str) -> dagmanager_pb2.DiffChunk:
         """Call ``DiffService.Diff`` with retries and collect the stream."""
         request = dagmanager_pb2.DiffRequest(strategy_id=strategy_id, dag_json=dag_json)

--- a/qmtl/gateway/queue.py
+++ b/qmtl/gateway/queue.py
@@ -23,5 +23,13 @@ class RedisFIFOQueue:
             return None
         return data.decode() if isinstance(data, bytes) else data
 
+    async def healthy(self) -> bool:
+        """Return ``True`` if the underlying Redis connection is alive."""
+        try:
+            pong = await self.redis.ping()
+            return bool(pong)
+        except Exception:
+            return False
+
 
 __all__ = ["RedisFIFOQueue"]

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -49,6 +49,10 @@ class WebSocketHub:
         async with self._lock:
             self._clients.clear()
 
+    def is_running(self) -> bool:
+        """Return ``True`` if the WebSocket server is active."""
+        return self._server is not None
+
     async def _handler(self, websocket: WebSocketServerProtocol) -> None:
         async with self._lock:
             self._clients.add(websocket)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -5,6 +5,17 @@ from qmtl.gateway.api import create_app as gw_create_app
 from qmtl.dagmanager.http_server import create_app as dag_http_create_app
 from qmtl.dagmanager.api import create_app as dag_api_create_app
 from qmtl.dagmanager.gc import QueueInfo
+from qmtl.gateway.queue import RedisFIFOQueue
+from qmtl.gateway.dagmanager_client import DagManagerClient
+from qmtl.gateway.ws import WebSocketHub
+from qmtl.gateway.worker import StrategyWorker
+from qmtl.gateway.fsm import StrategyFSM
+from qmtl.gateway.api import PostgresDatabase
+
+import fakeredis
+import grpc
+import asyncio
+import pytest
 
 
 class DummyGC:
@@ -31,3 +42,92 @@ def test_dagmanager_api_health():
     resp = client.get("/health")
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_grpc_ping():
+    from qmtl.dagmanager.grpc_server import serve
+
+    class FakeDriver:
+        def session(self):
+            class S:
+                def run(self, *a, **k):
+                    return []
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    pass
+
+            return S()
+
+    class FakeAdmin:
+        def list_topics(self):
+            return {}
+
+        def create_topic(self, *a, **k):
+            pass
+
+    class FakeStream:
+        def send(self, chunk):
+            pass
+
+        def wait_for_ack(self):
+            pass
+
+        def ack(self):
+            pass
+
+    driver = FakeDriver()
+    admin = FakeAdmin()
+    stream = FakeStream()
+    server, port = serve(driver, admin, stream, host="127.0.0.1", port=0)
+    await server.start()
+    try:
+        client = DagManagerClient(f"127.0.0.1:{port}")
+        assert await client.ping() is True
+    finally:
+        await server.stop(None)
+
+
+@pytest.mark.asyncio
+async def test_queue_healthy():
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    queue = RedisFIFOQueue(redis)
+    assert await queue.healthy() is True
+
+
+@pytest.mark.asyncio
+async def test_ws_hub_is_running():
+    hub = WebSocketHub()
+    assert hub.is_running() is False
+    await hub.start()
+    try:
+        assert hub.is_running() is True
+    finally:
+        await hub.stop()
+
+
+@pytest.mark.asyncio
+async def test_worker_healthy(monkeypatch):
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+    class FakeDB(PostgresDatabase):
+        def __init__(self):
+            super().__init__("postgresql://localhost/test")
+            self._pool = None
+
+        async def healthy(self):
+            return True
+
+    db = FakeDB()
+    fsm = StrategyFSM(redis, db)
+    queue = RedisFIFOQueue(redis)
+    client = DagManagerClient("127.0.0.1:1")
+    async def ping():
+        return True
+    monkeypatch.setattr(client, "ping", ping)
+
+    worker = StrategyWorker(redis, db, fsm, queue, client)
+    assert await worker.healthy() is True


### PR DESCRIPTION
## Summary
- expose health checks for Redis queue, Postgres database, DagManager client, WebSocket hub and worker
- add unit tests covering gRPC ping, queue health, WebSocketHub running state and worker health

## Testing
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684d81e7a9bc83298ed151c32ab6341d