### PR TITLE
Add backfill docs snippet

### DIFF
--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -42,3 +42,17 @@ To execute the entire test suite run:
 uv run pytest -q tests
 ```
 
+## Backfills
+
+Start a backfill when executing a strategy to load historical data before
+live processing begins:
+
+```bash
+python -m qmtl.sdk tests.sample_strategy:SampleStrategy \
+       --mode backtest \
+       --start-time 1700000000 \
+       --end-time 1700003600
+```
+
+See [backfill.md](backfill.md) for a full overview of the workflow.
+


### PR DESCRIPTION
## Summary
- document how to start a backfill from the CLI in the e2e guide

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684f407228b48329afaea9438121d2e6