### PR TITLE
Fix string interval usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ import pandas as pd
 from qmtl.sdk import DataFetcher, QuestDBLoader
 
 class BinanceFetcher:
-    async def fetch(self, start: int, end: int, *, node_id: str, interval: int) -> pd.DataFrame:
+    async def fetch(self, start: int, end: int, *, node_id: str, interval: str) -> pd.DataFrame:
         url = (
             "https://api.binance.com/api/v3/klines"
-            f"?symbol={node_id}&interval={interval}m"
+            f"?symbol={node_id}&interval={interval}"
             f"&startTime={start * 1000}&endTime={end * 1000}"
         )
         async with httpx.AsyncClient() as client:

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -52,10 +52,10 @@ import pandas as pd
 from qmtl.sdk import DataFetcher
 
 class BinanceFetcher:
-    async def fetch(self, start: int, end: int, *, node_id: str, interval: int) -> pd.DataFrame:
+    async def fetch(self, start: int, end: int, *, node_id: str, interval: str) -> pd.DataFrame:
         url = (
             "https://api.binance.com/api/v3/klines"
-            f"?symbol={node_id}&interval={interval}m"
+            f"?symbol={node_id}&interval={interval}"
             f"&startTime={start * 1000}&endTime={end * 1000}"
         )
         async with httpx.AsyncClient() as client:

--- a/tests/gateway/test_queue_update_ws_execution.py
+++ b/tests/gateway/test_queue_update_ws_execution.py
@@ -40,7 +40,7 @@ async def test_node_unpauses_on_queue_update():
     gw_app = create_app(dag_client=DummyDag(), ws_hub=ws_hub)
     transport = httpx.ASGITransport(gw_app)
     calls = []
-    node = TagQueryNode(["t1"], interval=60, period=1, compute_fn=lambda v: calls.append(v))
+    node = TagQueryNode(["t1"], interval="60s", period=1, compute_fn=lambda v: calls.append(v))
     manager.register(node)
 
     assert not node.execute

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -16,19 +16,19 @@ class DummyProducer:
 
 
 def test_basic_flow():
-    src = StreamInput(interval=1, period=1)
+    src = StreamInput(interval="1s", period=1)
 
     def mul2(view):
         ts, val = view[src][1].latest()
         return val * 2
 
-    n1 = ProcessingNode(input=src, compute_fn=mul2, name="n1", interval=1, period=1)
+    n1 = ProcessingNode(input=src, compute_fn=mul2, name="n1", interval="1s", period=1)
 
     def add1(view):
         ts, val = view[n1][1].latest()
         return val + 1
 
-    n2 = ProcessingNode(input=n1, compute_fn=add1, name="n2", interval=1, period=1)
+    n2 = ProcessingNode(input=n1, compute_fn=add1, name="n2", interval="1s", period=1)
 
     prod = DummyProducer()
     n1.queue_topic = "n1"
@@ -45,10 +45,10 @@ def test_basic_flow():
 
 
 def test_execute_false_pass_through():
-    src = StreamInput(interval=1, period=1)
-    n1 = ProcessingNode(input=src, compute_fn=lambda v: None, name="n1", interval=1, period=1)
+    src = StreamInput(interval="1s", period=1)
+    n1 = ProcessingNode(input=src, compute_fn=lambda v: None, name="n1", interval="1s", period=1)
     n1.execute = False
-    n2 = ProcessingNode(input=n1, compute_fn=lambda v: v[n1][1].latest()[1] + 5, name="n2", interval=1, period=1)
+    n2 = ProcessingNode(input=n1, compute_fn=lambda v: v[n1][1].latest()[1] + 5, name="n2", interval="1s", period=1)
 
     pipe = Pipeline([src, n1, n2])
 

--- a/tests/runner/test_execution.py
+++ b/tests/runner/test_execution.py
@@ -47,8 +47,8 @@ def test_backtest_executes_nodes(monkeypatch):
 
     class Strat(Strategy):
         def setup(self):
-            src = StreamInput(interval=60, period=2, history_provider=DummyProvider())
-            node = Node(input=src, compute_fn=lambda v: calls.append(v), interval=60, period=2)
+            src = StreamInput(interval="60s", period=2, history_provider=DummyProvider())
+            node = Node(input=src, compute_fn=lambda v: calls.append(v), interval="60s", period=2)
             self.add_nodes([src, node])
 
     Runner.backtest(Strat, start_time=60, end_time=120, gateway_url="http://gw")
@@ -60,9 +60,9 @@ def test_offline_executes_nodes():
 
     class Strat(Strategy):
         def setup(self):
-            src = StreamInput(interval=60, period=2)
+            src = StreamInput(interval="60s", period=2)
             src.cache.backfill_bulk(src.node_id, 60, [(60, {"v": 1}), (120, {"v": 2})])
