### PR TITLE
Ensure consistent config handling

### DIFF
--- a/dag-manager.md
+++ b/dag-manager.md
@@ -263,3 +263,18 @@ neo4j_password: secret
 queue_backend: kafka
 kafka_bootstrap: localhost:9092
 ```
+
+```
+qmtl-dagmgr-server --config dagmgr.yml --repo-backend neo4j \
+                   --queue-backend kafka --neo4j-uri bolt://db:7687
+```
+
+Available flags:
+
+- ``--config`` – path to configuration file.
+- ``--repo-backend`` – select repository implementation (default ``neo4j``).
+- ``--queue-backend`` – select queue implementation (default ``kafka``).
+- ``--neo4j-uri`` – Neo4j connection URI.
+- ``--neo4j-user`` – database user.
+- ``--neo4j-password`` – database password.
+- ``--kafka-bootstrap`` – Kafka bootstrap servers.

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -28,4 +28,6 @@ def load_dagmanager_config(path: str) -> DagManagerConfig:
     """Load :class:`DagManagerConfig` from a YAML file."""
     with open(path, "r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise TypeError("DagManager config must be a mapping")
     return DagManagerConfig(**data)

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -1,0 +1,20 @@
+import yaml
+from pathlib import Path
+from qmtl.dagmanager.config import load_dagmanager_config, DagManagerConfig
+
+
+def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
+    data = {
+        "repo_backend": "neo4j",
+        "neo4j_uri": "bolt://db:7687",
+        "neo4j_user": "neo4j",
+        "neo4j_password": "pw",
+        "queue_backend": "kafka",
+        "kafka_bootstrap": "localhost:9092",
+    }
+    cfg_file = tmp_path / "dm.yml"
+    cfg_file.write_text(yaml.safe_dump(data))
+    cfg = load_dagmanager_config(str(cfg_file))
+    assert cfg.neo4j_uri == data["neo4j_uri"]
+    assert cfg.kafka_bootstrap == data["kafka_bootstrap"]
+


### PR DESCRIPTION
## Summary
- validate mapping type in `load_dagmanager_config`
- document CLI usage for the server
- add unit test for DagManager config loader

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c95887ebc83298b247f306668341f