### PR TITLE
Stream history loading update

### DIFF
--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -13,9 +13,6 @@ async def _main() -> None:
     parser.add_argument("--end-time")
     parser.add_argument("--on-missing", default="skip")
     parser.add_argument("--gateway-url")
-    parser.add_argument("--backfill-source")
-    parser.add_argument("--backfill-start", type=int)
-    parser.add_argument("--backfill-end", type=int)
     args = parser.parse_args()
 
     module_name, class_name = args.strategy.split(":")
@@ -29,28 +26,19 @@ async def _main() -> None:
             end_time=args.end_time,
             on_missing=args.on_missing,
             gateway_url=args.gateway_url,
-            backfill_source=args.backfill_source,
-            backfill_start=args.backfill_start,
-            backfill_end=args.backfill_end,
         )
     elif args.mode == "dryrun":
         await Runner.dryrun_async(
             strategy_cls,
             gateway_url=args.gateway_url,
-            backfill_source=args.backfill_source,
-            backfill_start=args.backfill_start,
-            backfill_end=args.backfill_end,
         )
     elif args.mode == "live":
         await Runner.live_async(
             strategy_cls,
             gateway_url=args.gateway_url,
-            backfill_source=args.backfill_source,
-            backfill_start=args.backfill_start,
-            backfill_end=args.backfill_end,
         )
     else:  # offline
-        Runner.offline(strategy_cls)
+        await Runner.offline_async(strategy_cls)
 
 def main() -> None:
     asyncio.run(_main())


### PR DESCRIPTION
## Summary
- add optional history backfill to `StreamInput`
- load history for streams through Runner before execution
- drop old runner backfill interface and CLI options
- extend runner and backfill engine tests

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0f639c448329aca00b212ef441de