### PR TITLE
Package examples directory in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,11 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["qmtl", "examples"]
+packages = ["qmtl"]
 include-package-data = true
 
-[tool.setuptools.package-data]
-examples = ["*.py", "*.yml", "README.md"]
+[tool.setuptools.data-files]
+"examples" = ["examples/*.py", "examples/*.yml", "examples/README.md"]
 
 [tool.pytest.ini_options]
 addopts = "-p pytest_asyncio"


### PR DESCRIPTION
## Summary
- ship `examples/` as package data
- leave `setuptools` configured to include package data

## Testing
- `uv run -m pytest -W error`
- `uv build --wheel -o dist`

------
https://chatgpt.com/codex/tasks/task_e_6865d147197c8329bad49a0cafb34a31