### PR TITLE
Add Gateway config support and CLI overrides

### DIFF
--- a/gateway.md
+++ b/gateway.md
@@ -146,3 +146,20 @@ Gateway also listens for `sentinel_weight` CloudEvents emitted by DAG‑Manager.
 * **Sentinel Traffic Δ 확인 루프** – `traffic_weight` 변경 후 Gateway 라우팅
   테이블과 SDK 로컬 라우터가 5초 이내 동기화됐는지를 `sentinel_skew_seconds`
   지표로 측정한다.
+
+### Gateway CLI Options
+
+The ``qmtl-gateway`` entrypoint reads configuration from a YAML/JSON file or command-line flags.
+The file may contain ``redis_dsn``, ``database_backend`` and ``database_dsn`` fields.
+
+```
+qmtl-gateway --config gateway.yml --database-backend postgres \
+             --redis-dsn redis://localhost:6379 --database-dsn postgresql://db
+```
+
+Available flags:
+
+- ``--config`` – path to configuration file.
+- ``--database-backend`` – select database implementation (default ``postgres``).
+- ``--database-dsn`` – database connection string.
+- ``--redis-dsn`` – Redis connection string.

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -5,7 +5,8 @@ import asyncio
 
 import redis.asyncio as redis
 
-from .api import create_app, PostgresDatabase
+from .api import create_app
+from .config import GatewayConfig, load_gateway_config
 
 
 async def _main(argv: list[str] | None = None) -> None:
@@ -13,26 +14,41 @@ async def _main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="qmtl-gateway")
     parser.add_argument("--host", default="0.0.0.0", help="Bind address")
     parser.add_argument("--port", type=int, default=8000, help="Bind port")
+    parser.add_argument("--config", help="Path to configuration file")
     parser.add_argument(
         "--redis-dsn",
-        default="redis://localhost:6379",
         help="Redis connection DSN",
     )
+    parser.add_argument("--database-dsn", help="Database connection DSN")
     parser.add_argument(
-        "--postgres-dsn",
-        default="postgresql://localhost/qmtl",
-        help="PostgreSQL connection DSN",
+        "--database-backend",
+        default="postgres",
+        help="Database backend (postgres, memory)",
     )
     args = parser.parse_args(argv)
 
-    redis_client = redis.from_url(args.redis_dsn, decode_responses=True)
-    db = PostgresDatabase(args.postgres_dsn)
-    try:
-        await db.connect()
-    except Exception:
-        pass
+    config = GatewayConfig()
+    if args.config:
+        config = load_gateway_config(args.config)
+    if args.redis_dsn:
+        config.redis_dsn = args.redis_dsn
+    if args.database_dsn:
+        config.database_dsn = args.database_dsn
+    if args.database_backend:
+        config.database_backend = args.database_backend
 
-    app = create_app(redis_client=redis_client, database=db)
+    redis_client = redis.from_url(config.redis_dsn, decode_responses=True)
+    app = create_app(
+        redis_client=redis_client,
+        database_backend=config.database_backend,
+        database_dsn=config.database_dsn,
+    )
+    db = app.state.database
+    if hasattr(db, "connect"):
+        try:
+            await db.connect()  # type: ignore[attr-defined]
+        except Exception:
+            pass
 
     import uvicorn
 

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class GatewayConfig:
+    """Configuration for Gateway service."""
+
+    redis_dsn: str = "redis://localhost:6379"
+    database_backend: str = "postgres"
+    database_dsn: str = "postgresql://localhost/qmtl"
+
+
+def load_gateway_config(path: str) -> GatewayConfig:
+    """Load configuration from YAML or JSON file."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise TypeError("Gateway config must be a mapping")
+    return GatewayConfig(**data)

--- a/tests/test_gateway_cli.py
+++ b/tests/test_gateway_cli.py
@@ -7,4 +7,6 @@ def test_gateway_cli_help():
     assert result.returncode == 0
     assert "--host" in result.stdout
     assert "--port" in result.stdout
+    assert "--config" in result.stdout
+    assert "--database-backend" in result.stdout
 

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+import yaml
+
+from qmtl.gateway.config import load_gateway_config, GatewayConfig
+
+
+def test_load_gateway_config_yaml(tmp_path: Path) -> None:
+    data = {
+        "redis_dsn": "redis://test:6379",
+        "database_backend": "postgres",
+        "database_dsn": "postgresql://db/test",
+    }
+    cfg_file = tmp_path / "gw.yaml"
+    cfg_file.write_text(yaml.safe_dump(data))
+    cfg = load_gateway_config(str(cfg_file))
+    assert cfg.redis_dsn == data["redis_dsn"]
+    assert cfg.database_backend == "postgres"
+    assert cfg.database_dsn == data["database_dsn"]
+
+
+def test_load_gateway_config_json(tmp_path: Path) -> None:
+    data = {
+        "redis_dsn": "redis://j:6379",
+        "database_backend": "memory",
+        "database_dsn": "sqlite:///:memory:",
+    }
+    cfg_file = tmp_path / "gw.json"
+    cfg_file.write_text(json.dumps(data))
+    cfg = load_gateway_config(str(cfg_file))
+    assert cfg.database_backend == "memory"
+    assert cfg.database_dsn == data["database_dsn"]


### PR DESCRIPTION
## Summary
- introduce `GatewayConfig` dataclass and loader
- add `--config`, `--database-backend`, `--database-dsn`, `--redis-dsn` CLI flags
- support memory backend stub and expose database via `app.state`
- document CLI configuration options
- test configuration loading and new help output

## Testing
- `uv run pytest tests/test_gateway_cli.py tests/test_gateway_config.py -q`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c926c31ac8329bf2094758e132a91