### PR TITLE
Add unified qmtl CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ Start the gateway HTTP server and interact with the DAG manager using the
 provided CLI tools.
 
 ```bash
-qmtl-gateway --redis-dsn redis://localhost:6379 \
-             --postgres-dsn postgresql://localhost/qmtl
+qmtl gw --redis-dsn redis://localhost:6379 \
+        --postgres-dsn postgresql://localhost/qmtl
 
 # submit a DAG diff
-qmtl-dagm diff --file dag.json --target localhost:50051
+qmtl dagm diff --file dag.json --target localhost:50051
 ```
 
 See [gateway.md](gateway.md) and [dag-manager.md](dag-manager.md) for more

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -236,13 +236,13 @@ sequenceDiagram
 
 ```shell
 # diff dry‑run
-qmtl-dagm diff --file dag.json --dry-run
+qmtl dagm diff --file dag.json --dry-run
 # queue stats
-qmtl-dagm queue-stats --tag indicator --interval 1h
+qmtl dagm queue-stats --tag indicator --interval 1h
 # trigger GC for a sentinel
-qmtl-dagm gc --sentinel v1.2.3
+qmtl dagm gc --sentinel v1.2.3
 # export schema DDL
-qmtl-dagm export-schema --out schema.cypher
+qmtl dagm export-schema --out schema.cypher
 ```
 
 For canary deployment steps see
@@ -250,7 +250,7 @@ For canary deployment steps see
 
 ## 12. 서버 설정 파일 사용법
 
-`qmtl-dagmgr-server`는 YAML 형식의 설정 파일을 읽어 기본 값을 채울 수 있다.
+`qmtl dagmgr-server` 서브커맨드는 YAML 형식의 설정 파일을 읽어 기본 값을 채울 수 있다.
 `--config` 옵션으로 경로를 지정하며 CLI 플래그가 우선 적용된다.
 
 예시:
@@ -265,7 +265,7 @@ kafka_bootstrap: localhost:9092
 ```
 
 ```
-qmtl-dagmgr-server --config dagmgr.yml --repo-backend neo4j \
+qmtl dagmgr-server --config dagmgr.yml --repo-backend neo4j \
                    --queue-backend kafka --neo4j-uri bolt://db:7687
 ```
 

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -26,7 +26,7 @@ Start all services using Docker Compose:
 docker compose -f tests/docker-compose.e2e.yml up -d
 ```
 
-This launches Redis, Postgres, Neo4j, Kafka, Zookeeper and the `qmtl-gateway` and `qmtl-dagm` containers. The gateway exposes port `8000` and the DAG‑Manager gRPC endpoint is available on `50051`.
+This launches Redis, Postgres, Neo4j, Kafka, Zookeeper and the `qmtl gw` and `qmtl dagm` containers. The gateway exposes port `8000` and the DAG‑Manager gRPC endpoint is available on `50051`.
 
 ## Running the tests
 

--- a/gateway.md
+++ b/gateway.md
@@ -149,12 +149,12 @@ Gateway also listens for `sentinel_weight` CloudEvents emitted by DAG‑Manager.
 
 ### Gateway CLI Options
 
-The ``qmtl-gateway`` entrypoint reads configuration from a YAML/JSON file or command-line flags.
+The ``qmtl gw`` subcommand reads configuration from a YAML/JSON file or command-line flags.
 The file may contain ``redis_dsn``, ``database_backend`` and ``database_dsn`` fields.
 
 ```
-qmtl-gateway --config gateway.yml --database-backend postgres \
-             --redis-dsn redis://localhost:6379 --database-dsn postgresql://db
+qmtl gw --config gateway.yml --database-backend postgres \
+        --redis-dsn redis://localhost:6379 --database-dsn postgresql://db
 ```
 
 Available flags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ generators = []
 transforms = []
 
 [project.scripts]
+qmtl = "qmtl.cli:main"
 qmtl-dagm = "qmtl.dagmanager.cli:main"
 qmtl-gateway = "qmtl.gateway.cli:main"
 

--- a/qmtl/__main__.py
+++ b/qmtl/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/qmtl/cli.py
+++ b/qmtl/cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="qmtl")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("gw", help="Gateway CLI", add_help=False)
+    sub.add_parser("dagm", help="Dag manager admin CLI", add_help=False)
+    sub.add_parser("dagmgr-server", help="Run DAG manager servers", add_help=False)
+    sub.add_parser("sdk", help="Run strategy via SDK", add_help=False)
+
+    args, rest = parser.parse_known_args(argv)
+
+    if args.cmd == "gw":
+        from .gateway.cli import main as gw_main
+        gw_main(rest)
+    elif args.cmd == "dagm":
+        from .dagmanager.cli import main as dagm_main
+        dagm_main(rest)
+    elif args.cmd == "dagmgr-server":
+        from .dagmanager.server import main as server_main
+        server_main(rest)
+    elif args.cmd == "sdk":
+        import logging
+        from .sdk.cli import main as sdk_main
+        logging.basicConfig(level=logging.INFO)
+        sdk_main(rest)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -130,7 +130,7 @@ def _cmd_export_schema(args: argparse.Namespace) -> None:
 
 
 async def _main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(prog="qmtl-dagm")
