### PR TITLE
Introduce fake_redis fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+import pytest_asyncio
+from fakeredis.aioredis import FakeRedis
+
+@pytest_asyncio.fixture
+async def fake_redis():
+    redis = FakeRedis(decode_responses=True)
+    try:
+        yield redis
+    finally:
+        await redis.close()

--- a/tests/gateway/test_api.py
+++ b/tests/gateway/test_api.py
@@ -3,7 +3,6 @@ import json
 
 import pytest
 from fastapi.testclient import TestClient
-from fakeredis.aioredis import FakeRedis
 
 from qmtl.gateway.api import create_app, Database, StrategySubmit
 from qmtl.common import crc32_of_list
@@ -30,10 +29,9 @@ class FakeDB(Database):
 
 
 @pytest.fixture
-def app():
-    redis = FakeRedis(decode_responses=True)
+def app(fake_redis):
     db = FakeDB()
-    return create_app(redis_client=redis, database=db)
+    return create_app(redis_client=fake_redis, database=db)
 
 
 def test_ingest_and_status(app):

--- a/tests/gateway/test_fsm.py
+++ b/tests/gateway/test_fsm.py
@@ -1,5 +1,4 @@
 import pytest
-from fakeredis.aioredis import FakeRedis
 
 from qmtl.gateway.fsm import StrategyFSM
 from qmtl.gateway.database import Database
@@ -24,8 +23,8 @@ class FakeDB(Database):
 
 
 @pytest.mark.asyncio
-async def test_state_recovery_after_redis_failure():
-    redis = FakeRedis(decode_responses=True)
+async def test_state_recovery_after_redis_failure(fake_redis):
+    redis = fake_redis
     db = FakeDB()
     fsm = StrategyFSM(redis, db)
 

--- a/tests/gateway/test_metrics.py
+++ b/tests/gateway/test_metrics.py
@@ -2,7 +2,6 @@ import time
 
 import pytest
 from fastapi.testclient import TestClient
-from fakeredis.aioredis import FakeRedis
 
 from qmtl.gateway.api import create_app, Database, StrategySubmit
 from qmtl.common import crc32_of_list
@@ -24,10 +23,9 @@ class FakeDB(Database):
 
 
 @pytest.fixture
-def app():
-    redis = FakeRedis(decode_responses=True)
+def app(fake_redis):
     db = FakeDB()
-    return create_app(redis_client=redis, database=db)
+    return create_app(redis_client=fake_redis, database=db)
 
 
 def test_metrics_endpoint(app):
@@ -56,10 +54,9 @@ def test_latency_metric_recorded(app):
     assert metrics.gateway_e2e_latency_p95._value.get() > 0
 
 
-def test_lost_requests_counter(monkeypatch):
+def test_lost_requests_counter(monkeypatch, fake_redis):
     metrics.reset_metrics()
-    redis = FakeRedis(decode_responses=True)
-
+    redis = fake_redis
     async def fail(*args, **kwargs):
         raise RuntimeError("fail")
 

--- a/tests/gateway/test_nodeid.py
+++ b/tests/gateway/test_nodeid.py
@@ -3,7 +3,6 @@ import json
 import hashlib
 import pytest
 from fastapi.testclient import TestClient
-from fakeredis.aioredis import FakeRedis
 
 from qmtl.dagmanager import compute_node_id
 from qmtl.gateway.api import create_app, Database, StrategySubmit
@@ -30,11 +29,10 @@ class FakeDB(Database):
 
 
 @pytest.fixture
-def client_and_redis():
-    redis = FakeRedis(decode_responses=True)
+def client_and_redis(fake_redis):
     db = FakeDB()
-    app = create_app(redis_client=redis, database=db)
-    return TestClient(app), redis
+    app = create_app(redis_client=fake_redis, database=db)
+    return TestClient(app), fake_redis
 
 
 def test_compute_node_id_collision():
@@ -64,8 +62,8 @@ async def test_sentinel_inserted(client_and_redis):
 
 
 @pytest.mark.asyncio
-async def test_sentinel_skip():
-    redis = FakeRedis(decode_responses=True)
+async def test_sentinel_skip(fake_redis):
+    redis = fake_redis
     db = FakeDB()
     app = create_app(redis_client=redis, database=db, insert_sentinel=False)
     client = TestClient(app)

--- a/tests/gateway/test_worker.py
+++ b/tests/gateway/test_worker.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-from fakeredis.aioredis import FakeRedis
 
 from types import SimpleNamespace
 
@@ -34,8 +33,8 @@ class FakeDB(Database):
 
 
 @pytest.mark.asyncio
-async def test_worker_locking_single_processing():
-    redis = FakeRedis(decode_responses=True)
+async def test_worker_locking_single_processing(fake_redis):
+    redis = fake_redis
     queue = RedisFIFOQueue(redis, "strategy_queue")
     db = FakeDB()
     fsm = StrategyFSM(redis, db)
@@ -75,8 +74,8 @@ class DummyHub(WebSocketHub):
 
 
 @pytest.mark.asyncio
-async def test_worker_diff_success_broadcasts():
-    redis = FakeRedis(decode_responses=True)
+async def test_worker_diff_success_broadcasts(fake_redis):
+    redis = fake_redis
     queue = RedisFIFOQueue(redis, "strategy_queue")
     db = FakeDB()
     fsm = StrategyFSM(redis, db)
