### PR TITLE
Add new technical indicators

### DIFF
--- a/qmtl/indicators/__init__.py
+++ b/qmtl/indicators/__init__.py
@@ -1,5 +1,37 @@
 """Technical indicator nodes built on top of ``qmtl.sdk``."""
 
 from .sma import sma
+from .ema import ema
+from .atr import atr
+from .chandelier_exit import chandelier_exit
+from .ichimoku_cloud import ichimoku_cloud
+from .supertrend import supertrend
+from .rsi import rsi
+from .kdj import kdj
+from .bollinger_bands import bollinger_bands
+from .keltner_channel import keltner_channel
+from .obv import obv
+from .vwap import vwap
+from .anchored_vwap import anchored_vwap
+from .kalman_trend import kalman_trend
+from .rough_bergami import rough_bergami
+from .stoch_rsi import stoch_rsi
 
-__all__ = ["sma"]
+__all__ = [
+    "sma",
+    "ema",
+    "atr",
+    "chandelier_exit",
+    "ichimoku_cloud",
+    "supertrend",
+    "rsi",
+    "kdj",
+    "bollinger_bands",
+    "keltner_channel",
+    "obv",
+    "vwap",
+    "anchored_vwap",
+    "kalman_trend",
+    "rough_bergami",
+    "stoch_rsi",
+]

--- a/qmtl/indicators/anchored_vwap.py
+++ b/qmtl/indicators/anchored_vwap.py
@@ -1,0 +1,32 @@
+"""Anchored VWAP indicator."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def anchored_vwap(price: Node, volume: Node, anchor_ts: int, *, name: str | None = None) -> Node:
+    """Return a Node computing VWAP anchored at ``anchor_ts``."""
+
+    def compute(view: CacheView):
+        prices = view[price][price.interval]
+        vols = view[volume][volume.interval]
+        filtered = [
+            (p, v)
+            for (t, p), (_, v) in zip(prices, vols)
+            if t >= anchor_ts
+        ]
+        if not filtered:
+            return None
+        num = sum(p * v for p, v in filtered)
+        den = sum(v for _, v in filtered)
+        if den == 0:
+            return None
+        return num / den
+
+    return Node(
+        input=[price, volume],
+        compute_fn=compute,
+        name=name or "anchored_vwap",
+        interval=price.interval,
+        period=price.period,
+    )

--- a/qmtl/indicators/atr.py
+++ b/qmtl/indicators/atr.py
@@ -1,0 +1,31 @@
+"""Average True Range indicator."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def atr(high: Node, low: Node, close: Node, window: int, *, name: str | None = None) -> Node:
+    """Return a Node computing Average True Range."""
+
+    def compute(view: CacheView):
+        highs = view[high][high.interval][-window:]
+        lows = view[low][low.interval][-window:]
+        closes = view[close][close.interval][-(window + 1):]
+        if len(highs) < window or len(lows) < window or len(closes) < window + 1:
+            return None
+        tr_values = []
+        for i in range(1, window + 1):
+            h = highs[i - 1][1]
+            l = lows[i - 1][1]
+            pc = closes[i - 1][1]
+            tr = max(h - l, abs(h - pc), abs(l - pc))
+            tr_values.append(tr)
+        return sum(tr_values) / window
+
+    return Node(
+        input=[high, low, close],
+        compute_fn=compute,
+        name=name or "atr",
+        interval=close.interval,
+        period=window,
+    )

--- a/qmtl/indicators/bollinger_bands.py
+++ b/qmtl/indicators/bollinger_bands.py
@@ -1,0 +1,29 @@
+"""Bollinger Bands indicator."""
+
+import math
+from statistics import mean, pstdev
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def bollinger_bands(source: Node, window: int, multiplier: float = 2.0, *, name: str | None = None) -> Node:
+    """Return a Node computing Bollinger Bands as (mid, upper, lower)."""
+
+    def compute(view: CacheView):
+        data = [v for _, v in view[source][source.interval][-window:]]
+        if len(data) < window:
+            return None
+        mid = mean(data)
+        std = pstdev(data)
+        upper = mid + multiplier * std
+        lower = mid - multiplier * std
+        return {"mid": mid, "upper": upper, "lower": lower}
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "bollinger_bands",
+        interval=source.interval,
+        period=window,
+    )

