### PR TITLE
Remove start/end args from examples

### DIFF
--- a/examples/cross_market_lag_strategy.py
+++ b/examples/cross_market_lag_strategy.py
@@ -9,8 +9,6 @@ class CrossMarketLagStrategy(Strategy):
             interval="60s",
             period=120,
             history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            start=1700000000,
-            end=1700003600,
             event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
         )
         mstr_price = StreamInput(
@@ -18,8 +16,6 @@ class CrossMarketLagStrategy(Strategy):
             interval="60s",
             period=120,
             history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            start=1700000000,
-            end=1700003600,
             event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
         )
         def lagged_corr(view):
@@ -39,4 +35,5 @@ class CrossMarketLagStrategy(Strategy):
 
 
 if __name__ == "__main__":
+    # For backtesting provide start_time and end_time to Runner.backtest
     Runner.dryrun(CrossMarketLagStrategy)

--- a/examples/general_strategy.py
+++ b/examples/general_strategy.py
@@ -8,8 +8,6 @@ class GeneralStrategy(Strategy):
             interval="60s",
             period=30,
             history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            start=1700000000,
-            end=1700003600,
             event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
         )
 
@@ -28,6 +26,7 @@ class GeneralStrategy(Strategy):
 
 
 if __name__ == "__main__":
+    # The backfill range is provided via Runner.backtest
     Runner.backtest(
         GeneralStrategy,
         start_time="2024-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary
- clean up example strategies to no longer use `start` and `end`
- note in examples that backfill range is provided through `Runner.backtest`

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851435e3f888329933607bfd9d27c84