@@ -104,8 +103,8 @@ async def test_worker_diff_success_broadcasts():
 
 
 @pytest.mark.asyncio
-async def test_worker_diff_failure_sets_failed_and_broadcasts():
-    redis = FakeRedis(decode_responses=True)
+async def test_worker_diff_failure_sets_failed_and_broadcasts(fake_redis):
+    redis = fake_redis
     queue = RedisFIFOQueue(redis, "strategy_queue")
     db = FakeDB()
     fsm = StrategyFSM(redis, db)

--- a/tests/integrity/test_checksum.py
+++ b/tests/integrity/test_checksum.py
@@ -3,7 +3,6 @@ import json
 
 import pytest
 from fastapi.testclient import TestClient
-from fakeredis.aioredis import FakeRedis
 
 from qmtl.gateway.api import create_app, Database, StrategySubmit
 from qmtl.common import crc32_of_list
@@ -24,10 +23,9 @@ class FakeDB(Database):
 
 
 @pytest.fixture
-def client():
-    redis = FakeRedis(decode_responses=True)
+def client(fake_redis):
     db = FakeDB()
-    app = create_app(redis_client=redis, database=db)
+    app = create_app(redis_client=fake_redis, database=db)
     return TestClient(app)
 
 

--- a/tests/reliability/test_worker_alerts.py
+++ b/tests/reliability/test_worker_alerts.py
@@ -1,6 +1,5 @@
 import asyncio
 import pytest
-from fakeredis.aioredis import FakeRedis
 
 from qmtl.gateway.worker import StrategyWorker
 from qmtl.gateway.queue import RedisFIFOQueue
@@ -42,8 +41,8 @@ class DummyAlerts:
 
 
 @pytest.mark.asyncio
-async def test_worker_alerts_after_repeated_failures():
-    redis = FakeRedis(decode_responses=True)
+async def test_worker_alerts_after_repeated_failures(fake_redis):
+    redis = fake_redis
     queue = RedisFIFOQueue(redis, "strategy_queue")
     db = FakeDB()
     fsm = StrategyFSM(redis, db)

--- a/tests/strategy/test_conflict.py
+++ b/tests/strategy/test_conflict.py
@@ -3,7 +3,6 @@ import json
 
 import pytest
 from fastapi.testclient import TestClient
-from fakeredis.aioredis import FakeRedis
 
 from qmtl.gateway.api import create_app, Database, StrategySubmit
 from qmtl.common import crc32_of_list
@@ -24,10 +23,9 @@ class FakeDB(Database):
 
 
 @pytest.fixture
-def client():
-    redis = FakeRedis(decode_responses=True)
+def client(fake_redis):
     db = FakeDB()
-    app = create_app(redis_client=redis, database=db)
+    app = create_app(redis_client=fake_redis, database=db)
     return TestClient(app)
 
 

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -7,7 +7,6 @@ from qmtl.sdk import Strategy, TagQueryNode, Runner
 from qmtl.gateway.api import create_app, Database
 from qmtl.gateway.ws import WebSocketHub
 from qmtl.common.cloudevents import format_event
-from fakeredis.aioredis import FakeRedis
 
 
 class DummyDag:
@@ -36,7 +35,7 @@ class TQStrategy(Strategy):
 
 
 @pytest.mark.asyncio
-async def test_live_auto_subscribes(monkeypatch):
+async def test_live_auto_subscribes(monkeypatch, fake_redis):
     class DummyWS:
         def __init__(self, url, *, on_message=None):
             self.on_message = on_message
@@ -72,7 +71,7 @@ async def test_live_auto_subscribes(monkeypatch):
         client.on_message = on_message
         return client
     hub = DummyHub(client)
-    redis = FakeRedis(decode_responses=True)
+    redis = fake_redis
     gw_app = create_app(dag_client=DummyDag(), ws_hub=hub, redis_client=redis, database=FakeDB())
     transport = httpx.ASGITransport(gw_app)
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -12,7 +12,6 @@ from qmtl.gateway.worker import StrategyWorker
 from qmtl.gateway.fsm import StrategyFSM
 from qmtl.gateway.database import PostgresDatabase
 
-import fakeredis
 import grpc
 import asyncio
 import pytest
@@ -37,8 +36,8 @@ class FakeDB(PostgresDatabase):
         return True
 
 
-def test_gateway_status():
-    redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+def test_gateway_status(fake_redis):
+    redis_client = fake_redis
     db = FakeDB()
     client = TestClient(
         gw_create_app(redis_client=redis_client, database=db, dag_client=FakeDagClient())
@@ -113,8 +112,8 @@ async def test_grpc_status():
 
 
 @pytest.mark.asyncio
-async def test_queue_healthy():
-    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+async def test_queue_healthy(fake_redis):
+    redis = fake_redis
     queue = RedisFIFOQueue(redis)
     assert await queue.healthy() is True
 
@@ -131,8 +130,8 @@ async def test_ws_hub_is_running():
 
 
 @pytest.mark.asyncio
-async def test_worker_healthy(monkeypatch):
-    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+async def test_worker_healthy(monkeypatch, fake_redis):
+    redis = fake_redis
 
     class FakeDB(PostgresDatabase):
         def __init__(self):


### PR DESCRIPTION
## Summary
- add `fake_redis` async fixture to centralise FakeRedis setup
- refactor tests to use the new fixture and close redis clients

## Testing
- `uv run -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68618d2f31248329ae7e1f29448f8863