### PR TITLE
Implement history replay for offline/backtest

### DIFF
--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -124,6 +124,12 @@ Runner.backtest(
 )
 ```
 
+During backtest and offline runs the SDK **replays** cached history through a
+``Pipeline``.  Events from each ``StreamInput`` are collected concurrently with
+``asyncio.gather`` and sorted by timestamp before being fed into the graph.
+If Ray is installed, compute functions may execute in parallel during this
+replay phase.
+
 ## Monitoring Progress
 
 Backfill operations emit Prometheus metrics via `qmtl.sdk.metrics`:


### PR DESCRIPTION
## Summary
- stream history replay via new `_replay_history` helper
- propagate on-missing policies through `Pipeline`
- update docs on replay behaviour
- add tests covering replay execution and missing-policy error handling

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ab895f78832982cbb67f3f53ba08