### PR TITLE
Update AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,5 @@
 - Use `pytest` for running tests. Ensure `pytest` succeeds before committing.
 - Implementations must adhere to the specifications in `architecture.md`,
   `gateway.md` and `dag-manager.md`.
+- When providing task lists or suggestions, highlight opportunities for
+  parallel execution where feasible.


### PR DESCRIPTION
## Summary
- update AGENTS guidelines to advise highlighting parallelizable tasks when crafting suggestions

## Testing
- `uv pip install -e .[dev]`
- `uv run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f362db9f08329ac5e570ee2189594