### PR TITLE
Unify connection string naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Here’s a short workflow summary based on the repository’s guidelines:
 
 For additional rules—such as adhering to architecture documents or managing distributable wheels—refer to [AGENTS.md](AGENTS.md) in the project root for the full guidelines.
 
+## Coding Style
+
+Use consistent naming for connection strings across the project. Prefer the `*_dsn` suffix for all connection parameters (for example `redis_dsn`, `database_dsn`, `neo4j_dsn`, `kafka_dsn`). Avoid one-letter variable names except in short loops; use descriptive names like `redis_client` or `dag_manager`.
+
 ## Optional Modules
 
 Install additional functionality on demand. Each entry links to its

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -257,11 +257,11 @@ For canary deployment steps see
 
 ```yaml
 repo_backend: neo4j
-neo4j_uri: bolt://db:7687
+neo4j_dsn: bolt://db:7687
 neo4j_user: neo4j
 neo4j_password: secret
 queue_backend: kafka
-kafka_bootstrap: localhost:9092
+kafka_dsn: localhost:9092
 ```
 
 The sample file installed by ``qmtl init`` instead defaults to in-memory

--- a/examples/qmtl.yml
+++ b/examples/qmtl.yml
@@ -15,11 +15,11 @@ dagmanager:
   queue_backend: memory
   # Example cluster configuration using Neo4j and Kafka
   # repo_backend: neo4j
-  # neo4j_uri: bolt://localhost:7687
+  # neo4j_dsn: bolt://localhost:7687
   # neo4j_user: neo4j
   # neo4j_password: neo4j
   # queue_backend: kafka
-  # kafka_bootstrap: localhost:9092
+  # kafka_dsn: localhost:9092
   grpc_host: 0.0.0.0
   grpc_port: 50051
   http_host: 0.0.0.0

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -11,12 +11,12 @@ class DagManagerConfig:
     """Configuration for DAG manager server."""
 
     repo_backend: str = "neo4j"
-    neo4j_uri: str = "bolt://localhost:7687"
+    neo4j_dsn: str = "bolt://localhost:7687"
     neo4j_user: str = "neo4j"
     neo4j_password: str = "neo4j"
     memory_repo_path: str = "memrepo.gpickle"
     queue_backend: str = "kafka"
-    kafka_bootstrap: str = "localhost:9092"
+    kafka_dsn: str = "localhost:9092"
     grpc_host: str = "0.0.0.0"
     grpc_port: int = 50051
     http_host: str = "0.0.0.0"

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -62,7 +62,7 @@ async def _run(cfg: DagManagerConfig) -> None:
         from neo4j import GraphDatabase  # pragma: no cover - external dependency
 
         driver = GraphDatabase.driver(
-            cfg.neo4j_uri, auth=(cfg.neo4j_user, cfg.neo4j_password)
+            cfg.neo4j_dsn, auth=(cfg.neo4j_user, cfg.neo4j_password)
         )
         repo = None
     elif cfg.repo_backend == "memory":
@@ -70,7 +70,7 @@ async def _run(cfg: DagManagerConfig) -> None:
 
         repo = MemoryNodeRepository(cfg.memory_repo_path)
     if cfg.queue_backend == "kafka":
-        admin_client = _KafkaAdminClient(cfg.kafka_bootstrap)
+        admin_client = _KafkaAdminClient(cfg.kafka_dsn)
         queue = None
     elif cfg.queue_backend == "memory":
         from .kafka_admin import InMemoryAdminClient, KafkaAdmin

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -7,17 +7,17 @@ from qmtl.dagmanager.config import load_dagmanager_config, DagManagerConfig
 def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
     data = {
         "repo_backend": "neo4j",
-        "neo4j_uri": "bolt://db:7687",
+        "neo4j_dsn": "bolt://db:7687",
         "neo4j_user": "neo4j",
         "neo4j_password": "pw",
         "queue_backend": "kafka",
-        "kafka_bootstrap": "localhost:9092",
+        "kafka_dsn": "localhost:9092",
     }
-    cfg_file = tmp_path / "dm.yml"
-    cfg_file.write_text(yaml.safe_dump(data))
-    cfg = load_dagmanager_config(str(cfg_file))
-    assert cfg.neo4j_uri == data["neo4j_uri"]
-    assert cfg.kafka_bootstrap == data["kafka_bootstrap"]
+    config_file = tmp_path / "dm.yml"
+    config_file.write_text(yaml.safe_dump(data))
+    config = load_dagmanager_config(str(config_file))
+    assert config.neo4j_dsn == data["neo4j_dsn"]
+    assert config.kafka_dsn == data["kafka_dsn"]
 
 
 def test_load_dagmanager_config_missing_file():

--- a/tests/test_gateway_cli.py
+++ b/tests/test_gateway_cli.py
@@ -9,8 +9,8 @@ def test_gateway_cli_help():
 
 
 def test_gateway_cli_config_file(monkeypatch, tmp_path):
