### PR TITLE
Add Korean translation for compute_fn TypeError

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -349,7 +349,7 @@ class Node:
             )
             if len(positional) != 1 or has_var_positional:
                 raise TypeError(
-                    "compute_fn must accept exactly one positional argument"
+                    "compute_fn must accept exactly one positional argument (지원되지 않는 함수 시그니처)"
                 )
 
         self.input = input


### PR DESCRIPTION
## Summary
- improve compute function signature validation message by adding Korean explanation
- keep node validation tests expecting `TypeError`

## Testing
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850af8665c88329896a50d7ca139191