### PR TITLE
Improve dag-manager status checks

### DIFF
--- a/qmtl/dagmanager/http_server.py
+++ b/qmtl/dagmanager/http_server.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from .callbacks import post_with_backoff
 from ..common.cloudevents import format_event
 from . import metrics
+from .status import get_status
 
 
 class WeightUpdate(BaseModel):
@@ -27,10 +28,10 @@ def create_app(
 ) -> FastAPI:
     app = FastAPI()
 
-    @app.get("/health")
-    async def health() -> dict[str, str]:
-        """Simple health probe used in CI pipelines."""
-        return {"status": "ok"}
+    @app.get("/status")
+    async def status_endpoint() -> dict[str, str]:
+        """Return system status including Neo4j connectivity."""
+        return get_status(driver)
 
     store = weights if weights is not None else {}
 

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -69,7 +69,7 @@ async def _run(args: argparse.Namespace) -> None:
     )
     await grpc_server.start()
 
-    app = create_app(gc, callback_url=args.gc_callback)
+    app = create_app(gc, callback_url=args.gc_callback, driver=driver)
     config = uvicorn.Config(app, host=args.http_host, port=args.http_port, loop="asyncio", log_level="info")
     http_server = uvicorn.Server(config)
 

--- a/qmtl/dagmanager/status.py
+++ b/qmtl/dagmanager/status.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - optional import for typing
+    from neo4j import Driver
+
+
+def get_status(driver: "Driver" | None = None) -> dict[str, str]:
+    """Return status information about DAG manager and dependencies."""
+    neo4j_status = "unknown"
+    if driver is not None:
+        try:
+            with driver.session() as session:
+                session.run("RETURN 1")
+            neo4j_status = "ok"
+        except Exception:
+            neo4j_status = "error"
+    return {
+        "status": "ok" if neo4j_status == "ok" else "degraded",
+        "neo4j": neo4j_status,
+        "dag_manager": "running",
+    }

--- a/qmtl/gateway/dagmanager_client.py
+++ b/qmtl/gateway/dagmanager_client.py
@@ -14,13 +14,13 @@ class DagManagerClient:
     def __init__(self, target: str) -> None:
         self._target = target
 
-    async def ping(self) -> bool:
-        """Return ``True`` if the remote DAG manager responds to ``Ping``."""
+    async def status(self) -> bool:
+        """Return ``True`` if the remote DAG manager reports healthy status."""
         channel = grpc.aio.insecure_channel(self._target)
         stub = dagmanager_pb2_grpc.HealthCheckStub(channel)
         try:
-            await stub.Ping(dagmanager_pb2.PingRequest())
-            return True
+            reply = await stub.Status(dagmanager_pb2.StatusRequest())
+            return reply.neo4j == "ok" and reply.state == "running"
         except Exception:
             return False
         finally:

--- a/qmtl/gateway/worker.py
+++ b/qmtl/gateway/worker.py
@@ -48,7 +48,7 @@ class StrategyWorker:
             except Exception:
                 db_ok = False
         try:
-            dag_ok = await self.dag_client.ping()
+            dag_ok = await self.dag_client.status()
         except Exception:
             dag_ok = False
         return bool(redis_ok) and dag_ok and db_ok

--- a/qmtl/proto/dagmanager.proto
+++ b/qmtl/proto/dagmanager.proto
@@ -76,9 +76,12 @@ message DiffResult {
   string sentinel_id = 2;
 }
 
-message PingRequest {}
-message PingReply {}
+message StatusRequest {}
+message StatusReply {
+  string neo4j = 1;
+  string state = 2;
+}
 
 service HealthCheck {
-  rpc Ping(PingRequest) returns (PingReply);
+  rpc Status(StatusRequest) returns (StatusReply);
 }

