### PR TITLE
Refactor backfill IO interfaces

### DIFF
--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -2,19 +2,19 @@
 
 This guide explains how to populate node caches with past values before a strategy starts processing live data.
 
-## Configuring a BackfillSource
+## Configuring a CacheLoader
 
-A `BackfillSource` provides historical data for a `(node_id, interval)` pair. It must implement the `fetch(start, end, *, node_id, interval)` method and return a `pandas.DataFrame` where each row contains a timestamp column `ts` and any payload fields.
+A `CacheLoader` provides historical data for a `(node_id, interval)` pair. It must implement the `fetch(start, end, *, node_id, interval)` method and return a `pandas.DataFrame` where each row contains a timestamp column `ts` and any payload fields.
 
-The SDK ships with `QuestDBSource` which reads from a QuestDB instance:
+The SDK ships with `QuestDBLoader` which reads from a QuestDB instance:
 
 ```python
-from qmtl.sdk import QuestDBSource
+from qmtl.sdk import QuestDBLoader
 
-source = QuestDBSource("postgresql://user:pass@localhost:8812/qdb")
+source = QuestDBLoader("postgresql://user:pass@localhost:8812/qdb")
 ```
 
-Custom sources can subclass `BackfillSource` or provide an object with the same interface.
+Custom loaders can implement `CacheLoader` or provide an object with the same interface.
 
 ## Running a Backfill
 

--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -7,7 +7,8 @@ from .strategy import Strategy
 from .runner import Runner
 from .cli import main as _cli
 from .ws_client import WebSocketClient
-from .backfill import BackfillSource, QuestDBSource
+from .backfill import BackfillSource
+from .data_io import CacheLoader, DataSink, QuestDBLoader, QuestDBSink
 from .backfill_engine import BackfillEngine
 from . import metrics
 