-            node = Node(input=src, compute_fn=lambda v: calls.append(v), interval=60, period=2)
+            node = Node(input=src, compute_fn=lambda v: calls.append(v), interval="60s", period=2)
             self.add_nodes([src, node])
 
     Runner.offline(Strat)

--- a/tests/runner/test_kafka_consumers.py
+++ b/tests/runner/test_kafka_consumers.py
@@ -18,8 +18,8 @@ async def test_single_node_consumption(monkeypatch):
     def compute(view):
         calls.append(view)
 
-    src = StreamInput(interval=60, period=2)
-    node = ProcessingNode(input=src, compute_fn=compute, name="n1", interval=60, period=2)
+    src = StreamInput(interval="60s", period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n1", interval="60s", period=2)
     node.queue_topic = "t1"
     strategy = DummyStrategy([src, node])
 
@@ -49,12 +49,12 @@ async def test_multi_node_consumption(monkeypatch):
     def compute2(view):
         calls.append("n2")
 
-    src1 = StreamInput(interval=60, period=2)
-    node1 = ProcessingNode(input=src1, compute_fn=compute1, name="n1", interval=60, period=2)
+    src1 = StreamInput(interval="60s", period=2)
+    node1 = ProcessingNode(input=src1, compute_fn=compute1, name="n1", interval="60s", period=2)
     node1.queue_topic = "t1"
 
-    src2 = StreamInput(interval=60, period=2)
-    node2 = ProcessingNode(input=src2, compute_fn=compute2, name="n2", interval=60, period=2)
+    src2 = StreamInput(interval="60s", period=2)
+    node2 = ProcessingNode(input=src2, compute_fn=compute2, name="n2", interval="60s", period=2)
     node2.queue_topic = "t2"
 
     strategy = DummyStrategy([src1, node1, src2, node2])

--- a/tests/runner/test_run_pipeline.py
+++ b/tests/runner/test_run_pipeline.py
@@ -29,14 +29,14 @@ def _mock_gateway(monkeypatch):
 def _make_strategy(calls, results):
     class Strat(Strategy):
         def setup(self):
-            src = StreamInput(interval=60, period=2)
+            src = StreamInput(interval="60s", period=2)
             src.cache.backfill_bulk(src.node_id, 60, [(60, {"v": 1}), (120, {"v": 2})])
 
             def n1_fn(view):
                 calls.append("n1")
                 return view[src][60].latest()[1]["v"] + 1
 
-            n1 = ProcessingNode(input=src, compute_fn=n1_fn, name="n1", interval=60, period=1)
+            n1 = ProcessingNode(input=src, compute_fn=n1_fn, name="n1", interval="60s", period=1)
 
             def n2_fn(view):
                 calls.append("n2")
@@ -45,7 +45,7 @@ def _make_strategy(calls, results):
                 results.append(out)
                 return out
 
-            n2 = ProcessingNode(input=n1, compute_fn=n2_fn, name="n2", interval=60, period=1)
+            n2 = ProcessingNode(input=n1, compute_fn=n2_fn, name="n2", interval="60s", period=1)
 
             self.add_nodes([src, n1, n2])
 

--- a/tests/sample_strategy.py
+++ b/tests/sample_strategy.py
@@ -2,6 +2,6 @@ from qmtl.sdk import Strategy, ProcessingNode, StreamInput
 
 class SampleStrategy(Strategy):
     def setup(self):
-        src = StreamInput(interval=1, period=1)
-        node = ProcessingNode(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
+        src = StreamInput(interval="1s", period=1)
+        node = ProcessingNode(input=src, compute_fn=lambda df: df, name="out", interval="1s", period=1)
         self.add_nodes([src, node])

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -30,7 +30,7 @@ class FakeDB(Database):
 
 class TQStrategy(Strategy):
     def setup(self):
-        self.tq = TagQueryNode(["t1"], interval=60, period=1)
+        self.tq = TagQueryNode(["t1"], interval="60s", period=1)
         self.add_nodes([self.tq])
 
 

--- a/tests/test_arrow_cache.py
+++ b/tests/test_arrow_cache.py
@@ -22,7 +22,7 @@ def test_arrow_cache_basic():
 @pytest.mark.skipif(not arrow_cache.ARROW_AVAILABLE, reason="pyarrow missing")
 def test_node_uses_arrow_cache(monkeypatch):
     monkeypatch.setenv("QMTL_ARROW_CACHE", "1")
-    src = StreamInput(interval=60, period=2)
-    node = ProcessingNode(input=src, compute_fn=lambda v: None, name="n", interval=60, period=2)
+    src = StreamInput(interval="60s", period=2)
+    node = ProcessingNode(input=src, compute_fn=lambda v: None, name="n", interval="60s", period=2)
     assert isinstance(node.cache, arrow_cache.NodeCacheArrow)
     monkeypatch.delenv("QMTL_ARROW_CACHE", raising=False)

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -168,7 +168,7 @@ def test_stream_input_records_on_feed():
         async def persist(self, node_id, interval, timestamp, payload):
             events.append((node_id, interval, timestamp, payload))
 
-    s = StreamInput(interval=60, period=1, event_recorder=DummyRecorder())
+    s = StreamInput(interval="60s", period=1, event_recorder=DummyRecorder())
 
     s.feed("s", 60, 1, {"v": 1})
     assert events == [(s.node_id, 60, 1, {"v": 1})]

--- a/tests/test_backfill_engine.py
+++ b/tests/test_backfill_engine.py
@@ -25,7 +25,7 @@ class DummySource:
 
 @pytest.mark.asyncio
 async def test_concurrent_backfill_and_live_append():
-    node = SourceNode(interval=60, period=5)
+    node = SourceNode(interval="60s", period=5)
     df = pd.DataFrame([
         {"ts": 60, "value": 1},
         {"ts": 120, "value": 2},
@@ -52,7 +52,7 @@ async def test_concurrent_backfill_and_live_append():
 
 @pytest.mark.asyncio
 async def test_retry_logic():
-    node = SourceNode(interval=60, period=2)
+    node = SourceNode(interval="60s", period=2)
     df = pd.DataFrame([{"ts": 60, "v": 1}])
     src = DummySource(df, delay=0.01, fail=1)
     engine = BackfillEngine(src, max_retries=2)
@@ -67,7 +67,7 @@ async def test_metrics_and_logs(caplog):
     from qmtl.sdk import metrics as sdk_metrics
     sdk_metrics.reset_metrics()
 
-    node = SourceNode(interval=60, period=1)
+    node = SourceNode(interval="60s", period=1)
     df = pd.DataFrame([{"ts": 60, "v": 1}])
     src = DummySource(df, delay=0.0, fail=1)
     engine = BackfillEngine(src, max_retries=2)
@@ -93,7 +93,7 @@ async def test_failure_metrics_and_logs(caplog):
     from qmtl.sdk import metrics as sdk_metrics
     sdk_metrics.reset_metrics()
 
-    node = SourceNode(interval=60, period=1)
+    node = SourceNode(interval="60s", period=1)
     df = pd.DataFrame([])
     src = DummySource(df, delay=0.0, fail=5)
     engine = BackfillEngine(src, max_retries=2)
@@ -120,7 +120,7 @@ async def test_streaminput_load_history():
     ])
     src = DummySource(df, delay=0.0)
     stream = StreamInput(
-        interval=60,
+        interval="60s",
         period=3,
         history_provider=src,
     )

--- a/tests/test_completion_monitor.py
+++ b/tests/test_completion_monitor.py
@@ -13,7 +13,7 @@ class DummyRepo(NodeRepository):
             node_type="N",
             code_hash="c",
             schema_hash="s",
-            interval=60,
+            interval="60s",
             period=1,
             tags=["t1"],
             topic="q1",

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -192,8 +192,8 @@ def test_diff_with_sdk_nodes():
 
     class _S(Strategy):
         def setup(self):
-            src = StreamInput(interval=1, period=1)
-            node = ProcessingNode(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
+            src = StreamInput(interval="1s", period=1)
+            node = ProcessingNode(input=src, compute_fn=lambda x: x, name="out", interval="1s", period=1)
             self.add_nodes([src, node])
 
     s = _S()

--- a/tests/test_gc_endpoint.py
+++ b/tests/test_gc_endpoint.py
@@ -12,7 +12,7 @@ class FakeGC:
 
     def collect(self):
         self.calls += 1
-        return [QueueInfo("q1", "raw", datetime.now(UTC), interval=60)]
+        return [QueueInfo("q1", "raw", datetime.now(UTC), interval="60s")]
 
 
 def test_gc_route_triggers_collect():

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -2,7 +2,7 @@ from qmtl.generators import GarchInput, HestonInput, RoughBergomiInput
 
 
 def _test_stream(cls):
-    stream = cls(interval=1, period=2, seed=42)
+    stream = cls(interval="1s", period=2, seed=42)
     data = stream.generate(5)
     assert len(data) == 5
     assert all(ts == i + 1 for i, (ts, _) in enumerate(data))

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -19,7 +19,7 @@ import pytest
 
 class DummyGC:
     def collect(self):
-        return [QueueInfo("q", "raw", datetime.now(UTC), interval=60)]
+        return [QueueInfo("q", "raw", datetime.now(UTC), interval="60s")]
 
 
 class FakeDagClient:

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -4,7 +4,7 @@ from qmtl.sdk.cache_view import CacheView
 
 
 def test_sma_compute():
-    src = SourceNode(interval=1, period=3)
+    src = SourceNode(interval="1s", period=3)
     node = sma(src, window=2)
     data = {src.node_id: {1: [(0, 1), (1, 3)]}}
     view = CacheView(data)
@@ -30,7 +30,7 @@ from qmtl.indicators import (
 
 
 def test_ema_compute():
-    src = SourceNode(interval=1, period=3)
+    src = SourceNode(interval="1s", period=3)
     node = ema(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
@@ -38,7 +38,7 @@ def test_ema_compute():
 
 
 def test_rsi_compute():
-    src = SourceNode(interval=1, period=15)
+    src = SourceNode(interval="1s", period=15)
     node = rsi(src, window=14)
     data = {src.node_id: {1: [(i, float(i)) for i in range(15)]}}
     view = CacheView(data)
@@ -46,7 +46,7 @@ def test_rsi_compute():
 
 
 def test_bollinger_bands_compute():
-    src = SourceNode(interval=1, period=3)
+    src = SourceNode(interval="1s", period=3)
     node = bollinger_bands(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
@@ -57,9 +57,9 @@ def test_bollinger_bands_compute():
 
 
 def test_atr_compute():
-    h = SourceNode(interval=1, period=3, config={"id": "h"})
-    l = SourceNode(interval=1, period=3, config={"id": "l"})
-    c = SourceNode(interval=1, period=4, config={"id": "c"})
+    h = SourceNode(interval="1s", period=3, config={"id": "h"})
+    l = SourceNode(interval="1s", period=3, config={"id": "l"})
+    c = SourceNode(interval="1s", period=4, config={"id": "c"})
     node = atr(h, l, c, window=3)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
@@ -71,9 +71,9 @@ def test_atr_compute():
 
 
 def test_chandelier_exit_compute():
-    h = SourceNode(interval=1, period=3, config={"id": "h"})
-    l = SourceNode(interval=1, period=3, config={"id": "l"})
-    c = SourceNode(interval=1, period=4, config={"id": "c"})
+    h = SourceNode(interval="1s", period=3, config={"id": "h"})
+    l = SourceNode(interval="1s", period=3, config={"id": "l"})
+    c = SourceNode(interval="1s", period=4, config={"id": "c"})
     node = chandelier_exit(h, l, c, window=3, multiplier=3)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
@@ -87,8 +87,8 @@ def test_chandelier_exit_compute():
 
 
 def test_vwap_compute():
-    p = SourceNode(interval=1, period=3, config={"id": "p"})
-    v = SourceNode(interval=1, period=3, config={"id": "v"})
+    p = SourceNode(interval="1s", period=3, config={"id": "p"})
+    v = SourceNode(interval="1s", period=3, config={"id": "v"})
     node = vwap(p, v, window=3)
     data = {
         p.node_id: {1: [(0, 1), (1, 2), (2, 3)]},
@@ -99,8 +99,8 @@ def test_vwap_compute():
 
 
 def test_anchored_vwap_compute():
-    p = SourceNode(interval=1, period=3, config={"id": "p"})
-    v = SourceNode(interval=1, period=3, config={"id": "v"})
+    p = SourceNode(interval="1s", period=3, config={"id": "p"})
+    v = SourceNode(interval="1s", period=3, config={"id": "v"})
     node = anchored_vwap(p, v, anchor_ts=1)
     data = {
         p.node_id: {1: [(0, 1), (1, 2), (2, 3)]},
@@ -111,9 +111,9 @@ def test_anchored_vwap_compute():
 
 
 def test_keltner_channel_compute():
-    h = SourceNode(interval=1, period=3, config={"id": "h"})
-    l = SourceNode(interval=1, period=3, config={"id": "l"})
-    c = SourceNode(interval=1, period=4, config={"id": "c"})
+    h = SourceNode(interval="1s", period=3, config={"id": "h"})
+    l = SourceNode(interval="1s", period=3, config={"id": "l"})
+    c = SourceNode(interval="1s", period=4, config={"id": "c"})
     node = keltner_channel(h, l, c, ema_window=3, atr_window=3, multiplier=2)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
@@ -128,8 +128,8 @@ def test_keltner_channel_compute():
 
 
 def test_obv_compute():
-    c = SourceNode(interval=1, period=3, config={"id": "c"})
-    v = SourceNode(interval=1, period=3, config={"id": "v"})
+    c = SourceNode(interval="1s", period=3, config={"id": "c"})
+    v = SourceNode(interval="1s", period=3, config={"id": "v"})
     node = obv(c, v)
     data = {
         c.node_id: {1: [(0, 1), (1, 2), (2, 1)]},
@@ -140,9 +140,9 @@ def test_obv_compute():
 
 
 def test_supertrend_compute():
-    h = SourceNode(interval=1, period=3, config={"id": "h"})
-    l = SourceNode(interval=1, period=3, config={"id": "l"})
-    c = SourceNode(interval=1, period=4, config={"id": "c"})
+    h = SourceNode(interval="1s", period=3, config={"id": "h"})
+    l = SourceNode(interval="1s", period=3, config={"id": "l"})
+    c = SourceNode(interval="1s", period=4, config={"id": "c"})
     node = supertrend(h, l, c, window=3, multiplier=2)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
@@ -154,9 +154,9 @@ def test_supertrend_compute():
 
 
 def test_ichimoku_cloud_compute():
-    h = SourceNode(interval=1, period=52, config={"id": "h"})
-    l = SourceNode(interval=1, period=52, config={"id": "l"})
-    c = SourceNode(interval=1, period=52, config={"id": "c"})
+    h = SourceNode(interval="1s", period=52, config={"id": "h"})
+    l = SourceNode(interval="1s", period=52, config={"id": "l"})
+    c = SourceNode(interval="1s", period=52, config={"id": "c"})
     node = ichimoku_cloud(h, l, c)
     highs = [(i, i + 1) for i in range(52)]
     lows = [(i, i) for i in range(52)]
@@ -170,7 +170,7 @@ def test_ichimoku_cloud_compute():
 
 
 def test_kalman_trend_compute():
-    src = SourceNode(interval=1, period=5, config={"id": "src"})
+    src = SourceNode(interval="1s", period=5, config={"id": "src"})
     node = kalman_trend(src)
     data = {src.node_id: {1: [(i, float(i)) for i in range(5)]}}
     view = CacheView(data)
@@ -179,7 +179,7 @@ def test_kalman_trend_compute():
 
 
 def test_rough_bergami_compute():
-    src = SourceNode(interval=1, period=4, config={"id": "src"})
+    src = SourceNode(interval="1s", period=4, config={"id": "src"})
     node = rough_bergami(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 1), (3, 2)]}}
     view = CacheView(data)
@@ -187,7 +187,7 @@ def test_rough_bergami_compute():
 
 
 def test_stoch_rsi_compute():
-    src = SourceNode(interval=1, period=30, config={"id": "src"})
+    src = SourceNode(interval="1s", period=30, config={"id": "src"})
     node = stoch_rsi(src, window=14)
     values = [(i, float(i % 5)) for i in range(30)]
     data = {src.node_id: {1: values}}
@@ -197,9 +197,9 @@ def test_stoch_rsi_compute():
 
 
 def test_kdj_compute():
-    h = SourceNode(interval=1, period=3, config={"id": "h"})
-    l = SourceNode(interval=1, period=3, config={"id": "l"})
-    c = SourceNode(interval=1, period=3, config={"id": "c"})
+    h = SourceNode(interval="1s", period=3, config={"id": "h"})
+    l = SourceNode(interval="1s", period=3, config={"id": "l"})
+    c = SourceNode(interval="1s", period=3, config={"id": "c"})
     node = kdj(h, l, c, window=3)
     data = {
         h.node_id: {1: [(0, 3), (1, 4), (2, 5)]},

--- a/tests/test_multi_input_node.py
+++ b/tests/test_multi_input_node.py
@@ -3,23 +3,23 @@ from qmtl.sdk import ProcessingNode, StreamInput, TagQueryNode
 
 
 def test_multi_input_serialization_list():
-    s1 = StreamInput(interval=60, period=1)
-    s2 = StreamInput(interval=60, period=1)
-    node = ProcessingNode(input=[s1, s2], compute_fn=lambda x: x, name="out", interval=60, period=1)
+    s1 = StreamInput(interval="60s", period=1)
+    s2 = StreamInput(interval="60s", period=1)
+    node = ProcessingNode(input=[s1, s2], compute_fn=lambda x: x, name="out", interval="60s", period=1)
     d = node.to_dict()
     assert set(d["inputs"]) == {s1.node_id, s2.node_id}
 
 
 def test_multi_input_serialization_dict():
-    s1 = StreamInput(interval=60, period=1)
-    s2 = StreamInput(interval=60, period=1)
+    s1 = StreamInput(interval="60s", period=1)
+    s2 = StreamInput(interval="60s", period=1)
     with pytest.raises(TypeError):
-        ProcessingNode(input={"a": s1, "b": s2}, compute_fn=lambda x: x, name="out", interval=60, period=1)
+        ProcessingNode(input={"a": s1, "b": s2}, compute_fn=lambda x: x, name="out", interval="60s", period=1)
 
 
 def test_multi_input_with_tag_query():
-    tq = TagQueryNode(["t"], interval=60, period=1)
-    s = StreamInput(interval=60, period=1)
-    node = ProcessingNode(input=[tq, s], compute_fn=lambda x: x, name="out", interval=60, period=1)
+    tq = TagQueryNode(["t"], interval="60s", period=1)
+    s = StreamInput(interval="60s", period=1)
+    node = ProcessingNode(input=[tq, s], compute_fn=lambda x: x, name="out", interval="60s", period=1)
     d = node.to_dict()
     assert set(d["inputs"]) == {tq.node_id, s.node_id}

--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -9,8 +9,8 @@ def test_cache_warmup_and_compute():
     def fn(view):
         calls.append(view)
 
-    src = StreamInput(interval=60, period=2)
-    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval=60, period=2)
+    src = StreamInput(interval="60s", period=2)
+    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval="60s", period=2)
 
     Runner.feed_queue_data(node, "q1", 60, 60, {"v": 1})
     assert node.pre_warmup
@@ -41,8 +41,8 @@ def test_node_feed_does_not_execute(monkeypatch):
     def fn(view):
         calls.append(view)
 
-    src = StreamInput(interval=60, period=2)
-    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval=60, period=2)
+    src = StreamInput(interval="60s", period=2)
+    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval="60s", period=2)
     node.execute = False
 
     ready1 = node.feed("q1", 60, 60, {"v": 1})
@@ -59,8 +59,8 @@ def test_multiple_upstreams():
     def fn(view):
         calls.append(view)
 
-    src = StreamInput(interval=60, period=2)
-    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval=60, period=2)
+    src = StreamInput(interval="60s", period=2)
+    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval="60s", period=2)
 
     Runner.feed_queue_data(node, "u1", 60, 60, {"v": 1})
     Runner.feed_queue_data(node, "u2", 60, 60, {"v": 1})
@@ -108,8 +108,8 @@ def test_on_missing_policy_skip_and_fail():
     def fn(view):
         calls.append(view)
 
-    src = StreamInput(interval=60, period=2)
-    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval=60, period=2)
+    src = StreamInput(interval="60s", period=2)
+    node = ProcessingNode(input=src, compute_fn=fn, name="n", interval="60s", period=2)
 
     Runner.feed_queue_data(node, "q1", 60, 1, {"v": 1})
     # Gap -> should skip
