### PR TITLE
Update TagQuery docs and examples

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -299,10 +299,25 @@ if __name__ == "__main__":
 
 **TagQueryNode 동작 요약**
 
-1. Gateway는 (query\_tags, interval) 조건으로 글로벌 DAG를 탐색한다.
-2. 해당 조건에 부합하는 모든 큐들을 업스트림으로 설정한다.
-3. SDK는 각 큐의 데이터를 수집해 read-only **CacheView** 하나로 묶어 `compute_fn`에 전달한다. `compute_fn`은 반드시 이 뷰 단일 인자만을 받아야 하며, 병합 방식 역시 함수 내부에서 정의한다.
-4. 각 큐가 설정된 period를 만족하지 않으면 노드는 ‘pre-warmup’ 상태에 머물며, 충족 시점부터 연산을 시작한다. Gateway는 `(query_tags, interval)` 조건에 부합하는 신규 큐가 전역 DAG에 추가될 때마다 콜백 이벤트를 통해 TagQueryNode에 알리고, 해당 노드는 런타임 중에도 업스트림 큐 목록을 동적으로 확장할 수 있다.
+1. Runner가 생성한 **TagQueryManager**가 Gateway에 `(query_tags, interval)` 조건을 조회한다.
+2. Gateway는 글로벌 DAG을 탐색한 후 매칭되는 큐 목록을 반환하고, TagQueryManager가 이를 ``TagQueryNode`` 에 전달한다.
+3. TagQueryNode는 받은 큐 ID만 보관하며, 실제 Kafka 구독과 WebSocket 갱신 역시 TagQueryManager가 담당한다.
+4. SDK는 각 큐의 데이터를 수집해 read-only **CacheView** 하나로 묶어 `compute_fn`에 전달한다. `compute_fn`은 반드시 이 뷰 단일 인자만을 받아야 하며, 병합 방식 역시 함수 내부에서 정의한다.
+5. 각 큐가 설정된 period를 만족하지 않으면 노드는 ‘pre-warmup’ 상태에 머물며, Gateway가 새로운 큐를 발견하면 TagQueryManager가 `update_queues()`를 호출해 런타임 중에도 업스트림 목록을 확장한다.
+
+```mermaid
+sequenceDiagram
+    participant R as Runner
+    participant M as TagQueryManager
+    participant G as Gateway
+    participant N as TagQueryNode
+    R->>M: register TagQueryNode
+    M->>G: GET /queues/by_tag
+    G-->>M: queue list
+    M->>N: update_queues(list)
+    G-->>M: queue_update (WebSocket)
+    M->>N: update_queues(list)
+```
 
 이 구조로 전략 작성자는 **큐 이름이나 위치를 몰라도 태그 기반으로 지표 집합을 참조**할 수 있으며, 지표가 추가될 때마다 전략 수정 없이 자동 반영된다.
 
@@ -373,7 +388,8 @@ Runner.dryrun(CrossMarketLagStrategy)
 4. **Sentinel Traffic Shift 확인** — `traffic_weight` 변경 시 Gateway와 SDK가 5초
    이내 동기화되었는지 측정한다.
 5. **TagQueryNode 동적 확장** — Gateway가 새 `(tags, interval)` 큐를 발견하면
-   `tagquery.upsert` CloudEvent를 발행해 SDK 버퍼 초기화를 유도한다.
+   `tagquery.upsert` CloudEvent를 발행하고, Runner의 **TagQueryManager**가 이를
+   수신해 각 노드의 버퍼를 자동 초기화한다.
 6. **Minor‑schema 버퍼링** — `schema_minor_change`는 재사용하되 7일 후 자동
    full‑recompute가 실행된다.
 7. **SSA DAG Lint** — SDK 빌드 시 DAG를 SSA 중간 표현으로 변환해 해시 불일치를

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -19,7 +19,7 @@ uv pip install -e .[generators]  # 시뮬레이션 데이터 생성기
 
 ## 기본 구조
 
-SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `TagQueryNode` 와 같은 **소스 노드**(`SourceNode`)와 다른 노드를 처리하는 **프로세싱 노드**(`ProcessingNode`)로 나뉩니다. `ProcessingNode`는 하나 이상의 업스트림을 반드시 가져야 합니다.
+SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `TagQueryNode` 와 같은 **소스 노드**(`SourceNode`)와 다른 노드를 처리하는 **프로세싱 노드**(`ProcessingNode`)로 나뉩니다. `ProcessingNode`는 하나 이상의 업스트림을 반드시 가져야 합니다. `TagQueryNode` 자체는 네트워크 요청을 수행하지 않고, Runner가 생성하는 **TagQueryManager**가 Gateway와 통신하여 큐 목록을 갱신합니다.
 
 ```python
 from qmtl.sdk import Strategy, ProcessingNode, StreamInput
@@ -49,6 +49,9 @@ python -m qmtl.sdk tests.sample_strategy:SampleStrategy --mode offline
 from qmtl.sdk import Runner
 Runner.dryrun(MyStrategy)
 ```
+
+`Runner`를 사용하면 각 `TagQueryNode`가 등록된 후 자동으로 Gateway와 통신하여
+해당 태그에 매칭되는 큐를 조회하고 WebSocket 구독을 시작합니다.
 
 ## CLI 도움말
 

--- a/examples/correlation_strategy.py
+++ b/examples/correlation_strategy.py
@@ -8,6 +8,8 @@ class CorrelationStrategy(Strategy):
             interval="1h",
             period=24,
         )
+        # Queue resolution and subscription are handled automatically by Runner
+        # through TagQueryManager.
 
         def calc_corr(view):
             df = pd.concat(
@@ -25,4 +27,6 @@ class CorrelationStrategy(Strategy):
 
 
 if __name__ == "__main__":
+    # Running via Runner will automatically fetch matching queues and
+    # subscribe to updates.
     Runner.live(CorrelationStrategy)

--- a/examples/tag_query_strategy.py
+++ b/examples/tag_query_strategy.py
@@ -13,6 +13,8 @@ class TagQueryStrategy(Strategy):
             interval="1h",
             period=24,
         )
+        # Runner creates TagQueryManager so the node receives queue mappings
+        # and subscriptions automatically.
 
         def calc_corr(view) -> pd.DataFrame:
             frames = [pd.DataFrame([v for _, v in view[u][3600]]) for u in view]
@@ -36,4 +38,6 @@ class TagQueryStrategy(Strategy):
 
 
 if __name__ == "__main__":
+    # Simply running the strategy triggers automatic tag resolution and
+    # WebSocket subscriptions.
     Runner.live(TagQueryStrategy)


### PR DESCRIPTION
## Summary
- explain TagQueryManager role in architecture and gateway
- note automatic queue resolution in sdk tutorial
- update TagQuery examples to highlight automatic subscriptions

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a1e289108329b5af41fe96a5866d