--- a/qmtl/indicators/chandelier_exit.py
+++ b/qmtl/indicators/chandelier_exit.py
@@ -1,0 +1,43 @@
+"""Chandelier Exit indicator."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def chandelier_exit(
+    high: Node,
+    low: Node,
+    close: Node,
+    *,
+    window: int = 22,
+    multiplier: float = 3.0,
+    name: str | None = None,
+) -> Node:
+    """Return a Node computing Chandelier Exit levels."""
+
+    def compute(view: CacheView):
+        highs = view[high][high.interval][-window:]
+        lows = view[low][low.interval][-window:]
+        closes = view[close][close.interval][-(window + 1):]
+        if len(highs) < window or len(lows) < window or len(closes) < window + 1:
+            return None
+        tr_values = []
+        for i in range(1, window + 1):
+            h = highs[i - 1][1]
+            l = lows[i - 1][1]
+            pc = closes[i - 1][1]
+            tr_values.append(max(h - l, abs(h - pc), abs(l - pc)))
+        atr_val = sum(tr_values) / window
+        highest_high = max(v for _, v in highs)
+        lowest_low = min(v for _, v in lows)
+        long_exit = highest_high - multiplier * atr_val
+        short_exit = lowest_low + multiplier * atr_val
+        return {"long": long_exit, "short": short_exit}
+
+    return Node(
+        input=[high, low, close],
+        compute_fn=compute,
+        name=name or "chandelier_exit",
+        interval=close.interval,
+        period=window,
+    )

--- a/qmtl/indicators/ema.py
+++ b/qmtl/indicators/ema.py
@@ -1,0 +1,27 @@
+"""Exponential moving average indicator."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def ema(source: Node, window: int, *, name: str | None = None) -> Node:
+    """Return a Node computing an exponential moving average."""
+
+    alpha = 2 / (window + 1)
+
+    def compute(view: CacheView):
+        data = [v for _, v in view[source][source.interval][-window:]]
+        if len(data) < window:
+            return None
+        value = data[0]
+        for x in data[1:]:
+            value = alpha * x + (1 - alpha) * value
+        return value
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "ema",
+        interval=source.interval,
+        period=window,
+    )

--- a/qmtl/indicators/ichimoku_cloud.py
+++ b/qmtl/indicators/ichimoku_cloud.py
@@ -1,0 +1,35 @@
+"""Ichimoku Cloud indicator (simplified)."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def ichimoku_cloud(high: Node, low: Node, close: Node, *, name: str | None = None) -> Node:
+    """Return a Node computing Ichimoku Cloud values."""
+
+    def compute(view: CacheView):
+        highs = [v for _, v in view[high][high.interval]]
+        lows = [v for _, v in view[low][low.interval]]
+        closes = [v for _, v in view[close][close.interval]]
+        if len(highs) < 52 or len(lows) < 52 or len(closes) < 26:
+            return None
+        tenkan = (max(highs[-9:]) + min(lows[-9:])) / 2
+        kijun = (max(highs[-26:]) + min(lows[-26:])) / 2
+        senkou_a = (tenkan + kijun) / 2
+        senkou_b = (max(highs[-52:]) + min(lows[-52:])) / 2
+        chikou = closes[-26]
+        return {
+            "tenkan": tenkan,
+            "kijun": kijun,
+            "senkou_a": senkou_a,
+            "senkou_b": senkou_b,
+            "chikou": chikou,
+        }
+
+    return Node(
+        input=[high, low, close],
+        compute_fn=compute,
+        name=name or "ichimoku_cloud",
+        interval=close.interval,
+        period=52,
+    )

--- a/qmtl/indicators/kalman_trend.py
+++ b/qmtl/indicators/kalman_trend.py
@@ -1,0 +1,35 @@
+"""Simple Kalman filter trend line."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def kalman_trend(
+    source: Node,
+    *,
+    process_variance: float = 1e-5,
+    measurement_variance: float = 1e-2,
+    name: str | None = None,
+) -> Node:
+    """Return a Node computing a Kalman filter smoothed value."""
+
+    def compute(view: CacheView):
+        data = [v for _, v in view[source][source.interval]]
+        if not data:
+            return None
+        x = data[0]
+        p = 1.0
+        for z in data[1:]:
+            p += process_variance
+            k = p / (p + measurement_variance)
+            x = x + k * (z - x)
+            p *= 1 - k
+        return x
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "kalman_trend",
+        interval=source.interval,
+        period=source.period,
+    )

