### PR TITLE
Simplify server CLIs and config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ Here’s a short workflow summary based on the repository’s guidelines:
 
    This command ensures all development dependencies are available.
 
-2. **Testing** – Run `pytest` (via the `uv` environment) before committing any changes to verify everything works properly. Commit only after tests pass.
+2. **Testing** – Run the tests via `uv` before committing:
+
+   ```bash
+   uv run -- pytest
+   ```
+
+   Commit only after tests pass.
 
 3. **Design Approach** – Follow the Single Responsibility Principle (SRP) when designing modules and classes. This keeps features modular and easier to maintain.
 
@@ -74,7 +80,7 @@ See [docs/e2e_testing.md](docs/e2e_testing.md) for the full guide.
 Run all unit and integration tests with:
 
 ```bash
-uv run pytest -q tests
+uv run -- pytest
 ```
 
 ## Running Services
@@ -83,17 +89,13 @@ Start the gateway HTTP server and interact with the DAG manager using the
 provided CLI tools.
 
 ```bash
-qmtl gw --config gateway.yml
-
-# gateway.yml example
-# redis_dsn: redis://localhost:6379
-# database_backend: sqlite
-# database_dsn: sqlite:///qmtl.db
-# offline: true
+qmtl gw --config examples/gateway.yml
 
 # submit a DAG diff
 qmtl dagm diff --file dag.json --target localhost:50051
 ```
+
+Customize the sample YAML files in `examples/` to match your environment.
 
 See [gateway.md](gateway.md) and [dag-manager.md](dag-manager.md) for more
 information on configuration and advanced usage.

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -250,8 +250,8 @@ For canary deployment steps see
 
 ## 12. 서버 설정 파일 사용법
 
-`qmtl dagmgr-server` 서브커맨드는 YAML 형식의 설정 파일을 읽어 기본 값을 채울 수 있다.
-`--config` 옵션으로 경로를 지정하며 CLI 플래그가 우선 적용된다.
+`qmtl dagmgr-server` 서브커맨드는 YAML 형식의 설정 파일 하나만 받는다.
+모든 서버 옵션은 YAML에 작성하고 ``--config`` 로 경로를 지정한다.
 
 예시:
 
@@ -265,16 +265,11 @@ kafka_bootstrap: localhost:9092
 ```
 
 ```
-qmtl dagmgr-server --config dagmgr.yml --repo-backend neo4j \
-                   --queue-backend kafka --neo4j-uri bolt://db:7687
+qmtl dagmgr-server --config examples/dagmgr.yml
 ```
 
 Available flags:
 
 - ``--config`` – path to configuration file.
-- ``--repo-backend`` – select repository implementation (default ``neo4j``).
-- ``--queue-backend`` – select queue implementation (default ``kafka``).
-- ``--neo4j-uri`` – Neo4j connection URI.
-- ``--neo4j-user`` – database user.
-- ``--neo4j-password`` – database password.
-- ``--kafka-bootstrap`` – Kafka bootstrap servers.
+
+`examples/dagmgr.yml` contains comments showing every available field.

--- a/examples/dagmgr.yml
+++ b/examples/dagmgr.yml
@@ -1,0 +1,14 @@
+# Example DAG manager configuration
+repo_backend: neo4j
+neo4j_uri: bolt://localhost:7687
+neo4j_user: neo4j
+neo4j_password: neo4j
+memory_repo_path: memrepo.gpickle  # used when repo_backend: memory
+queue_backend: kafka
+kafka_bootstrap: localhost:9092
+grpc_host: 0.0.0.0
+grpc_port: 50051
+http_host: 0.0.0.0
+http_port: 8000
+diff_callback: http://gateway/callback  # optional
+gc_callback: http://gateway/gc-callback  # optional

--- a/examples/gateway.yml
+++ b/examples/gateway.yml
@@ -1,0 +1,9 @@
+# Example gateway configuration
+host: 0.0.0.0  # HTTP bind address
+port: 8000     # HTTP port
+redis_dsn: redis://localhost:6379
+# database_backend can be postgres, sqlite or memory
+database_backend: postgres
+# connection string for the selected backend
+database_dsn: postgresql://localhost/qmtl
+offline: false  # use in-memory Redis when true

--- a/gateway.md
+++ b/gateway.md
@@ -149,27 +149,15 @@ Gateway also listens for `sentinel_weight` CloudEvents emitted by DAG‑Manager.
 
 ### Gateway CLI Options
 
-The ``qmtl gw`` subcommand reads configuration from a YAML/JSON file or command-line flags.
-The file may contain ``redis_dsn``, ``database_backend``, ``database_dsn`` and ``offline`` fields.
+The ``qmtl gw`` subcommand only accepts ``--config``. All server parameters such as
+``host``, ``port`` and database settings must be provided via YAML.
 
-Example YAML configuration:
-
-```yaml
-redis_dsn: redis://localhost:6379
-database_backend: sqlite
-database_dsn: sqlite:///qmtl.db
-offline: true
+```bash
+qmtl gw --config examples/gateway.yml
 ```
 
-```
-qmtl gw --config gateway.yml --database-backend postgres \
-        --redis-dsn redis://localhost:6379 --database-dsn postgresql://db
-```
+See ``examples/gateway.yml`` for a fully annotated configuration template.
 
 Available flags:
 
 - ``--config`` – path to configuration file.
