### PR TITLE
Add SDK extension examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,17 @@ For instructions on implementing strategies with the SDK, see
 
 ## Example Strategies
 
-Run a sample strategy with:
+Run the samples inside the `examples/` directory:
 
 ```bash
 python examples/general_strategy.py
+python examples/indicators_strategy.py
+python examples/transforms_strategy.py
+python examples/generators_example.py
+python examples/extensions_combined_strategy.py
 ```
 
-See [examples/README.md](examples/README.md) for more details.
+See [examples/README.md](examples/README.md) for additional scripts such as `tag_query_strategy.py` or `ws_metrics_example.py`.
 
 ## Backfills
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,11 @@
 - `tag_query_strategy.py`: 태그 기반 지표 조회 및 다중 노드 조합 예시
 - `correlation_strategy.py`: 태그로 선택한 지표들의 상관계수 계산
 - `cross_market_lag_strategy.py`: 교차 시장 시차 상관 전략
+- `indicators_strategy.py`: EMA 지표 활용 예제
+- `transforms_strategy.py`: rate-of-change 변환 예제
+- `generators_example.py`: GARCH 기반 시뮬레이션 데이터 생성
+- `extensions_combined_strategy.py`: 확장 모듈 조합 예제
+- `ws_metrics_example.py`: WebSocket 클라이언트와 메트릭 활용
 
 ## 예제 실행 방법
 
@@ -14,6 +19,11 @@ python examples/general_strategy.py
 python examples/tag_query_strategy.py
 python examples/correlation_strategy.py
 python examples/cross_market_lag_strategy.py
+python examples/indicators_strategy.py
+python examples/transforms_strategy.py
+python examples/generators_example.py
+python examples/extensions_combined_strategy.py
+python examples/ws_metrics_example.py
 ```
 
 > **중요:**

--- a/examples/extensions_combined_strategy.py
+++ b/examples/extensions_combined_strategy.py
@@ -1,0 +1,19 @@
+from qmtl.sdk import Strategy, Runner
+from qmtl.generators import GarchInput
+from qmtl.indicators import ema
+from qmtl.transforms import rate_of_change
+
+
+class CombinedExtensionsStrategy(Strategy):
+    def setup(self):
+        self.source = GarchInput(interval=60, period=30, seed=42)
+        self.ema_node = ema(self.source, window=5)
+        self.roc_node = rate_of_change(self.ema_node, period=5)
+        self.add_nodes([self.source, self.ema_node, self.roc_node])
+
+    def define_execution(self):
+        self.set_target(self.roc_node.name)
+
+
+if __name__ == "__main__":
+    Runner.offline(CombinedExtensionsStrategy)

--- a/examples/generators_example.py
+++ b/examples/generators_example.py
@@ -1,0 +1,12 @@
+from qmtl.generators import GarchInput
+
+
+def main() -> None:
+    stream = GarchInput(interval=60, period=5, seed=42)
+    data = stream.generate(10)
+    for ts, payload in data:
+        print(ts, payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/indicators_strategy.py
+++ b/examples/indicators_strategy.py
@@ -1,0 +1,16 @@
+from qmtl.sdk import Strategy, StreamInput, Runner
+from qmtl.indicators import ema
+
+
+class EmaStrategy(Strategy):
+    def setup(self):
+        self.price = StreamInput(interval=60, period=20)
+        self.ema_node = ema(self.price, window=10)
+        self.add_nodes([self.price, self.ema_node])
+
+    def define_execution(self):
+        self.set_target(self.ema_node.name)
+
+
+if __name__ == "__main__":
+    Runner.offline(EmaStrategy)

--- a/examples/transforms_strategy.py
+++ b/examples/transforms_strategy.py
@@ -1,0 +1,16 @@
+from qmtl.sdk import Strategy, StreamInput, Runner
+from qmtl.transforms import rate_of_change
+
+
+class RocStrategy(Strategy):
+    def setup(self):
+        self.price = StreamInput(interval=60, period=5)
+        self.roc_node = rate_of_change(self.price, period=3)
+        self.add_nodes([self.price, self.roc_node])
+
+    def define_execution(self):
+        self.set_target(self.roc_node.name)
+
+
+if __name__ == "__main__":
+    Runner.offline(RocStrategy)

--- a/examples/ws_metrics_example.py
+++ b/examples/ws_metrics_example.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from qmtl.sdk import WebSocketClient, metrics
+
+
+async def main() -> None:
+    metrics.start_metrics_server(port=8000)
+    client = WebSocketClient("ws://localhost:8000/ws")
+    await client.start()
+    await asyncio.sleep(5)  # Listen briefly
+    await client.stop()
+    print("Topics:", client.queue_topics)
+    print("Weights:", client.sentinel_weights)
+    print(metrics.collect_metrics())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add example scripts for indicators, transforms, generators
- show how to combine extension modules in a single strategy
- demonstrate WebSocket client and metrics usage
- update README files with instructions and new examples

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684f5afd28848329a651bad45bd9cf37