### PR TITLE
Handle queue_update events via websockets

### DIFF
--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -284,6 +284,8 @@ def create_app(
                     interval = None
             if tags and interval is not None:
                 await watch.broadcast(tags, interval, list(queues))
+                if ws:
+                    await ws.send_queue_update(tags, interval, list(queues))
         elif event_type == "sentinel_weight":
             gateway = getattr(app.state, "gateway", None)
             if gateway is None:

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -105,6 +105,17 @@ class WebSocketHub:
         )
         await self.broadcast(event)
 
+    async def send_queue_update(
+        self, tags: list[str], interval: int, queues: list[str]
+    ) -> None:
+        """Broadcast queue update events."""
+        event = format_event(
+            "qmtl.gateway",
+            "queue_update",
+            {"tags": tags, "interval": interval, "queues": queues},
+        )
+        await self.broadcast(event)
+
     async def send_sentinel_weight(self, sentinel_id: str, weight: float) -> None:
         """Broadcast sentinel weight updates."""
         event = format_event(

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -211,7 +211,7 @@ class Runner:
                 raise RuntimeError("gap detected")
             if on_missing == "skip":
                 return
-        if not node.pre_warmup and node.compute_fn:
+        if not node.pre_warmup and node.compute_fn and node.execute:
             Runner._execute_compute_fn(node.compute_fn, node.cache.view())
 
     @staticmethod

--- a/tests/gateway/test_queue_update_ws_execution.py
+++ b/tests/gateway/test_queue_update_ws_execution.py
@@ -1,0 +1,58 @@
+import asyncio
+import httpx
+import pytest
+
+from qmtl.gateway.api import create_app
+from qmtl.gateway.ws import WebSocketHub
+from qmtl.sdk import TagQueryNode, Runner
+from qmtl.sdk.ws_client import WebSocketClient
+from qmtl.common.cloudevents import format_event
+
+
+class DummyDag:
+    async def get_queues_by_tag(self, tags, interval):
+        return []
+
+
+class DummyHub(WebSocketHub):
+    def __init__(self, client: WebSocketClient) -> None:
+        super().__init__()
+        self.client = client
+
+    async def send_queue_update(self, tags, interval, queues):  # type: ignore[override]
+        await self.client._handle({
+            "type": "queue_update",
+            "data": {"tags": tags, "interval": interval, "queues": queues},
+        })
+
+
+@pytest.mark.asyncio
+async def test_node_unpauses_on_queue_update():
+    client = WebSocketClient("ws://dummy")
+    ws_hub = DummyHub(client)
+    gw_app = create_app(dag_client=DummyDag(), ws_hub=ws_hub)
+    transport = httpx.ASGITransport(gw_app)
+    calls = []
+    node = TagQueryNode(["t1"], interval=60, period=1, compute_fn=lambda v: calls.append(v))
+    client.register_tag_query_node(node)
+
+    assert not node.execute
+
+    event = format_event(
+        "qmtl.dagmanager",
+        "queue_update",
+        {"tags": ["t1"], "interval": 60, "queues": ["q1"]},
+    )
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.post("/callbacks/dag-event", json=event)
+        assert resp.status_code == 202
+
+    await asyncio.sleep(0.2)
+
+    assert node.execute
+    assert node.upstreams == ["q1"]
+
+    Runner.feed_queue_data(node, "q1", 60, 60, {"v": 1})
+    assert calls
+
+    await client.stop()

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -5,6 +5,7 @@ import pytest
 import websockets
 
 from qmtl.sdk.ws_client import WebSocketClient
+from qmtl.sdk import TagQueryNode
 
 
 @pytest.mark.asyncio
@@ -12,6 +13,7 @@ async def test_ws_client_updates_state():
     events = [
         {"event": "queue_created", "queue_id": "n1", "topic": "t1"},
         {"event": "sentinel_weight", "sentinel_id": "s1", "weight": 0.75},
+        {"event": "queue_update", "tags": ["t"], "interval": 60, "queues": ["q1"]},
     ]
 
     async def handler(websocket):
@@ -24,11 +26,15 @@ async def test_ws_client_updates_state():
     url = f"ws://localhost:{port}"
     try:
         client = WebSocketClient(url)
+        node = TagQueryNode(["t"], interval=60, period=1)
+        client.register_tag_query_node(node)
         await client.start()
         await asyncio.sleep(0.2)
         await client.stop()
         assert client.queue_topics == {"n1": "t1"}
         assert client.sentinel_weights == {"s1": 0.75}
+        assert node.upstreams == ["q1"]
+        assert node.execute
     finally:
         server.close()
         await server.wait_closed()


### PR DESCRIPTION
## Summary
- send queue_update events to websocket clients
- record tag-based queue data and update nodes in `WebSocketClient`
- honor node `execute` flag when feeding data
- expose queue updates in `TagQueryNode`
- add integration test for queue update resume
- extend websocket client tests

## Testing
- `uv pip install -e .[dev]`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6a292ad08329ab71f9834c640744