### PR TITLE
Add unified config loader

### DIFF
--- a/qmtl/config.py
+++ b/qmtl/config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import yaml
+
+from .gateway.config import GatewayConfig
+from .dagmanager.config import DagManagerConfig
+
+
+@dataclass
+class UnifiedConfig:
+    """Configuration aggregating gateway and DAG manager settings."""
+
+    gateway: GatewayConfig = field(default_factory=GatewayConfig)
+    dagmanager: DagManagerConfig = field(default_factory=DagManagerConfig)
+
+
+def load_config(path: str) -> UnifiedConfig:
+    """Parse YAML/JSON and populate :class:`UnifiedConfig`."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    if not isinstance(data, dict):
+        raise TypeError("Unified config must be a mapping")
+
+    gw_data = data.get("gateway", {})
+    dm_data = data.get("dagmanager", {})
+
+    if not isinstance(gw_data, dict):
+        raise TypeError("gateway section must be a mapping")
+    if not isinstance(dm_data, dict):
+        raise TypeError("dagmanager section must be a mapping")
+
+    gateway_cfg = GatewayConfig(**gw_data)
+    dagmanager_cfg = DagManagerConfig(**dm_data)
+    return UnifiedConfig(gateway=gateway_cfg, dagmanager=dagmanager_cfg)

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+import pytest
+import yaml
+
+from qmtl.config import load_config, UnifiedConfig
+
+
+def test_load_unified_config_yaml(tmp_path: Path) -> None:
+    data = {
+        "gateway": {
+            "redis_dsn": "redis://test:6379",
+        },
+        "dagmanager": {
+            "neo4j_uri": "bolt://db:7687",
+        },
+    }
+    cfg_file = tmp_path / "cfg.yml"
+    cfg_file.write_text(yaml.safe_dump(data))
+    cfg = load_config(str(cfg_file))
+    assert cfg.gateway.redis_dsn == data["gateway"]["redis_dsn"]
+    assert cfg.dagmanager.neo4j_uri == data["dagmanager"]["neo4j_uri"]
+
+
+def test_load_unified_config_json(tmp_path: Path) -> None:
+    data = {
+        "gateway": {"host": "127.0.0.1"},
+        "dagmanager": {"grpc_port": 1234},
+    }
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text(json.dumps(data))
+    cfg = load_config(str(cfg_file))
+    assert cfg.gateway.host == "127.0.0.1"
+    assert cfg.dagmanager.grpc_port == 1234
+
+
+def test_load_unified_config_missing_file() -> None:
+    with pytest.raises(FileNotFoundError):
+        load_config("missing.yml")
+
+
+def test_load_unified_config_malformed(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "bad.yml"
+    cfg_file.write_text("- 1")
+    with pytest.raises(TypeError):
+        load_config(str(cfg_file))


### PR DESCRIPTION
## Summary
- introduce `UnifiedConfig` dataclass bundling Gateway and DagManager
- implement `load_config` helper for unified YAML/JSON
- test YAML/JSON parsing of UnifiedConfig

## Testing
- `uv run -m pytest tests/test_unified_config.py -W error`
- `uv run -m pytest -W error` *(fails: multiple unraisable exception warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6863017fd6d48329a931cba5c551271b