-    cfg = tmp_path / "cfg.yml"
-    cfg.write_text(
+    config_path = tmp_path / "cfg.yml"
+    config_path.write_text(
         "\n".join(
             [
                 "gateway:",
@@ -46,7 +46,7 @@ def test_gateway_cli_config_file(monkeypatch, tmp_path):
     fake_uvicorn = SimpleNamespace(run=lambda app, host, port: captured.update({"host": host, "port": port}))
     monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
 
-    cli.main(["--config", str(cfg)])
+    cli.main(["--config", str(config_path)])
 
     assert captured["host"] == "127.0.0.1"
     assert captured["port"] == 12345

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -13,13 +13,13 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
         "database_dsn": "postgresql://db/test",
         "offline": True,
     }
-    cfg_file = tmp_path / "gw.yaml"
-    cfg_file.write_text(yaml.safe_dump(data))
-    cfg = load_gateway_config(str(cfg_file))
-    assert cfg.redis_dsn == data["redis_dsn"]
-    assert cfg.database_backend == "postgres"
-    assert cfg.database_dsn == data["database_dsn"]
-    assert cfg.offline is True
+    config_file = tmp_path / "gw.yaml"
+    config_file.write_text(yaml.safe_dump(data))
+    config = load_gateway_config(str(config_file))
+    assert config.redis_dsn == data["redis_dsn"]
+    assert config.database_backend == "postgres"
+    assert config.database_dsn == data["database_dsn"]
+    assert config.offline is True
 
 
 def test_load_gateway_config_json(tmp_path: Path) -> None:
@@ -29,12 +29,12 @@ def test_load_gateway_config_json(tmp_path: Path) -> None:
         "database_dsn": "sqlite:///:memory:",
         "offline": False,
     }
-    cfg_file = tmp_path / "gw.json"
-    cfg_file.write_text(json.dumps(data))
-    cfg = load_gateway_config(str(cfg_file))
-    assert cfg.database_backend == "memory"
-    assert cfg.database_dsn == data["database_dsn"]
-    assert cfg.offline is False
+    config_file = tmp_path / "gw.json"
+    config_file.write_text(json.dumps(data))
+    config = load_gateway_config(str(config_file))
+    assert config.database_backend == "memory"
+    assert config.database_dsn == data["database_dsn"]
+    assert config.offline is False
 
 
 def test_load_gateway_config_missing_file():

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -14,9 +14,9 @@ def test_server_help(capsys):
 def test_server_defaults(monkeypatch):
     captured = {}
 
-    async def fake_run(cfg):
-        captured["repo"] = cfg.repo_backend
-        captured["queue"] = cfg.queue_backend
+    async def fake_run(config):
+        captured["repo"] = config.repo_backend
+        captured["queue"] = config.queue_backend
 
     monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
     main([])
@@ -25,14 +25,16 @@ def test_server_defaults(monkeypatch):
 
 
 def test_server_config_file(monkeypatch, tmp_path):
-    cfg = tmp_path / "cfg.yml"
-    cfg.write_text(yaml.safe_dump({"dagmanager": {"neo4j_uri": "bolt://test:7687"}}))
+    config_path = tmp_path / "cfg.yml"
+    config_path.write_text(
+        yaml.safe_dump({"dagmanager": {"neo4j_dsn": "bolt://test:7687"}})
+    )
 
     captured = {}
 
-    async def fake_run(cfg):
-        captured["uri"] = cfg.neo4j_uri
+    async def fake_run(config):
+        captured["uri"] = config.neo4j_dsn
 
     monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
-    main(["--config", str(cfg)])
+    main(["--config", str(config_path)])
     assert captured["uri"] == "bolt://test:7687"

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -38,21 +38,21 @@ def test_topic_name_generation():
 
 
 def test_queue_config_values():
-    cfg = get_config("raw")
-    assert cfg == TopicConfig(partitions=3, replication_factor=3, retention_ms=7 * 24 * 60 * 60 * 1000)
+    config = get_config("raw")
+    assert config == TopicConfig(partitions=3, replication_factor=3, retention_ms=7 * 24 * 60 * 60 * 1000)
     ind = get_config("indicator")
     assert ind == TopicConfig(partitions=1, replication_factor=2, retention_ms=30 * 24 * 60 * 60 * 1000)
-    exec_cfg = get_config("trade_exec")
-    assert exec_cfg == TopicConfig(partitions=1, replication_factor=3, retention_ms=90 * 24 * 60 * 60 * 1000)
+    exec_config = get_config("trade_exec")
+    assert exec_config == TopicConfig(partitions=1, replication_factor=3, retention_ms=90 * 24 * 60 * 60 * 1000)
 
 
 def test_idempotent_topic_creation():
     admin = FakeAdmin({"exists": {}})
     wrapper = KafkaAdmin(admin)
 
-    cfg = TopicConfig(1, 1, 1000)
-    wrapper.create_topic_if_needed("exists", cfg)
-    wrapper.create_topic_if_needed("new", cfg)
+    config = TopicConfig(1, 1, 1000)
+    wrapper.create_topic_if_needed("exists", config)
+    wrapper.create_topic_if_needed("new", config)
 
     assert len(admin.created) == 1
     name, parts, repl, conf = admin.created[0]

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -12,14 +12,14 @@ def test_load_unified_config_yaml(tmp_path: Path) -> None:
             "redis_dsn": "redis://test:6379",
         },
         "dagmanager": {
-            "neo4j_uri": "bolt://db:7687",
+            "neo4j_dsn": "bolt://db:7687",
         },
     }
