### PR TITLE
Use persistent gRPC channel for DagManagerClient

### DIFF
--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -205,6 +205,10 @@ def create_app(
     watch = watch_hub or QueueWatchHub()
     ws = ws_hub
 
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        await dagm.close()
+
     @app.get("/status")
     async def status_endpoint() -> dict[str, str]:
         return await gateway_status(r, db, dagm)

--- a/qmtl/gateway/worker.py
+++ b/qmtl/gateway/worker.py
@@ -105,5 +105,10 @@ class StrategyWorker:
         await self._process(strategy_id)
         return strategy_id
 
+    async def close(self) -> None:
+        """Close resources associated with this worker."""
+        if hasattr(self.dag_client, "close"):
+            await self.dag_client.close()
+
 
 __all__ = ["StrategyWorker"]

--- a/tests/gateway/test_dagmanager_client.py
+++ b/tests/gateway/test_dagmanager_client.py
@@ -1,0 +1,22 @@
+import pytest
+import grpc
+
+from qmtl.gateway.dagmanager_client import DagManagerClient
+from qmtl.proto import dagmanager_pb2_grpc
+
+class DummyChannel:
+    def __init__(self):
+        self.closed = False
+    async def close(self):
+        self.closed = True
+
+@pytest.mark.asyncio
+async def test_close_closes_channel(monkeypatch):
+    chan = DummyChannel()
+    monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: chan)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "DiffServiceStub", lambda c: None)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", lambda c: None)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", lambda c: None)
+    client = DagManagerClient("dummy")
+    await client.close()
+    assert chan.closed is True

--- a/tests/gateway/test_diff.py
+++ b/tests/gateway/test_diff.py
@@ -43,6 +43,8 @@ async def test_diff_collects_chunks(monkeypatch):
     ]
     Stub, _ = make_stub(chunks)
     monkeypatch.setattr(dagmanager_pb2_grpc, "DiffServiceStub", Stub)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", lambda c: None)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", lambda c: None)
     monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
 
     client = DagManagerClient("127.0.0.1:1")
@@ -62,6 +64,8 @@ async def test_diff_returns_buffer_nodes(monkeypatch):
     ]
     Stub, _ = make_stub(chunks)
     monkeypatch.setattr(dagmanager_pb2_grpc, "DiffServiceStub", Stub)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", lambda c: None)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", lambda c: None)
     monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
 
     client = DagManagerClient("127.0.0.1:1")
@@ -75,6 +79,8 @@ async def test_diff_retries(monkeypatch):
     chunk = dagmanager_pb2.DiffChunk(queue_map={"A": "t"}, sentinel_id="s")
     Stub, get_calls = make_stub([chunk], fail_times=2)
     monkeypatch.setattr(dagmanager_pb2_grpc, "DiffServiceStub", Stub)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", lambda c: None)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", lambda c: None)
     monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
     orig_sleep = asyncio.sleep
     monkeypatch.setattr(asyncio, "sleep", lambda t: orig_sleep(0))


### PR DESCRIPTION
## Summary
- hold a persistent `grpc.aio.Channel` inside `DagManagerClient`
- close the channel during FastAPI shutdown
- expose a `close()` API on `StrategyWorker`
- adapt tests for new client behaviour
- cover the new close coroutine

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa8c896588329b1411830ebd219c6