### PR TITLE
Add database closing methods and fix tests

### DIFF
--- a/qmtl/dagmanager/gc.py
+++ b/qmtl/dagmanager/gc.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Garbage collection utilities for orphan Kafka queues."""
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Iterable, Protocol, Optional
 
 from .metrics import orphan_queue_total
@@ -63,7 +63,7 @@ class S3ArchiveClient:
 
     def archive(self, queue: str) -> None:
         """Store queue dump in ``self.bucket`` under a timestamped key."""
-        key = f"{queue}-{datetime.utcnow().strftime('%Y%m%dT%H%M%S')}"
+        key = f"{queue}-{datetime.now(UTC).strftime('%Y%m%dT%H%M%S')}"
         self._client.put_object(Bucket=self.bucket, Key=key, Body=b"")
 
 
@@ -94,7 +94,7 @@ class GarbageCollector:
 
     def collect(self, now: Optional[datetime] = None) -> list[QueueInfo]:
         """Run one GC batch and return processed QueueInfo items."""
-        now = now or datetime.utcnow()
+        now = now or datetime.now(UTC)
         all_queues = list(self.store.list_orphan_queues())
         orphan_queue_total.set(len(all_queues))
         orphan_queue_total._val = len(all_queues)  # type: ignore[attr-defined]

--- a/qmtl/dagmanager/node_repository.py
+++ b/qmtl/dagmanager/node_repository.py
@@ -23,7 +23,7 @@ def _load_graph(path: Path) -> None:
         except Exception:
             try:
                 data = json.loads(path.read_text())
-                _GRAPH = nx.node_link_graph(data)
+                _GRAPH = nx.node_link_graph(data, edges="edges")
             except Exception:
                 _GRAPH = nx.DiGraph()
     _LOADED = True
@@ -36,7 +36,7 @@ def _save_graph() -> None:
         nx.write_gpickle(_GRAPH, _GRAPH_PATH)
     except Exception:
         try:
-            data = nx.node_link_data(_GRAPH)
+            data = nx.node_link_data(_GRAPH, edges="edges")
             _GRAPH_PATH.write_text(json.dumps(data))
         except Exception:
             pass

--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -128,6 +128,12 @@ def create_app(
     async def lifespan(app: FastAPI):
         yield
         await dagm.close()
+        db_obj = getattr(app.state, "database", None)
+        if db_obj is not None and hasattr(db_obj, "close"):
+            try:
+                await db_obj.close()  # type: ignore[attr-defined]
+            except Exception:
+                logger.exception("Failed to close database connection")
 
     app = FastAPI(lifespan=lifespan)
     app.state.database = db

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -39,7 +39,14 @@ async def _main(argv: list[str] | None = None) -> None:
 
     import uvicorn
 
-    uvicorn.run(app, host=config.host, port=config.port)
+    try:
+        uvicorn.run(app, host=config.host, port=config.port)
+    finally:
+        if hasattr(db, "close"):
+            try:
+                await db.close()  # type: ignore[attr-defined]
+            except Exception:
+                pass
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/qmtl/gateway/database.py
+++ b/qmtl/gateway/database.py
@@ -30,6 +30,11 @@ class Database:
     async def healthy(self) -> bool:
         raise NotImplementedError
 
+    async def close(self) -> None:
+        """Release any held resources."""
+        # Default implementation for backends that do not need cleanup
+        return None
+
 
 class PostgresDatabase(Database):
     """PostgreSQL-backed implementation."""
@@ -120,6 +125,10 @@ class PostgresDatabase(Database):
             return True
         except Exception:
             return False
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
 
 
 class SQLiteDatabase(Database):
@@ -215,6 +224,10 @@ class SQLiteDatabase(Database):
             return True
         except Exception:
             return False
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            await self._conn.close()
 
 
 class MemoryDatabase(Database):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,4 +8,7 @@ async def fake_redis():
     try:
         yield redis
     finally:
-        await redis.close()
+        if hasattr(redis, "aclose"):
+            await redis.aclose(close_connection_pool=True)
+        else:
+            await redis.close()

--- a/tests/gateway/test_sqlite_db.py
+++ b/tests/gateway/test_sqlite_db.py
@@ -10,19 +10,22 @@ async def test_sqlite_crud(tmp_path):
     db_path = tmp_path / "test.db"
     db = SQLiteDatabase(f"sqlite:///{db_path}")
     await db.connect()
-    await db.insert_strategy("s1", {"u": "a"})
-    assert await db.get_status("s1") == "queued"
+    try:
+        await db.insert_strategy("s1", {"u": "a"})
+        assert await db.get_status("s1") == "queued"
 
-    await db.set_status("s1", "processing")
-    assert await db.get_status("s1") == "processing"
+        await db.set_status("s1", "processing")
+        assert await db.get_status("s1") == "processing"
 
-    await db.append_event("s1", "PROCESS")
-    assert await db.healthy() is True
+        await db.append_event("s1", "PROCESS")
+        assert await db.healthy() is True
 
-    # Verify event persisted
-    async with db._conn.execute(
-        "SELECT COUNT(*) FROM strategy_events WHERE strategy_id=?",
-        ("s1",),
-    ) as cur:
-        row = await cur.fetchone()
-        assert row[0] >= 1
+        # Verify event persisted
+        async with db._conn.execute(
+            "SELECT COUNT(*) FROM strategy_events WHERE strategy_id=?",
+            ("s1",),
+        ) as cur:
+            row = await cur.fetchone()
+            assert row[0] >= 1
+    finally:
+        await db.close()

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 from qmtl.dagmanager.gc import GarbageCollector, QueueInfo, S3ArchiveClient
 
@@ -32,7 +32,7 @@ class FakeArchive:
 
 
 def test_gc_policy_drop_and_archive():
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     queues = [
         QueueInfo("raw_q", "raw", now - timedelta(days=10)),
         QueueInfo("sentinel_q", "sentinel", now - timedelta(days=220)),
@@ -50,7 +50,7 @@ def test_gc_policy_drop_and_archive():
 
 
 def test_gc_batch_halved_on_high_load():
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     queues = [
         QueueInfo(f"q{i}", "raw", now - timedelta(days=10)) for i in range(4)
     ]
@@ -64,7 +64,7 @@ def test_gc_batch_halved_on_high_load():
 
 
 def test_gc_respects_grace_period():
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     # Queue age is exactly TTL but within grace period
     queues = [QueueInfo("q", "raw", now - timedelta(days=7))]
     store = FakeStore(queues)
@@ -78,7 +78,7 @@ def test_gc_respects_grace_period():
 
 
 def test_gc_archives_with_client():
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     queues = [QueueInfo("s", "sentinel", now - timedelta(days=400))]
     store = FakeStore(queues)
     metrics = FakeMetrics(0)
@@ -110,7 +110,7 @@ def test_s3_archive_client_puts_object():
 
 
 def test_gc_invokes_s3_archive():
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     queues = [QueueInfo("q", "sentinel", now - timedelta(days=400))]
     store = FakeStore(queues)
     metrics = FakeMetrics(0)

--- a/tests/test_gc_endpoint.py
+++ b/tests/test_gc_endpoint.py
@@ -3,7 +3,7 @@ import httpx
 
 from qmtl.dagmanager.api import create_app
 from qmtl.dagmanager.gc import QueueInfo
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 class FakeGC:
@@ -12,7 +12,7 @@ class FakeGC:
 
     def collect(self):
         self.calls += 1
-        return [QueueInfo("q1", "raw", datetime.utcnow(), interval=60)]
+        return [QueueInfo("q1", "raw", datetime.now(UTC), interval=60)]
 
 
 def test_gc_route_triggers_collect():

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 import grpc
 import pytest
@@ -246,7 +246,7 @@ class DummyArchive:
 
 @pytest.mark.asyncio
 async def test_grpc_cleanup_triggers_gc():
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     store = DummyStore([QueueInfo("q", "raw", now - timedelta(days=10))])
     gc = GarbageCollector(store, DummyMetrics(), batch_size=1)
 
@@ -264,7 +264,7 @@ async def test_grpc_cleanup_triggers_gc():
 
 @pytest.mark.asyncio
 async def test_grpc_cleanup_archives():
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     store = DummyStore([QueueInfo("s", "sentinel", now - timedelta(days=400))])
     archive = DummyArchive()
     gc = GarbageCollector(store, DummyMetrics(), archive=archive, batch_size=1)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 from fastapi.testclient import TestClient
 
 from qmtl.gateway.api import create_app as gw_create_app
@@ -19,7 +19,7 @@ import pytest
 
 class DummyGC:
     def collect(self):
-        return [QueueInfo("q", "raw", datetime.utcnow(), interval=60)]
+        return [QueueInfo("q", "raw", datetime.now(UTC), interval=60)]
 
 
 class FakeDagClient:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 import pytest
 
@@ -103,7 +103,7 @@ def test_diff_duration_and_error_metrics():
 
 def test_gc_sets_orphan_gauge():
     metrics.reset_metrics()
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     store = [QueueInfo("q", "raw", now - timedelta(days=10))]
 
     class Store:


### PR DESCRIPTION
## Summary
- implement close() in database backends
- call database.close in API shutdown and CLI
- ensure SQLite tests close connection
- update tests to avoid datetime.utcnow deprecation
- make NodeRepository use explicit edges kwarg
- close FakeRedis properly in tests

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6861e81ee9608329a8690f1585594f71