### PR TITLE
Add EventRecorder and integrate into StreamInput

### DIFF
--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -8,7 +8,7 @@ from .runner import Runner
 from .cli import main as _cli
 from .ws_client import WebSocketClient
 from .backfill import BackfillSource
-from .data_io import CacheLoader, DataSink, QuestDBLoader, QuestDBSink
+from .data_io import CacheLoader, EventRecorder, QuestDBLoader, QuestDBRecorder
 from .backfill_engine import BackfillEngine
 from . import metrics
 
@@ -24,9 +24,9 @@ __all__ = [
     "WebSocketClient",
     "BackfillSource",
     "CacheLoader",
-    "DataSink",
+    "EventRecorder",
     "QuestDBLoader",
-    "QuestDBSink",
+    "QuestDBRecorder",
     "BackfillEngine",
     "metrics",
     "_cli",

--- a/qmtl/sdk/data_io.py
+++ b/qmtl/sdk/data_io.py
@@ -17,7 +17,7 @@ class CacheLoader(Protocol):
         ...
 
 
-class DataSink(Protocol):
+class EventRecorder(Protocol):
     """Interface for persisting processed node data."""
 
     async def persist(
@@ -51,8 +51,8 @@ class QuestDBLoader:
         return pd.DataFrame([dict(r) for r in rows])
 
 
-class QuestDBSink:
-    """DataSink implementation that writes records to QuestDB."""
+class QuestDBRecorder:
+    """EventRecorder implementation that writes records to QuestDB."""
 
     def __init__(self, dsn: str, table: str = "node_data") -> None:
         self.dsn = dsn


### PR DESCRIPTION
## Summary
- rename `DataSink` protocol to `EventRecorder`
- implement `QuestDBRecorder` as reference recorder
- allow `StreamInput` to take an optional `event_recorder`
- persist payloads through recorder on every feed
- update tests for new recorder API

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1227b1c08329824733769152da37