-    cfg_file = tmp_path / "cfg.yml"
-    cfg_file.write_text(yaml.safe_dump(data))
-    cfg = load_config(str(cfg_file))
-    assert cfg.gateway.redis_dsn == data["gateway"]["redis_dsn"]
-    assert cfg.dagmanager.neo4j_uri == data["dagmanager"]["neo4j_uri"]
+    config_file = tmp_path / "cfg.yml"
+    config_file.write_text(yaml.safe_dump(data))
+    config = load_config(str(config_file))
+    assert config.gateway.redis_dsn == data["gateway"]["redis_dsn"]
+    assert config.dagmanager.neo4j_dsn == data["dagmanager"]["neo4j_dsn"]
 
 
 def test_load_unified_config_json(tmp_path: Path) -> None:
@@ -27,11 +27,11 @@ def test_load_unified_config_json(tmp_path: Path) -> None:
         "gateway": {"host": "127.0.0.1"},
         "dagmanager": {"grpc_port": 1234},
     }
-    cfg_file = tmp_path / "cfg.json"
-    cfg_file.write_text(json.dumps(data))
-    cfg = load_config(str(cfg_file))
-    assert cfg.gateway.host == "127.0.0.1"
-    assert cfg.dagmanager.grpc_port == 1234
+    config_file = tmp_path / "cfg.json"
+    config_file.write_text(json.dumps(data))
+    config = load_config(str(config_file))
+    assert config.gateway.host == "127.0.0.1"
+    assert config.dagmanager.grpc_port == 1234
 
 
 def test_load_unified_config_missing_file() -> None:
@@ -40,31 +40,31 @@ def test_load_unified_config_missing_file() -> None:
 
 
 def test_load_unified_config_malformed(tmp_path: Path) -> None:
-    cfg_file = tmp_path / "bad.yml"
-    cfg_file.write_text("- 1")
+    config_file = tmp_path / "bad.yml"
+    config_file.write_text("- 1")
     with pytest.raises(TypeError):
-        load_config(str(cfg_file))
+        load_config(str(config_file))
 
 
 def test_load_unified_config_defaults(tmp_path: Path) -> None:
     """Empty files should load default configs."""
-    cfg_file = tmp_path / "empty.yml"
-    cfg_file.write_text("{}")
-    cfg = load_config(str(cfg_file))
-    assert isinstance(cfg, UnifiedConfig)
-    assert cfg.gateway.redis_dsn == "redis://localhost:6379"
-    assert cfg.dagmanager.grpc_port == 50051
+    config_file = tmp_path / "empty.yml"
+    config_file.write_text("{}")
+    config = load_config(str(config_file))
+    assert isinstance(config, UnifiedConfig)
+    assert config.gateway.redis_dsn == "redis://localhost:6379"
+    assert config.dagmanager.grpc_port == 50051
 
 
 def test_load_unified_config_bad_gateway(tmp_path: Path) -> None:
-    cfg_file = tmp_path / "bad.yml"
-    cfg_file.write_text(yaml.safe_dump({"gateway": [1, 2, 3]}))
+    config_file = tmp_path / "bad.yml"
+    config_file.write_text(yaml.safe_dump({"gateway": [1, 2, 3]}))
     with pytest.raises(TypeError, match="gateway section must be a mapping"):
-        load_config(str(cfg_file))
+        load_config(str(config_file))
 
 
 def test_load_unified_config_bad_dagmanager(tmp_path: Path) -> None:
-    cfg_file = tmp_path / "bad.yml"
-    cfg_file.write_text(yaml.safe_dump({"dagmanager": [1]}))
+    config_file = tmp_path / "bad.yml"
+    config_file.write_text(yaml.safe_dump({"dagmanager": [1]}))
     with pytest.raises(TypeError, match="dagmanager section must be a mapping"):
-        load_config(str(cfg_file))
+        load_config(str(config_file))


### PR DESCRIPTION
## Summary
- rename `neo4j_uri`/`kafka_bootstrap` to `*_dsn`
- use descriptive local variables in `create_app`
- document naming conventions
- update examples and docs
- adjust tests for new names

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6863ceb310f88329b1d16c94a35eea5b