### PR TITLE
Add Node.add_tag method

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,3 +9,4 @@
   removed `start`/`end` arguments from `StreamInput`.
 - `TagQueryNode.resolve()` has been removed. Use
   `TagQueryManager.resolve_tags()` to fetch queue mappings before execution.
+- Added `Node.add_tag()` to attach tags after node creation.

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -305,7 +305,8 @@ class Node:
     the cached data and mirrors the structure returned by
     :py:meth:`NodeCache.view`. Positional arguments other than the cache view are
     **not** supported. ``input`` may be a single ``Node`` or an iterable of
-    ``Node`` instances. Passing dictionaries is no longer supported.
+    ``Node`` instances. Passing dictionaries is no longer supported. Tags can be
+    assigned at initialization or later via :py:meth:`add_tag`.
     """
 
     # ------------------------------------------------------------------
@@ -373,6 +374,12 @@ class Node:
         return (
             f"Node(name={self.name!r}, interval={self.interval}, period={self.period})"
         )
+
+    def add_tag(self, tag: str) -> "Node":
+        """Append ``tag`` to :attr:`tags` if missing and return ``self``."""
+        if tag not in self.tags:
+            self.tags.append(tag)
+        return self
 
     # --- hashing helpers -------------------------------------------------
     @staticmethod

--- a/tests/test_node_tags.py
+++ b/tests/test_node_tags.py
@@ -1,0 +1,18 @@
+import pytest
+from qmtl.sdk.node import SourceNode
+
+
+def test_add_tag():
+    n = SourceNode(interval=1, period=1)
+    original = n.node_id
+    assert n.tags == []
+
+    n.add_tag("a")
+    assert n.tags == ["a"]
+    assert n.node_id == original
+
+    n.add_tag("b")
+    n.add_tag("a")
+    assert n.tags == ["a", "b"]
+    assert n.node_id == original
+    assert n.to_dict()["tags"] == ["a", "b"]


### PR DESCRIPTION
## Summary
- allow adding tags after node creation via `Node.add_tag`
- document the new method in `CHANGELOG`
- test tag mutation behavior

## Testing
- `uv pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858441f466c83298576dce39e419929