### PR TITLE
Refactor runner and alerts to async APIs

### DIFF
--- a/qmtl/dagmanager/alerts.py
+++ b/qmtl/dagmanager/alerts.py
@@ -11,14 +11,14 @@ import httpx
 class PagerDutySender(Protocol):
     """Protocol for sending PagerDuty events."""
 
-    def send(self, message: str) -> None:
+    async def send(self, message: str) -> None:
         ...
 
 
 class SlackSender(Protocol):
     """Protocol for sending Slack messages."""
 
-    def send(self, message: str) -> None:
+    async def send(self, message: str) -> None:
         ...
 
 
@@ -26,16 +26,18 @@ class SlackSender(Protocol):
 class PagerDutyClient:
     url: str
 
-    def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
-        httpx.post(self.url, json={"text": message})
+    async def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
+        async with httpx.AsyncClient() as client:
+            await client.post(self.url, json={"text": message})
 
 
 @dataclass
 class SlackClient:
     url: str
 
-    def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
-        httpx.post(self.url, json={"text": message})
+    async def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
+        async with httpx.AsyncClient() as client:
+            await client.post(self.url, json={"text": message})
 
 
 @dataclass
@@ -43,11 +45,11 @@ class AlertManager:
     pagerduty: PagerDutySender
     slack: SlackSender
 
-    def send_pagerduty(self, message: str) -> None:
-        self.pagerduty.send(message)
+    async def send_pagerduty(self, message: str) -> None:
+        await self.pagerduty.send(message)
 
-    def send_slack(self, message: str) -> None:
-        self.slack.send(message)
+    async def send_slack(self, message: str) -> None:
+        await self.slack.send(message)
 
 
 __all__ = ["PagerDutyClient", "SlackClient", "AlertManager"]

--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -121,7 +121,7 @@ def _cmd_export_schema(args: argparse.Namespace) -> None:
         print(text, end="")
 
 
-def main(argv: list[str] | None = None) -> None:
+async def _main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="qmtl-dagm")
     parser.add_argument("--target", default="localhost:50051", help="gRPC service target")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -150,15 +150,19 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     if args.cmd == "diff":
-        asyncio.run(_cmd_diff(args))
+        await _cmd_diff(args)
     elif args.cmd == "queue-stats":
-        asyncio.run(_cmd_queue_stats(args))
+        await _cmd_queue_stats(args)
     elif args.cmd == "gc":
-        asyncio.run(_cmd_gc(args))
+        await _cmd_gc(args)
     elif args.cmd == "redo-diff":
-        asyncio.run(_cmd_redo_diff(args))
+        await _cmd_redo_diff(args)
     elif args.cmd == "export-schema":
         _cmd_export_schema(args)
+
+
+def main(argv: list[str] | None = None) -> None:
+    asyncio.run(_main(argv))
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/qmtl/dagmanager/diff_service.py
+++ b/qmtl/dagmanager/diff_service.py
@@ -10,6 +10,7 @@ except Exception:  # pragma: no cover - fallback
 
 _json_loads = _json.loads
 import time