+    parser = argparse.ArgumentParser(prog="qmtl dagm")
     parser.add_argument("--target", default="localhost:50051", help="gRPC service target")
     sub = parser.add_subparsers(dest="cmd", required=True)
 

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -92,7 +92,7 @@ async def _run(args: argparse.Namespace) -> None:
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(prog="qmtl-dagmgr-server", description="Run DAG manager gRPC and HTTP servers")
+    parser = argparse.ArgumentParser(prog="qmtl dagmgr-server", description="Run DAG manager gRPC and HTTP servers")
     parser.add_argument("--config")
     parser.add_argument("--repo-backend", default="neo4j")
     parser.add_argument("--queue-backend", default="kafka")

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -11,7 +11,7 @@ from .config import GatewayConfig, load_gateway_config
 
 async def _main(argv: list[str] | None = None) -> None:
     """Run the Gateway HTTP server."""
-    parser = argparse.ArgumentParser(prog="qmtl-gateway")
+    parser = argparse.ArgumentParser(prog="qmtl gw")
     parser.add_argument("--host", default="0.0.0.0", help="Bind address")
     parser.add_argument("--port", type=int, default=8000, help="Bind port")
     parser.add_argument("--config", help="Path to configuration file")

--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
 import argparse
 import importlib
 
 import asyncio
+from typing import List
 from .runner import Runner
 
 
-async def _main() -> None:
+async def _main(argv: List[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
-        description="Run QMTL strategy (backtest/dry-run/live/offline)"
+        prog="qmtl sdk",
+        description="Run QMTL strategy (backtest/dry-run/live/offline)",
     )
     parser.add_argument("strategy", help="Import path as module:Class")
     parser.add_argument(
@@ -26,7 +29,7 @@ async def _main() -> None:
         "--gateway-url",
         help="Gateway base URL (required for backtest, dryrun and live modes)",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     module_name, class_name = args.strategy.split(":")
     module = importlib.import_module(module_name)
@@ -53,5 +56,6 @@ async def _main() -> None:
     else:  # offline
         await Runner.offline_async(strategy_cls)
 
-def main() -> None:
-    asyncio.run(_main())
+def main(argv: List[str] | None = None) -> None:
+    asyncio.run(_main(argv))
+

--- a/tests/docker-compose.e2e.yml
+++ b/tests/docker-compose.e2e.yml
@@ -40,7 +40,7 @@ services:
 
   dag-manager:
     image: python:3
-    command: ["qmtl-dagm", "grpc-server"]
+    command: ["qmtl", "dagmgr-server"]
     depends_on:
       - kafka
       - neo4j
@@ -49,7 +49,7 @@ services:
 
   gateway:
     image: python:3
-    command: ["qmtl-gateway", "serve"]
+    command: ["qmtl", "gw", "serve"]
     depends_on:
       - dag-manager
       - redis

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ STRATEGY_PATH = "tests.sample_strategy:SampleStrategy"
 
 
 def test_cli_help():
-    result = subprocess.run([sys.executable, "-m", "qmtl.sdk", "--help"], capture_output=True, text=True)
+    result = subprocess.run([sys.executable, "-m", "qmtl", "sdk", "--help"], capture_output=True, text=True)
     assert result.returncode == 0
     assert "Run QMTL strategy" in result.stdout
 
@@ -14,7 +14,8 @@ def test_cli_dryrun():
     result = subprocess.run([
         sys.executable,
         "-m",
-        "qmtl.sdk",
+        "qmtl",
+        "sdk",
         STRATEGY_PATH,
         "--mode",
         "dryrun",
@@ -28,7 +29,8 @@ def test_cli_offline():
     result = subprocess.run([
         sys.executable,
         "-m",
-        "qmtl.sdk",
+        "qmtl",
+        "sdk",
         STRATEGY_PATH,
         "--mode",
         "offline",

--- a/tests/test_gateway_cli.py
+++ b/tests/test_gateway_cli.py
@@ -3,7 +3,7 @@ import sys
 
 
 def test_gateway_cli_help():
-    result = subprocess.run([sys.executable, "-m", "qmtl.gateway", "--help"], capture_output=True, text=True)
+    result = subprocess.run([sys.executable, "-m", "qmtl", "gw", "--help"], capture_output=True, text=True)
     assert result.returncode == 0
     assert "--host" in result.stdout
     assert "--port" in result.stdout

--- a/tests/test_qmtl_cli.py
+++ b/tests/test_qmtl_cli.py
@@ -1,0 +1,9 @@
+import subprocess
+import sys
+
+
+def test_qmtl_help():
+    result = subprocess.run([sys.executable, "-m", "qmtl", "--help"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "gw" in result.stdout
+    assert "dagm" in result.stdout

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -5,7 +5,7 @@ from qmtl.dagmanager.server import main
 def test_server_help(capsys):
     with pytest.raises(SystemExit):
         main(["--help"])
-    assert "qmtl-dagmgr-server" in capsys.readouterr().out
+    assert "qmtl dagmgr-server" in capsys.readouterr().out
 
 
 def test_server_defaults(monkeypatch):


### PR DESCRIPTION
## Summary
- introduce `qmtl` CLI with gw/dagm/dagmgr-server/sdk subcommands
- wire SDK CLI to accept argv and update logging for offline mode
- update docs to use unified CLI
- adjust tests for new command names

## Testing
- `uv pip install -e .[dev]`
- `uv run -- pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c984a8b54832986ebe203e34e1f87