### PR TITLE
Docs: clarify TagQuery resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ python examples/extensions_combined_strategy.py
 
 See [examples/README.md](examples/README.md) for additional scripts such as `tag_query_strategy.py` or `ws_metrics_example.py`.
 
+## TagQuery Node Resolution
+
+`TagQueryNode` instances no longer resolve queues themselves. The
+`TagQueryManager.resolve_tags()` method retrieves queue mappings from the Gateway
+and updates all registered nodes. `Runner` creates a manager automatically and
+invokes this method in every mode, so manual calls are rarely needed.
+
 `ProcessingNode` instances accept either a single upstream `Node` or a list of nodes via the `input` parameter. Dictionary inputs are no longer supported.
 
 ## Backfills

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,3 +7,5 @@
   calling the snapshot helper.
 - Added `coverage()` and `fill_missing()` interfaces for history providers and
   removed `start`/`end` arguments from `StreamInput`.
+- `TagQueryNode.resolve()` has been removed. Use
+  `TagQueryManager.resolve_tags()` to fetch queue mappings before execution.

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -20,7 +20,7 @@ uv pip install -e .[generators]  # 시뮬레이션 데이터 생성기
 ## 기본 구조
 
 
- SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `TagQueryNode` 와 같은 **소스 노드**(`SourceNode`)와 다른 노드를 처리하는 **프로세싱 노드**(`ProcessingNode`)로 나뉩니다. `ProcessingNode`는 하나 이상의 업스트림을 반드시 가져야 합니다. `interval`과 `period` 값은 정수 또는 `"1h"`, `"30m"`, `"45s"`처럼 단위 접미사를 가진 문자열로 지정할 수 있습니다. `TagQueryNode` 자체는 네트워크 요청을 수행하지 않고, Runner가 생성하는 **TagQueryManager**가 Gateway와 통신하여 큐 목록을 갱신합니다.
+SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `TagQueryNode` 와 같은 **소스 노드**(`SourceNode`)와 다른 노드를 처리하는 **프로세싱 노드**(`ProcessingNode`)로 나뉩니다. `ProcessingNode`는 하나 이상의 업스트림을 반드시 가져야 합니다. `interval`과 `period` 값은 정수 또는 `"1h"`, `"30m"`, `"45s"`처럼 단위 접미사를 가진 문자열로 지정할 수 있습니다. `TagQueryNode` 자체는 네트워크 요청을 수행하지 않고, Runner가 생성하는 **TagQueryManager**가 Gateway와 통신하여 큐 목록을 갱신합니다. 각 노드가 등록된 후 `TagQueryManager.resolve_tags()`를 호출하여 초기 큐 목록을 받아오며, 이후 업데이트는 WebSocket을 통해 처리됩니다.
 
  `ProcessingNode`의 `input`은 단일 노드 또는 노드들의 리스트로 지정합니다. 딕셔너리 입력 형식은 더 이상 지원되지 않습니다.
 

--- a/gateway.md
+++ b/gateway.md
@@ -129,9 +129,10 @@ Immediately after ingest, Gateway inserts a `VersionSentinel` node into the DAG 
 Gateway persists its FSM in Redis with AOF enabled and mirrors crucial events in PostgreSQL's Write-Ahead Log. This mitigates the Redis failure scenario described in the architecture (§2).
 
 When resolving `TagQueryNode` dependencies, the Runner's **TagQueryManager**
-calls ``/queues/by_tag``. Gateway consults DAG-Manager for queues matching
-`(tags, interval)` and returns the list so that TagQueryNode instances remain
-network‑agnostic and only nodes lacking upstream queues execute locally.
+invokes ``resolve_tags()`` which issues a ``/queues/by_tag`` request. Gateway
+consults DAG-Manager for queues matching `(tags, interval)` and returns the list
+so that TagQueryNode instances remain network‑agnostic and only nodes lacking
+upstream queues execute locally.
 
 Gateway also listens for `sentinel_weight` CloudEvents emitted by DAG‑Manager. Upon receiving an update, the in-memory routing table is adjusted and the new weight broadcast to SDK clients via WebSocket. The effective ratio per version is exported as the Prometheus gauge `gateway_sentinel_traffic_ratio{version="<id>"}`.
 


### PR DESCRIPTION
## Summary
- mention TagQueryManager.resolve_tags in README
- expand TagQuery section of sdk_tutorial
- update gateway docs for resolve_tags call
- note removal of TagQueryNode.resolve in CHANGELOG

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850b13fef108329abd102c6f3cf3b9e