### PR TITLE
Improve gateway reliability

### DIFF
--- a/qmtl/common/__init__.py
+++ b/qmtl/common/__init__.py
@@ -9,3 +9,11 @@ def crc32_of_list(items: Iterable[str]) -> int:
         crc = zlib.crc32(item.encode(), crc)
     return crc & 0xFFFFFFFF
 
+
+from .reconnect import ReconnectingRedis, ReconnectingNeo4j
+
+__all__ = [
+    "crc32_of_list",
+    "ReconnectingRedis",
+    "ReconnectingNeo4j",
+]

--- a/qmtl/common/reconnect.py
+++ b/qmtl/common/reconnect.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Connection wrappers with automatic reconnection."""
+
+from typing import Any, Callable
+
+import redis.asyncio as redis
+
+
+class ReconnectingRedis:
+    """Redis client that reconnects on errors."""
+
+    def __init__(self, dsn: str, *, attempts: int = 2, **opts: Any) -> None:
+        self._dsn = dsn
+        self._opts = {"decode_responses": True}
+        self._opts.update(opts)
+        self._attempts = attempts
+        self._client = redis.from_url(self._dsn, **self._opts)
+
+    async def _reconnect(self) -> None:
+        self._client = redis.from_url(self._dsn, **self._opts)
+
+    def __getattr__(self, name: str) -> Callable[..., Any]:
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            method = getattr(self._client, name)
+            try:
+                return await method(*args, **kwargs)
+            except Exception:
+                await self._reconnect()
+                method = getattr(self._client, name)
+                return await method(*args, **kwargs)
+
+        return wrapper
+
+
+class _ReconnectingSession:
+    def __init__(self, factory: Callable[[], Any], reconnect: Callable[[], None]) -> None:
+        self._factory = factory
+        self._reconnect = reconnect
+        self._session = self._factory()
+
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        for attempt in range(2):
+            try:
+                return self._session.run(*args, **kwargs)
+            except Exception:
+                if attempt == 1:
+                    raise
+                self._session.close()
+                self._reconnect()
+                self._session = self._factory()
+        raise RuntimeError("unreachable")
+
+    def close(self) -> None:
+        self._session.close()
+
+    def __enter__(self) -> "_ReconnectingSession":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._session.close()
+
+
+class ReconnectingNeo4j:
+    """Neo4j driver wrapper with reconnection logic."""
+
+    def __init__(self, uri: str, user: str, password: str, *, attempts: int = 2) -> None:
+        from neo4j import GraphDatabase
+
+        self._uri = uri
+        self._auth = (user, password)
+        self._attempts = attempts
+        self._GraphDatabase = GraphDatabase
+        self._driver = GraphDatabase.driver(self._uri, auth=self._auth)
+
+    def _reconnect(self) -> None:
+        self._driver.close()
+        self._driver = self._GraphDatabase.driver(self._uri, auth=self._auth)
+
+    def session(self, *args: Any, **kwargs: Any) -> _ReconnectingSession:
+        def factory():
+            return self._driver.session(*args, **kwargs)
+
+        return _ReconnectingSession(factory, self._reconnect)
+
+    def close(self) -> None:
+        self._driver.close()
+
+
+__all__ = ["ReconnectingRedis", "ReconnectingNeo4j"]

--- a/tests/reliability/test_reconnect.py
+++ b/tests/reliability/test_reconnect.py
@@ -1,0 +1,87 @@
+import pytest
+import sys
+import types
+import redis.asyncio as redis
+
+from qmtl.common.reconnect import ReconnectingRedis, ReconnectingNeo4j
+
+
+class DummyRedis:
+    def __init__(self, fail_first: bool = True):
+        self.calls = 0
+        self.fail_first = fail_first
+
+    async def ping(self):
+        self.calls += 1
+        if self.fail_first and self.calls == 1:
+            raise RuntimeError("fail")
+        return True
+
+
+class DummySession:
+    def __init__(self, should_fail=True):
+        self.should_fail = should_fail
+        self.calls = 0
+
+    def run(self, q, **p):
+        self.calls += 1
+        if self.should_fail and self.calls == 1:
+            raise RuntimeError("fail")
+        return "ok"
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyDriver:
+    def __init__(self, fail=True):
+        self.fail = fail
+        self.session_created = 0
+
+    def session(self):
+        self.session_created += 1
+        return DummySession(self.fail and self.session_created == 1)
+
+    def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_reconnecting_redis(monkeypatch):
+    r1 = DummyRedis()
+    r2 = DummyRedis(fail_first=False)
+    calls = [r1, r2]
+
+    def from_url(url, **opts):
+        return calls.pop(0)
+
+    monkeypatch.setattr(redis, "from_url", from_url)
+    client = ReconnectingRedis("redis://")
+
+    await client.ping()
+    assert r1.calls == 1
+    assert r2.calls == 1
+
+
+def test_reconnecting_neo4j(monkeypatch):
+    driver1 = DummyDriver(True)
+    driver2 = DummyDriver(False)
+    drivers = [driver1, driver2]
+
+    class FakeGraphDB:
+        @staticmethod
+        def driver(uri, auth):
+            return drivers.pop(0)
+
+    monkeypatch.setitem(sys.modules, 'neo4j', types.SimpleNamespace(GraphDatabase=FakeGraphDB))
+
+    client = ReconnectingNeo4j('bolt://', 'u', 'p')
+    with client.session() as sess:
+        assert sess.run('Q') == 'ok'
+    assert driver2.session_created >= 1

--- a/tests/reliability/test_worker_alerts.py
+++ b/tests/reliability/test_worker_alerts.py
@@ -1,0 +1,71 @@
+import asyncio
+import pytest
+from fakeredis.aioredis import FakeRedis
+
+from qmtl.gateway.worker import StrategyWorker
+from qmtl.gateway.queue import RedisFIFOQueue
+from qmtl.gateway.fsm import StrategyFSM
+from qmtl.gateway.api import Database
+
+
+class FakeDB(Database):
+    def __init__(self) -> None:
+        self.states: dict[str, str] = {}
+
+    async def insert_strategy(self, strategy_id: str, meta=None) -> None:
+        self.states[strategy_id] = "queued"
+
+    async def set_status(self, strategy_id: str, status: str) -> None:
+        self.states[strategy_id] = status
+
+    async def get_status(self, strategy_id: str):
+        return self.states.get(strategy_id)
+
+    async def append_event(self, strategy_id: str, event: str) -> None:
+        pass
+
+
+class DummyDag:
+    async def diff(self, sid: str, dag: str):
+        raise RuntimeError("grpc fail")
+
+
+class DummyAlerts:
+    def __init__(self):
+        self.slack: list[str] = []
+
+    async def send_slack(self, msg: str) -> None:
+        self.slack.append(msg)
+
+    async def send_pagerduty(self, msg: str) -> None:
+        self.slack.append(msg)
+
+
+@pytest.mark.asyncio
+async def test_worker_alerts_after_repeated_failures():
+    redis = FakeRedis(decode_responses=True)
+    queue = RedisFIFOQueue(redis, "strategy_queue")
+    db = FakeDB()
+    fsm = StrategyFSM(redis, db)
+    alerts = DummyAlerts()
+    worker = StrategyWorker(
+        redis,
+        db,
+        fsm,
+        queue,
+        DummyDag(),
+        ws_hub=None,
+        alert_manager=alerts,
+        grpc_fail_threshold=2,
+    )
+
+    # enqueue three strategies that will all fail
+    for sid in ["s1", "s2", "s3"]:
+        await fsm.create(sid, None)
+        await redis.hset(f"strategy:{sid}", mapping={"dag": "{}"})
+        await queue.push(sid)
+
+    for _ in range(3):
+        await worker.run_once()
+
+    assert len(alerts.slack) == 1


### PR DESCRIPTION
## Summary
- add ReconnectingRedis and ReconnectingNeo4j utilities
- trigger Slack alerts on repeated gRPC failures in workers
- test reconnection logic and alert handling

## Testing
- `uv venv && uv pip install -e .[dev]`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685085c7ae348329b43bf6c6c546c052