-- ``--database-backend`` – select database implementation (default ``postgres``).
-- ``--database-dsn`` – database connection string.
-- ``--redis-dsn`` – Redis connection string.
-- ``--offline`` – use in-memory Redis (overrides ``redis_dsn``).

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -14,37 +14,12 @@ from .config import GatewayConfig, load_gateway_config
 async def _main(argv: list[str] | None = None) -> None:
     """Run the Gateway HTTP server."""
     parser = argparse.ArgumentParser(prog="qmtl gw")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind address")
-    parser.add_argument("--port", type=int, default=8000, help="Bind port")
     parser.add_argument("--config", help="Path to configuration file")
-    parser.add_argument(
-        "--redis-dsn",
-        help="Redis connection DSN",
-    )
-    parser.add_argument(
-        "--offline",
-        action="store_true",
-        help="Use in-memory Redis instead of connecting to a server",
-    )
-    parser.add_argument("--database-dsn", help="Database connection DSN")
-    parser.add_argument(
-        "--database-backend",
-        default="postgres",
-        help="Database backend (postgres, memory, sqlite)",
-    )
     args = parser.parse_args(argv)
 
     config = GatewayConfig()
     if args.config:
         config = load_gateway_config(args.config)
-    if args.redis_dsn:
-        config.redis_dsn = args.redis_dsn
-    if args.database_dsn:
-        config.database_dsn = args.database_dsn
-    if args.database_backend:
-        config.database_backend = args.database_backend
-    if args.offline:
-        config.offline = True
 
     if config.offline:
         redis_client = InMemoryRedis()
@@ -64,7 +39,7 @@ async def _main(argv: list[str] | None = None) -> None:
 
     import uvicorn
 
-    uvicorn.run(app, host=args.host, port=args.port)
+    uvicorn.run(app, host=config.host, port=config.port)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -9,6 +9,8 @@ import yaml
 class GatewayConfig:
     """Configuration for Gateway service."""
 
+    host: str = "0.0.0.0"
+    port: int = 8000
     redis_dsn: str = "redis://localhost:6379"
     database_backend: str = "postgres"
     database_dsn: str = "postgresql://localhost/qmtl"

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -1,4 +1,5 @@
 import yaml
+import pytest
 from pathlib import Path
 from qmtl.dagmanager.config import load_dagmanager_config, DagManagerConfig
 
@@ -17,4 +18,16 @@ def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
     cfg = load_dagmanager_config(str(cfg_file))
     assert cfg.neo4j_uri == data["neo4j_uri"]
     assert cfg.kafka_bootstrap == data["kafka_bootstrap"]
+
+
+def test_load_dagmanager_config_missing_file():
+    with pytest.raises(FileNotFoundError):
+        load_dagmanager_config("nope.yml")
+
+
+def test_load_dagmanager_config_malformed(tmp_path: Path):
+    f = tmp_path / "bad.yml"
+    f.write_text("- 1")
+    with pytest.raises(TypeError):
+        load_dagmanager_config(str(f))
 

--- a/tests/test_gateway_cli.py
+++ b/tests/test_gateway_cli.py
@@ -5,8 +5,5 @@ import sys
 def test_gateway_cli_help():
     result = subprocess.run([sys.executable, "-m", "qmtl", "gw", "--help"], capture_output=True, text=True)
     assert result.returncode == 0
-    assert "--host" in result.stdout
-    assert "--port" in result.stdout
     assert "--config" in result.stdout
-    assert "--database-backend" in result.stdout
 

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import pytest
 import yaml
 
 from qmtl.gateway.config import load_gateway_config, GatewayConfig
@@ -34,3 +35,15 @@ def test_load_gateway_config_json(tmp_path: Path) -> None:
     assert cfg.database_backend == "memory"
     assert cfg.database_dsn == data["database_dsn"]
     assert cfg.offline is False
+
+
+def test_load_gateway_config_missing_file():
+    with pytest.raises(FileNotFoundError):
+        load_gateway_config("nope.yml")
+
+
+def test_load_gateway_config_malformed(tmp_path: Path):
+    p = tmp_path / "bad.yml"
+    p.write_text("- 1")
+    with pytest.raises(TypeError):
+        load_gateway_config(str(p))

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -5,15 +5,17 @@ from qmtl.dagmanager.server import main
 def test_server_help(capsys):
     with pytest.raises(SystemExit):
         main(["--help"])
-    assert "qmtl dagmgr-server" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "qmtl dagmgr-server" in out
+    assert "--config" in out
 
 
 def test_server_defaults(monkeypatch):
     captured = {}
 
-    async def fake_run(args):
-        captured["repo"] = args.repo_backend
-        captured["queue"] = args.queue_backend
+    async def fake_run(cfg):
+        captured["repo"] = cfg.repo_backend
+        captured["queue"] = cfg.queue_backend
 
     monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
     main([])
@@ -27,8 +29,8 @@ def test_server_config_file(monkeypatch, tmp_path):
 
     captured = {}
 
-    async def fake_run(args):
-        captured["uri"] = args.neo4j_uri
+    async def fake_run(cfg):
+        captured["uri"] = cfg.neo4j_uri
 
     monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
     main(["--config", str(cfg)])


### PR DESCRIPTION
## Summary
- support host/port fields in GatewayConfig
- simplify gateway CLI to accept only `--config`
- streamline dagmgr server CLI and pass DagManagerConfig directly
- allow qmtl dagm CLI to load default target from YAML
- document usage with example configuration files
- add sample `gateway.yml` and `dagmgr.yml`
- update README and docs with new testing instructions
- adjust tests for updated CLIs and add config error cases

## Testing
- `uv pip install -e .[dev]`
- `uv run -- pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cc839642c832997b6410cb189863d