--- a/qmtl/indicators/kdj.py
+++ b/qmtl/indicators/kdj.py
@@ -1,0 +1,31 @@
+"""KDJ oscillator indicator (simplified)."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def kdj(high: Node, low: Node, close: Node, window: int, *, name: str | None = None) -> Node:
+    """Return a Node computing a simplified KDJ oscillator."""
+
+    def compute(view: CacheView):
+        highs = [v for _, v in view[high][high.interval][-window:]]
+        lows = [v for _, v in view[low][low.interval][-window:]]
+        closes = [v for _, v in view[close][close.interval][-1:]]
+        if len(highs) < window or len(lows) < window or not closes:
+            return None
+        highest = max(highs)
+        lowest = min(lows)
+        if highest == lowest:
+            rsv = 0.0
+        else:
+            rsv = (closes[-1] - lowest) / (highest - lowest) * 100
+        # simplified K=D=J=RSV
+        return {"K": rsv, "D": rsv, "J": rsv}
+
+    return Node(
+        input=[high, low, close],
+        compute_fn=compute,
+        name=name or "kdj",
+        interval=close.interval,
+        period=window,
+    )

--- a/qmtl/indicators/keltner_channel.py
+++ b/qmtl/indicators/keltner_channel.py
@@ -1,0 +1,56 @@
+"""Keltner Channel indicator."""
+
+from statistics import mean
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def keltner_channel(
+    high: Node,
+    low: Node,
+    close: Node,
+    *,
+    ema_window: int = 20,
+    atr_window: int = 10,
+    multiplier: float = 2.0,
+    name: str | None = None,
+) -> Node:
+    """Return a Node computing Keltner Channel (mid, upper, lower)."""
+
+    alpha = 2 / (ema_window + 1)
+
+    def compute(view: CacheView):
+        highs = view[high][high.interval][-atr_window:]
+        lows = view[low][low.interval][-atr_window:]
+        closes = view[close][close.interval][-(max(ema_window, atr_window) + 1):]
+        if (
+            len(highs) < atr_window
+            or len(lows) < atr_window
+            or len(closes) < max(ema_window, atr_window) + 1
+        ):
+            return None
+        # EMA
+        ema_val = closes[-ema_window][1]
+        for _, val in closes[-ema_window + 1 :]:
+            ema_val = alpha * val + (1 - alpha) * ema_val
+        # ATR
+        tr_values = []
+        for i in range(1, atr_window + 1):
+            h = highs[i - 1][1]
+            l = lows[i - 1][1]
+            pc = closes[i - 1][1]
+            tr = max(h - l, abs(h - pc), abs(l - pc))
+            tr_values.append(tr)
+        atr_val = sum(tr_values) / atr_window
+        upper = ema_val + multiplier * atr_val
+        lower = ema_val - multiplier * atr_val
+        return {"mid": ema_val, "upper": upper, "lower": lower}
+
+    return Node(
+        input=[high, low, close],
+        compute_fn=compute,
+        name=name or "keltner_channel",
+        interval=close.interval,
+        period=max(ema_window, atr_window),
+    )

--- a/qmtl/indicators/obv.py
+++ b/qmtl/indicators/obv.py
@@ -1,0 +1,35 @@
+"""On-Balance Volume indicator."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def obv(close: Node, volume: Node, *, name: str | None = None, window: int | None = None) -> Node:
+    """Return a Node computing OBV over ``window`` entries if given."""
+
+    def compute(view: CacheView):
+        closes = list(view[close][close.interval])
+        vols = list(view[volume][volume.interval])
+        if window is not None:
+            closes = closes[-(window + 1):]
+            vols = vols[-(window + 1):]
+        if len(closes) < 2 or len(vols) < 2:
+            return None
+        total = 0.0
+        for i in range(1, min(len(closes), len(vols))):
+            c_prev = closes[i - 1][1]
+            c_curr = closes[i][1]
+            v = vols[i][1]
+            if c_curr > c_prev:
+                total += v
+            elif c_curr < c_prev:
+                total -= v
+        return total
+
+    return Node(
+        input=[close, volume],
+        compute_fn=compute,
+        name=name or "obv",
+        interval=close.interval,
+        period=window or 2,
+    )

