### PR TITLE
Ensure TestClient cleanup in tests

### DIFF
--- a/tests/gateway/test_api.py
+++ b/tests/gateway/test_api.py
@@ -35,17 +35,17 @@ def app(fake_redis):
 
 
 def test_ingest_and_status(app):
-    client = TestClient(app)
-    payload = StrategySubmit(
-        dag_json="{}",
-        meta={"user": "alice"},
-        run_type="dry-run",
-        node_ids_crc32=crc32_of_list([]),
-    )
-    resp = client.post("/strategies", json=payload.model_dump())
-    assert resp.status_code == 202
-    sid = resp.json()["strategy_id"]
+    with TestClient(app) as client:
+        payload = StrategySubmit(
+            dag_json="{}",
+            meta={"user": "alice"},
+            run_type="dry-run",
+            node_ids_crc32=crc32_of_list([]),
+        )
+        resp = client.post("/strategies", json=payload.model_dump())
+        assert resp.status_code == 202
+        sid = resp.json()["strategy_id"]
 
-    resp = client.get(f"/strategies/{sid}/status")
-    assert resp.status_code == 200
-    assert resp.json()["status"] == "queued"
+        resp = client.get(f"/strategies/{sid}/status")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "queued"

--- a/tests/integrity/test_checksum.py
+++ b/tests/integrity/test_checksum.py
@@ -26,7 +26,8 @@ class FakeDB(Database):
 def client(fake_redis):
     db = FakeDB()
     app = create_app(redis_client=fake_redis, database=db)
-    return TestClient(app)
+    with TestClient(app) as c:
+        yield c
 
 
 def test_checksum_rejects_tampered_ids(client):

--- a/tests/strategy/test_conflict.py
+++ b/tests/strategy/test_conflict.py
@@ -26,7 +26,8 @@ class FakeDB(Database):
 def client(fake_redis):
     db = FakeDB()
     app = create_app(redis_client=fake_redis, database=db)
-    return TestClient(app)
+    with TestClient(app) as c:
+        yield c
 
 
 def make_payload(dag: dict) -> StrategySubmit:

--- a/tests/test_gc_endpoint.py
+++ b/tests/test_gc_endpoint.py
@@ -18,11 +18,11 @@ class FakeGC:
 def test_gc_route_triggers_collect():
     gc = FakeGC()
     app = create_app(gc)
-    client = TestClient(app)
-    resp = client.post("/admin/gc-trigger", json={"id": "s"})
-    assert resp.status_code == 202
-    assert gc.calls == 1
-    assert resp.json()["processed"] == ["q1"]
+    with TestClient(app) as client:
+        resp = client.post("/admin/gc-trigger", json={"id": "s"})
+        assert resp.status_code == 202
+        assert gc.calls == 1
+        assert resp.json()["processed"] == ["q1"]
 
 
 def test_gc_route_emits_callback(monkeypatch):
@@ -36,11 +36,11 @@ def test_gc_route_emits_callback(monkeypatch):
     monkeypatch.setattr("qmtl.dagmanager.api.post_with_backoff", fake_post)
 
     app = create_app(gc, callback_url="http://gw/cb")
-    client = TestClient(app)
-    client.post("/admin/gc-trigger", json={"id": "x"})
+    with TestClient(app) as client:
+        client.post("/admin/gc-trigger", json={"id": "x"})
 
-    assert events
-    assert events[0][0] == "http://gw/cb"
-    assert events[0][1]["type"] == "gc"
-    assert events[0][1]["data"]["id"] == "x"
+        assert events
+        assert events[0][0] == "http://gw/cb"
+        assert events[0][1]["type"] == "gc"
+        assert events[0][1]["data"]["id"] == "x"
 


### PR DESCRIPTION
## Summary
- close `TestClient` instances across tests to avoid unclosed sockets
- add `close` method to `FakeDagClient`
- update fixtures to use context-managed TestClient

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6861f658dfe883299ccd91d6763bd76a