@@ -22,7 +23,10 @@ __all__ = [
     "Runner",
     "WebSocketClient",
     "BackfillSource",
-    "QuestDBSource",
+    "CacheLoader",
+    "DataSink",
+    "QuestDBLoader",
+    "QuestDBSink",
     "BackfillEngine",
     "metrics",
     "_cli",

--- a/qmtl/sdk/backfill_engine.py
+++ b/qmtl/sdk/backfill_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from .backfill import BackfillSource
+from .data_io import CacheLoader
 from .node import Node
 from . import metrics as sdk_metrics
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class BackfillEngine:
     """Run backfill jobs concurrently using ``asyncio`` tasks."""
 
-    def __init__(self, source: BackfillSource, *, max_retries: int = 3) -> None:
+    def __init__(self, source: CacheLoader, *, max_retries: int = 3) -> None:
         self.source = source
         self.max_retries = max_retries
         self._tasks: set[asyncio.Task] = set()

--- a/qmtl/sdk/data_io.py
+++ b/qmtl/sdk/data_io.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Utilities for loading and persisting node cache data."""
+
+from typing import Protocol, Any
+import pandas as pd
+import asyncpg
+
+
+class CacheLoader(Protocol):
+    """Interface for loading historical data into node caches."""
+
+    async def fetch(
+        self, start: int, end: int, *, node_id: str, interval: int
+    ) -> pd.DataFrame:
+        """Return data in ``[start, end)`` for ``node_id`` and ``interval``."""
+        ...
+
+
+class DataSink(Protocol):
+    """Interface for persisting processed node data."""
+
+    async def persist(
+        self, node_id: str, interval: int, timestamp: int, payload: Any
+    ) -> None:
+        """Store ``payload`` for ``(node_id, interval, timestamp)``."""
+        ...
+
+
+class QuestDBLoader:
+    """CacheLoader implementation backed by QuestDB."""
+
+    def __init__(self, dsn: str, table: str = "node_data") -> None:
+        self.dsn = dsn
+        self.table = table
+
+    async def fetch(
+        self, start: int, end: int, *, node_id: str, interval: int
+    ) -> pd.DataFrame:
+        conn = await asyncpg.connect(self.dsn)
+        try:
+            sql = (
+                f"SELECT * FROM {self.table} "
+                "WHERE node_id=$1 AND interval=$2 AND ts >= $3 AND ts < $4 "
+                "ORDER BY ts"
+            )
+            rows = await conn.fetch(sql, node_id, interval, start, end)
+        finally:
+            await conn.close()
+
+        return pd.DataFrame([dict(r) for r in rows])
+
+
+class QuestDBSink:
+    """DataSink implementation that writes records to QuestDB."""
+
+    def __init__(self, dsn: str, table: str = "node_data") -> None:
+        self.dsn = dsn
+        self.table = table
+
+    async def persist(
+        self, node_id: str, interval: int, timestamp: int, payload: dict
+    ) -> None:
+        conn = await asyncpg.connect(self.dsn)
+        try:
+            columns = ", ".join(payload.keys())
+            values = payload.values()
+            placeholders = ", ".join(f"${i}" for i in range(4, 4 + len(payload)))
+            sql = (
+                f"INSERT INTO {self.table}(node_id, interval, ts"
+                + (f", {columns}" if columns else "")
+                + f") VALUES($1, $2, $3"
+                + (f", {placeholders}" if placeholders else "")
+                + ")"
+            )
+            await conn.execute(sql, node_id, interval, timestamp, *values)
+        finally:
+            await conn.close()

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -8,7 +8,7 @@ from typing import Optional
 import httpx
 
 from .strategy import Strategy
-from .backfill import BackfillSource, QuestDBSource
+from .data_io import CacheLoader, QuestDBLoader
 
 try:  # Optional Ray dependency
     import ray  # type: ignore
@@ -23,17 +23,17 @@ class Runner:
 
     # ------------------------------------------------------------------
     @staticmethod
-    def _create_backfill_source(spec: str) -> BackfillSource:
-        """Return BackfillSource instance for ``spec``."""
+    def _create_backfill_source(spec: str) -> CacheLoader:
+        """Return CacheLoader instance for ``spec``."""
         if spec.startswith("questdb:"):
             dsn = spec.split(":", 1)[1]
-            return QuestDBSource(dsn)
+            return QuestDBLoader(dsn)
         raise RuntimeError("unsupported backfill source")
 
     @staticmethod
     async def _run_backfill(
         strategy: Strategy,
-        source: BackfillSource,
+        source: CacheLoader,
         start: int,
         end: int,
     ) -> None:

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from qmtl.sdk.backfill import QuestDBSource
+from qmtl.sdk.data_io import QuestDBLoader, QuestDBSink
 
 
 class DummyConn:
@@ -26,9 +26,35 @@ async def dummy_connect(_):
 
 @pytest.mark.asyncio
 async def test_questdb_fetch(monkeypatch):
-    monkeypatch.setattr("qmtl.sdk.backfill.asyncpg.connect", dummy_connect)
-    src = QuestDBSource("db")
+    monkeypatch.setattr("qmtl.sdk.data_io.asyncpg.connect", dummy_connect)
+    src = QuestDBLoader("db")
     df = await src.fetch(1, 3, node_id="n1", interval=60)
     expected = pd.DataFrame([{"ts": 1, "value": 10}, {"ts": 2, "value": 20}])
     pd.testing.assert_frame_equal(df.reset_index(drop=True), expected)
+
+
+@pytest.mark.asyncio
+async def test_questdb_persist(monkeypatch):
+    record: dict = {}
+
+    class DummyConn:
+        async def execute(self, query, *args):
+            record["query"] = query
+            record["args"] = args
+
+        async def close(self):
+            record["closed"] = True
+
+    async def _connect(dsn):
+        record["dsn"] = dsn
+        return DummyConn()
+
+    monkeypatch.setattr("qmtl.sdk.data_io.asyncpg.connect", _connect)
+    sink = QuestDBSink("db", table="t")
+    await sink.persist("n", 60, 1, {"v": 99})
+
+    assert record["dsn"] == "db"
+    assert record["closed"] is True
+    assert "INSERT INTO t" in record["query"]
+    assert record["args"] == ("n", 60, 1, 99)
 


### PR DESCRIPTION
## Summary
- add `data_io` module with `CacheLoader`/`DataSink`
- implement `QuestDBLoader` and `QuestDBSink`
- expose new classes from `qmtl.sdk`
- update runner and backfill engine to use new loader
- adjust documentation and tests

## Testing
- `uv run -- python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f08d7ed0083298417918da976e00c