### PR TITLE
Add execute change logging in Runner queue mapping

### DIFF
--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -5,6 +5,9 @@ import json
 import asyncio
 import time
 from typing import Optional, Iterable
+import logging
+
+logger = logging.getLogger(__name__)
 
 import httpx
 
@@ -79,6 +82,7 @@ class Runner:
 
         for node in strategy.nodes:
             mapping = queue_map.get(node.node_id)
+            old_execute = node.execute
             if isinstance(node, TagQueryNode):
                 if isinstance(mapping, list):
                     node.upstreams = list(mapping)
@@ -93,6 +97,15 @@ class Runner:
                 else:
                     node.execute = True
                     node.queue_topic = None
+
+            if node.execute != old_execute:
+                logger.debug(
+                    "execute changed for %s: %s -> %s (mapping=%s)",
+                    node.node_id,
+                    old_execute,
+                    node.execute,
+                    mapping,
+                )
 
     @staticmethod
     def _init_tag_manager(strategy: Strategy, gateway_url: str | None) -> TagQueryManager:

--- a/tests/test_queue_map_logging.py
+++ b/tests/test_queue_map_logging.py
@@ -1,0 +1,32 @@
+import logging
+
+from qmtl.sdk import Runner, Strategy, StreamInput, ProcessingNode, TagQueryNode
+
+
+class _Strat(Strategy):
+    def setup(self):
+        self.src = StreamInput(interval=60, period=2)
+        self.proc = ProcessingNode(
+            input=self.src, compute_fn=lambda v: v, name="proc", interval=60, period=2
+        )
+        self.tq = TagQueryNode(["t"], interval=60, period=2)
+        self.add_nodes([self.src, self.proc, self.tq])
+
+
+def test_apply_queue_map_logs_on_change(caplog):
+    strat = _Strat()
+    strat.setup()
+    mapping = {strat.proc.node_id: "topic1", strat.tq.node_id: ["q1"]}
+
+    caplog.set_level(logging.DEBUG, logger="qmtl.sdk.runner")
+    Runner._apply_queue_map(strat, mapping)
+
+    msgs = [r.getMessage() for r in caplog.records if r.name == "qmtl.sdk.runner"]
+    assert any(strat.proc.node_id in m for m in msgs)
+    assert any(strat.tq.node_id in m for m in msgs)
+
+    caplog.clear()
+    Runner._apply_queue_map(strat, mapping)
+    msgs = [r.getMessage() for r in caplog.records if r.name == "qmtl.sdk.runner"]
+    assert not msgs
+


### PR DESCRIPTION
## Summary
- log execute flag changes when applying queue maps
- add regression test for logging side effect

## Testing
- `uv pip install --system -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b0790ab08329a91e723aa30aeb91