### PR TITLE
Add in-memory Kafka admin client

### DIFF
--- a/qmtl/dagmanager/kafka_admin.py
+++ b/qmtl/dagmanager/kafka_admin.py
@@ -29,6 +29,36 @@ class AdminClient(Protocol):
         ...
 
 
+class InMemoryAdminClient:
+    """Simple in-memory implementation of :class:`AdminClient`."""
+
+    def __init__(self) -> None:
+        self.topics: Dict[str, dict] = {}
+
+    def list_topics(self) -> Mapping[str, dict]:
+        return self.topics
+
+    def create_topic(
+        self,
+        name: str,
+        *,
+        num_partitions: int,
+        replication_factor: int,
+        config: Mapping[str, str] | None = None,
+    ) -> None:
+        if name in self.topics:
+            raise TopicExistsError
+        self.topics[name] = {
+            "config": dict(config or {}),
+            "num_partitions": num_partitions,
+            "replication_factor": replication_factor,
+            "size": 0,
+        }
+
+    def get_size(self, name: str) -> int:
+        return int(self.topics.get(name, {}).get("size", 0))
+
+
 @dataclass
 class KafkaAdmin:
     client: AdminClient
@@ -61,4 +91,9 @@ class KafkaAdmin:
         return stats
 
 
-__all__ = ["KafkaAdmin", "AdminClient", "TopicExistsError"]
+__all__ = [
+    "KafkaAdmin",
+    "AdminClient",
+    "TopicExistsError",
+    "InMemoryAdminClient",
+]

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -68,6 +68,12 @@ async def _run(args: argparse.Namespace) -> None:
     if args.queue_backend == "kafka":
         admin_client = _KafkaAdminClient(args.kafka_bootstrap)
         queue = None
+    elif args.queue_backend == "memory":
+        from .kafka_admin import InMemoryAdminClient, KafkaAdmin
+        from .diff_service import KafkaQueueManager
+
+        admin_client = InMemoryAdminClient()
+        queue = KafkaQueueManager(KafkaAdmin(admin_client))
 
     gc = GarbageCollector(_EmptyStore(), _EmptyMetrics())
 

--- a/tests/dagmanager/test_in_memory_admin.py
+++ b/tests/dagmanager/test_in_memory_admin.py
@@ -1,0 +1,24 @@
+import pytest
+
+from qmtl.dagmanager.kafka_admin import KafkaAdmin, InMemoryAdminClient, TopicExistsError
+from qmtl.dagmanager.diff_service import KafkaQueueManager
+from qmtl.dagmanager.topic import TopicConfig
+
+
+def test_in_memory_admin_create_and_list():
+    client = InMemoryAdminClient()
+    admin = KafkaAdmin(client)
+    manager = KafkaQueueManager(admin, TopicConfig(1, 1, 1000))
+
+    topic = manager.upsert("asset", "N", "abcd", "v1")
+
+    assert topic in client.list_topics()
+    assert client.get_size(topic) == 0
+
+
+def test_in_memory_admin_duplicate_topic():
+    client = InMemoryAdminClient()
+    client.create_topic("t1", num_partitions=1, replication_factor=1)
+    with pytest.raises(TopicExistsError):
+        client.create_topic("t1", num_partitions=1, replication_factor=1)
+


### PR DESCRIPTION
## Summary
- implement `InMemoryAdminClient` for queue management
- hook `dagmgr-server` to use it when queue backend is set to `memory`
- test the in-memory admin under `tests/dagmanager`

## Testing
- `uv run -m pytest tests/dagmanager/test_in_memory_admin.py -q`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb9a501a8832995fb5390a52ab252