### PR TITLE
Make Strategy target inference automatic

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -245,8 +245,6 @@ class GeneralStrategy(Strategy):
         )
 
         self.add_nodes([price_stream, signal_node])
-
-    def define_execution(self):
         self.set_target("momentum_signal")
 
 # 백테스트 실행 예시
@@ -293,8 +291,6 @@ class CorrelationStrategy(Strategy):
         )
 
         self.add_nodes([indicators, corr_node])
-
-    def define_execution(self):
         self.set_target("indicator_corr")
 
 # 실시간 실행 예시
@@ -341,8 +337,6 @@ class CrossMarketLagStrategy(Strategy):
         )
 
         self.add_nodes([btc_price, mstr_price, corr_node])
-
-    def define_execution(self):
         self.set_target("btc_mstr_corr")
 
 # 실시간 dry‑run: 거래 여부 검증

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -19,7 +19,7 @@ uv pip install -e .[generators]  # 시뮬레이션 데이터 생성기
 
 ## 기본 구조
 
-SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()`과 `define_execution()` 메서드를 구현합니다. 노드는 `StreamInput`, `Node`, `TagQueryNode` 등을 이용해 정의하며 모든 노드는 하나 이상의 업스트림을 가져야 합니다.
+SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 실행 대상 노드는 `setup()` 안에서 `set_target()`으로 지정하거나 생략하면 마지막으로 추가된 노드가 자동 선택됩니다. 노드는 `StreamInput`, `Node`, `TagQueryNode` 등을 이용해 정의하며 모든 노드는 하나 이상의 업스트림을 가져야 합니다.
 
 ```python
 from qmtl.sdk import Strategy, Node, StreamInput
@@ -33,8 +33,6 @@ class MyStrategy(Strategy):
 
         out = Node(input=price, compute_fn=compute, name="out")
         self.add_nodes([price, out])
-
-    def define_execution(self):
         self.set_target("out")
 ```
 

--- a/examples/correlation_strategy.py
+++ b/examples/correlation_strategy.py
@@ -22,8 +22,6 @@ class CorrelationStrategy(Strategy):
             name="indicator_corr",
         )
         self.add_nodes([indicators, corr_node])
-
-    def define_execution(self):
         self.set_target("indicator_corr")
 
 

--- a/examples/cross_market_lag_strategy.py
+++ b/examples/cross_market_lag_strategy.py
@@ -35,8 +35,6 @@ class CrossMarketLagStrategy(Strategy):
         )
 
         self.add_nodes([btc_price, mstr_price, corr_node])
-
-    def define_execution(self):
         self.set_target("btc_mstr_corr")
 
 

--- a/examples/general_strategy.py
+++ b/examples/general_strategy.py
@@ -25,8 +25,6 @@ class GeneralStrategy(Strategy):
             name="momentum_signal",
         )
         self.add_nodes([price_stream, signal_node])
-
-    def define_execution(self):
         self.set_target("momentum_signal")
 
 

--- a/examples/tag_query_strategy.py
+++ b/examples/tag_query_strategy.py
@@ -33,8 +33,6 @@ class TagQueryStrategy(Strategy):
         avg_node = Node(input=corr_node, compute_fn=avg_corr, name="avg_corr")
 
         self.add_nodes([indicators, corr_node, avg_node])
-
-    def define_execution(self):
         self.set_target("avg_corr")
 
 

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -61,7 +61,6 @@ class Runner:
     def _prepare(strategy_cls: type[Strategy]) -> Strategy:
         strategy = strategy_cls()
         strategy.setup()
-        strategy.define_execution()
         return strategy
 
     @staticmethod

--- a/qmtl/sdk/strategy.py
+++ b/qmtl/sdk/strategy.py
@@ -15,11 +15,16 @@ class Strategy:
         raise NotImplementedError
 
     def define_execution(self):
-        raise NotImplementedError
+        """Select the execution target if not already set."""
+        if self.target is None and self.nodes:
+            last = self.nodes[-1]
+            self.target = last.name or last.node_id
 
     # DAG serialization ---------------------------------------------------
     def serialize(self) -> dict:
         """Serialize strategy DAG using node IDs."""
+        if self.target is None:
+            self.define_execution()
         return {
             "nodes": [node.to_dict() for node in self.nodes],
             "target": self.target,

--- a/tests/sample_strategy.py
+++ b/tests/sample_strategy.py
@@ -5,6 +5,4 @@ class SampleStrategy(Strategy):
         src = StreamInput(interval=1, period=1)
         node = Node(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
         self.add_nodes([src, node])
-
-    def define_execution(self):
         self.set_target("out")

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -184,13 +184,10 @@ def test_diff_with_sdk_nodes():
             src = StreamInput(interval=1, period=1)
             node = Node(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
             self.add_nodes([src, node])
-
-        def define_execution(self):
             self.set_target("out")
 
     s = _S()
     s.setup()
-    s.define_execution()
     dag_json = json.dumps(s.serialize())
 
     repo = FakeRepo()

--- a/tests/test_node_id.py
+++ b/tests/test_node_id.py
@@ -12,15 +12,12 @@ class _S(Strategy):
         src = StreamInput(interval=1, period=1)
         node = Node(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
         self.add_nodes([src, node])
-
-    def define_execution(self):
         self.set_target("out")
 
 
 def test_strategy_serialize():
     s = _S()
     s.setup()
-    s.define_execution()
     dag = s.serialize()
     assert "nodes" in dag
     ids = [n["node_id"] for n in dag["nodes"]]


### PR DESCRIPTION
## Summary
- drop Runner's call to `define_execution`
- implement default target inference for `Strategy`
- update docs and examples to use `set_target` in `setup`
- adjust sample strategy and tests accordingly

## Testing
- `uv pip install -e .[dev]`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f5dcfee088329997797c17b304fc9