### PR TITLE
Check execute flag in feed calls

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -456,7 +456,7 @@ class Node:
                 raise RuntimeError("gap detected")
             if on_missing == "skip":
                 return
-        if not self.pre_warmup and self.compute_fn:
+        if not self.pre_warmup and self.compute_fn and self.execute:
             Runner._execute_compute_fn(self.compute_fn, self.cache.view())
 
     def to_dict(self) -> dict:

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -211,7 +211,7 @@ class Runner:
                 raise RuntimeError("gap detected")
             if on_missing == "skip":
                 return
-        if not node.pre_warmup and node.compute_fn:
+        if not node.pre_warmup and node.compute_fn and node.execute:
             Runner._execute_compute_fn(node.compute_fn, node.cache.view())
 
     @staticmethod

--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -33,6 +33,24 @@ def test_cache_warmup_and_compute():
     assert len(calls) == 2
 
 
+def test_node_feed_respects_execute_flag(monkeypatch):
+    monkeypatch.setattr(Runner, "_ray_available", False)
+
+    calls = []
+
+    def fn(view):
+        calls.append(view)
+
+    src = StreamInput(interval=60, period=2)
+    node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
+    node.execute = False
+
+    node.feed("q1", 60, 60, {"v": 1})
+    node.feed("q1", 60, 120, {"v": 2})
+
+    assert len(calls) == 0
+
+
 def test_multiple_upstreams():
     calls = []
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -313,6 +313,26 @@ def test_feed_queue_data_without_ray(monkeypatch):
     assert len(calls) == 1
 
 
+def test_feed_queue_data_respects_execute_flag(monkeypatch):
+    from qmtl.sdk import Node, StreamInput
+
+    monkeypatch.setattr(Runner, "_ray_available", False)
+
+    calls = []
+
+    def compute(view):
+        calls.append(view)
+
+    src = StreamInput(interval=60, period=2)
+    node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
+    node.execute = False
+
+    Runner.feed_queue_data(node, "q", 60, 60, {"v": 1})
+    Runner.feed_queue_data(node, "q", 60, 120, {"v": 2})
+
+    assert not calls
+
+
 def test_load_history_called(monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(202, json={"strategy_id": "s"})


### PR DESCRIPTION
## Summary
- respect `execute` flag in Node.feed and Runner.feed_queue_data
- test execute flag handling in queue feeds
- test execute flag handling in Node.feed

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f69eff34483298c82176c5c079cce