### PR TITLE
Add init scaffold command

### DIFF
--- a/qmtl/cli.py
+++ b/qmtl/cli.py
@@ -11,6 +11,8 @@ def main(argv: List[str] | None = None) -> None:
     sub.add_parser("dagm", help="Dag manager admin CLI", add_help=False)
     sub.add_parser("dagmgr-server", help="Run DAG manager servers", add_help=False)
     sub.add_parser("sdk", help="Run strategy via SDK", add_help=False)
+    p_init = sub.add_parser("init", help="Initialize new project")
+    p_init.add_argument("path", help="Project directory")
 
     args, rest = parser.parse_known_args(argv)
 
@@ -28,6 +30,11 @@ def main(argv: List[str] | None = None) -> None:
         from .sdk.cli import main as sdk_main
         logging.basicConfig(level=logging.INFO)
         sdk_main(rest)
+    elif args.cmd == "init":
+        from pathlib import Path
+        from .scaffold import create_project
+
+        create_project(Path(args.path))
     else:
         parser.print_help()
 

--- a/qmtl/scaffold.py
+++ b/qmtl/scaffold.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+_EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+
+
+def create_project(path: Path) -> None:
+    """Create a new project scaffold under *path*."""
+    dest = Path(path)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy(_EXAMPLES_DIR / "qmtl.yml", dest / "qmtl.yml")
+    shutil.copy(_EXAMPLES_DIR / "general_strategy.py", dest / "strategy.py")
+
+
+__all__ = ["create_project"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from qmtl.scaffold import create_project
+
+
+def test_create_project(tmp_path: Path):
+    dest = tmp_path / "proj"
+    create_project(dest)
+    assert (dest / "qmtl.yml").is_file()
+    assert (dest / "strategy.py").is_file()
+
+
+def test_init_cli(tmp_path: Path):
+    dest = tmp_path / "cli_proj"
+    result = subprocess.run([sys.executable, "-m", "qmtl", "init", str(dest)], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert (dest / "qmtl.yml").is_file()
+    assert (dest / "strategy.py").is_file()

--- a/tests/test_qmtl_cli.py
+++ b/tests/test_qmtl_cli.py
@@ -7,3 +7,4 @@ def test_qmtl_help():
     assert result.returncode == 0
     assert "gw" in result.stdout
     assert "dagm" in result.stdout
+    assert "init" in result.stdout


### PR DESCRIPTION
## Summary
- add project scaffolding via `qmtl init`
- register the new subcommand in the CLI
- ensure help shows the command
- test scaffold creation and CLI invocation

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6863102d0b108329be22ad848d4f55ee