--- a/qmtl/indicators/rough_bergami.py
+++ b/qmtl/indicators/rough_bergami.py
@@ -1,0 +1,28 @@
+"""Placeholder Rough Bergomi-based indicator."""
+
+import math
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def rough_bergami(source: Node, window: int, *, name: str | None = None) -> Node:
+    """Return a Node computing a simple rough volatility estimate."""
+
+    def compute(view: CacheView):
+        data = [v for _, v in view[source][source.interval][- (window + 1):]]
+        if len(data) < window + 1:
+            return None
+        returns = [math.log(data[i] / data[i - 1]) for i in range(1, len(data))]
+        if not returns:
+            return None
+        mean_ret = sum(returns) / len(returns)
+        var = sum((r - mean_ret) ** 2 for r in returns) / len(returns)
+        return math.sqrt(var)
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "rough_bergami",
+        interval=source.interval,
+        period=window + 1,
+    )

--- a/qmtl/indicators/rsi.py
+++ b/qmtl/indicators/rsi.py
@@ -1,0 +1,35 @@
+"""Relative Strength Index indicator."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def rsi(source: Node, window: int, *, name: str | None = None) -> Node:
+    """Return a Node computing the RSI."""
+
+    def compute(view: CacheView):
+        data = [v for _, v in view[source][source.interval][-(window + 1):]]
+        if len(data) < window + 1:
+            return None
+        gains = []
+        losses = []
+        for i in range(1, len(data)):
+            diff = data[i] - data[i - 1]
+            if diff >= 0:
+                gains.append(diff)
+            else:
+                losses.append(-diff)
+        avg_gain = sum(gains) / window
+        avg_loss = sum(losses) / window
+        if avg_loss == 0:
+            return 100.0
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "rsi",
+        interval=source.interval,
+        period=window + 1,
+    )

--- a/qmtl/indicators/stoch_rsi.py
+++ b/qmtl/indicators/stoch_rsi.py
@@ -1,0 +1,47 @@
+"""Stochastic RSI indicator."""
+
+import math
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def stoch_rsi(source: Node, window: int, *, name: str | None = None) -> Node:
+    """Return a Node computing Stochastic RSI."""
+
+    def _rsi(values: list[float]) -> float:
+        gains = []
+        losses = []
+        for i in range(1, len(values)):
+            diff = values[i] - values[i - 1]
+            if diff >= 0:
+                gains.append(diff)
+            else:
+                losses.append(-diff)
+        avg_gain = sum(gains) / (len(values) - 1)
+        avg_loss = sum(losses) / (len(values) - 1)
+        if avg_loss == 0:
+            return 100.0
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
+
+    def compute(view: CacheView):
+        values = [v for _, v in view[source][source.interval][-(window * 2):]]
+        if len(values) < window * 2:
+            return None
+        rsi_vals = [
+            _rsi(values[i : i + window + 1]) for i in range(len(values) - window)
+        ]
+        current = rsi_vals[-1]
+        lowest = min(rsi_vals)
+        highest = max(rsi_vals)
+        if highest == lowest:
+            return 0.0
+        return (current - lowest) / (highest - lowest) * 100
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "stoch_rsi",
+        interval=source.interval,
+        period=window * 2,
+    )

--- a/qmtl/indicators/supertrend.py
+++ b/qmtl/indicators/supertrend.py
@@ -1,0 +1,47 @@
+"""Supertrend indicator (simplified)."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def supertrend(
+    high: Node,
+    low: Node,
+    close: Node,
+    *,
+    window: int = 10,
+    multiplier: float = 3.0,
+    name: str | None = None,
+) -> Node:
+    """Return a Node computing a simplified Supertrend value."""
+
+    def compute(view: CacheView):
+        highs = view[high][high.interval][-window:]
+        lows = view[low][low.interval][-window:]
+        closes = view[close][close.interval][-(window + 1):]
+        if len(highs) < window or len(lows) < window or len(closes) < window + 1:
+            return None
+        tr_values = []
+        for i in range(1, window + 1):
+            h = highs[i - 1][1]
+            l = lows[i - 1][1]
+            pc = closes[i - 1][1]
+            tr_values.append(max(h - l, abs(h - pc), abs(l - pc)))
+        atr_val = sum(tr_values) / window
+        mid = (highs[-1][1] + lows[-1][1]) / 2
+        upper = mid + multiplier * atr_val
+        lower = mid - multiplier * atr_val
+        close_val = closes[-1][1]
+        if close_val > upper:
+            return lower
+        if close_val < lower:
+            return upper
+        return lower if close_val > (upper + lower) / 2 else upper
+
+    return Node(
+        input=[high, low, close],
+        compute_fn=compute,
+        name=name or "supertrend",
+        interval=close.interval,
+        period=window,
+    )

