### PR TITLE
Remove unused target field from Strategy

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -245,7 +245,6 @@ class GeneralStrategy(Strategy):
         )
 
         self.add_nodes([price_stream, signal_node])
-        self.set_target("momentum_signal")
 
 # 백테스트 실행 예시
 if __name__ == "__main__":
@@ -291,7 +290,6 @@ class CorrelationStrategy(Strategy):
         )
 
         self.add_nodes([indicators, corr_node])
-        self.set_target("indicator_corr")
 
 # 실시간 실행 예시
 if __name__ == "__main__":
@@ -337,7 +335,6 @@ class CrossMarketLagStrategy(Strategy):
         )
 
         self.add_nodes([btc_price, mstr_price, corr_node])
-        self.set_target("btc_mstr_corr")
 
 # 실시간 dry‑run: 거래 여부 검증
 Runner.dryrun(CrossMarketLagStrategy)

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -19,7 +19,7 @@ uv pip install -e .[generators]  # 시뮬레이션 데이터 생성기
 
 ## 기본 구조
 
-SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 실행 대상 노드는 `setup()` 안에서 `set_target()`으로 지정하거나 생략하면 마지막으로 추가된 노드가 자동 선택됩니다. 노드는 `StreamInput`, `Node`, `TagQueryNode` 등을 이용해 정의하며 모든 노드는 하나 이상의 업스트림을 가져야 합니다.
+SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `Node`, `TagQueryNode` 등을 이용해 정의하며 모든 노드는 하나 이상의 업스트림을 가져야 합니다.
 
 ```python
 from qmtl.sdk import Strategy, Node, StreamInput
@@ -33,7 +33,6 @@ class MyStrategy(Strategy):
 
         out = Node(input=price, compute_fn=compute, name="out")
         self.add_nodes([price, out])
-        self.set_target("out")
 ```
 
 ## 실행 모드

--- a/examples/correlation_strategy.py
+++ b/examples/correlation_strategy.py
@@ -22,7 +22,6 @@ class CorrelationStrategy(Strategy):
             name="indicator_corr",
         )
         self.add_nodes([indicators, corr_node])
-        self.set_target("indicator_corr")
 
 
 if __name__ == "__main__":

--- a/examples/cross_market_lag_strategy.py
+++ b/examples/cross_market_lag_strategy.py
@@ -35,7 +35,6 @@ class CrossMarketLagStrategy(Strategy):
         )
 
         self.add_nodes([btc_price, mstr_price, corr_node])
-        self.set_target("btc_mstr_corr")
 
 
 if __name__ == "__main__":

--- a/examples/extensions_combined_strategy.py
+++ b/examples/extensions_combined_strategy.py
@@ -11,9 +11,5 @@ class CombinedExtensionsStrategy(Strategy):
         self.roc_node = rate_of_change(self.ema_node, period=5)
         self.add_nodes([self.source, self.ema_node, self.roc_node])
 
-    def define_execution(self):
-        self.set_target(self.roc_node.name)
-
-
 if __name__ == "__main__":
     Runner.offline(CombinedExtensionsStrategy)

--- a/examples/general_strategy.py
+++ b/examples/general_strategy.py
@@ -25,7 +25,6 @@ class GeneralStrategy(Strategy):
             name="momentum_signal",
         )
         self.add_nodes([price_stream, signal_node])
-        self.set_target("momentum_signal")
 
 
 if __name__ == "__main__":

--- a/examples/indicators_strategy.py
+++ b/examples/indicators_strategy.py
@@ -8,9 +8,5 @@ class EmaStrategy(Strategy):
         self.ema_node = ema(self.price, window=10)
         self.add_nodes([self.price, self.ema_node])
 
-    def define_execution(self):
-        self.set_target(self.ema_node.name)
-
-
 if __name__ == "__main__":
     Runner.offline(EmaStrategy)

--- a/examples/tag_query_strategy.py
+++ b/examples/tag_query_strategy.py
@@ -33,7 +33,6 @@ class TagQueryStrategy(Strategy):
         avg_node = Node(input=corr_node, compute_fn=avg_corr, name="avg_corr")
 
         self.add_nodes([indicators, corr_node, avg_node])
-        self.set_target("avg_corr")
 
 
 if __name__ == "__main__":

--- a/examples/transforms_strategy.py
+++ b/examples/transforms_strategy.py
@@ -8,9 +8,5 @@ class RocStrategy(Strategy):
         self.roc_node = rate_of_change(self.price, period=3)
         self.add_nodes([self.price, self.roc_node])
 
-    def define_execution(self):
-        self.set_target(self.roc_node.name)
-
-
 if __name__ == "__main__":
     Runner.offline(RocStrategy)

--- a/qmtl/sdk/strategy.py
+++ b/qmtl/sdk/strategy.py
@@ -3,29 +3,16 @@ class Strategy:
 
     def __init__(self):
         self.nodes = []
-        self.target = None
 
     def add_nodes(self, nodes):
         self.nodes.extend(nodes)
 
-    def set_target(self, node_name):
-        self.target = node_name
-
     def setup(self):
         raise NotImplementedError
-
-    def define_execution(self):
-        """Select the execution target if not already set."""
-        if self.target is None and self.nodes:
-            last = self.nodes[-1]
-            self.target = last.name or last.node_id
 
     # DAG serialization ---------------------------------------------------
     def serialize(self) -> dict:
         """Serialize strategy DAG using node IDs."""
-        if self.target is None:
-            self.define_execution()
         return {
             "nodes": [node.to_dict() for node in self.nodes],
-            "target": self.target,
         }

--- a/tests/sample_strategy.py
+++ b/tests/sample_strategy.py
@@ -5,4 +5,3 @@ class SampleStrategy(Strategy):
         src = StreamInput(interval=1, period=1)
         node = Node(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
         self.add_nodes([src, node])
-        self.set_target("out")

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -184,7 +184,6 @@ def test_diff_with_sdk_nodes():
             src = StreamInput(interval=1, period=1)
             node = Node(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
             self.add_nodes([src, node])
-            self.set_target("out")
 
     s = _S()
     s.setup()

--- a/tests/test_node_id.py
+++ b/tests/test_node_id.py
@@ -12,7 +12,6 @@ class _S(Strategy):
         src = StreamInput(interval=1, period=1)
         node = Node(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
         self.add_nodes([src, node])
-        self.set_target("out")
 
 
 def test_strategy_serialize():


### PR DESCRIPTION
## Summary
- drop `set_target` and related logic from `Strategy`
- update docs and examples to remove target usage
- clean up tests

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f632a22348329aa549f41db923f1d