+import asyncio
 
 from .metrics import (
     observe_diff_duration,
@@ -268,6 +269,9 @@ class DiffService:
         finally:
             duration_ms = (time.perf_counter() - start) * 1000
             observe_diff_duration(duration_ms)
+
+    async def diff_async(self, request: DiffRequest) -> DiffChunk:
+        return await asyncio.to_thread(self.diff, request)
 
 
 class Neo4jNodeRepository(NodeRepository):

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -8,7 +8,7 @@ import redis.asyncio as redis
 from .api import create_app, PostgresDatabase
 
 
-def main(argv: list[str] | None = None) -> None:
+async def _main(argv: list[str] | None = None) -> None:
     """Run the Gateway HTTP server."""
     parser = argparse.ArgumentParser(prog="qmtl-gateway")
     parser.add_argument("--host", default="0.0.0.0", help="Bind address")
@@ -27,9 +27,8 @@ def main(argv: list[str] | None = None) -> None:
 
     redis_client = redis.from_url(args.redis_dsn, decode_responses=True)
     db = PostgresDatabase(args.postgres_dsn)
-    # Connect database if possible; ignore failures to ease testing
     try:
-        asyncio.run(db.connect())
+        await db.connect()
     except Exception:
         pass
 
@@ -38,6 +37,10 @@ def main(argv: list[str] | None = None) -> None:
     import uvicorn
 
     uvicorn.run(app, host=args.host, port=args.port)
+
+
+def main(argv: list[str] | None = None) -> None:
+    asyncio.run(_main(argv))
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/qmtl/sdk/backfill.py
+++ b/qmtl/sdk/backfill.py
@@ -12,8 +12,10 @@ import asyncpg
 class BackfillSource(Protocol):
     """Interface for fetching historical data for nodes."""
 
-    def fetch(self, start: int, end: int, *, node_id: str, interval: int) -> pd.DataFrame:
-        """Return data in [start, end) for the given node and interval."""
+    async def fetch(
+        self, start: int, end: int, *, node_id: str, interval: int
+    ) -> pd.DataFrame:
+        """Return data in ``[start, end)`` for ``node_id`` and ``interval``."""
         ...
 
 
@@ -24,18 +26,18 @@ class QuestDBSource:
         self.dsn = dsn
         self.table = table
 
-    def fetch(self, start: int, end: int, *, node_id: str, interval: int) -> pd.DataFrame:
-        async def _query() -> list[asyncpg.Record]:
-            conn = await asyncpg.connect(self.dsn)
-            try:
-                sql = (
-                    f"SELECT * FROM {self.table} "
-                    "WHERE node_id=$1 AND interval=$2 AND ts >= $3 AND ts < $4 "
-                    "ORDER BY ts"
-                )
-                return await conn.fetch(sql, node_id, interval, start, end)
-            finally:
-                await conn.close()
+    async def fetch(
+        self, start: int, end: int, *, node_id: str, interval: int
+    ) -> pd.DataFrame:
+        conn = await asyncpg.connect(self.dsn)
+        try:
+            sql = (
+                f"SELECT * FROM {self.table} "
+                "WHERE node_id=$1 AND interval=$2 AND ts >= $3 AND ts < $4 "
+                "ORDER BY ts"
+            )
+            rows = await conn.fetch(sql, node_id, interval, start, end)
+        finally:
+            await conn.close()
 
-        rows = asyncio.run(_query())
         return pd.DataFrame([dict(r) for r in rows])

--- a/qmtl/sdk/backfill_engine.py
+++ b/qmtl/sdk/backfill_engine.py
@@ -36,8 +36,7 @@ class BackfillEngine:
         attempts = 0
         while True:
             try:
-                df = await asyncio.to_thread(
-                    self.source.fetch,
+                df = await self.source.fetch(
                     start,
                     end,
                     node_id=node.node_id,

--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -1,10 +1,11 @@
 import argparse
 import importlib
 
+import asyncio
 from .runner import Runner
 
 
-def main() -> None:
+async def _main() -> None:
     parser = argparse.ArgumentParser(description="Run QMTL strategy")
     parser.add_argument("strategy", help="Import path as module:Class")
     parser.add_argument("--mode", choices=["backtest", "dryrun", "live", "offline"], required=True)
@@ -22,7 +23,7 @@ def main() -> None:
     strategy_cls = getattr(module, class_name)
 
     if args.mode == "backtest":
-        Runner.backtest(
+        await Runner.backtest_async(
             strategy_cls,
             start_time=args.start_time,
             end_time=args.end_time,
@@ -33,7 +34,7 @@ def main() -> None:
             backfill_end=args.backfill_end,
         )
     elif args.mode == "dryrun":
-        Runner.dryrun(
+        await Runner.dryrun_async(
             strategy_cls,
             gateway_url=args.gateway_url,
             backfill_source=args.backfill_source,
@@ -41,7 +42,7 @@ def main() -> None:
             backfill_end=args.backfill_end,
         )
     elif args.mode == "live":
-        Runner.live(
+        await Runner.live_async(
             strategy_cls,
             gateway_url=args.gateway_url,
             backfill_source=args.backfill_source,
@@ -50,3 +51,6 @@ def main() -> None:
         )
     else:  # offline
         Runner.offline(strategy_cls)
+
+def main() -> None:
+    asyncio.run(_main())

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -24,10 +24,11 @@ async def dummy_connect(_):
     return DummyConn(rows)
 
 
-def test_questdb_fetch(monkeypatch):
+@pytest.mark.asyncio
+async def test_questdb_fetch(monkeypatch):
     monkeypatch.setattr("qmtl.sdk.backfill.asyncpg.connect", dummy_connect)
     src = QuestDBSource("db")
-    df = src.fetch(1, 3, node_id="n1", interval=60)
+    df = await src.fetch(1, 3, node_id="n1", interval=60)
     expected = pd.DataFrame([{"ts": 1, "value": 10}, {"ts": 2, "value": 20}])
     pd.testing.assert_frame_equal(df.reset_index(drop=True), expected)
 

--- a/tests/test_backfill_engine.py
+++ b/tests/test_backfill_engine.py
@@ -15,11 +15,11 @@ class DummySource:
         self.fail = fail
         self.calls = 0
 
-    def fetch(self, start: int, end: int, *, node_id: str, interval: int) -> pd.DataFrame:
+    async def fetch(self, start: int, end: int, *, node_id: str, interval: int) -> pd.DataFrame:
         self.calls += 1
         if self.calls <= self.fail:
             raise RuntimeError("fail")
-        time.sleep(self.delay)
+        await asyncio.sleep(self.delay)
         return self.df
 
 

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -142,6 +142,9 @@ async def test_grpc_redo_diff(monkeypatch):
                 queue_map={"x": "t"}, sentinel_id=request.strategy_id + "-sentinel"
             )
 
+        async def diff_async(self, request: DiffRequest):
+            return self.diff(request)
+
     monkeypatch.setattr("qmtl.dagmanager.grpc_server.DiffService", DummyDiff)
 
     driver = FakeDriver()

--- a/tests/test_monitor_loop.py
+++ b/tests/test_monitor_loop.py
@@ -8,7 +8,7 @@ class DummyMonitor:
     def __init__(self):
         self.called = 0
 
-    def check_once(self) -> None:
+    async def check_once(self) -> None:
         self.called += 1
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,11 +14,18 @@ def test_backtest(capsys, monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     strategy = Runner.backtest(
         SampleStrategy,
@@ -37,11 +44,18 @@ def test_backtest_requires_start_and_end(monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     with pytest.raises(ValueError):
         Runner.backtest(
@@ -64,11 +78,18 @@ def test_dryrun(capsys, monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     strategy = Runner.dryrun(SampleStrategy, gateway_url="http://gw")
     captured = capsys.readouterr().out
@@ -82,11 +103,18 @@ def test_live(capsys, monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     strategy = Runner.live(SampleStrategy, gateway_url="http://gw")
     captured = capsys.readouterr().out
@@ -108,11 +136,18 @@ def test_gateway_queue_mapping(monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     strategy = Runner.dryrun(SampleStrategy, gateway_url="http://gw")
     first_node = strategy.nodes[0]
@@ -126,11 +161,18 @@ def test_gateway_error(monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     with pytest.raises(RuntimeError):
         Runner.dryrun(SampleStrategy, gateway_url="http://gw")
@@ -143,10 +185,17 @@ def test_offline_mode():
 
 
 def test_connection_failure(monkeypatch):
-    def mock_post(url, json):
-        raise httpx.RequestError("fail", request=httpx.Request("POST", url))
+    class DummyClient:
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def post(self, url, json=None):
+            raise httpx.RequestError("fail", request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     with pytest.raises(RuntimeError):
         Runner.dryrun(SampleStrategy, gateway_url="http://gw")
@@ -158,11 +207,18 @@ def test_offline_same_ids(monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     online = Runner.dryrun(SampleStrategy, gateway_url="http://gw")
     offline = Runner.offline(SampleStrategy)
@@ -175,11 +231,18 @@ def test_no_gateway_same_ids(monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     online = Runner.dryrun(SampleStrategy, gateway_url="http://gw")
     with pytest.raises(RuntimeError):
@@ -255,11 +318,18 @@ def test_backfill_started(monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     called = []
 
@@ -289,11 +359,18 @@ def test_cli_backfill_options(monkeypatch):
 
     transport = httpx.MockTransport(handler)
 
-    def mock_post(url, json):
-        with httpx.Client(transport=transport) as client:
-            return client.post(url, json=json)
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
 
-    monkeypatch.setattr(httpx, "post", mock_post)
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
 
     called = []
 


### PR DESCRIPTION
## Summary
- make backfill source async
- refactor Runner to use async HTTP calls and expose async entrypoints
- add async resolve for TagQueryNode
- update alert clients and monitor to be async
- adjust CLI tools to run async functions
- add async wrapper in DiffService and gRPC server
- update unit tests for new async behavior

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684edd7a9af08329a43897c2c9fbdc7c