### PR TITLE
Add Arrow-based cache backend

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -75,6 +75,9 @@ Strategy SDK ──▶ Gateway ──▶ DAG-Manager ──▶ Graph DB (Neo4j)
 * **메모리 가드레일**: period × interval 초과 영역은 슬라이스 단위로 즉시 evict하며,
   Tensor 슬라이스는 Apache Arrow chunk로 매핑해 zero‑copy 전달한다. GC 작업은 Ray
   Actor로 분리 스케줄링한다.
+* **Arrow 캐시 백엔드 옵션**: 환경 변수 `QMTL_ARROW_CACHE=1`을 설정하면 PyArrow 기반
+  캐시가 활성화됩니다. `QMTL_CACHE_EVICT_INTERVAL` 값으로 만료 슬라이스를 검사하는
+  주기를 조정하며, Ray가 설치되어 있는 경우 eviction 로직은 Ray Actor로 실행됩니다.
 * **다중 인터벌·다중 업스트림 지원**: `u` 축 (업스트림)과 `i` 축 (인터벌)을 분리함으로써 1m·5m·1h 등 다양한 간격과 여러 태그 큐를 동시에 저장·검색 가능.
 * **캐시 채우기 규칙**: 노드는 `∀(u,i) : |C[u,i]| ≥ Pᵢ` 조건을 만족할 때에만 프로세싱 함수가 호출된다.
 * **타임스탬프 정렬 예시**: interval = 1 m, period = 10, 시스템 UTC = 10:10:30 ⇒ 필요한 `t` 슬롯은 10:01 … 10:10 (10개 캔들).

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -80,6 +80,10 @@ python -m qmtl.sdk --help
 전달됩니다. 이전 버전에서 사용하던 `NodeCache.snapshot()`은 내부 구현으로
 변경되었으므로 전략 코드에서 직접 호출하지 않아야 합니다.
 
+PyArrow 기반 캐시를 사용하려면 환경 변수 `QMTL_ARROW_CACHE=1`을 설정합니다.
+만료 슬라이스 정리는 `QMTL_CACHE_EVICT_INTERVAL`(초) 값에 따라 주기적으로 실행되며
+Ray가 설치되어 있는 경우 Ray Actor에서 동작합니다.
+
 ## 백필 작업
 
 노드 캐시를 과거 데이터로 초기화하는 방법은

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "grpcio-tools",
     "pytest-asyncio",
     "xstate",
+    "pyarrow",
 ]
 
 ray = ["ray"]

--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -8,6 +8,7 @@ from .node import (
     TagQueryNode,
     NodeCache,
 )
+from .arrow_cache import NodeCacheArrow
 from .backfill_state import BackfillState
 from .cache_view import CacheView
 from .strategy import Strategy
@@ -15,6 +16,7 @@ from .runner import Runner
 from .tagquery_manager import TagQueryManager
 from .cli import main as _cli
 from .ws_client import WebSocketClient
