### PR TITLE
Enable offline backend via gateway config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,13 @@ Start the gateway HTTP server and interact with the DAG manager using the
 provided CLI tools.
 
 ```bash
-qmtl gw --redis-dsn redis://localhost:6379 \
-        --postgres-dsn postgresql://localhost/qmtl
+qmtl gw --config gateway.yml
+
+# gateway.yml example
+# redis_dsn: redis://localhost:6379
+# database_backend: sqlite
+# database_dsn: sqlite:///qmtl.db
+# offline: true
 
 # submit a DAG diff
 qmtl dagm diff --file dag.json --target localhost:50051

--- a/gateway.md
+++ b/gateway.md
@@ -150,7 +150,16 @@ Gateway also listens for `sentinel_weight` CloudEvents emitted by DAG‑Manager.
 ### Gateway CLI Options
 
 The ``qmtl gw`` subcommand reads configuration from a YAML/JSON file or command-line flags.
-The file may contain ``redis_dsn``, ``database_backend`` and ``database_dsn`` fields.
+The file may contain ``redis_dsn``, ``database_backend``, ``database_dsn`` and ``offline`` fields.
+
+Example YAML configuration:
+
+```yaml
+redis_dsn: redis://localhost:6379
+database_backend: sqlite
+database_dsn: sqlite:///qmtl.db
+offline: true
+```
 
 ```
 qmtl gw --config gateway.yml --database-backend postgres \
@@ -163,3 +172,4 @@ Available flags:
 - ``--database-backend`` – select database implementation (default ``postgres``).
 - ``--database-dsn`` – database connection string.
 - ``--redis-dsn`` – Redis connection string.
+- ``--offline`` – use in-memory Redis (overrides ``redis_dsn``).

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -43,8 +43,10 @@ async def _main(argv: list[str] | None = None) -> None:
         config.database_dsn = args.database_dsn
     if args.database_backend:
         config.database_backend = args.database_backend
-
     if args.offline:
+        config.offline = True
+
+    if config.offline:
         redis_client = InMemoryRedis()
     else:
         redis_client = redis.from_url(config.redis_dsn, decode_responses=True)

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -12,6 +12,7 @@ class GatewayConfig:
     redis_dsn: str = "redis://localhost:6379"
     database_backend: str = "postgres"
     database_dsn: str = "postgresql://localhost/qmtl"
+    offline: bool = False
 
 
 def load_gateway_config(path: str) -> GatewayConfig:

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -10,6 +10,7 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
         "redis_dsn": "redis://test:6379",
         "database_backend": "postgres",
         "database_dsn": "postgresql://db/test",
+        "offline": True,
     }
     cfg_file = tmp_path / "gw.yaml"
     cfg_file.write_text(yaml.safe_dump(data))
@@ -17,6 +18,7 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
     assert cfg.redis_dsn == data["redis_dsn"]
     assert cfg.database_backend == "postgres"
     assert cfg.database_dsn == data["database_dsn"]
+    assert cfg.offline is True
 
 
 def test_load_gateway_config_json(tmp_path: Path) -> None:
@@ -24,9 +26,11 @@ def test_load_gateway_config_json(tmp_path: Path) -> None:
         "redis_dsn": "redis://j:6379",
         "database_backend": "memory",
         "database_dsn": "sqlite:///:memory:",
+        "offline": False,
     }
     cfg_file = tmp_path / "gw.json"
     cfg_file.write_text(json.dumps(data))
     cfg = load_gateway_config(str(cfg_file))
     assert cfg.database_backend == "memory"
     assert cfg.database_dsn == data["database_dsn"]
+    assert cfg.offline is False


### PR DESCRIPTION
## Summary
- add `offline` option to `GatewayConfig`
- allow CLI to override `offline` and use it when creating Redis client
- document offline mode in README and gateway docs
- cover new config option with tests

## Testing
- `uv pip install --system -e .[dev]`
- `uv run -- pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cbd846db883299e25eeaad719383c