### PR TITLE
Improve QuestDB backfill tests

### DIFF
--- a/tests/dummy_fetcher.py
+++ b/tests/dummy_fetcher.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from qmtl.sdk.data_io import DataFetcher
+
+
+class DummyDataFetcher:
+    """A simple DataFetcher returning predetermined rows."""
+
+    def __init__(self, rows=None):
+        if rows is None:
+            rows = [
+                {"ts": 120, "value": 1},
+                {"ts": 180, "value": 2},
+            ]
+        self.df = pd.DataFrame(rows)
+
+    async def fetch(self, start, end, *, node_id, interval):
+        # ignore parameters and return the stored dataframe
+        return self.df
+


### PR DESCRIPTION
## Summary
- add a dummy `DataFetcher` implementation for tests
- ensure `fill_missing` inserts rows from the dummy fetcher
- check that calling `fill_missing` without a fetcher raises `RuntimeError`

## Testing
- `uv pip install --system -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f353b423c83298ed3f0d1d85c471e