### PR TITLE
Optimize NodeCache with dict-based ring buffers

### DIFF
--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -78,8 +78,8 @@ def test_multiple_upstreams():
 def test_tensor_memory():
     cache = NodeCache(period=4)
     cache.append("u1", 60, 60, {"v": 1})
-    expected = 1 * 1 * 4 * 2 * 8
-    assert cache._tensor.nbytes == expected
+    expected = 4 * 2 * 8
+    assert cache.resident_bytes == expected
 
 
 def test_gap_detection():


### PR DESCRIPTION
## Summary
- refactor `NodeCache` to store per `(u, interval)` ring buffers
- expose a `resident_bytes` property for memory accounting
- update memory usage test

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cad44cc0c8329829c1f79bf00828e