@@ -117,7 +117,7 @@ def test_on_missing_policy_skip_and_fail():
     assert node.cache.missing_flags()["q1"][60]
     assert len(calls) == 0
 
-    node2 = ProcessingNode(input=src, compute_fn=fn, name="n2", interval=60, period=2)
+    node2 = ProcessingNode(input=src, compute_fn=fn, name="n2", interval="60s", period=2)
     Runner.feed_queue_data(node2, "q1", 60, 1, {"v": 1})
     with pytest.raises(RuntimeError):
         Runner.feed_queue_data(node2, "q1", 60, 3, {"v": 2}, on_missing="fail")
@@ -216,7 +216,7 @@ def test_cache_view_access():
 
 
 def test_cache_view_accepts_node_instance():
-    stream = StreamInput(interval=60, period=2)
+    stream = StreamInput(interval="60s", period=2)
     cache = NodeCache(period=2)
     cache.append(stream.node_id, 60, 60, {"v": 1})
 

--- a/tests/test_node_id.py
+++ b/tests/test_node_id.py
@@ -1,7 +1,7 @@
 from qmtl.sdk import SourceNode, ProcessingNode, StreamInput, Strategy
 
 def test_node_id_generation():
-    node = SourceNode(compute_fn=lambda x: x, name="n", interval=1, period=1)
+    node = SourceNode(compute_fn=lambda x: x, name="n", interval="1s", period=1)
     node_id = node.node_id
     assert len(node_id) == 64
     assert node_id == node.node_id  # deterministic
