### PR TITLE
Add DagManager configuration and CLI improvements

### DIFF
--- a/dag-manager.md
+++ b/dag-manager.md
@@ -247,3 +247,19 @@ qmtl-dagm export-schema --out schema.cypher
 
 For canary deployment steps see
 [`docs/canary_rollout.md`](docs/canary_rollout.md).
+
+## 12. 서버 설정 파일 사용법
+
+`qmtl-dagmgr-server`는 YAML 형식의 설정 파일을 읽어 기본 값을 채울 수 있다.
+`--config` 옵션으로 경로를 지정하며 CLI 플래그가 우선 적용된다.
+
+예시:
+
+```yaml
+repo_backend: neo4j
+neo4j_uri: bolt://db:7687
+neo4j_user: neo4j
+neo4j_password: secret
+queue_backend: kafka
+kafka_bootstrap: localhost:9092
+```

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import yaml
+
+
+@dataclass
+class DagManagerConfig:
+    """Configuration for DAG manager server."""
+
+    repo_backend: str = "neo4j"
+    neo4j_uri: str = "bolt://localhost:7687"
+    neo4j_user: str = "neo4j"
+    neo4j_password: str = "neo4j"
+    queue_backend: str = "kafka"
+    kafka_bootstrap: str = "localhost:9092"
+    grpc_host: str = "0.0.0.0"
+    grpc_port: int = 50051
+    http_host: str = "0.0.0.0"
+    http_port: int = 8000
+    diff_callback: Optional[str] = None
+    gc_callback: Optional[str] = None
+
+
+def load_dagmanager_config(path: str) -> DagManagerConfig:
+    """Load :class:`DagManagerConfig` from a YAML file."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return DagManagerConfig(**data)

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -6,3 +6,30 @@ def test_server_help(capsys):
     with pytest.raises(SystemExit):
         main(["--help"])
     assert "qmtl-dagmgr-server" in capsys.readouterr().out
+
+
+def test_server_defaults(monkeypatch):
+    captured = {}
+
+    async def fake_run(args):
+        captured["repo"] = args.repo_backend
+        captured["queue"] = args.queue_backend
+
+    monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
+    main([])
+    assert captured["repo"] == "neo4j"
+    assert captured["queue"] == "kafka"
+
+
+def test_server_config_file(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("neo4j_uri: bolt://test:7687\n")
+
+    captured = {}
+
+    async def fake_run(args):
+        captured["uri"] = args.neo4j_uri
+
+    monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
+    main(["--config", str(cfg)])
+    assert captured["uri"] == "bolt://test:7687"


### PR DESCRIPTION
## Summary
- add `DagManagerConfig` dataclass and YAML loader
- extend server CLI with `--config`, `--repo-backend`, and `--queue-backend`
- allow passing repository and queue instances to `serve`
- update documentation with configuration example
- test new CLI options

## Testing
- `uv pip install --system -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c926c47748329a0208d291a1889be