### PR TITLE
Add TagQuery match_mode docs

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -284,6 +284,7 @@ class CorrelationStrategy(Strategy):
             query_tags=["ta-indicator"],  # RSI, MFI 등 사전 계산 지표 노드들과 매칭
             interval="1h",               # 1시간 바 기준
             period=24,                    # 24시간 캐시(24개)
+            match_mode="any",             # 기본값은 OR 매칭
             compute_fn=calc_corr          # 병합 후 바로 상관계수 계산
         )
 
@@ -294,6 +295,9 @@ class CorrelationStrategy(Strategy):
         )
 
         self.add_nodes([indicators, corr_node])
+
+        # match_mode="any" 는 하나 이상의 태그가 일치하면 매칭되며,
+        # "all" 로 지정하면 모든 태그가 존재하는 큐만 선택된다.
 
 # 실시간 실행 예시
 if __name__ == "__main__":

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -20,7 +20,7 @@ uv pip install -e .[generators]  # 시뮬레이션 데이터 생성기
 ## 기본 구조
 
 
-SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `TagQueryNode` 와 같은 **소스 노드**(`SourceNode`)와 다른 노드를 처리하는 **프로세싱 노드**(`ProcessingNode`)로 나뉩니다. `ProcessingNode`는 하나 이상의 업스트림을 반드시 가져야 합니다. `interval`과 `period` 값은 정수 또는 `"1h"`, `"30m"`, `"45s"`처럼 단위 접미사를 가진 문자열로 지정할 수 있습니다. `TagQueryNode` 자체는 네트워크 요청을 수행하지 않고, Runner가 생성하는 **TagQueryManager**가 Gateway와 통신하여 큐 목록을 갱신합니다. 각 노드가 등록된 후 `TagQueryManager.resolve_tags()`를 호출하여 초기 큐 목록을 받아오며, 이후 업데이트는 WebSocket을 통해 처리됩니다.
+SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드만 구현하면 됩니다. 노드는 `StreamInput`, `TagQueryNode` 와 같은 **소스 노드**(`SourceNode`)와 다른 노드를 처리하는 **프로세싱 노드**(`ProcessingNode`)로 나뉩니다. `ProcessingNode`는 하나 이상의 업스트림을 반드시 가져야 합니다. `interval`과 `period` 값은 정수 또는 `"1h"`, `"30m"`, `"45s"`처럼 단위 접미사를 가진 문자열로 지정할 수 있습니다. `TagQueryNode` 자체는 네트워크 요청을 수행하지 않고, Runner가 생성하는 **TagQueryManager**가 Gateway와 통신하여 큐 목록을 갱신합니다. 각 노드가 등록된 후 `TagQueryManager.resolve_tags()`를 호출하여 초기 큐 목록을 받아오며, 이후 업데이트는 WebSocket을 통해 처리됩니다. 태그 매칭 방식은 `match_mode` 옵션으로 지정하며 기본값은 OR 조건에 해당하는 `"any"` 입니다. 모든 태그가 일치해야 할 경우 `match_mode="all"`을 사용합니다.
 
 `ProcessingNode`의 `input`은 단일 노드 또는 노드들의 리스트로 지정합니다. 딕셔너리 입력 형식은 더 이상 지원되지 않습니다.
 

--- a/examples/correlation_strategy.py
+++ b/examples/correlation_strategy.py
@@ -7,6 +7,7 @@ class CorrelationStrategy(Strategy):
             query_tags=["ta-indicator"],
             interval="1h",
             period=24,
+            match_mode="any",  # default OR matching
         )
         # Queue resolution and subscription are handled automatically by Runner
         # through TagQueryManager.

--- a/examples/tag_query_strategy.py
+++ b/examples/tag_query_strategy.py
@@ -12,6 +12,7 @@ class TagQueryStrategy(Strategy):
             query_tags=["ta-indicator"],
             interval="1h",
             period=24,
+            match_mode="any",  # default OR matching
         )
         # Runner creates TagQueryManager so the node receives queue mappings
         # and subscriptions automatically.

--- a/qmtl/gateway/dagmanager_client.py
+++ b/qmtl/gateway/dagmanager_client.py
@@ -62,6 +62,16 @@ class DagManagerClient:
     ) -> list[str]:
         """Return queues matching ``tags`` and ``interval``.
 
+        Parameters
+        ----------
+        tags:
+            태그 이름 목록.
+        interval:
+            조회할 바 주기(초 단위).
+        match_mode:
+            ``"any"`` (기본값)일 때는 하나 이상의 태그가 일치하면 매칭하며,
+            ``"all"`` 은 모든 태그가 존재하는 큐만 반환한다.
+
         This delegates to DAG‑Manager which is expected to expose a
         ``TagQuery`` RPC. Retries with exponential backoff are applied
         similar to :meth:`diff`.


### PR DESCRIPTION
## Summary
- document TagQueryNode match_mode usage in SDK tutorial and architecture doc
- include `match_mode` in examples
- expand DagManagerClient.get_queues_by_tag docstring

## Testing
- `uv pip install -e .[dev]`
- `uv pip wheel .` *(fails: unrecognized subcommand)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595e9e7b7483299dc47a0a30c3d986