--- a/qmtl/proto/dagmanager_pb2.py
+++ b/qmtl/proto/dagmanager_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10\x64\x61gmanager.proto\x12\x0fqmtl.dagmanager\"4\n\x0b\x44iffRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\x9c\x01\n\x11\x42ufferInstruction\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x11\n\tnode_type\x18\x02 \x01(\t\x12\x11\n\tcode_hash\x18\x03 \x01(\t\x12\x13\n\x0bschema_hash\x18\x04 \x01(\t\x12\x10\n\x08interval\x18\x05 \x01(\x03\x12\x0e\n\x06period\x18\x06 \x01(\x05\x12\x0c\n\x04tags\x18\x07 \x03(\t\x12\x0b\n\x03lag\x18\x08 \x01(\x05\"\xc8\x01\n\tDiffChunk\x12;\n\tqueue_map\x18\x01 \x03(\x0b\x32(.qmtl.dagmanager.DiffChunk.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x12\x38\n\x0c\x62uffer_nodes\x18\x03 \x03(\x0b\x32\".qmtl.dagmanager.BufferInstruction\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"1\n\x08\x43hunkAck\x12\x13\n\x0bsentinel_id\x18\x01 \x01(\t\x12\x10\n\x08\x63hunk_id\x18\x02 \x01(\r\"1\n\x0fTagQueryRequest\x12\x0c\n\x04tags\x18\x01 \x03(\t\x12\x10\n\x08interval\x18\x02 \x01(\x03\"\x1f\n\rTagQueryReply\x12\x0e\n\x06queues\x18\x01 \x03(\t\"%\n\x0e\x43leanupRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\"\x11\n\x0f\x43leanupResponse\"#\n\x11QueueStatsRequest\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\"q\n\nQueueStats\x12\x35\n\x05sizes\x18\x01 \x03(\x0b\x32&.qmtl.dagmanager.QueueStats.SizesEntry\x1a,\n\nSizesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"8\n\x0fRedoDiffRequest\x12\x13\n\x0bsentinel_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\x90\x01\n\nDiffResult\x12<\n\tqueue_map\x18\x01 \x03(\x0b\x32).qmtl.dagmanager.DiffResult.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\r\n\x0bPingRequest\"\x0b\n\tPingReply2\x93\x01\n\x0b\x44iffService\x12\x42\n\x04\x44iff\x12\x1c.qmtl.dagmanager.DiffRequest\x1a\x1a.qmtl.dagmanager.DiffChunk0\x01\x12@\n\x08\x41\x63kChunk\x12\x19.qmtl.dagmanager.ChunkAck\x1a\x19.qmtl.dagmanager.ChunkAck2Y\n\x08TagQuery\x12M\n\tGetQueues\x12 .qmtl.dagmanager.TagQueryRequest\x1a\x1e.qmtl.dagmanager.TagQueryReply2\xf9\x01\n\x0c\x41\x64minService\x12L\n\x07\x43leanup\x12\x1f.qmtl.dagmanager.CleanupRequest\x1a .qmtl.dagmanager.CleanupResponse\x12P\n\rGetQueueStats\x12\".qmtl.dagmanager.QueueStatsRequest\x1a\x1b.qmtl.dagmanager.QueueStats\x12I\n\x08RedoDiff\x12 .qmtl.dagmanager.RedoDiffRequest\x1a\x1b.qmtl.dagmanager.DiffResult2O\n\x0bHealthCheck\x12@\n\x04Ping\x12\x1c.qmtl.dagmanager.PingRequest\x1a\x1a.qmtl.dagmanager.PingReplyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10\x64\x61gmanager.proto\x12\x0fqmtl.dagmanager\"4\n\x0b\x44iffRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\x9c\x01\n\x11\x42ufferInstruction\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x11\n\tnode_type\x18\x02 \x01(\t\x12\x11\n\tcode_hash\x18\x03 \x01(\t\x12\x13\n\x0bschema_hash\x18\x04 \x01(\t\x12\x10\n\x08interval\x18\x05 \x01(\x03\x12\x0e\n\x06period\x18\x06 \x01(\x05\x12\x0c\n\x04tags\x18\x07 \x03(\t\x12\x0b\n\x03lag\x18\x08 \x01(\x05\"\xc8\x01\n\tDiffChunk\x12;\n\tqueue_map\x18\x01 \x03(\x0b\x32(.qmtl.dagmanager.DiffChunk.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x12\x38\n\x0c\x62uffer_nodes\x18\x03 \x03(\x0b\x32\".qmtl.dagmanager.BufferInstruction\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"1\n\x08\x43hunkAck\x12\x13\n\x0bsentinel_id\x18\x01 \x01(\t\x12\x10\n\x08\x63hunk_id\x18\x02 \x01(\r\"1\n\x0fTagQueryRequest\x12\x0c\n\x04tags\x18\x01 \x03(\t\x12\x10\n\x08interval\x18\x02 \x01(\x03\"\x1f\n\rTagQueryReply\x12\x0e\n\x06queues\x18\x01 \x03(\t\"%\n\x0e\x43leanupRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\"\x11\n\x0f\x43leanupResponse\"#\n\x11QueueStatsRequest\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\"q\n\nQueueStats\x12\x35\n\x05sizes\x18\x01 \x03(\x0b\x32&.qmtl.dagmanager.QueueStats.SizesEntry\x1a,\n\nSizesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"8\n\x0fRedoDiffRequest\x12\x13\n\x0bsentinel_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\x90\x01\n\nDiffResult\x12<\n\tqueue_map\x18\x01 \x03(\x0b\x32).qmtl.dagmanager.DiffResult.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x0f\n\rStatusRequest\"+\n\x0bStatusReply\x12\r\n\x05neo4j\x18\x01 \x01(\t\x12\r\n\x05state\x18\x02 \x01(\t2\x93\x01\n\x0b\x44iffService\x12\x42\n\x04\x44iff\x12\x1c.qmtl.dagmanager.DiffRequest\x1a\x1a.qmtl.dagmanager.DiffChunk0\x01\x12@\n\x08\x41\x63kChunk\x12\x19.qmtl.dagmanager.ChunkAck\x1a\x19.qmtl.dagmanager.ChunkAck2Y\n\x08TagQuery\x12M\n\tGetQueues\x12 .qmtl.dagmanager.TagQueryRequest\x1a\x1e.qmtl.dagmanager.TagQueryReply2\xf9\x01\n\x0c\x41\x64minService\x12L\n\x07\x43leanup\x12\x1f.qmtl.dagmanager.CleanupRequest\x1a .qmtl.dagmanager.CleanupResponse\x12P\n\rGetQueueStats\x12\".qmtl.dagmanager.QueueStatsRequest\x1a\x1b.qmtl.dagmanager.QueueStats\x12I\n\x08RedoDiff\x12 .qmtl.dagmanager.RedoDiffRequest\x1a\x1b.qmtl.dagmanager.DiffResult2U\n\x0bHealthCheck\x12\x46\n\x06Status\x12\x1e.qmtl.dagmanager.StatusRequest\x1a\x1c.qmtl.dagmanager.StatusReplyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -67,16 +67,16 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_DIFFRESULT']._serialized_end=1001
   _globals['_DIFFRESULT_QUEUEMAPENTRY']._serialized_start=404
   _globals['_DIFFRESULT_QUEUEMAPENTRY']._serialized_end=451
-  _globals['_PINGREQUEST']._serialized_start=1003
-  _globals['_PINGREQUEST']._serialized_end=1016
-  _globals['_PINGREPLY']._serialized_start=1018
-  _globals['_PINGREPLY']._serialized_end=1029
-  _globals['_DIFFSERVICE']._serialized_start=1032
-  _globals['_DIFFSERVICE']._serialized_end=1179
-  _globals['_TAGQUERY']._serialized_start=1181
-  _globals['_TAGQUERY']._serialized_end=1270
-  _globals['_ADMINSERVICE']._serialized_start=1273
-  _globals['_ADMINSERVICE']._serialized_end=1522
-  _globals['_HEALTHCHECK']._serialized_start=1524
-  _globals['_HEALTHCHECK']._serialized_end=1603
+  _globals['_STATUSREQUEST']._serialized_start=1003
+  _globals['_STATUSREQUEST']._serialized_end=1018
+  _globals['_STATUSREPLY']._serialized_start=1020
+  _globals['_STATUSREPLY']._serialized_end=1063
+  _globals['_DIFFSERVICE']._serialized_start=1066
+  _globals['_DIFFSERVICE']._serialized_end=1213
+  _globals['_TAGQUERY']._serialized_start=1215
+  _globals['_TAGQUERY']._serialized_end=1304
+  _globals['_ADMINSERVICE']._serialized_start=1307
+  _globals['_ADMINSERVICE']._serialized_end=1556
+  _globals['_HEALTHCHECK']._serialized_start=1558
+  _globals['_HEALTHCHECK']._serialized_end=1643
 # @@protoc_insertion_point(module_scope)

--- a/qmtl/proto/dagmanager_pb2_grpc.py
+++ b/qmtl/proto/dagmanager_pb2_grpc.py
@@ -379,17 +379,17 @@ class HealthCheckStub(object):
         Args:
             channel: A grpc.Channel.
         """
-        self.Ping = channel.unary_unary(
-                '/qmtl.dagmanager.HealthCheck/Ping',
-                request_serializer=dagmanager__pb2.PingRequest.SerializeToString,
-                response_deserializer=dagmanager__pb2.PingReply.FromString,
+        self.Status = channel.unary_unary(
+                '/qmtl.dagmanager.HealthCheck/Status',
+                request_serializer=dagmanager__pb2.StatusRequest.SerializeToString,
+                response_deserializer=dagmanager__pb2.StatusReply.FromString,
                 _registered_method=True)
 
 
 class HealthCheckServicer(object):
     """Missing associated documentation comment in .proto file."""
 
-    def Ping(self, request, context):
+    def Status(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -398,10 +398,10 @@ class HealthCheckServicer(object):
 
 def add_HealthCheckServicer_to_server(servicer, server):
     rpc_method_handlers = {
-            'Ping': grpc.unary_unary_rpc_method_handler(
-                    servicer.Ping,
-                    request_deserializer=dagmanager__pb2.PingRequest.FromString,
-                    response_serializer=dagmanager__pb2.PingReply.SerializeToString,
+            'Status': grpc.unary_unary_rpc_method_handler(
+                    servicer.Status,
+                    request_deserializer=dagmanager__pb2.StatusRequest.FromString,
+                    response_serializer=dagmanager__pb2.StatusReply.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -415,7 +415,7 @@ class HealthCheck(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
-    def Ping(request,
+    def Status(request,
             target,
             options=(),
             channel_credentials=None,
@@ -428,9 +428,9 @@ class HealthCheck(object):
         return grpc.experimental.unary_unary(
             request,
             target,
-            '/qmtl.dagmanager.HealthCheck/Ping',
-            dagmanager__pb2.PingRequest.SerializeToString,
-            dagmanager__pb2.PingReply.FromString,
+            '/qmtl.dagmanager.HealthCheck/Status',
+            dagmanager__pb2.StatusRequest.SerializeToString,
+            dagmanager__pb2.StatusReply.FromString,
             options,
             channel_credentials,
             insecure,


### PR DESCRIPTION
## Summary
- add `get_status` helper for DAG manager
- expose `/status` HTTP endpoint
- support Status RPC over gRPC
- update DagManagerClient and worker health checks
- refresh protobufs
- adapt tests for new status API

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684d8ea8b79c8329bfc069db1e7aa207