### PR TITLE
Update server CLI config loader

### DIFF
--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -8,7 +8,8 @@ from typing import Iterable
 import uvicorn
 
 from .grpc_server import serve
-from .config import DagManagerConfig, load_dagmanager_config
+from .config import DagManagerConfig
+from ..config import load_config
 from .api import create_app
 from .gc import GarbageCollector, QueueInfo, MetricsProvider, QueueStore
 from .diff_service import StreamSender
@@ -109,7 +110,7 @@ def main(argv: list[str] | None = None) -> None:
 
     cfg = DagManagerConfig()
     if args.config:
-        cfg = load_dagmanager_config(args.config)
+        cfg = load_config(args.config).dagmanager
 
     asyncio.run(_run(cfg))
 

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -1,4 +1,5 @@
 import pytest
+import yaml
 from qmtl.dagmanager.server import main
 
 
@@ -25,7 +26,7 @@ def test_server_defaults(monkeypatch):
 
 def test_server_config_file(monkeypatch, tmp_path):
     cfg = tmp_path / "cfg.yml"
-    cfg.write_text("neo4j_uri: bolt://test:7687\n")
+    cfg.write_text(yaml.safe_dump({"dagmanager": {"neo4j_uri": "bolt://test:7687"}}))
 
     captured = {}
 


### PR DESCRIPTION
## Summary
- use the unified configuration loader in `dagmgr-server`
- keep default `DagManagerConfig` when no config file is specified
- adjust server CLI tests for unified configuration files

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_686307b5d0908329b2cb0b12aae79e01