### PR TITLE
Remove obsolete commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,6 @@ transforms = []
 
 [project.scripts]
 qmtl = "qmtl.cli:main"
-qmtl-dagm = "qmtl.dagmanager.cli:main"
-qmtl-gateway = "qmtl.gateway.cli:main"
 
 [build-system]
 requires = ["setuptools"]

--- a/qmtl/dagmanager/__main__.py
+++ b/qmtl/dagmanager/__main__.py
@@ -1,4 +1,0 @@
-from .server import main
-
-if __name__ == "__main__":
-    main()

--- a/qmtl/gateway/__main__.py
+++ b/qmtl/gateway/__main__.py
@@ -1,5 +1,0 @@
-from .cli import main
-
-if __name__ == "__main__":
-    main()
-


### PR DESCRIPTION
## Summary
- drop qmtl-dagm and qmtl-gateway script entrypoints
- delete redundant `__main__` modules

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_686320842a888329810a2b46a7b9904f