### PR TITLE
Update docs for unified configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,16 @@ uv run -- pytest
 
 ## Running Services
 
-Start the gateway HTTP server and interact with the DAG manager using the
-provided CLI tools.
+Start the Gateway and DAG manager using the combined configuration file. Each
+service reads its own section from `qmtl.yml`.
 
 ```bash
+
+# start the gateway HTTP server
 qmtl gw --config examples/qmtl.yml
+
+# start the DAG manager
+qmtl dagmgr-server --config examples/qmtl.yml
 
 # submit a DAG diff
 qmtl dagm diff --file dag.json --target localhost:50051

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -251,7 +251,7 @@ For canary deployment steps see
 ## 12. 서버 설정 파일 사용법
 
 `qmtl dagmgr-server` 서브커맨드는 YAML 형식의 설정 파일 하나만 받는다.
-모든 서버 옵션은 YAML에 작성하고 ``--config`` 로 경로를 지정한다.
+아래 예시와 같이 모든 서버 옵션을 YAML에 작성하고 ``--config`` 로 경로를 지정한다.
 
 예시:
 
@@ -268,8 +268,9 @@ kafka_bootstrap: localhost:9092
 qmtl dagmgr-server --config examples/qmtl.yml
 ```
 
+해당 명령은 `examples/qmtl.yml` 의 ``dagmanager`` 섹션을 읽어 서버를 실행한다.
+`examples/qmtl.yml` contains comments showing every available field.
+
 Available flags:
 
 - ``--config`` – path to configuration file.
-
-`examples/qmtl.yml` contains comments showing every available field.

--- a/gateway.md
+++ b/gateway.md
@@ -149,14 +149,14 @@ Gateway also listens for `sentinel_weight` CloudEvents emitted by DAG‑Manager.
 
 ### Gateway CLI Options
 
-The ``qmtl gw`` subcommand only accepts ``--config``. All server parameters such as
-``host``, ``port`` and database settings must be provided via YAML.
+Run the Gateway service using the combined configuration file:
 
 ```bash
 qmtl gw --config examples/qmtl.yml
 ```
 
-See ``examples/qmtl.yml`` for a fully annotated configuration template.
+The command reads the ``gateway`` section of ``examples/qmtl.yml`` for all
+server parameters. See the file for a fully annotated configuration template.
 
 Available flags:
 


### PR DESCRIPTION
## Summary
- clarify gateway command using unified qmtl.yml
- explain dag-manager config section usage
- show both services started from the combined file in README

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68630b1e20448329a6a892b45ba7612e