### PR TITLE
Fix missing examples in wheel and project init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,5 +45,12 @@ qmtl = "qmtl.cli:main"
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = ["qmtl", "examples"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+examples = ["*.py", "*.yml", "README.md"]
+
 [tool.pytest.ini_options]
 addopts = "-p pytest_asyncio"

--- a/qmtl/scaffold.py
+++ b/qmtl/scaffold.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 import shutil
+import importlib.resources as resources
 
-_EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+
+_EXAMPLES_PKG = "examples"
 
 
 def create_project(path: Path) -> None:
@@ -17,8 +19,9 @@ def create_project(path: Path) -> None:
         pkg.mkdir(exist_ok=True)
         (pkg / "__init__.py").touch()
 
-    shutil.copy(_EXAMPLES_DIR / "qmtl.yml", dest / "qmtl.yml")
-    shutil.copy(_EXAMPLES_DIR / "general_strategy.py", dest / "strategy.py")
+    examples_dir = resources.files(_EXAMPLES_PKG)
+    shutil.copy(examples_dir / "qmtl.yml", dest / "qmtl.yml")
+    shutil.copy(examples_dir / "general_strategy.py", dest / "strategy.py")
 
 
 __all__ = ["create_project"]


### PR DESCRIPTION
## Summary
- package `examples` modules and data files when building the wheel
- use `importlib.resources` in `qmtl.scaffold` so `qmtl init` finds packaged files

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_6865cf93890483299539049776d2a05b