### PR TITLE
Introduce SourceNode and ProcessingNode

### DIFF
--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -19,10 +19,10 @@ uv pip install -e .[generators]  # 시뮬레이션 데이터 생성기
 
 ## 기본 구조
 
-SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `Node`, `TagQueryNode` 등을 이용해 정의하며 모든 노드는 하나 이상의 업스트림을 가져야 합니다.
+SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `TagQueryNode` 와 같은 **소스 노드**(`SourceNode`)와 다른 노드를 처리하는 **프로세싱 노드**(`ProcessingNode`)로 나뉩니다. `ProcessingNode`는 하나 이상의 업스트림을 반드시 가져야 합니다.
 
 ```python
-from qmtl.sdk import Strategy, Node, StreamInput
+from qmtl.sdk import Strategy, ProcessingNode, StreamInput
 
 class MyStrategy(Strategy):
     def setup(self):
@@ -31,7 +31,7 @@ class MyStrategy(Strategy):
         def compute(view):
             return view
 
-        out = Node(input=price, compute_fn=compute, name="out")
+        out = ProcessingNode(input=price, compute_fn=compute, name="out")
         self.add_nodes([price, out])
 ```
 

--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -1,6 +1,13 @@
 """QMTL strategy SDK."""
 
-from .node import Node, StreamInput, TagQueryNode, NodeCache
+from .node import (
+    Node,
+    SourceNode,
+    ProcessingNode,
+    StreamInput,
+    TagQueryNode,
+    NodeCache,
+)
 from .backfill_state import BackfillState
 from .cache_view import CacheView
 from .strategy import Strategy
@@ -19,6 +26,8 @@ from . import metrics
 
 __all__ = [
     "Node",
+    "SourceNode",
+    "ProcessingNode",
     "StreamInput",
     "TagQueryNode",
     "NodeCache",

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -483,7 +483,24 @@ class Node:
         }
 
 
