### PR TITLE
Update README for e2e test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,19 @@ uv pip install -e .[transforms]
 
 ## End-to-End Testing
 
-For instructions on spinning up the entire stack and running the e2e suite, see [docs/e2e_testing.md](docs/e2e_testing.md).
+Bring up the stack with Docker Compose:
+
+```bash
+docker compose -f tests/docker-compose.e2e.yml up -d
+```
+
+Run the tests using uv:
+
+```bash
+uv run -- pytest tests/e2e
+```
+
+See [docs/e2e_testing.md](docs/e2e_testing.md) for the full guide.
 
 ## Running the Test Suite
 


### PR DESCRIPTION
## Summary
- clarify how to bring up the e2e Docker stack
- note `uv run -- pytest tests/e2e` in the readme

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_684f40759f288329a6a5eca88038b8dd