@@ -9,8 +9,8 @@ def test_node_id_generation():
 
 class _S(Strategy):
     def setup(self):
-        src = StreamInput(interval=1, period=1)
-        node = ProcessingNode(input=src, compute_fn=lambda x: x, name="out", interval=1, period=1)
+        src = StreamInput(interval="1s", period=1)
+        node = ProcessingNode(input=src, compute_fn=lambda x: x, name="out", interval="1s", period=1)
         self.add_nodes([src, node])
 
 

--- a/tests/test_node_inputs.py
+++ b/tests/test_node_inputs.py
@@ -3,16 +3,16 @@ from qmtl.sdk import ProcessingNode, StreamInput
 
 
 def test_processing_node_accepts_list_or_node():
-    s1 = StreamInput(interval=60, period=1)
-    node = ProcessingNode(input=s1, compute_fn=lambda v: None, name="n", interval=60, period=1)
+    s1 = StreamInput(interval="60s", period=1)
+    node = ProcessingNode(input=s1, compute_fn=lambda v: None, name="n", interval="60s", period=1)
     assert node.inputs == [s1]
-    s2 = StreamInput(interval=60, period=1)
-    node2 = ProcessingNode(input=[s1, s2], compute_fn=lambda v: None, name="n2", interval=60, period=1)
+    s2 = StreamInput(interval="60s", period=1)
+    node2 = ProcessingNode(input=[s1, s2], compute_fn=lambda v: None, name="n2", interval="60s", period=1)
     assert node2.inputs == [s1, s2]
 
 
 def test_processing_node_rejects_dict():
