### PR TITLE
Update default sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ uv run -- pytest
 ## Running Services
 
 Start the Gateway and DAG manager using the combined configuration file. Each
-service reads its own section from `qmtl.yml`.
+service reads its own section from `qmtl.yml`. The default template uses
+lightweight in-memory/SQLite backends for easy local testing. Commented lines in
+the file show how to enable cluster-ready services like Postgres, Neo4j and
+Kafka.
 
 ```bash
 

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -264,6 +264,10 @@ queue_backend: kafka
 kafka_bootstrap: localhost:9092
 ```
 
+The sample file installed by ``qmtl init`` instead defaults to in-memory
+repositories and queues for local development. Commented lines show the above
+cluster configuration ready to be enabled.
+
 ```
 qmtl dagmgr-server --config examples/qmtl.yml
 ```

--- a/examples/qmtl.yml
+++ b/examples/qmtl.yml
@@ -1,8 +1,26 @@
 gateway:
   host: 0.0.0.0
   port: 8000
-  # ...
+  redis_dsn: redis://localhost:6379
+  # Lightweight local store for quick testing
+  database_backend: sqlite
+  database_dsn: ./qmtl.db
+  # To use Postgres in a production cluster uncomment below
+  # database_backend: postgres
+  # database_dsn: postgresql://user:pass@db/qmtl
+
 dagmanager:
-  repo_backend: neo4j
-  neo4j_uri: bolt://localhost:7687
-  # ...
+  repo_backend: memory
+  memory_repo_path: memrepo.gpickle
+  queue_backend: memory
+  # Example cluster configuration using Neo4j and Kafka
+  # repo_backend: neo4j
+  # neo4j_uri: bolt://localhost:7687
+  # neo4j_user: neo4j
+  # neo4j_password: neo4j
+  # queue_backend: kafka
+  # kafka_bootstrap: localhost:9092
+  grpc_host: 0.0.0.0
+  grpc_port: 50051
+  http_host: 0.0.0.0
+  http_port: 8000

--- a/gateway.md
+++ b/gateway.md
@@ -156,7 +156,9 @@ qmtl gw --config examples/qmtl.yml
 ```
 
 The command reads the ``gateway`` section of ``examples/qmtl.yml`` for all
-server parameters. See the file for a fully annotated configuration template.
+server parameters. The template defaults to a lightweight SQLite database and
+Redis instance. Commented lines illustrate how to switch to a clustered
+Postgres setup. See the file for a fully annotated configuration template.
 
 Available flags:
 


### PR DESCRIPTION
## Summary
- expand `qmtl.yml` template with SQLite and memory backends by default
- explain cluster configuration in README and documentation

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68631a927edc832981b0421c17f57c61