### PR TITLE
Add GC scheduler and dashboards

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -67,3 +67,9 @@ receivers:
           severity: critical
         annotations:
           summary: Diff submissions lost
+      - alert: GCSchedulerStall
+        expr: time() - gc_last_run_timestamp > 600
+        labels:
+          severity: warning
+        annotations:
+          summary: Garbage collector has not run for 10 minutes

--- a/docs/dashboards/gc_dashboard.json
+++ b/docs/dashboards/gc_dashboard.json
@@ -1,0 +1,12 @@
+{
+  "title": "QMTL GC",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Orphan Queue Count",
+      "targets": [
+        {"expr": "orphan_queue_total"}
+      ]
+    }
+  ]
+}

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,12 @@
+# Monitoring and Alerting
+
+This document outlines sample Prometheus alerts and Grafana dashboards for QMTL services.
+
+## Alert Rules
+
+Prometheus can load `alert_rules.yml` to activate alerts for the DAG manager and gateway. Additional rules have been added for garbage collection. The file can be mounted into the Prometheus container via its configuration.
+
+## Grafana Dashboards
+
+Example Grafana dashboards are provided in `docs/dashboards/`. Import the JSON file into Grafana to visualise queue counts and garbage collector activity. The dashboard uses the `orphan_queue_total` metric exposed by the DAG manager.
+

--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -34,6 +34,7 @@ def compute_node_id(
 from .topic import TopicConfig, topic_name, get_config
 from .kafka_admin import KafkaAdmin
 from .gc import GarbageCollector, DEFAULT_POLICY, S3ArchiveClient
+from .gc_scheduler import GCScheduler
 from .alerts import PagerDutyClient, SlackClient, AlertManager
 from .monitor import Monitor, MonitorLoop
 from .completion import QueueCompletionMonitor
@@ -49,6 +50,7 @@ __all__ = [
     "GarbageCollector",
     "DEFAULT_POLICY",
     "S3ArchiveClient",
+    "GCScheduler",
     "PagerDutyClient",
     "SlackClient",
     "AlertManager",

--- a/qmtl/dagmanager/gc.py
+++ b/qmtl/dagmanager/gc.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from typing import Iterable, Protocol, Optional
 
 from .metrics import orphan_queue_total
+from .metrics import gc_last_run_timestamp
 
 
 @dataclass(frozen=True)
@@ -118,6 +119,8 @@ class GarbageCollector:
                     self.archive.archive(q.name)
                 self.store.drop_queue(q.name)
             processed.append(q)
+        gc_last_run_timestamp.set(now.timestamp())
+        gc_last_run_timestamp._val = gc_last_run_timestamp._value.get()  # type: ignore[attr-defined]
         return processed
 
 

--- a/qmtl/dagmanager/gc_scheduler.py
+++ b/qmtl/dagmanager/gc_scheduler.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
+from .gc import GarbageCollector
+
+
+@dataclass
+class GCScheduler:
+    """Run :meth:`GarbageCollector.collect` periodically."""
+
+    gc: GarbageCollector
+    interval: float = 60.0
+    _task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Begin scheduling in the background."""
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                self.gc.collect()
+                await asyncio.sleep(self.interval)
+        except asyncio.CancelledError:  # pragma: no cover - background task
+            pass
+
+    async def stop(self) -> None:
+        """Stop the scheduler."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            finally:
+                self._task = None
+
+
+__all__ = ["GCScheduler"]

--- a/qmtl/dagmanager/metrics.py
+++ b/qmtl/dagmanager/metrics.py
@@ -62,6 +62,12 @@ orphan_queue_total = Gauge(
     registry=global_registry,
 )
 
+gc_last_run_timestamp = Gauge(
+    "gc_last_run_timestamp",
+    "Timestamp of the last successful garbage collection",
+    registry=global_registry,
+)
+
 # Expose the active traffic weight per version. Guard against duplicate
 # registration when this module is reloaded during tests.
 if "active_version_weight" in global_registry._names_to_collectors:
@@ -131,6 +137,8 @@ def reset_metrics() -> None:
     sentinel_gap_count._val = 0  # type: ignore[attr-defined]
     orphan_queue_total.set(0)
     orphan_queue_total._val = 0  # type: ignore[attr-defined]
+    gc_last_run_timestamp.set(0)
+    gc_last_run_timestamp._val = 0  # type: ignore[attr-defined]
     if hasattr(active_version_weight, "clear"):
         active_version_weight.clear()
     active_version_weight._vals = {}  # type: ignore[attr-defined]

--- a/tests/gc/test_scheduler.py
+++ b/tests/gc/test_scheduler.py
@@ -1,0 +1,23 @@
+import asyncio
+import pytest
+
+from qmtl.dagmanager.gc_scheduler import GCScheduler
+
+
+class DummyGC:
+    def __init__(self):
+        self.calls = 0
+
+    def collect(self):
+        self.calls += 1
+        return []
+
+
+@pytest.mark.asyncio
+async def test_gc_scheduler_runs_collect():
+    gc = DummyGC()
+    sched = GCScheduler(gc, interval=0.01)
+    await sched.start()
+    await asyncio.sleep(0.03)
+    await sched.stop()
+    assert gc.calls >= 2


### PR DESCRIPTION
## Summary
- add async GCScheduler to run periodic collection
- track last GC timestamp and expose metric
- document alert rules and dashboards
- provide sample Grafana dashboard json
- test scheduler behaviour

## Testing
- `uv pip install -e .[dev]`
- `uv run -- pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507dd38234832999032e8c411810dd