### PR TITLE
Implement offline/backtest history replay

### DIFF
--- a/qmtl/gateway/dagmanager_client.py
+++ b/qmtl/gateway/dagmanager_client.py
@@ -13,6 +13,10 @@ class DagManagerClient:
 
     def __init__(self, target: str) -> None:
         self._target = target
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.set_event_loop(asyncio.new_event_loop())
         self._channel = grpc.aio.insecure_channel(self._target)
         self._health_stub = dagmanager_pb2_grpc.HealthCheckStub(self._channel)
         self._diff_stub = dagmanager_pb2_grpc.DiffServiceStub(self._channel)

--- a/tests/runner/test_execution.py
+++ b/tests/runner/test_execution.py
@@ -1,0 +1,69 @@
+import httpx
+import pandas as pd
+import pytest
+
+from qmtl.sdk import Runner, Strategy, StreamInput, Node
+
+class DummyProvider:
+    async def fetch(self, start, end, *, node_id, interval):
+        return pd.DataFrame([
+            {"ts": 60, "v": 1},
+            {"ts": 120, "v": 2},
+        ])
+
+    async def coverage(self, *, node_id, interval):
+        return [(60, 120)]
+
+    async def fill_missing(self, start, end, *, node_id, interval):
+        pass
+
+
+def _mock_gateway(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(202, json={"strategy_id": "s"})
+
+    transport = httpx.MockTransport(handler)
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+
+        async def post(self, url, json=None):
+            request = httpx.Request("POST", url, json=json)
+            return handler(request)
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+
+
+def test_backtest_executes_nodes(monkeypatch):
+    _mock_gateway(monkeypatch)
+    calls = []
+
+    class Strat(Strategy):
+        def setup(self):
+            src = StreamInput(interval=60, period=2, history_provider=DummyProvider())
+            node = Node(input=src, compute_fn=lambda v: calls.append(v), interval=60, period=2)
+            self.add_nodes([src, node])
+
+    Runner.backtest(Strat, start_time=60, end_time=120, gateway_url="http://gw")
+    assert len(calls) == 1
+
+
+def test_offline_executes_nodes():
+    calls = []
+
+    class Strat(Strategy):
+        def setup(self):
+            src = StreamInput(interval=60, period=2)
+            src.cache.backfill_bulk(src.node_id, 60, [(60, {"v": 1}), (120, {"v": 2})])
+            node = Node(input=src, compute_fn=lambda v: calls.append(v), interval=60, period=2)
+            self.add_nodes([src, node])
+
+    Runner.offline(Strat)
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- replay cached history during backtest and offline runs
- ensure gRPC client works without existing event loop
- test backtest/offline execution flows

## Testing
- `uv venv && uv pip install -e .[dev]`
- `.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509c21107483299852ba1917e37328