### PR TITLE
Add module overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ uv pip install -e .[generators]
 uv pip install -e .[transforms]
 ```
 
+## Optional Modules
+
+Install additional functionality on demand. Each entry links to its
+documentation and shows the corresponding extra:
+
+- [Indicators](qmtl/indicators/README.md) &mdash; `pip install qmtl[indicators]`
+- [Streams](qmtl/streams/README.md) &mdash; `pip install qmtl[streams]`
+- [Generators](qmtl/generators/README.md) &mdash; `pip install qmtl[generators]`
+- [Transforms](qmtl/transforms/README.md) &mdash; `pip install qmtl[transforms]`
+
 ## End-to-End Testing
 
 For instructions on spinning up the entire stack and running the e2e suite, see [docs/e2e_testing.md](docs/e2e_testing.md).


### PR DESCRIPTION
## Summary
- document module extras in README

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_684f4072bd3c832990f9d2cb6bc23c8d