### PR TITLE
Refactor stream input history range

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -484,8 +484,6 @@ class StreamInput(Node):
         period: int | None = None,
         *,
         history_provider: "HistoryProvider" | None = None,
-        start: int | None = None,
-        end: int | None = None,
         event_recorder: "EventRecorder" | None = None,
     ) -> None:
         super().__init__(
@@ -497,20 +495,16 @@ class StreamInput(Node):
             tags=tags or [],
         )
         self.history_provider = history_provider
-        self.start = start
-        self.end = end
         self.event_recorder = event_recorder
 
-    async def load_history(self) -> None:
+    async def load_history(self, start: int, end: int) -> None:
         """Load historical data if a provider was configured."""
         if not self.history_provider or self.interval is None:
-            return
-        if self.start is None or self.end is None:
             return
         from .backfill_engine import BackfillEngine
 
         engine = BackfillEngine(self.history_provider)
-        engine.submit(self, self.start, self.end)
+        engine.submit(self, start, end)
         await engine.wait()
 
 

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -75,12 +75,17 @@ class Runner:
                 node.queue_topic = None
 
     @staticmethod
-    async def _load_history(strategy: Strategy) -> None:
+    async def _load_history(
+        strategy: Strategy, start: int | None = None, end: int | None = None
+    ) -> None:
         """Load history for all StreamInput nodes."""
         from .node import StreamInput
 
+        if start is None or end is None:
+            return
+
         tasks = [
-            asyncio.create_task(n.load_history())
+            asyncio.create_task(n.load_history(start, end))
             for n in strategy.nodes
             if isinstance(n, StreamInput)
         ]
@@ -142,7 +147,7 @@ class Runner:
             raise RuntimeError("failed to connect to Gateway") from exc
 
         Runner._apply_queue_map(strategy, queue_map)
-        await Runner._load_history(strategy)
+        await Runner._load_history(strategy, start_time, end_time)
         # Placeholder for backtest logic
         return strategy
 
@@ -194,7 +199,7 @@ class Runner:
             raise RuntimeError("failed to connect to Gateway") from exc
 
         Runner._apply_queue_map(strategy, queue_map)
-        await Runner._load_history(strategy)
+        await Runner._load_history(strategy, None, None)
         # Placeholder for dry-run logic
         return strategy
 
@@ -239,7 +244,7 @@ class Runner:
             raise RuntimeError("failed to connect to Gateway") from exc
 
         Runner._apply_queue_map(strategy, queue_map)
-        await Runner._load_history(strategy)
+        await Runner._load_history(strategy, None, None)
         # Placeholder for live trading logic
         return strategy
 
@@ -268,6 +273,6 @@ class Runner:
         strategy = Runner._prepare(strategy_cls)
         print(f"[OFFLINE] {strategy_cls.__name__} starting")
         Runner._apply_queue_map(strategy, {})
-        await Runner._load_history(strategy)
+        await Runner._load_history(strategy, None, None)
         # Placeholder for offline execution logic
         return strategy

--- a/tests/test_backfill_engine.py
+++ b/tests/test_backfill_engine.py
@@ -123,10 +123,8 @@ async def test_streaminput_load_history():
         interval=60,
         period=3,
         history_provider=src,
-        start=60,
-        end=120,
     )
-    await stream.load_history()
+    await stream.load_history(60, 120)
     assert stream.cache.get_slice(stream.node_id, 60, count=2) == [
         (60, {"ts": 60, "v": 1}),
         (120, {"ts": 120, "v": 2}),

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -334,17 +334,19 @@ def test_load_history_called(monkeypatch):
 
     called = []
 
-    async def dummy_load_history(self):
-        called.append(self)
+    async def dummy_load_history(self, start, end):
+        called.append((start, end))
 
     monkeypatch.setattr(StreamInput, "load_history", dummy_load_history)
 
-    Runner.dryrun(
+    Runner.backtest(
         SampleStrategy,
+        start_time=1,
+        end_time=2,
         gateway_url="http://gw",
     )
 
-    assert len(called) == 1
+    assert called == [(1, 2)]
 
 
 def test_cli_execution(monkeypatch):
@@ -371,8 +373,8 @@ def test_cli_execution(monkeypatch):
 
     called = []
 
-    async def dummy_load_history(self):
-        called.append(self)
+    async def dummy_load_history(self, start, end):
+        called.append((start, end))
 
     monkeypatch.setattr(StreamInput, "load_history", dummy_load_history)
 
@@ -380,10 +382,14 @@ def test_cli_execution(monkeypatch):
         "qmtl.sdk",
         "tests.sample_strategy:SampleStrategy",
         "--mode",
-        "dryrun",
+        "backtest",
+        "--start-time",
+        "1",
+        "--end-time",
+        "2",
         "--gateway-url",
         "http://gw",
     ]
     monkeypatch.setattr(sys, "argv", argv)
     main()
-    assert len(called) == 1
+    assert called == [("1", "2")]


### PR DESCRIPTION
## Summary
- refactor `StreamInput` to take backfill range via `load_history`
- update `Runner` to forward ranges when loading history
- adjust tests for new `load_history` signature

## Testing
- `uv pip install -e .[dev]`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2652bc7883298681d6c6effd1dfd