### PR TITLE
Implement DataFetcher for QuestDB backfill

### DIFF
--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -7,7 +7,13 @@ from .strategy import Strategy
 from .runner import Runner
 from .cli import main as _cli
 from .ws_client import WebSocketClient
-from .data_io import HistoryProvider, EventRecorder, QuestDBLoader, QuestDBRecorder
+from .data_io import (
+    HistoryProvider,
+    EventRecorder,
+    QuestDBLoader,
+    QuestDBRecorder,
+    DataFetcher,
+)
 from .backfill_engine import BackfillEngine
 from . import metrics
 
@@ -22,6 +28,7 @@ __all__ = [
     "Runner",
     "WebSocketClient",
     "HistoryProvider",
+    "DataFetcher",
     "EventRecorder",
     "QuestDBLoader",
     "QuestDBRecorder",


### PR DESCRIPTION
## Summary
- introduce `DataFetcher` protocol
- allow `QuestDBLoader` to accept an optional fetcher
- use injected fetcher in `fill_missing` and export new protocol
- document fetcher injection in backfill guide
- test new behaviour for `fill_missing`

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684f3037c3648329baa3731564059acf