### PR TITLE
Add transforms module with rate of change node

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Install additional indicator, stream, or generator packages only when needed:
 uv pip install -e .[indicators]
 uv pip install -e .[streams]
 uv pip install -e .[generators]
+uv pip install -e .[transforms]
 ```
 
 ## Backfills

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ backfill = ["pandas", "asyncpg"]
 indicators = []
 streams = []
 generators = []
+transforms = []
 
 [project.scripts]
 qmtl-dagm = "qmtl.dagmanager.cli:main"

--- a/qmtl/transforms/README.md
+++ b/qmtl/transforms/README.md
@@ -1,0 +1,18 @@
+# qmtl.transforms
+
+Derived transformation nodes for the QMTL SDK.
+
+- Each transform stays focused on a single calculation.
+- Add tests for new transforms under `tests/`.
+
+Install with:
+
+```bash
+pip install qmtl[transforms]
+```
+
+Example:
+
+```python
+from qmtl.transforms import rate_of_change
+```

--- a/qmtl/transforms/__init__.py
+++ b/qmtl/transforms/__init__.py
@@ -1,0 +1,5 @@
+"""Derived transformation nodes for qmtl."""
+
+from .rate_of_change import rate_of_change
+
+__all__ = ["rate_of_change"]

--- a/qmtl/transforms/rate_of_change.py
+++ b/qmtl/transforms/rate_of_change.py
@@ -1,0 +1,34 @@
+"""Upstream rate-of-change transformation."""
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def rate_of_change(
+    source: Node,
+    *,
+    interval: int | None = None,
+    period: int = 2,
+    name: str | None = None,
+) -> Node:
+    """Return a node computing percentage change over ``period`` values."""
+
+    interval = interval or source.interval
+
+    def compute(view: CacheView):
+        data = view[source][interval][-period:]
+        if len(data) < 2:
+            return None
+        start = data[0][1]
+        end = data[-1][1]
+        if start == 0:
+            return None
+        return (end - start) / start
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "rate_of_change",
+        interval=interval,
+        period=period,
+    )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,11 @@
+from qmtl.transforms import rate_of_change
+from qmtl.sdk.node import Node
+from qmtl.sdk.cache_view import CacheView
+
+
+def test_rate_of_change_compute():
+    src = Node(interval=1, period=3)
+    node = rate_of_change(src, period=2)
+    data = {src.node_id: {1: [(0, 1), (1, 3)]}}
+    view = CacheView(data)
+    assert node.compute_fn(view) == 2.0


### PR DESCRIPTION
## Summary
- add optional `qmtl.transforms` extension package
- implement `rate_of_change` node for calculating upstream change
- expose new extras and mention in README
- tests for the new transform

## Testing
- `uv pip install -e .[dev] --system`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684efb687a348329b467953395b85ccd