### PR TITLE
Update changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,3 +5,5 @@
 - `NodeCache.snapshot()` has been deprecated in favor of the read-only
   `CacheView` returned by `NodeCache.view()`. Strategy code should avoid
   calling the snapshot helper.
+- Added `coverage()` and `fill_missing()` interfaces for history providers and
+  removed `start`/`end` arguments from `StreamInput`.


### PR DESCRIPTION
## Summary
- document new coverage and gap-fill APIs

## Testing
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684f37b005248329917839680391cd88