### PR TITLE
Add queue completion monitor and event

### DIFF
--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -36,6 +36,7 @@ from .kafka_admin import KafkaAdmin
 from .gc import GarbageCollector, DEFAULT_POLICY, S3ArchiveClient
 from .alerts import PagerDutyClient, SlackClient, AlertManager
 from .monitor import Monitor, MonitorLoop
+from .completion import QueueCompletionMonitor
 from .metrics import start_metrics_server
 from .api import create_app
 
@@ -53,6 +54,7 @@ __all__ = [
     "AlertManager",
     "Monitor",
     "MonitorLoop",
+    "QueueCompletionMonitor",
     "start_metrics_server",
     "create_app",
 ]

--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -36,6 +36,12 @@ class _MemRepo(NodeRepository):
     def get_queues_by_tag(self, tags: Iterable[str], interval: int) -> list[str]:
         return []
 
+    def get_node_by_queue(self, queue: str) -> NodeRecord | None:
+        for rec in self.records.values():
+            if rec.topic == queue:
+                return rec
+        return None
+
 
 class _MemQueue(QueueManager):
     def __init__(self) -> None:

--- a/qmtl/dagmanager/completion.py
+++ b/qmtl/dagmanager/completion.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+import asyncio
+
+from .callbacks import post_with_backoff
+from ..common.cloudevents import format_event
+from .diff_service import NodeRepository
+from .kafka_admin import KafkaAdmin
+
+
+@dataclass
+class QueueCompletionMonitor:
+    """Detect inactive queues and emit events when completed."""
+
+    repo: NodeRepository
+    admin: KafkaAdmin
+    callback_url: str
+    interval: float = 5.0
+    threshold: int = 2
+    _sizes: Dict[str, int] = field(default_factory=dict)
+    _stalled: Dict[str, int] = field(default_factory=dict)
+    _completed: set[str] = field(default_factory=set)
+    _task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            finally:
+                self._task = None
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                await self.check_once()
+                await asyncio.sleep(self.interval)
+        except asyncio.CancelledError:  # pragma: no cover - background task
+            pass
+
+    async def check_once(self) -> None:
+        sizes = self.admin.get_topic_sizes()
+        for topic, size in sizes.items():
+            prev = self._sizes.get(topic)
+            if prev is not None and size == prev:
+                self._stalled[topic] = self._stalled.get(topic, 0) + 1
+            else:
+                self._stalled[topic] = 0
+            self._sizes[topic] = size
+            if (
+                self._stalled[topic] >= self.threshold
+                and topic not in self._completed
+            ):
+                record = self.repo.get_node_by_queue(topic)
+                if record and record.interval is not None and record.tags:
+                    event = format_event(
+                        "qmtl.dagmanager",
+                        "queue_update",
+                        {"tags": list(record.tags), "interval": record.interval, "queues": []},
+                    )
+                    await post_with_backoff(self.callback_url, event)
+                    self._completed.add(topic)
+
+
+__all__ = ["QueueCompletionMonitor"]

--- a/tests/gateway/test_queue_update_watch.py
+++ b/tests/gateway/test_queue_update_watch.py
@@ -75,3 +75,68 @@ async def test_queue_update_reaches_subscriber(monkeypatch):
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+async def test_node_completed_reaches_subscriber(monkeypatch):
+    watch = QueueWatchHub()
+    gw_app = create_app(dag_client=DummyDag(), watch_hub=watch)
+    transport = httpx.ASGITransport(gw_app)
+
+    real_client = httpx.AsyncClient
+
+    class DummyStream:
+        def __init__(self, gen):
+            self._gen = gen
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            await self._gen.aclose()
+
+        async def aiter_lines(self):
+            async for queues in self._gen:
+                yield json.dumps({"queues": queues})
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = real_client(*a, **k)
+
+        async def __aenter__(self):
+            await self._client.__aenter__()
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            await self._client.__aexit__(exc_type, exc, tb)
+
+        def stream(self, method, url, params=None):
+            if url.endswith("/queues/watch"):
+                gen = watch.subscribe(["t1"], 60)
+                return DummyStream(gen)
+            return self._client.stream(method, url, params=params)
+
+        async def post(self, url, json=None):
+            return await self._client.post(url, json=json)
+
+    monkeypatch.setattr("qmtl.sdk.node.httpx.AsyncClient", DummyClient)
+
+    node = TagQueryNode(["t1"], interval=60, period=1)
+    task = asyncio.create_task(node.subscribe_updates("http://gw"))
+    await asyncio.sleep(0.2)
+
+    event = format_event(
+        "qmtl.dagmanager",
+        "queue_update",
+        {"tags": ["t1"], "interval": 60, "queues": []},
+    )
+    async with httpx.AsyncClient(transport=transport, base_url="http://gw") as c:
+        resp = await c.post("/callbacks/dag-event", json=event)
+        assert resp.status_code == 202
+
+    await asyncio.sleep(0.1)
+    assert node.upstreams == []
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_completion_monitor.py
+++ b/tests/test_completion_monitor.py
@@ -1,0 +1,82 @@
+import httpx
+import pytest
+
+from qmtl.dagmanager.completion import QueueCompletionMonitor
+from qmtl.dagmanager.diff_service import NodeRecord, NodeRepository
+from qmtl.dagmanager.kafka_admin import KafkaAdmin
+
+
+class DummyRepo(NodeRepository):
+    def __init__(self) -> None:
+        self.rec = NodeRecord(
+            node_id="n1",
+            node_type="N",
+            code_hash="c",
+            schema_hash="s",
+            interval=60,
+            period=1,
+            tags=["t1"],
+            topic="q1",
+        )
+
+    def get_nodes(self, node_ids):
+        return {}
+
+    def insert_sentinel(self, sentinel_id, node_ids):
+        pass
+
+    def get_queues_by_tag(self, tags, interval):
+        return []
+
+    def get_node_by_queue(self, queue):
+        if queue == "q1":
+            return self.rec
+        return None
+
+
+class DummyAdminClient:
+    def __init__(self, sizes):
+        self.sizes = sizes
+        self.calls = 0
+
+    def list_topics(self):
+        data = {}
+        if self.calls < len(self.sizes):
+            for k, v in self.sizes[self.calls].items():
+                data[k] = {"size": v}
+        self.calls += 1
+        return data
+
+    def create_topic(self, *a, **k):
+        pass
+
+
+def make_admin(sizes) -> KafkaAdmin:
+    client = DummyAdminClient(sizes)
+    return KafkaAdmin(client)
+
+
+@pytest.mark.asyncio
+async def test_completion_emits_event(monkeypatch):
+    repo = DummyRepo()
+    admin = make_admin([{"q1": 10}, {"q1": 10}])
+    events = []
+
+    async def fake_post(url, payload, **_):
+        events.append(payload)
+        return httpx.Response(202)
+
+    monkeypatch.setattr(
+        "qmtl.dagmanager.completion.post_with_backoff",
+        fake_post,
+    )
+
+    monitor = QueueCompletionMonitor(repo, admin, "http://gw/cb", threshold=1)
+    await monitor.check_once()
+    await monitor.check_once()
+
+    assert events
+    evt = events[0]
+    assert evt["type"] == "queue_update"
+    assert evt["data"]["queues"] == []
+    assert evt["data"]["tags"] == ["t1"]


### PR DESCRIPTION
## Summary
- detect when Kafka topics stop growing via `QueueCompletionMonitor`
- send `queue_update` events when queues complete
- expose monitor in package exports
- handle completed queue updates in gateway tests
- cover monitor with unit test

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6a3352f48329b4d0fff292841d3d