### PR TITLE
Add SDK docker stack with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ qmtl-dagm diff --file dag.json --target localhost:50051
 See [gateway.md](gateway.md) and [dag-manager.md](dag-manager.md) for more
 information on configuration and advanced usage.
 
+## SDK Docker Environment
+
+Spin up the Gateway and DAG Manager with all required services using Docker Compose:
+
+```bash
+docker compose -f docker-compose.sdk.yml up -d
+```
+
+This starts Neo4j, Postgres, Redis, Kafka and Zookeeper alongside the two components. Refer to [docs/sdk_docker.md](docs/sdk_docker.md) for full instructions.
+
 ## SDK Tutorial
 
 For instructions on implementing strategies with the SDK, see

--- a/docker-compose.sdk.yml
+++ b/docker-compose.sdk.yml
@@ -1,0 +1,57 @@
+version: '3'
+services:
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: example
+    ports:
+      - "5432:5432"
+
+  neo4j:
+    image: neo4j:latest
+    environment:
+      NEO4J_AUTH: neo4j/test
+    ports:
+      - "7687:7687"
+      - "7474:7474"
+
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: bitnami/kafka:latest
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+
+  dag-manager:
+    image: python:3
+    command: ["qmtl-dagm", "grpc-server"]
+    depends_on:
+      - kafka
+      - neo4j
+    ports:
+      - "50051:50051"
+
+  gateway:
+    image: python:3
+    command: ["qmtl-gateway", "serve"]
+    depends_on:
+      - dag-manager
+      - redis
+    ports:
+      - "8000:8000"

--- a/docs/sdk_docker.md
+++ b/docs/sdk_docker.md
@@ -1,0 +1,40 @@
+# SDK Docker Environment
+
+This guide explains how to start the Gateway and DAG Manager with their required services using Docker Compose. It provides a quick setup for testing strategies with the SDK.
+
+## Requirements
+
+- `docker`
+- `uv` for installing dependencies
+
+## Starting the stack
+
+Launch all services with Docker Compose:
+
+```bash
+docker compose -f docker-compose.sdk.yml up -d
+```
+
+The compose file starts Neo4j, Postgres, Redis, Zookeeper, Kafka and runs the `qmtl-gateway` and `qmtl-dagm` containers. The Gateway listens on port `8000` while the DAG Manager gRPC endpoint is exposed on `50051`.
+
+Stop the stack when finished:
+
+```bash
+docker compose -f docker-compose.sdk.yml down
+```
+
+## Running a sample strategy
+
+After the stack is running, install dependencies and execute a strategy:
+
+```bash
+uv venv
+uv pip install -e .[dev]
+python -m qmtl.sdk tests.sample_strategy:SampleStrategy \
+    --mode backtest \
+    --start-time 2024-01-01 \
+    --end-time 2024-02-01 \
+    --gateway-url http://localhost:8000
+```
+
+For additional details on the SDK and strategy implementation, see [sdk_tutorial.md](sdk_tutorial.md).

--- a/tests/test_docker_compose_sdk.py
+++ b/tests/test_docker_compose_sdk.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import yaml
+
+COMPOSE_FILE = Path(__file__).parent.parent / "docker-compose.sdk.yml"
+
+
+def test_sdk_compose_services():
+    data = yaml.safe_load(COMPOSE_FILE.read_text())
+    services = set(data.get("services", {}).keys())
+    expected = {"redis", "postgres", "neo4j", "gateway", "dag-manager"}
+    assert expected.issubset(services)


### PR DESCRIPTION
## Summary
- add `docker-compose.sdk.yml` to run gateway and dag-manager with dependencies
- document how to use the stack in `docs/sdk_docker.md`
- link to new guide from README
- test Compose file to ensure required services exist

## Testing
- `uv pip install -e .[dev]`
- `uv run -- pytest -q tests/test_docker_compose_sdk.py`
- `bash -c 'uv run pytest -q tests > /tmp/full_pytest.log && tail -n 20 /tmp/full_pytest.log'`

------
https://chatgpt.com/codex/tasks/task_e_6856acd97b20832989c8f8188f9c96ff