### PR TITLE
Implement strategy-level defaults for node interval and period

### DIFF
--- a/examples/general_strategy.py
+++ b/examples/general_strategy.py
@@ -3,10 +3,11 @@ from qmtl.io import QuestDBLoader, QuestDBRecorder
 import pandas as pd
 
 class GeneralStrategy(Strategy):
+    def __init__(self):
+        super().__init__(default_interval="60s", default_period=30)
+
     def setup(self):
         price_stream = StreamInput(
-            interval="60s",
-            period=30,
             history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
             event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
         )

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -362,8 +362,8 @@ class Node:
         config: dict | None = None,
         schema: dict | None = None,
     ) -> None:
-        interval_val = parse_interval(interval)
-        period_val = parse_period(period)
+        interval_val = parse_interval(interval) if interval is not None else None
+        period_val = parse_period(period) if period is not None else None
 
         if compute_fn is not None:
             sig = inspect.signature(compute_fn)

--- a/qmtl/sdk/strategy.py
+++ b/qmtl/sdk/strategy.py
@@ -1,10 +1,41 @@
+from .util import parse_interval, parse_period
+from . import arrow_cache
+from .node import NodeCache
+import os
+
+
 class Strategy:
     """Base class for strategies."""
 
-    def __init__(self):
+    def __init__(self, *, default_interval=None, default_period=None):
         self.nodes = []
+        self.default_interval = (
+            parse_interval(default_interval) if default_interval is not None else None
+        )
+        self.default_period = (
+            parse_period(default_period) if default_period is not None else None
+        )
 
     def add_nodes(self, nodes):
+        for node in nodes:
+            if node.interval is None:
+                if self.default_interval is None:
+                    raise ValueError("interval not specified and no default_interval set")
+                node.interval = self.default_interval
+            node.interval = parse_interval(node.interval)
+
+            if node.period is None:
+                if self.default_period is None:
+                    raise ValueError("period not specified and no default_period set")
+                node.period = self.default_period
+            node.period = parse_period(node.period)
+
+            if getattr(node.cache, "period", None) != node.period:
+                if arrow_cache.ARROW_AVAILABLE and os.getenv("QMTL_ARROW_CACHE") == "1":
+                    node.cache = arrow_cache.NodeCacheArrow(node.period)
+                else:
+                    node.cache = NodeCache(node.period)
+
         self.nodes.extend(nodes)
 
     def setup(self):

--- a/tests/test_node_validation.py
+++ b/tests/test_node_validation.py
@@ -4,8 +4,6 @@ from qmtl.sdk.node import SourceNode, ProcessingNode
 @pytest.mark.parametrize(
     "interval,period",
     [
-        (None, 1),
-        (1, None),
         (0, 1),
         (1, 0),
         (-1, 1),

--- a/tests/test_strategy_defaults.py
+++ b/tests/test_strategy_defaults.py
@@ -1,0 +1,57 @@
+import pytest
+from qmtl.sdk import Strategy, StreamInput, ProcessingNode
+
+
+class DefaultStrategy(Strategy):
+    def __init__(self):
+        super().__init__(default_interval=60, default_period=2)
+
+    def setup(self):
+        src = StreamInput()
+        node = ProcessingNode(input=src, compute_fn=lambda v: v, name="n")
+        self.add_nodes([src, node])
+
+
+def test_defaults_applied():
+    strat = DefaultStrategy()
+    strat.setup()
+    src, node = strat.nodes
+    assert src.interval == 60
+    assert src.period == 2
+    assert node.interval == 60
+    assert node.period == 2
+    assert src.cache.period == 2
+    assert node.cache.period == 2
+
+
+class OverrideStrategy(Strategy):
+    def __init__(self):
+        super().__init__(default_interval=60, default_period=2)
+
+    def setup(self):
+        src = StreamInput(interval=30, period=1)
+        node = ProcessingNode(input=src, compute_fn=lambda v: v, name="n", interval="30s", period=3)
+        self.add_nodes([src, node])
+
+
+def test_override_values():
+    strat = OverrideStrategy()
+    strat.setup()
+    src, node = strat.nodes
+    assert src.interval == 30
+    assert src.period == 1
+    assert node.interval == 30
+    assert node.period == 3
+
+
+class MissingDefaultsStrategy(Strategy):
+    def setup(self):
+        src = StreamInput()
+        node = ProcessingNode(input=src, compute_fn=lambda v: v, name="n")
+        self.add_nodes([src, node])
+
+
+def test_missing_defaults_error():
+    strat = MissingDefaultsStrategy()
+    with pytest.raises(ValueError):
+        strat.setup()


### PR DESCRIPTION
## Summary
- allow nodes to omit interval/period by parsing them only when provided
- support `default_interval` and `default_period` in `Strategy`
- reinitialize caches and validate when nodes are added
- update general strategy example to showcase defaults
- adjust node validation test for new semantics
- add tests for default inheritance and overrides

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68658b3a30d4832983512a5de1908d37