-class StreamInput(Node):
+class SourceNode(Node):
+    """Base class for nodes without upstream dependencies."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs.setdefault("input", None)
+        super().__init__(*args, **kwargs)
+
+
+class ProcessingNode(Node):
+    """Node that processes data from one or more upstream nodes."""
+
+    def __init__(self, input: Node | Iterable[Node] | Mapping[str, Node], *args, **kwargs) -> None:
+        super().__init__(input=input, *args, **kwargs)
+        if not self.inputs:
+            raise ValueError("processing node requires at least one upstream")
+
+
+class StreamInput(SourceNode):
     """Represents an upstream data stream placeholder."""
 
     def __init__(
@@ -517,7 +534,7 @@ class StreamInput(Node):
         await engine.wait()
 
 
-class TagQueryNode(Node):
+class TagQueryNode(SourceNode):
     """Node that selects upstream queues by tag and interval."""
 
     def __init__(

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -1,7 +1,7 @@
 import pytest
 
 from qmtl.pipeline import Pipeline
-from qmtl.sdk import Node, StreamInput
+from qmtl.sdk import ProcessingNode, StreamInput
 
 
 class DummyProducer:
@@ -22,13 +22,13 @@ def test_basic_flow():
         ts, val = view[src][1].latest()
         return val * 2
 
-    n1 = Node(input=src, compute_fn=mul2, name="n1", interval=1, period=1)
+    n1 = ProcessingNode(input=src, compute_fn=mul2, name="n1", interval=1, period=1)
 
     def add1(view):
         ts, val = view[n1][1].latest()
         return val + 1
 
-    n2 = Node(input=n1, compute_fn=add1, name="n2", interval=1, period=1)
+    n2 = ProcessingNode(input=n1, compute_fn=add1, name="n2", interval=1, period=1)
 
     prod = DummyProducer()
     n1.queue_topic = "n1"
@@ -46,9 +46,9 @@ def test_basic_flow():
 
 def test_execute_false_pass_through():
     src = StreamInput(interval=1, period=1)
-    n1 = Node(input=src, compute_fn=lambda v: None, name="n1", interval=1, period=1)
+    n1 = ProcessingNode(input=src, compute_fn=lambda v: None, name="n1", interval=1, period=1)
     n1.execute = False
-    n2 = Node(input=n1, compute_fn=lambda v: v[n1][1].latest()[1] + 5, name="n2", interval=1, period=1)
+    n2 = ProcessingNode(input=n1, compute_fn=lambda v: v[n1][1].latest()[1] + 5, name="n2", interval=1, period=1)
 
     pipe = Pipeline([src, n1, n2])
 

--- a/tests/runner/test_kafka_consumers.py
+++ b/tests/runner/test_kafka_consumers.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 
-from qmtl.sdk import Node, StreamInput, Strategy, Runner
+from qmtl.sdk import ProcessingNode, StreamInput, Strategy, Runner
 
 class DummyStrategy(Strategy):
     def __init__(self, nodes):
@@ -19,7 +19,7 @@ async def test_single_node_consumption(monkeypatch):
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=compute, name="n1", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n1", interval=60, period=2)
     node.queue_topic = "t1"
     strategy = DummyStrategy([src, node])
 
@@ -50,11 +50,11 @@ async def test_multi_node_consumption(monkeypatch):
         calls.append("n2")
 
     src1 = StreamInput(interval=60, period=2)
-    node1 = Node(input=src1, compute_fn=compute1, name="n1", interval=60, period=2)
+    node1 = ProcessingNode(input=src1, compute_fn=compute1, name="n1", interval=60, period=2)
     node1.queue_topic = "t1"
 
     src2 = StreamInput(interval=60, period=2)
-    node2 = Node(input=src2, compute_fn=compute2, name="n2", interval=60, period=2)
+    node2 = ProcessingNode(input=src2, compute_fn=compute2, name="n2", interval=60, period=2)
     node2.queue_topic = "t2"
 
     strategy = DummyStrategy([src1, node1, src2, node2])

--- a/tests/sample_strategy.py
+++ b/tests/sample_strategy.py
@@ -1,7 +1,7 @@
-from qmtl.sdk import Strategy, Node, StreamInput
+from qmtl.sdk import Strategy, ProcessingNode, StreamInput
 
 class SampleStrategy(Strategy):
     def setup(self):
         src = StreamInput(interval=1, period=1)
-        node = Node(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
+        node = ProcessingNode(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
         self.add_nodes([src, node])

--- a/tests/test_backfill_engine.py
+++ b/tests/test_backfill_engine.py
@@ -4,7 +4,7 @@ import logging
 import pandas as pd
 import pytest
 
-from qmtl.sdk.node import Node, StreamInput
+from qmtl.sdk.node import SourceNode, StreamInput
 from qmtl.sdk.backfill_engine import BackfillEngine
 
 
@@ -25,7 +25,7 @@ class DummySource:
 
 @pytest.mark.asyncio
 async def test_concurrent_backfill_and_live_append():
-    node = Node(interval=60, period=5)
+    node = SourceNode(interval=60, period=5)
     df = pd.DataFrame([
         {"ts": 60, "value": 1},
         {"ts": 120, "value": 2},
@@ -52,7 +52,7 @@ async def test_concurrent_backfill_and_live_append():
 
 @pytest.mark.asyncio
 async def test_retry_logic():
-    node = Node(interval=60, period=2)
+    node = SourceNode(interval=60, period=2)
     df = pd.DataFrame([{"ts": 60, "v": 1}])
     src = DummySource(df, delay=0.01, fail=1)
     engine = BackfillEngine(src, max_retries=2)
@@ -67,7 +67,7 @@ async def test_metrics_and_logs(caplog):
     from qmtl.sdk import metrics as sdk_metrics
     sdk_metrics.reset_metrics()
 
-    node = Node(interval=60, period=1)
+    node = SourceNode(interval=60, period=1)
     df = pd.DataFrame([{"ts": 60, "v": 1}])
     src = DummySource(df, delay=0.0, fail=1)
     engine = BackfillEngine(src, max_retries=2)
@@ -93,7 +93,7 @@ async def test_failure_metrics_and_logs(caplog):
     from qmtl.sdk import metrics as sdk_metrics
     sdk_metrics.reset_metrics()
 
-    node = Node(interval=60, period=1)
+    node = SourceNode(interval=60, period=1)
     df = pd.DataFrame([])
     src = DummySource(df, delay=0.0, fail=5)
     engine = BackfillEngine(src, max_retries=2)

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -187,12 +187,12 @@ def test_sentinel_insert_and_stream():
 
 def test_diff_with_sdk_nodes():
     """End-to-end check with nodes serialized by the SDK."""
-    from qmtl.sdk import StreamInput, Node, Strategy
+    from qmtl.sdk import StreamInput, ProcessingNode, Strategy
 
     class _S(Strategy):
         def setup(self):
             src = StreamInput(interval=1, period=1)
-            node = Node(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
+            node = ProcessingNode(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
             self.add_nodes([src, node])
 
     s = _S()

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,10 +1,10 @@
 from qmtl.indicators import sma
-from qmtl.sdk.node import Node
+from qmtl.sdk.node import SourceNode
 from qmtl.sdk.cache_view import CacheView
 
 
 def test_sma_compute():
-    src = Node(interval=1, period=3)
+    src = SourceNode(interval=1, period=3)
     node = sma(src, window=2)
     data = {src.node_id: {1: [(0, 1), (1, 3)]}}
     view = CacheView(data)
@@ -30,7 +30,7 @@ from qmtl.indicators import (
 
 
 def test_ema_compute():
-    src = Node(interval=1, period=3)
+    src = SourceNode(interval=1, period=3)
     node = ema(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
@@ -38,7 +38,7 @@ def test_ema_compute():
 
 
 def test_rsi_compute():
-    src = Node(interval=1, period=15)
+    src = SourceNode(interval=1, period=15)
     node = rsi(src, window=14)
     data = {src.node_id: {1: [(i, float(i)) for i in range(15)]}}
     view = CacheView(data)
@@ -46,7 +46,7 @@ def test_rsi_compute():
 
 
 def test_bollinger_bands_compute():
-    src = Node(interval=1, period=3)
+    src = SourceNode(interval=1, period=3)
     node = bollinger_bands(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
@@ -57,9 +57,9 @@ def test_bollinger_bands_compute():
 
 
 def test_atr_compute():
-    h = Node(interval=1, period=3, config={"id": "h"})
-    l = Node(interval=1, period=3, config={"id": "l"})
-    c = Node(interval=1, period=4, config={"id": "c"})
+    h = SourceNode(interval=1, period=3, config={"id": "h"})
+    l = SourceNode(interval=1, period=3, config={"id": "l"})
+    c = SourceNode(interval=1, period=4, config={"id": "c"})
     node = atr(h, l, c, window=3)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
@@ -71,9 +71,9 @@ def test_atr_compute():
 
 
 def test_chandelier_exit_compute():
-    h = Node(interval=1, period=3, config={"id": "h"})
-    l = Node(interval=1, period=3, config={"id": "l"})
-    c = Node(interval=1, period=4, config={"id": "c"})
+    h = SourceNode(interval=1, period=3, config={"id": "h"})
+    l = SourceNode(interval=1, period=3, config={"id": "l"})
+    c = SourceNode(interval=1, period=4, config={"id": "c"})
     node = chandelier_exit(h, l, c, window=3, multiplier=3)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
@@ -87,8 +87,8 @@ def test_chandelier_exit_compute():
 
 
 def test_vwap_compute():
-    p = Node(interval=1, period=3, config={"id": "p"})
-    v = Node(interval=1, period=3, config={"id": "v"})
+    p = SourceNode(interval=1, period=3, config={"id": "p"})
+    v = SourceNode(interval=1, period=3, config={"id": "v"})
     node = vwap(p, v, window=3)
     data = {
         p.node_id: {1: [(0, 1), (1, 2), (2, 3)]},
@@ -99,8 +99,8 @@ def test_vwap_compute():
 
 
 def test_anchored_vwap_compute():
-    p = Node(interval=1, period=3, config={"id": "p"})
-    v = Node(interval=1, period=3, config={"id": "v"})
+    p = SourceNode(interval=1, period=3, config={"id": "p"})
+    v = SourceNode(interval=1, period=3, config={"id": "v"})
     node = anchored_vwap(p, v, anchor_ts=1)
     data = {
         p.node_id: {1: [(0, 1), (1, 2), (2, 3)]},
@@ -111,9 +111,9 @@ def test_anchored_vwap_compute():
 
 
 def test_keltner_channel_compute():
-    h = Node(interval=1, period=3, config={"id": "h"})
-    l = Node(interval=1, period=3, config={"id": "l"})
-    c = Node(interval=1, period=4, config={"id": "c"})
+    h = SourceNode(interval=1, period=3, config={"id": "h"})
+    l = SourceNode(interval=1, period=3, config={"id": "l"})
+    c = SourceNode(interval=1, period=4, config={"id": "c"})
     node = keltner_channel(h, l, c, ema_window=3, atr_window=3, multiplier=2)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
@@ -128,8 +128,8 @@ def test_keltner_channel_compute():
 
 
 def test_obv_compute():
-    c = Node(interval=1, period=3, config={"id": "c"})
-    v = Node(interval=1, period=3, config={"id": "v"})
+    c = SourceNode(interval=1, period=3, config={"id": "c"})
+    v = SourceNode(interval=1, period=3, config={"id": "v"})
     node = obv(c, v)
     data = {
         c.node_id: {1: [(0, 1), (1, 2), (2, 1)]},
@@ -140,9 +140,9 @@ def test_obv_compute():
 
 
 def test_supertrend_compute():
-    h = Node(interval=1, period=3, config={"id": "h"})
-    l = Node(interval=1, period=3, config={"id": "l"})
-    c = Node(interval=1, period=4, config={"id": "c"})
+    h = SourceNode(interval=1, period=3, config={"id": "h"})
+    l = SourceNode(interval=1, period=3, config={"id": "l"})
+    c = SourceNode(interval=1, period=4, config={"id": "c"})
     node = supertrend(h, l, c, window=3, multiplier=2)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
@@ -154,9 +154,9 @@ def test_supertrend_compute():
 
 
 def test_ichimoku_cloud_compute():
-    h = Node(interval=1, period=52, config={"id": "h"})
-    l = Node(interval=1, period=52, config={"id": "l"})
-    c = Node(interval=1, period=52, config={"id": "c"})
+    h = SourceNode(interval=1, period=52, config={"id": "h"})
+    l = SourceNode(interval=1, period=52, config={"id": "l"})
+    c = SourceNode(interval=1, period=52, config={"id": "c"})
     node = ichimoku_cloud(h, l, c)
     highs = [(i, i + 1) for i in range(52)]
     lows = [(i, i) for i in range(52)]
@@ -170,7 +170,7 @@ def test_ichimoku_cloud_compute():
 
 
 def test_kalman_trend_compute():
-    src = Node(interval=1, period=5, config={"id": "src"})
+    src = SourceNode(interval=1, period=5, config={"id": "src"})
     node = kalman_trend(src)
     data = {src.node_id: {1: [(i, float(i)) for i in range(5)]}}
     view = CacheView(data)
@@ -179,7 +179,7 @@ def test_kalman_trend_compute():
 
 
 def test_rough_bergami_compute():
-    src = Node(interval=1, period=4, config={"id": "src"})
+    src = SourceNode(interval=1, period=4, config={"id": "src"})
     node = rough_bergami(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 1), (3, 2)]}}
     view = CacheView(data)
@@ -187,7 +187,7 @@ def test_rough_bergami_compute():
 
 
 def test_stoch_rsi_compute():
-    src = Node(interval=1, period=30, config={"id": "src"})
+    src = SourceNode(interval=1, period=30, config={"id": "src"})
     node = stoch_rsi(src, window=14)
     values = [(i, float(i % 5)) for i in range(30)]
     data = {src.node_id: {1: values}}
@@ -197,9 +197,9 @@ def test_stoch_rsi_compute():
 
 
 def test_kdj_compute():
-    h = Node(interval=1, period=3, config={"id": "h"})
-    l = Node(interval=1, period=3, config={"id": "l"})
-    c = Node(interval=1, period=3, config={"id": "c"})
+    h = SourceNode(interval=1, period=3, config={"id": "h"})
+    l = SourceNode(interval=1, period=3, config={"id": "l"})
+    c = SourceNode(interval=1, period=3, config={"id": "c"})
     node = kdj(h, l, c, window=3)
     data = {
         h.node_id: {1: [(0, 3), (1, 4), (2, 5)]},

--- a/tests/test_multi_input_node.py
+++ b/tests/test_multi_input_node.py
@@ -1,11 +1,11 @@
 import pytest
-from qmtl.sdk import Node, StreamInput, TagQueryNode
+from qmtl.sdk import ProcessingNode, StreamInput, TagQueryNode
 
 
 def test_multi_input_serialization_list():
     s1 = StreamInput(interval=60, period=1)
     s2 = StreamInput(interval=60, period=1)
-    node = Node(input=[s1, s2], compute_fn=lambda x: x, name="out", interval=60, period=1)
+    node = ProcessingNode(input=[s1, s2], compute_fn=lambda x: x, name="out", interval=60, period=1)
     d = node.to_dict()
     assert set(d["inputs"]) == {s1.node_id, s2.node_id}
 
@@ -13,7 +13,7 @@ def test_multi_input_serialization_list():
 def test_multi_input_serialization_dict():
     s1 = StreamInput(interval=60, period=1)
     s2 = StreamInput(interval=60, period=1)
-    node = Node(input={"a": s1, "b": s2}, compute_fn=lambda x: x, name="out", interval=60, period=1)
+    node = ProcessingNode(input={"a": s1, "b": s2}, compute_fn=lambda x: x, name="out", interval=60, period=1)
     d = node.to_dict()
     assert set(d["inputs"]) == {s1.node_id, s2.node_id}
 
@@ -21,6 +21,6 @@ def test_multi_input_serialization_dict():
 def test_multi_input_with_tag_query():
     tq = TagQueryNode(["t"], interval=60, period=1)
     s = StreamInput(interval=60, period=1)
-    node = Node(input=[tq, s], compute_fn=lambda x: x, name="out", interval=60, period=1)
+    node = ProcessingNode(input=[tq, s], compute_fn=lambda x: x, name="out", interval=60, period=1)
     d = node.to_dict()
     assert set(d["inputs"]) == {tq.node_id, s.node_id}

--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -1,6 +1,6 @@
 import pytest
 import xarray as xr
-from qmtl.sdk import Node, StreamInput, Runner, NodeCache
+from qmtl.sdk import ProcessingNode, StreamInput, Runner, NodeCache
 
 
 def test_cache_warmup_and_compute():
@@ -10,7 +10,7 @@ def test_cache_warmup_and_compute():
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval=60, period=2)
 
     Runner.feed_queue_data(node, "q1", 60, 60, {"v": 1})
     assert node.pre_warmup
@@ -42,7 +42,7 @@ def test_node_feed_respects_execute_flag(monkeypatch):
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval=60, period=2)
     node.execute = False
 
     node.feed("q1", 60, 60, {"v": 1})
@@ -58,7 +58,7 @@ def test_multiple_upstreams():
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval=60, period=2)
 
     Runner.feed_queue_data(node, "u1", 60, 60, {"v": 1})
     Runner.feed_queue_data(node, "u2", 60, 60, {"v": 1})
@@ -107,7 +107,7 @@ def test_on_missing_policy_skip_and_fail():
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=fn, name="n", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval=60, period=2)
 
     Runner.feed_queue_data(node, "q1", 60, 1, {"v": 1})
     # Gap -> should skip
@@ -115,7 +115,7 @@ def test_on_missing_policy_skip_and_fail():
     assert node.cache.missing_flags()["q1"][60]
     assert len(calls) == 0
 
-    node2 = Node(input=src, compute_fn=fn, name="n2", interval=60, period=2)
+    node2 = ProcessingNode(input=src, compute_fn=fn, name="n2", interval=60, period=2)
     Runner.feed_queue_data(node2, "q1", 60, 1, {"v": 1})
     with pytest.raises(RuntimeError):
         Runner.feed_queue_data(node2, "q1", 60, 3, {"v": 2}, on_missing="fail")

--- a/tests/test_node_feed.py
+++ b/tests/test_node_feed.py
@@ -1,5 +1,5 @@
 import qmtl.sdk.runner as rmod
-from qmtl.sdk import Node, StreamInput
+from qmtl.sdk import ProcessingNode, StreamInput
 
 
 def test_node_feed_with_ray(monkeypatch):
@@ -34,7 +34,7 @@ def test_node_feed_with_ray(monkeypatch):
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval=60, period=2)
 
     node.feed("q", 60, 60, {"v": 1})
     node.feed("q", 60, 120, {"v": 2})
@@ -52,7 +52,7 @@ def test_node_feed_without_ray(monkeypatch):
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval=60, period=2)
 
     node.feed("q", 60, 60, {"v": 1})
     node.feed("q", 60, 120, {"v": 2})

--- a/tests/test_node_id.py
+++ b/tests/test_node_id.py
@@ -1,7 +1,7 @@
-from qmtl.sdk import Node, StreamInput, Strategy
+from qmtl.sdk import SourceNode, ProcessingNode, StreamInput, Strategy
 
 def test_node_id_generation():
-    node = Node(compute_fn=lambda x: x, name="n", interval=1, period=1)
+    node = SourceNode(compute_fn=lambda x: x, name="n", interval=1, period=1)
     node_id = node.node_id
     assert len(node_id) == 64
     assert node_id == node.node_id  # deterministic
@@ -10,7 +10,7 @@ def test_node_id_generation():
 class _S(Strategy):
     def setup(self):
         src = StreamInput(interval=1, period=1)
-        node = Node(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
+        node = ProcessingNode(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
         self.add_nodes([src, node])
 
 

--- a/tests/test_node_validation.py
+++ b/tests/test_node_validation.py
@@ -1,5 +1,5 @@
 import pytest
-from qmtl.sdk.node import Node
+from qmtl.sdk.node import SourceNode, ProcessingNode
 
 @pytest.mark.parametrize(
     "interval,period",
@@ -14,7 +14,7 @@ from qmtl.sdk.node import Node
 )
 def test_invalid_node_parameters(interval, period):
     with pytest.raises(ValueError):
-        Node(interval=interval, period=period)
+        SourceNode(interval=interval, period=period)
 
 
 @pytest.mark.parametrize(
@@ -27,4 +27,9 @@ def test_invalid_node_parameters(interval, period):
 )
 def test_invalid_compute_fn(fn):
     with pytest.raises(TypeError):
-        Node(compute_fn=fn, interval=1, period=1)
+        SourceNode(compute_fn=fn, interval=1, period=1)
+
+
+def test_processing_node_requires_input():
+    with pytest.raises(ValueError):
+        ProcessingNode(input=None, compute_fn=lambda v: v, interval=1, period=1)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -5,7 +5,7 @@ import json
 import httpx
 import pytest
 from qmtl.sdk.runner import Runner
-from qmtl.sdk.node import StreamInput, Node
+from qmtl.sdk.node import StreamInput, ProcessingNode
 from tests.sample_strategy import SampleStrategy
 
 
@@ -251,7 +251,7 @@ def test_no_gateway_same_ids(monkeypatch):
 
 
 def test_feed_queue_data_with_ray(monkeypatch):
-    from qmtl.sdk import Node, StreamInput
+    from qmtl.sdk import ProcessingNode, StreamInput
 
     class DummyRay:
         def __init__(self):
@@ -285,7 +285,7 @@ def test_feed_queue_data_with_ray(monkeypatch):
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval=60, period=2)
 
     Runner.feed_queue_data(node, "q", 60, 60, {"v": 1})
     Runner.feed_queue_data(node, "q", 60, 120, {"v": 2})
@@ -295,7 +295,7 @@ def test_feed_queue_data_with_ray(monkeypatch):
 
 
 def test_feed_queue_data_without_ray(monkeypatch):
-    from qmtl.sdk import Node, StreamInput
+    from qmtl.sdk import ProcessingNode, StreamInput
 
     monkeypatch.setattr(Runner, "_ray_available", False)
 
@@ -305,7 +305,7 @@ def test_feed_queue_data_without_ray(monkeypatch):
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval=60, period=2)
 
     Runner.feed_queue_data(node, "q", 60, 60, {"v": 1})
     Runner.feed_queue_data(node, "q", 60, 120, {"v": 2})
@@ -314,7 +314,7 @@ def test_feed_queue_data_without_ray(monkeypatch):
 
 
 def test_feed_queue_data_respects_execute_flag(monkeypatch):
-    from qmtl.sdk import Node, StreamInput
+    from qmtl.sdk import ProcessingNode, StreamInput
 
     monkeypatch.setattr(Runner, "_ray_available", False)
 
@@ -324,7 +324,7 @@ def test_feed_queue_data_respects_execute_flag(monkeypatch):
         calls.append(view)
 
     src = StreamInput(interval=60, period=2)
-    node = Node(input=src, compute_fn=compute, name="n", interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval=60, period=2)
     node.execute = False
 
     Runner.feed_queue_data(node, "q", 60, 60, {"v": 1})
@@ -460,7 +460,7 @@ def test_history_gap_fill(monkeypatch):
     class Strat(SampleStrategy):
         def setup(self):
             src = StreamInput(interval=1, period=1, history_provider=provider)
-            node = Node(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
+            node = ProcessingNode(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
             self.add_nodes([src, node])
 
     Runner.backtest(Strat, start_time=60, end_time=120, gateway_url="http://gw")
@@ -513,7 +513,7 @@ def test_history_gap_fill_stops_on_ready(monkeypatch):
         def setup(self):
             src = StreamInput(interval=1, period=1, history_provider=provider)
             holder["src"] = src
-            node = Node(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
+            node = ProcessingNode(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
             self.add_nodes([src, node])
 
     Runner.dryrun(Strat, gateway_url="http://gw")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,10 +1,10 @@
 from qmtl.transforms import rate_of_change, stochastic, angle
-from qmtl.sdk.node import Node
+from qmtl.sdk.node import SourceNode
 from qmtl.sdk.cache_view import CacheView
 
 
 def test_rate_of_change_compute():
-    src = Node(interval=1, period=3)
+    src = SourceNode(interval=1, period=3)
     node = rate_of_change(src, period=2)
     data = {src.node_id: {1: [(0, 1), (1, 3)]}}
     view = CacheView(data)
@@ -12,7 +12,7 @@ def test_rate_of_change_compute():
 
 
 def test_stochastic_compute():
-    src = Node(interval=1, period=3)
+    src = SourceNode(interval=1, period=3)
     node = stochastic(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
@@ -20,7 +20,7 @@ def test_stochastic_compute():
 
 
 def test_angle_compute():
-    src = Node(interval=1, period=3)
+    src = SourceNode(interval=1, period=3)
     node = angle(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)


### PR DESCRIPTION
## Summary
- create `SourceNode` and `ProcessingNode` classes
- enforce upstream requirement on `ProcessingNode`
- update `StreamInput` and `TagQueryNode` to inherit from `SourceNode`
- adjust tests for new classes
- document node hierarchy in tutorial

## Testing
- `uv pip install -e .[dev]`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850998d21848329b00f82f11d53f176