### PR TITLE
Add match_mode support to TagQueryManager

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -554,6 +554,7 @@ class TagQueryNode(SourceNode):
         *,
         interval: int | str,
         period: int | str,
+        match_mode: str = "any",
         compute_fn=None,
         name: str | None = None,
     ) -> None:
@@ -566,6 +567,7 @@ class TagQueryNode(SourceNode):
             tags=list(query_tags),
         )
         self.query_tags = list(query_tags)
+        self.match_mode = match_mode
         self.upstreams: list[str] = []
         self.execute = False
 


### PR DESCRIPTION
## Summary
- extend `TagQueryNode` to take a `match_mode` parameter
- track match mode in `TagQueryManager` keys
- send `match_mode` with tag resolution requests and WebSocket updates
- test handling of match mode routing

## Testing
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584886050883298e49f2a6ac019686