### PR TITLE
Implement DAG content hash detection

### DIFF
--- a/tests/strategy/test_conflict.py
+++ b/tests/strategy/test_conflict.py
@@ -1,0 +1,51 @@
+import base64
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+from fakeredis.aioredis import FakeRedis
+
+from qmtl.gateway.api import create_app, Database, StrategySubmit
+from qmtl.common import crc32_of_list
+
+
+class FakeDB(Database):
+    async def insert_strategy(self, strategy_id: str, meta):
+        pass
+
+    async def set_status(self, strategy_id: str, status: str):
+        pass
+
+    async def get_status(self, strategy_id: str):
+        return "queued"
+
+    async def append_event(self, strategy_id: str, event: str):
+        pass
+
+
+@pytest.fixture
+def client():
+    redis = FakeRedis(decode_responses=True)
+    db = FakeDB()
+    app = create_app(redis_client=redis, database=db)
+    return TestClient(app)
+
+
+def make_payload(dag: dict) -> StrategySubmit:
+    return StrategySubmit(
+        dag_json=base64.b64encode(json.dumps(dag).encode()).decode(),
+        meta=None,
+        run_type="dry-run",
+        node_ids_crc32=crc32_of_list(n["node_id"] for n in dag.get("nodes", [])),
+    )
+
+
+def test_duplicate_strategy_returns_409(client):
+    dag = {"nodes": [{"node_id": "A"}]}
+    payload = make_payload(dag)
+    first = client.post("/strategies", json=payload.model_dump())
+    assert first.status_code == 202
+
+    second = client.post("/strategies", json=payload.model_dump())
+    assert second.status_code == 409
+    assert second.json()["detail"]["strategy_id"] == first.json()["strategy_id"]


### PR DESCRIPTION
## Summary
- compute a hash for submitted DAGs in the StrategyManager
- reject identical strategy submissions with HTTP 409
- add regression test for conflict detection

## Testing
- `uv pip install -e .[dev]`
- `uv run -- pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850834ea5488329ae4123adb45f764f