--- a/qmtl/indicators/vwap.py
+++ b/qmtl/indicators/vwap.py
@@ -1,0 +1,27 @@
+"""Volume Weighted Average Price indicator."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def vwap(price: Node, volume: Node, window: int, *, name: str | None = None) -> Node:
+    """Return a Node computing VWAP."""
+
+    def compute(view: CacheView):
+        prices = view[price][price.interval][-window:]
+        vols = view[volume][volume.interval][-window:]
+        if len(prices) < window or len(vols) < window:
+            return None
+        num = sum(p[1] * v[1] for p, v in zip(prices, vols))
+        den = sum(v[1] for v in vols)
+        if den == 0:
+            return None
+        return num / den
+
+    return Node(
+        input=[price, volume],
+        compute_fn=compute,
+        name=name or "vwap",
+        interval=price.interval,
+        period=window,
+    )

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -10,3 +10,202 @@ def test_sma_compute():
     view = CacheView(data)
     assert node.compute_fn(view) == 2
 
+from qmtl.indicators import (
+    ema,
+    rsi,
+    bollinger_bands,
+    atr,
+    chandelier_exit,
+    vwap,
+    anchored_vwap,
+    keltner_channel,
+    obv,
+    supertrend,
+    ichimoku_cloud,
+    kalman_trend,
+    rough_bergami,
+    stoch_rsi,
+    kdj,
+)
+
+
+def test_ema_compute():
+    src = Node(interval=1, period=3)
+    node = ema(src, window=3)
+    data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
+    view = CacheView(data)
+    assert node.compute_fn(view) == 2.25
+
+
+def test_rsi_compute():
+    src = Node(interval=1, period=15)
+    node = rsi(src, window=14)
+    data = {src.node_id: {1: [(i, float(i)) for i in range(15)]}}
+    view = CacheView(data)
+    assert node.compute_fn(view) == 100.0
+
+
+def test_bollinger_bands_compute():
+    src = Node(interval=1, period=3)
+    node = bollinger_bands(src, window=3)
+    data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
+    view = CacheView(data)
+    result = node.compute_fn(view)
+    assert round(result["mid"], 2) == 2.0
+    assert round(result["upper"], 3) == 3.633
+    assert round(result["lower"], 3) == 0.367
+
+
+def test_atr_compute():
+    h = Node(interval=1, period=3, config={"id": "h"})
+    l = Node(interval=1, period=3, config={"id": "l"})
+    c = Node(interval=1, period=4, config={"id": "c"})
+    node = atr(h, l, c, window=3)
+    data = {
+        h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
+        l.node_id: {1: [(0, 0), (1, 1), (2, 2)]},
+        c.node_id: {1: [(0, 1), (1, 2), (2, 3), (3, 4)]},
+    }
+    view = CacheView(data)
+    assert node.compute_fn(view) == 2
+
+
+def test_chandelier_exit_compute():
+    h = Node(interval=1, period=3, config={"id": "h"})
+    l = Node(interval=1, period=3, config={"id": "l"})
+    c = Node(interval=1, period=4, config={"id": "c"})
+    node = chandelier_exit(h, l, c, window=3, multiplier=3)
+    data = {
+        h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
+        l.node_id: {1: [(0, 0), (1, 1), (2, 2)]},
+        c.node_id: {1: [(0, 1), (1, 2), (2, 3), (3, 4)]},
+    }
+    view = CacheView(data)
+    result = node.compute_fn(view)
+    assert result["long"] == -2
+    assert result["short"] == 6
+
+
+def test_vwap_compute():
+    p = Node(interval=1, period=3, config={"id": "p"})
+    v = Node(interval=1, period=3, config={"id": "v"})
+    node = vwap(p, v, window=3)
+    data = {
+        p.node_id: {1: [(0, 1), (1, 2), (2, 3)]},
+        v.node_id: {1: [(0, 1), (1, 1), (2, 2)]},
+    }
+    view = CacheView(data)
+    assert node.compute_fn(view) == 2.25
+
+
+def test_anchored_vwap_compute():
+    p = Node(interval=1, period=3, config={"id": "p"})
+    v = Node(interval=1, period=3, config={"id": "v"})
+    node = anchored_vwap(p, v, anchor_ts=1)
+    data = {
+        p.node_id: {1: [(0, 1), (1, 2), (2, 3)]},
+        v.node_id: {1: [(0, 1), (1, 1), (2, 1)]},
+    }
+    view = CacheView(data)
+    assert node.compute_fn(view) == 2.5
+
+
+def test_keltner_channel_compute():
+    h = Node(interval=1, period=3, config={"id": "h"})
+    l = Node(interval=1, period=3, config={"id": "l"})
+    c = Node(interval=1, period=4, config={"id": "c"})
+    node = keltner_channel(h, l, c, ema_window=3, atr_window=3, multiplier=2)
+    data = {
+        h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
+        l.node_id: {1: [(0, 0), (1, 1), (2, 2)]},
+        c.node_id: {1: [(0, 1), (1, 2), (2, 3), (3, 4)]},
+    }
+    view = CacheView(data)
+    result = node.compute_fn(view)
+    assert round(result["mid"], 2) == 3.25
+    assert round(result["upper"], 2) == 7.25
+    assert round(result["lower"], 2) == -0.75
+
+
+def test_obv_compute():
+    c = Node(interval=1, period=3, config={"id": "c"})
+    v = Node(interval=1, period=3, config={"id": "v"})
+    node = obv(c, v)
+    data = {
+        c.node_id: {1: [(0, 1), (1, 2), (2, 1)]},
+        v.node_id: {1: [(0, 10), (1, 5), (2, 3)]},
+    }
+    view = CacheView(data)
+    assert node.compute_fn(view) == 2
+
+
+def test_supertrend_compute():
+    h = Node(interval=1, period=3, config={"id": "h"})
+    l = Node(interval=1, period=3, config={"id": "l"})
+    c = Node(interval=1, period=4, config={"id": "c"})
+    node = supertrend(h, l, c, window=3, multiplier=2)
+    data = {
+        h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
+        l.node_id: {1: [(0, 0), (1, 1), (2, 2)]},
+        c.node_id: {1: [(0, 1), (1, 2), (2, 3), (3, 4)]},
+    }
+    view = CacheView(data)
+    assert node.compute_fn(view) == -1
+
+
+def test_ichimoku_cloud_compute():
+    h = Node(interval=1, period=52, config={"id": "h"})
+    l = Node(interval=1, period=52, config={"id": "l"})
+    c = Node(interval=1, period=52, config={"id": "c"})
+    node = ichimoku_cloud(h, l, c)
+    highs = [(i, i + 1) for i in range(52)]
+    lows = [(i, i) for i in range(52)]
+    closes = [(i, i + 0.5) for i in range(52)]
+    data = {h.node_id: {1: highs}, l.node_id: {1: lows}, c.node_id: {1: closes}}
+    view = CacheView(data)
+    result = node.compute_fn(view)
+    assert result["tenkan"] == 47.5
+    assert result["kijun"] == 39
+    assert result["senkou_b"] == 26
+
+
+def test_kalman_trend_compute():
+    src = Node(interval=1, period=5, config={"id": "src"})
+    node = kalman_trend(src)
+    data = {src.node_id: {1: [(i, float(i)) for i in range(5)]}}
+    view = CacheView(data)
+    result = node.compute_fn(view)
+    assert isinstance(result, float)
+
+
+def test_rough_bergami_compute():
+    src = Node(interval=1, period=4, config={"id": "src"})
+    node = rough_bergami(src, window=3)
+    data = {src.node_id: {1: [(0, 1), (1, 2), (2, 1), (3, 2)]}}
+    view = CacheView(data)
+    assert round(node.compute_fn(view), 4) > 0
+
+
+def test_stoch_rsi_compute():
+    src = Node(interval=1, period=30, config={"id": "src"})
+    node = stoch_rsi(src, window=14)
+    values = [(i, float(i % 5)) for i in range(30)]
+    data = {src.node_id: {1: values}}
+    view = CacheView(data)
+    result = node.compute_fn(view)
+    assert 0 <= result <= 100
+
+
+def test_kdj_compute():
+    h = Node(interval=1, period=3, config={"id": "h"})
+    l = Node(interval=1, period=3, config={"id": "l"})
+    c = Node(interval=1, period=3, config={"id": "c"})
+    node = kdj(h, l, c, window=3)
+    data = {
+        h.node_id: {1: [(0, 3), (1, 4), (2, 5)]},
+        l.node_id: {1: [(0, 1), (1, 1), (2, 2)]},
+        c.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
+    }
+    view = CacheView(data)
+    result = node.compute_fn(view)
+    assert result["K"] == result["D"] == result["J"]


### PR DESCRIPTION
## Summary
- extend indicator library with many common TA indicators
- export all indicators in `__init__`
- test each indicator with simple data cases

## Testing
- `uv pip install -e .[dev]`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efad1c90883299d7d5a82cdf5e7e2