-    s1 = StreamInput(interval=60, period=1)
-    s2 = StreamInput(interval=60, period=1)
+    s1 = StreamInput(interval="60s", period=1)
+    s2 = StreamInput(interval="60s", period=1)
     with pytest.raises(TypeError):
-        ProcessingNode(input={"a": s1, "b": s2}, compute_fn=lambda v: None, name="n", interval=60, period=1)
+        ProcessingNode(input={"a": s1, "b": s2}, compute_fn=lambda v: None, name="n", interval="60s", period=1)

--- a/tests/test_node_tags.py
+++ b/tests/test_node_tags.py
@@ -3,7 +3,7 @@ from qmtl.sdk.node import SourceNode
 
 
 def test_add_tag():
-    n = SourceNode(interval=1, period=1)
+    n = SourceNode(interval="1s", period=1)
     original = n.node_id
     assert n.tags == []
 

--- a/tests/test_node_validation.py
+++ b/tests/test_node_validation.py
@@ -25,9 +25,9 @@ def test_invalid_node_parameters(interval, period):
 )
 def test_invalid_compute_fn(fn):
     with pytest.raises(TypeError):
-        SourceNode(compute_fn=fn, interval=1, period=1)
+        SourceNode(compute_fn=fn, interval="1s", period=1)
 
 
 def test_processing_node_requires_input():
     with pytest.raises(ValueError):
