### PR TITLE
Update gateway CLI to use unified config

### DIFF
--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -8,7 +8,8 @@ import redis.asyncio as redis
 from .redis_client import InMemoryRedis
 
 from .api import create_app
-from .config import GatewayConfig, load_gateway_config
+from .config import GatewayConfig
+from ..config import load_config
 
 
 async def _main(argv: list[str] | None = None) -> None:
@@ -19,7 +20,7 @@ async def _main(argv: list[str] | None = None) -> None:
 
     config = GatewayConfig()
     if args.config:
-        config = load_gateway_config(args.config)
+        config = load_config(args.config).gateway
 
     if config.offline:
         redis_client = InMemoryRedis()

--- a/tests/test_gateway_cli.py
+++ b/tests/test_gateway_cli.py
@@ -7,3 +7,50 @@ def test_gateway_cli_help():
     assert result.returncode == 0
     assert "--config" in result.stdout
 
+
+def test_gateway_cli_config_file(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text(
+        "\n".join(
+            [
+                "gateway:",
+                "  host: 127.0.0.1",
+                "  port: 12345",
+                "  offline: true",
+                "  database_backend: memory",
+                "  database_dsn: 'sqlite:///:memory:'",
+            ]
+        )
+    )
+
+    captured = {}
+
+    from types import SimpleNamespace
+    from qmtl.gateway import cli
+
+    class DummyDB:
+        async def connect(self):
+            captured["connect"] = True
+
+        async def close(self):
+            captured["close"] = True
+
+    def fake_create_app(**kwargs):
+        captured["db_backend"] = kwargs.get("database_backend")
+        captured["db_dsn"] = kwargs.get("database_dsn")
+        captured["redis"] = isinstance(kwargs.get("redis_client"), cli.InMemoryRedis)
+        return SimpleNamespace(state=SimpleNamespace(database=DummyDB()))
+
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+
+    fake_uvicorn = SimpleNamespace(run=lambda app, host, port: captured.update({"host": host, "port": port}))
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+
+    cli.main(["--config", str(cfg)])
+
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 12345
+    assert captured["db_backend"] == "memory"
+    assert captured["db_dsn"] == "sqlite:///:memory:"
+    assert captured["redis"]
+


### PR DESCRIPTION
## Summary
- load unified config in `gateway/cli.py`
- verify CLI uses unified config via new test

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68630516500483299742987c2bca715a