### PR TITLE
Add history fill stop-on-ready test

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -447,3 +447,56 @@ def test_history_gap_fill(monkeypatch):
 
     assert coverage_calls
     assert fill_calls
+
+
+def test_history_gap_fill_stops_on_ready(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(202, json={"strategy_id": "s"})
+
+    transport = httpx.MockTransport(handler)
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+
+    coverage_calls = []
+    fill_calls = []
+    holder = {}
+
+    class DummyProvider:
+        async def fetch(self, start, end, *, node_id, interval):
+            return None
+
+        async def coverage(self, *, node_id, interval):
+            coverage_calls.append((node_id, interval))
+            return []
+
+        async def fill_missing(self, start, end, *, node_id, interval):
+            fill_calls.append((start, end, node_id, interval))
+            holder["src"].pre_warmup = False
+
+    provider = DummyProvider()
+
+    class Strat(SampleStrategy):
+        def setup(self):
+            src = StreamInput(interval=1, period=1, history_provider=provider)
+            holder["src"] = src
+            node = Node(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
+            self.add_nodes([src, node])
+
+    Runner.dryrun(Strat, gateway_url="http://gw")
+
+    assert coverage_calls == [(holder["src"].node_id, 1)]
+    assert len(fill_calls) == 1


### PR DESCRIPTION
## Summary
- ensure history filling stops once StreamInput nodes warm up

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f37b5bba88329a1e3631a339d9d46