### PR TITLE
Disallow dict inputs for Nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ python examples/extensions_combined_strategy.py
 
 See [examples/README.md](examples/README.md) for additional scripts such as `tag_query_strategy.py` or `ws_metrics_example.py`.
 
+`ProcessingNode` instances accept either a single upstream `Node` or a list of nodes via the `input` parameter. Dictionary inputs are no longer supported.
+
 ## Backfills
 
 [docs/backfill.md](docs/backfill.md) explains how to preload historical data by

--- a/architecture.md
+++ b/architecture.md
@@ -348,7 +348,7 @@ class CrossMarketLagStrategy(Strategy):
         mstr_price = StreamInput(tags=["MSTR", "price", "nasdaq"], interval="60s", period=120)
 
         corr_node = Node(
-            input={"btc": btc_price, "mstr": mstr_price},
+            input=[btc_price, mstr_price],
             compute_fn=lagged_corr,
             name="btc_mstr_corr"
         )

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -20,7 +20,9 @@ uv pip install -e .[generators]  # 시뮬레이션 데이터 생성기
 ## 기본 구조
 
 
-SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `TagQueryNode` 와 같은 **소스 노드**(`SourceNode`)와 다른 노드를 처리하는 **프로세싱 노드**(`ProcessingNode`)로 나뉩니다. `ProcessingNode`는 하나 이상의 업스트림을 반드시 가져야 합니다. `interval`과 `period` 값은 정수 또는 `"1h"`, `"30m"`, `"45s"`처럼 단위 접미사를 가진 문자열로 지정할 수 있습니다. `TagQueryNode` 자체는 네트워크 요청을 수행하지 않고, Runner가 생성하는 **TagQueryManager**가 Gateway와 통신하여 큐 목록을 갱신합니다.
+ SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `TagQueryNode` 와 같은 **소스 노드**(`SourceNode`)와 다른 노드를 처리하는 **프로세싱 노드**(`ProcessingNode`)로 나뉩니다. `ProcessingNode`는 하나 이상의 업스트림을 반드시 가져야 합니다. `interval`과 `period` 값은 정수 또는 `"1h"`, `"30m"`, `"45s"`처럼 단위 접미사를 가진 문자열로 지정할 수 있습니다. `TagQueryNode` 자체는 네트워크 요청을 수행하지 않고, Runner가 생성하는 **TagQueryManager**가 Gateway와 통신하여 큐 목록을 갱신합니다.
+
+ `ProcessingNode`의 `input`은 단일 노드 또는 노드들의 리스트로 지정합니다. 딕셔너리 입력 형식은 더 이상 지원되지 않습니다.
 
 
 ```python

--- a/examples/cross_market_lag_strategy.py
+++ b/examples/cross_market_lag_strategy.py
@@ -28,8 +28,9 @@ class CrossMarketLagStrategy(Strategy):
             btc_shift = btc["close"].shift(90)
             corr = btc_shift.corr(mstr["close"])
             return pd.DataFrame({"lag_corr": [corr]})
+
         corr_node = Node(
-            input={"btc": btc_price, "mstr": mstr_price},
+            input=[btc_price, mstr_price],
             compute_fn=lagged_corr,
             name="btc_mstr_corr",
         )

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -301,25 +301,26 @@ class Node:
     returned by :py:meth:`NodeCache.view`. The view provides read-only access to
     the cached data and mirrors the structure returned by
     :py:meth:`NodeCache.view`. Positional arguments other than the cache view are
-    **not** supported.
+    **not** supported. ``input`` may be a single ``Node`` or an iterable of
+    ``Node`` instances. Passing dictionaries is no longer supported.
     """
 
     # ------------------------------------------------------------------
     @staticmethod
-    def _normalize_inputs(inp: Node | Iterable[Node] | Mapping[str, Node] | None) -> list[Node]:
+    def _normalize_inputs(inp: Node | Iterable[Node] | None) -> list[Node]:
         if inp is None:
             return []
         if isinstance(inp, Node):
             return [inp]
         if isinstance(inp, Mapping):
-            return list(inp.values())
+            raise TypeError("mapping inputs no longer supported")
         if isinstance(inp, Iterable):
             return list(inp)
         raise TypeError("invalid input type")
 
     def __init__(
         self,
-        input: Node | Iterable[Node] | Mapping[str, Node] | None = None,
+        input: Node | Iterable[Node] | None = None,
         compute_fn=None,
         name: str | None = None,
         interval: int | str | None = None,
@@ -492,7 +493,7 @@ class SourceNode(Node):
 class ProcessingNode(Node):
     """Node that processes data from one or more upstream nodes."""
 
-    def __init__(self, input: Node | Iterable[Node] | Mapping[str, Node], *args, **kwargs) -> None:
+    def __init__(self, input: Node | Iterable[Node], *args, **kwargs) -> None:
         super().__init__(input=input, *args, **kwargs)
         if not self.inputs:
             raise ValueError("processing node requires at least one upstream")

--- a/tests/test_multi_input_node.py
+++ b/tests/test_multi_input_node.py
@@ -13,9 +13,8 @@ def test_multi_input_serialization_list():
 def test_multi_input_serialization_dict():
     s1 = StreamInput(interval=60, period=1)
     s2 = StreamInput(interval=60, period=1)
-    node = ProcessingNode(input={"a": s1, "b": s2}, compute_fn=lambda x: x, name="out", interval=60, period=1)
-    d = node.to_dict()
-    assert set(d["inputs"]) == {s1.node_id, s2.node_id}
+    with pytest.raises(TypeError):
+        ProcessingNode(input={"a": s1, "b": s2}, compute_fn=lambda x: x, name="out", interval=60, period=1)
 
 
 def test_multi_input_with_tag_query():

--- a/tests/test_node_inputs.py
+++ b/tests/test_node_inputs.py
@@ -1,0 +1,18 @@
+import pytest
+from qmtl.sdk import ProcessingNode, StreamInput
+
+
+def test_processing_node_accepts_list_or_node():
+    s1 = StreamInput(interval=60, period=1)
+    node = ProcessingNode(input=s1, compute_fn=lambda v: None, name="n", interval=60, period=1)
+    assert node.inputs == [s1]
+    s2 = StreamInput(interval=60, period=1)
+    node2 = ProcessingNode(input=[s1, s2], compute_fn=lambda v: None, name="n2", interval=60, period=1)
+    assert node2.inputs == [s1, s2]
+
+
+def test_processing_node_rejects_dict():
+    s1 = StreamInput(interval=60, period=1)
+    s2 = StreamInput(interval=60, period=1)
+    with pytest.raises(TypeError):
+        ProcessingNode(input={"a": s1, "b": s2}, compute_fn=lambda v: None, name="n", interval=60, period=1)


### PR DESCRIPTION
## Summary
- drop dictionary support when specifying node inputs
- forbid mapping in `Node._normalize_inputs`
- update docs and examples to describe the new input format
- fix existing multi-input test and add new tests for invalid dicts

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6850ab4f213c8329aafb0cd29703a963