### PR TITLE
Add automatic reprocessing for buffered nodes

### DIFF
--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -35,6 +35,7 @@ from .topic import TopicConfig, topic_name, get_config
 from .kafka_admin import KafkaAdmin
 from .gc import GarbageCollector, DEFAULT_POLICY, S3ArchiveClient
 from .gc_scheduler import GCScheduler
+from .buffer_scheduler import BufferingScheduler
 from .alerts import PagerDutyClient, SlackClient, AlertManager
 from .monitor import Monitor, MonitorLoop
 from .completion import QueueCompletionMonitor
@@ -51,6 +52,7 @@ __all__ = [
     "DEFAULT_POLICY",
     "S3ArchiveClient",
     "GCScheduler",
+    "BufferingScheduler",
     "PagerDutyClient",
     "SlackClient",
     "AlertManager",

--- a/qmtl/dagmanager/buffer_scheduler.py
+++ b/qmtl/dagmanager/buffer_scheduler.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+import asyncio
+import json
+import time
+
+from .diff_service import DiffService, DiffRequest, NodeRepository
+
+
+@dataclass
+class BufferingScheduler:
+    """Automatically reprocess buffered nodes after a delay."""
+
+    repo: NodeRepository
+    diff: DiffService
+    interval: float = 3600.0
+    delay_days: int = 7
+    _task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            finally:
+                self._task = None
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                await self.check_once()
+                await asyncio.sleep(self.interval)
+        except asyncio.CancelledError:  # pragma: no cover - background task
+            pass
+
+    async def check_once(self) -> None:
+        cutoff = int((time.time() - self.delay_days * 86400) * 1000)
+        node_ids = self.repo.get_buffering_nodes(cutoff)
+        if not node_ids:
+            return
+        records = self.repo.get_nodes(node_ids)
+        for nid in node_ids:
+            rec = records.get(nid)
+            if rec is None:
+                continue
+            dag = {
+                "nodes": [
+                    {
+                        "node_id": rec.node_id,
+                        "node_type": rec.node_type,
+                        "code_hash": rec.code_hash,
+                        "schema_hash": rec.schema_hash,
+                        "interval": rec.interval,
+                        "period": rec.period,
+                        "tags": list(rec.tags),
+                    }
+                ]
+            }
+            dag_json = json.dumps(dag)
+            self.diff.diff(DiffRequest(strategy_id=nid, dag_json=dag_json))
+            self.repo.clear_buffering(nid)
+
+
+__all__ = ["BufferingScheduler"]

--- a/tests/buffer/test_buffer_scheduler.py
+++ b/tests/buffer/test_buffer_scheduler.py
@@ -1,0 +1,60 @@
+import asyncio
+import pytest
+
+from qmtl.dagmanager.buffer_scheduler import BufferingScheduler
+from qmtl.dagmanager.diff_service import DiffService, DiffRequest, NodeRepository, NodeRecord
+from qmtl.dagmanager.topic import topic_name
+
+
+class FakeRepo(NodeRepository):
+    def __init__(self):
+        self.records: dict[str, NodeRecord] = {}
+        self.buffered: dict[str, int] = {}
+        self.cleared: list[str] = []
+
+    def get_nodes(self, node_ids):
+        return {nid: self.records[nid] for nid in node_ids if nid in self.records}
+
+    def insert_sentinel(self, sentinel_id, node_ids):
+        pass
+
+    def get_queues_by_tag(self, tags, interval):
+        return []
+
+    def get_node_by_queue(self, queue):
+        return None
+
+    def mark_buffering(self, node_id, *, timestamp_ms=None):
+        self.buffered[node_id] = timestamp_ms or 0
+
+    def clear_buffering(self, node_id):
+        self.cleared.append(node_id)
+        self.buffered.pop(node_id, None)
+
+    def get_buffering_nodes(self, older_than_ms):
+        return [n for n, t in self.buffered.items() if t < older_than_ms]
+
+
+class FakeDiff(DiffService):
+    def __init__(self):
+        self.calls = []
+
+    def diff(self, request: DiffRequest):
+        self.calls.append(request)
+        return type("Chunk", (), {"queue_map": {}, "sentinel_id": request.strategy_id})()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_reprocesses_old_nodes():
+    repo = FakeRepo()
+    repo.records["A"] = NodeRecord(
+        "A", "N", "c", "s", None, None, [], topic_name("asset", "N", "c", "v1")
+    )
+    repo.mark_buffering("A", timestamp_ms=0)
+    diff = FakeDiff()
+    sched = BufferingScheduler(repo, diff, interval=0.01, delay_days=7)
+    await sched.start()
+    await asyncio.sleep(0.03)
+    await sched.stop()
+    assert diff.calls and diff.calls[0].strategy_id == "A"
+    assert repo.cleared == ["A"]

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -19,6 +19,7 @@ class FakeRepo(NodeRepository):
         self.fetched = []
         self.sentinels = []
         self.records = {}
+        self.buffered: dict[str, int] = {}
 
     def get_nodes(self, node_ids):
         self.fetched.append(list(node_ids))
@@ -29,6 +30,15 @@ class FakeRepo(NodeRepository):
 
     def get_queues_by_tag(self, tags, interval):
         return []
+
+    def mark_buffering(self, node_id, *, timestamp_ms=None):
+        self.buffered[node_id] = timestamp_ms or 0
+
+    def clear_buffering(self, node_id):
+        self.buffered.pop(node_id, None)
+
+    def get_buffering_nodes(self, older_than_ms):
+        return [n for n, t in self.buffered.items() if t < older_than_ms]
 
 
 class FakeQueue(QueueManager):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -26,6 +26,15 @@ class FakeRepo(NodeRepository):
     def get_queues_by_tag(self, tags, interval):
         return []
 
+    def mark_buffering(self, node_id, *, timestamp_ms=None):
+        pass
+
+    def clear_buffering(self, node_id):
+        pass
+
+    def get_buffering_nodes(self, older_than_ms):
+        return []
+
 
 class FakeQueue(QueueManager):
     def upsert(self, asset, node_type, code_hash, version, *, dryrun=False):


### PR DESCRIPTION
## Summary
- track buffering timestamps in `Neo4jNodeRepository`
- add `BufferingScheduler` to automatically re-run Diff
- mark nodes for buffering during Diff
- export scheduler from package
- test automatic reprocessing in new `tests/buffer/` suite

## Testing
- `uv pip install --system -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685096862a988329992209ba1ceb5968