+from . import arrow_cache
 from qmtl.sdk.data_io import (
     DataFetcher,
     HistoryProvider,
@@ -33,6 +35,7 @@ __all__ = [
     "StreamInput",
     "TagQueryNode",
     "NodeCache",
+    "NodeCacheArrow",
     "BackfillState",
     "CacheView",
     "Strategy",

--- a/qmtl/sdk/arrow_cache.py
+++ b/qmtl/sdk/arrow_cache.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict, Iterable
+
+try:
+    import pyarrow as pa
+except Exception:  # pragma: no cover - optional dependency
+    pa = None  # type: ignore
+
+try:
+    import ray
+except Exception:  # pragma: no cover - optional dependency
+    ray = None  # type: ignore
+
+ARROW_AVAILABLE = pa is not None
+RAY_AVAILABLE = ray is not None
+
+# Feature gate controlled via environment variable
+ARROW_CACHE_ENABLED = ARROW_AVAILABLE and os.getenv("QMTL_ARROW_CACHE") == "1"
+
+
+class _Slice:
+    def __init__(self, period: int) -> None:
+        self.period = period
+        if not ARROW_AVAILABLE:
+            raise RuntimeError("pyarrow is required for Arrow cache")
+        import pickle
+
+        self._pickle = pickle
+        self.ts = pa.array([], pa.int64())
+        self.vals = pa.array([], pa.binary())
+
+    def append(self, timestamp: int, payload: Any) -> None:
+        self.ts = pa.concat_arrays([self.ts, pa.array([timestamp], pa.int64())])
+        buf = self._pickle.dumps(payload)
+        self.vals = pa.concat_arrays([self.vals, pa.array([buf], pa.binary())])
+        if len(self.ts) > self.period:
+            start = len(self.ts) - self.period
+            self.ts = self.ts.slice(start)
+            self.vals = self.vals.slice(start)
+
+    def latest(self) -> tuple[int, Any] | None:
+        if len(self.ts) == 0:
+            return None
+        idx = len(self.ts) - 1
+        ts = self.ts[idx].as_py()
+        val = self._pickle.loads(self.vals[idx].as_py())
+        return int(ts), val
+
+    def get_list(self) -> list[tuple[int, Any]]:
+        ts = self.ts.to_pylist()
+        vals = [self._pickle.loads(x) for x in self.vals.to_pylist()]
+        return [(int(t), v) for t, v in zip(ts, vals)]
+
+    @property
+    def table(self) -> pa.Table:
+        return pa.table({"t": self.ts, "v": self.vals})
+
+    def slice_table(self, start: int, end: int) -> pa.Table:
+        start = max(0, start)
+        end = min(len(self.ts), end)
+        length = max(0, end - start)
+        return pa.table({"t": self.ts.slice(start, length), "v": self.vals.slice(start, length)})
+
+
+class ArrowCacheView:
+    def __init__(self, data: Dict[str, Dict[int, _Slice]], *, track_access: bool = False) -> None:
+        self._data = data
+        self._track_access = track_access
+        self._access_log: list[tuple[str, int]] = []
+
+    def __getitem__(self, key: str):
+        mp = self._data[key]
+        return _SecondLevelView(mp, self._track_access, self._access_log)
+
+    def access_log(self) -> list[tuple[str, int]]:
+        return list(self._access_log)
+
+
+class _SecondLevelView:
+    def __init__(self, data: Dict[int, _Slice], track_access: bool, log: list[tuple[str, int]]) -> None:
+        self._data = data
+        self._track_access = track_access
+        self._log = log
+
+    def __getitem__(self, key: int):
+        if self._track_access:
+            self._log.append(("?", key))  # upstream id not tracked here
+        return _SliceView(self._data[key])
+
+
+class _SliceView:
+    def __init__(self, sl: _Slice) -> None:
+        self._slice = sl
+
+    def latest(self) -> tuple[int, Any] | None:
+        return self._slice.latest()
+
+    def table(self) -> pa.Table:
+        return self._slice.table
+
+
+class NodeCacheArrow:
+    """Arrow based cache backend."""
+
+    def __init__(self, period: int) -> None:
+        if not ARROW_AVAILABLE:
+            raise RuntimeError("pyarrow not installed")
+        self.period = period
+        self._slices: Dict[tuple[str, int], _Slice] = {}
+        self._last_ts: Dict[tuple[str, int], int | None] = {}
+        self._missing: Dict[tuple[str, int], bool] = {}
+        self._filled: Dict[tuple[str, int], int] = {}
+        self._last_seen: Dict[tuple[str, int], int] = {}
+
+        self._evict_interval = int(os.getenv("QMTL_CACHE_EVICT_INTERVAL", "60"))
+        if RAY_AVAILABLE:
+            self._evictor = _Evictor.options(name=f"evictor_{id(self)}").remote(self._evict_interval)
+            self_ref = self
+            ray.get(self._evictor.start.remote(self_ref))
+        else:
+            self._start_thread_evictor()
+
+    def _start_thread_evictor(self) -> None:
+        import threading
+
+        def loop() -> None:
+            while True:
+                time.sleep(self._evict_interval)
+                self.evict_expired()
+
+        t = threading.Thread(target=loop, daemon=True)
+        t.start()
+
+    # --------------------------------------------------------------
+    def _ensure(self, u: str, interval: int) -> _Slice:
+        key = (u, interval)
+        if key not in self._slices:
+            self._slices[key] = _Slice(self.period)
+            self._last_ts[key] = None
+            self._missing[key] = False
+            self._filled[key] = 0
+            self._last_seen[key] = 0
+        return self._slices[key]
+
+    def append(self, u: str, interval: int, timestamp: int, payload: Any) -> None:
+        sl = self._ensure(u, interval)
+        bucket = timestamp - (timestamp % interval)
+        prev = self._last_ts.get((u, interval))
+        if prev is not None and prev + interval != bucket:
+            self._missing[(u, interval)] = True
+        else:
+            self._missing[(u, interval)] = False
+        self._last_ts[(u, interval)] = bucket
+        sl.append(bucket, payload)
+        filled = self._filled[(u, interval)]
+        if filled < self.period:
+            filled += 1
+        self._filled[(u, interval)] = filled
+        self._last_seen[(u, interval)] = bucket
+
+    def ready(self) -> bool:
+        if not self._slices:
+            return False
+        for key, count in self._filled.items():
+            if count < self.period:
+                return False
+        return True
+
+    def view(self, *, track_access: bool = False) -> ArrowCacheView:
+        by_upstream: Dict[str, Dict[int, _Slice]] = {}
+        for (u, i), sl in self._slices.items():
+            by_upstream.setdefault(u, {})[i] = sl
+        return ArrowCacheView(by_upstream, track_access=track_access)
+
+    def missing_flags(self) -> Dict[str, Dict[int, bool]]:
+        result: Dict[str, Dict[int, bool]] = {}
+        for (u, i), flag in self._missing.items():
+            result.setdefault(u, {})[i] = flag
+        return result
+
+    def last_timestamps(self) -> Dict[str, Dict[int, int | None]]:
+        result: Dict[str, Dict[int, int | None]] = {}
+        for (u, i), ts in self._last_ts.items():
+            result.setdefault(u, {})[i] = ts
+        return result
+
+    def latest(self, u: str, interval: int) -> tuple[int, Any] | None:
+        sl = self._slices.get((u, interval))
+        if not sl:
+            return None
+        return sl.latest()
+
+    def evict_expired(self) -> None:
+        now = int(time.time())
+        for key, last in list(self._last_seen.items()):
+            u, i = key
+            guard = self.period * i
+            if last is not None and now - last > guard:
+                self._slices.pop(key, None)
+                self._last_ts.pop(key, None)
+                self._missing.pop(key, None)
+                self._filled.pop(key, None)
+                self._last_seen.pop(key, None)
+
+
+if RAY_AVAILABLE:
+
+    @ray.remote
+    class _Evictor:
+        def __init__(self, interval: int) -> None:
+            self._interval = interval
+
+        def start(self, cache: NodeCacheArrow) -> None:
+            while True:
+                time.sleep(self._interval)
+                cache.evict_expired()
+
+else:
+
+    class _Evictor:  # pragma: no cover - dummy placeholder
+        pass
+

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import os
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from typing import Any, TYPE_CHECKING
@@ -16,6 +17,7 @@ import asyncio
 from .cache_view import CacheView
 from .backfill_state import BackfillState
 from .util import parse_interval, parse_period
+from . import arrow_cache
 
 if TYPE_CHECKING:  # pragma: no cover - type checking import
     from qmtl.io import HistoryProvider, EventRecorder
@@ -367,7 +369,10 @@ class Node:
         self.schema = schema or {}
         self.execute = True
         self.queue_topic: str | None = None
-        self.cache = NodeCache(period_val or 0)
+        if arrow_cache.ARROW_AVAILABLE and os.getenv("QMTL_ARROW_CACHE") == "1":
+            self.cache = arrow_cache.NodeCacheArrow(period_val or 0)
+        else:
+            self.cache = NodeCache(period_val or 0)
         self.pre_warmup = True
 
     def __repr__(self) -> str:  # pragma: no cover - simple repr

--- a/tests/test_arrow_cache.py
+++ b/tests/test_arrow_cache.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+
+from qmtl.sdk import arrow_cache
+from importlib import reload
+
+from qmtl.sdk import ProcessingNode, StreamInput
+
+pytestmark = pytest.mark.filterwarnings('ignore::RuntimeWarning')
+
+
+@pytest.mark.skipif(not arrow_cache.ARROW_AVAILABLE, reason="pyarrow missing")
+def test_arrow_cache_basic():
+    cache = arrow_cache.NodeCacheArrow(period=2)
+    cache.append("u1", 60, 60, {"v": 1})
+    cache.append("u1", 60, 120, {"v": 2})
+    view = cache.view()
+    assert view["u1"][60].latest() == (120, {"v": 2})
+    assert arrow_cache.pa and isinstance(view["u1"][60].table(), arrow_cache.pa.Table)
+
+
+@pytest.mark.skipif(not arrow_cache.ARROW_AVAILABLE, reason="pyarrow missing")
+def test_node_uses_arrow_cache(monkeypatch):
+    monkeypatch.setenv("QMTL_ARROW_CACHE", "1")
+    src = StreamInput(interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=lambda v: None, name="n", interval=60, period=2)
+    assert isinstance(node.cache, arrow_cache.NodeCacheArrow)
+    monkeypatch.delenv("QMTL_ARROW_CACHE", raising=False)


### PR DESCRIPTION
## Summary
- add optional pyarrow backend with Ray eviction loop
- support runtime toggle via `QMTL_ARROW_CACHE`
- document new options
- test Arrow backend activation

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca0757580832985e2770db0b2e80a