-        ProcessingNode(input=None, compute_fn=lambda v: v, interval=1, period=1)
+        ProcessingNode(input=None, compute_fn=lambda v: v, interval="1s", period=1)

--- a/tests/test_queue_map_logging.py
+++ b/tests/test_queue_map_logging.py
@@ -5,11 +5,11 @@ from qmtl.sdk import Runner, Strategy, StreamInput, ProcessingNode, TagQueryNode
 
 class _Strat(Strategy):
     def setup(self):
-        self.src = StreamInput(interval=60, period=2)
+        self.src = StreamInput(interval="60s", period=2)
         self.proc = ProcessingNode(
-            input=self.src, compute_fn=lambda v: v, name="proc", interval=60, period=2
+            input=self.src, compute_fn=lambda v: v, name="proc", interval="60s", period=2
         )
-        self.tq = TagQueryNode(["t"], interval=60, period=2)
+        self.tq = TagQueryNode(["t"], interval="60s", period=2)
         self.add_nodes([self.src, self.proc, self.tq])
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -290,8 +290,8 @@ def test_feed_queue_data_with_ray(monkeypatch):
     def compute(view):
         calls.append(view)
 
-    src = StreamInput(interval=60, period=2)
-    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval=60, period=2)
+    src = StreamInput(interval="60s", period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval="60s", period=2)
 
     Runner.feed_queue_data(node, "q", 60, 60, {"v": 1})
     Runner.feed_queue_data(node, "q", 60, 120, {"v": 2})
@@ -310,8 +310,8 @@ def test_feed_queue_data_without_ray(monkeypatch):
     def compute(view):
         calls.append(view)
 
-    src = StreamInput(interval=60, period=2)
-    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval=60, period=2)
+    src = StreamInput(interval="60s", period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval="60s", period=2)
 
     Runner.feed_queue_data(node, "q", 60, 60, {"v": 1})
     Runner.feed_queue_data(node, "q", 60, 120, {"v": 2})
@@ -329,8 +329,8 @@ def test_feed_queue_data_respects_execute_flag(monkeypatch):
     def compute(view):
         calls.append(view)
 
-    src = StreamInput(interval=60, period=2)
-    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval=60, period=2)
+    src = StreamInput(interval="60s", period=2)
+    node = ProcessingNode(input=src, compute_fn=compute, name="n", interval="60s", period=2)
     node.execute = False
 
     Runner.feed_queue_data(node, "q", 60, 60, {"v": 1})
@@ -465,8 +465,8 @@ def test_history_gap_fill(monkeypatch):
 
     class Strat(SampleStrategy):
         def setup(self):
-            src = StreamInput(interval=1, period=1, history_provider=provider)
-            node = ProcessingNode(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
+            src = StreamInput(interval="1s", period=1, history_provider=provider)
+            node = ProcessingNode(input=src, compute_fn=lambda df: df, name="out", interval="1s", period=1)
             self.add_nodes([src, node])
 
     Runner.backtest(Strat, start_time=60, end_time=120, gateway_url="http://gw")
@@ -517,9 +517,9 @@ def test_history_gap_fill_stops_on_ready(monkeypatch):
 
     class Strat(SampleStrategy):
         def setup(self):
-            src = StreamInput(interval=1, period=1, history_provider=provider)
+            src = StreamInput(interval="1s", period=1, history_provider=provider)
             holder["src"] = src
-            node = ProcessingNode(input=src, compute_fn=lambda df: df, name="out", interval=1, period=1)
+            node = ProcessingNode(input=src, compute_fn=lambda df: df, name="out", interval="1s", period=1)
             self.add_nodes([src, node])
 
     Runner.dryrun(Strat, gateway_url="http://gw")
@@ -567,15 +567,15 @@ def test_backtest_replay_history_multi_inputs(monkeypatch):
 
     class Strat(Strategy):
         def setup(self):
-            a = StreamInput(interval=60, period=2, history_provider=DummyProvider())
-            b = StreamInput(interval=60, period=2, history_provider=DummyProvider())
+            a = StreamInput(interval="60s", period=2, history_provider=DummyProvider())
+            b = StreamInput(interval="60s", period=2, history_provider=DummyProvider())
 
             def compute(view):
                 av = view[a][60].latest()[1]["v"]
                 bv = view[b][60].latest()[1]["v"]
                 calls.append(av + bv)
 
-            node = ProcessingNode(input=[a, b], compute_fn=compute, name="out", interval=60, period=2)
+            node = ProcessingNode(input=[a, b], compute_fn=compute, name="out", interval="60s", period=2)
             self.add_nodes([a, b, node])
 
     Runner.backtest(Strat, start_time=60, end_time=120, gateway_url="http://gw")
@@ -620,8 +620,8 @@ def test_backtest_on_missing_fail(monkeypatch):
 
     class Strat(Strategy):
         def setup(self):
-            src = StreamInput(interval=60, period=2, history_provider=GapProvider())
-            node = ProcessingNode(input=src, compute_fn=lambda v: v, name="n", interval=60, period=2)
+            src = StreamInput(interval="60s", period=2, history_provider=GapProvider())
+            node = ProcessingNode(input=src, compute_fn=lambda v: v, name="n", interval="60s", period=2)
             self.add_nodes([src, node])
 
     with pytest.raises(RuntimeError):

--- a/tests/test_strategy_defaults.py
+++ b/tests/test_strategy_defaults.py
@@ -4,7 +4,7 @@ from qmtl.sdk import Strategy, StreamInput, ProcessingNode
 
 class DefaultStrategy(Strategy):
     def __init__(self):
-        super().__init__(default_interval=60, default_period=2)
+        super().__init__(default_interval="60s", default_period=2)
 
     def setup(self):
         src = StreamInput()
@@ -26,10 +26,10 @@ def test_defaults_applied():
 
 class OverrideStrategy(Strategy):
     def __init__(self):
-        super().__init__(default_interval=60, default_period=2)
+        super().__init__(default_interval="60s", default_period=2)
 
     def setup(self):
-        src = StreamInput(interval=30, period=1)
+        src = StreamInput(interval="30s", period=1)
         node = ProcessingNode(input=src, compute_fn=lambda v: v, name="n", interval="30s", period=3)
         self.add_nodes([src, node])
 

--- a/tests/test_tagquery_manager.py
+++ b/tests/test_tagquery_manager.py
@@ -8,7 +8,7 @@ from qmtl.sdk.tagquery_manager import TagQueryManager
 
 @pytest.mark.asyncio
 async def test_resolve_and_update(monkeypatch):
-    node = TagQueryNode(["t1"], interval=60, period=1)
+    node = TagQueryNode(["t1"], interval="60s", period=1)
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/queues/by_tag"
@@ -59,7 +59,7 @@ async def test_resolve_and_update(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_resolve_handles_empty(monkeypatch):
-    node = TagQueryNode(["t1"], interval=60, period=1)
+    node = TagQueryNode(["t1"], interval="60s", period=1)
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"queues": []})
@@ -93,8 +93,8 @@ async def test_resolve_handles_empty(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_match_mode_routes_updates():
-    node_any = TagQueryNode(["t1"], interval=60, period=1, match_mode="any")
-    node_all = TagQueryNode(["t1"], interval=60, period=1, match_mode="all")
+    node_any = TagQueryNode(["t1"], interval="60s", period=1, match_mode="any")
+    node_all = TagQueryNode(["t1"], interval="60s", period=1, match_mode="all")
     manager = TagQueryManager()
     manager.register(node_any)
     manager.register(node_all)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -4,7 +4,7 @@ from qmtl.sdk.cache_view import CacheView
 
 
 def test_rate_of_change_compute():
-    src = SourceNode(interval=1, period=3)
+    src = SourceNode(interval="1s", period=3)
     node = rate_of_change(src, period=2)
     data = {src.node_id: {1: [(0, 1), (1, 3)]}}
     view = CacheView(data)
@@ -12,7 +12,7 @@ def test_rate_of_change_compute():
 
 
 def test_stochastic_compute():
-    src = SourceNode(interval=1, period=3)
+    src = SourceNode(interval="1s", period=3)
     node = stochastic(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
@@ -20,7 +20,7 @@ def test_stochastic_compute():
 
 
 def test_angle_compute():
-    src = SourceNode(interval=1, period=3)
+    src = SourceNode(interval="1s", period=3)
     node = angle(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)


### PR DESCRIPTION
## Summary
- use string intervals consistently in docs and test strategy code
- keep backfill examples aligned with string intervals

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6865af15dc0c8329800822ad09fd8105