### PR TITLE
Add recorder_strategy example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ Gateway와 DAG manager 실행을 위한 예시 설정은 `qmtl.yml` 파일에 �
 - `mode_switch_example.py`: 모드별 실행 방법 예제
 - `backfill_history_example.py`: QuestDBLoader를 이용한 캐시 백필 예제
 - `metrics_recorder_example.py`: EventRecorder와 메트릭 저장 예제
+- `recorder_strategy.py`: QuestDBRecorder와 모멘텀 계산 예제
 - `parallel_strategies_example.py`: 멀티 스트래티지 병렬 실행 예제
 
 ## 예제 실행 방법
@@ -33,6 +34,7 @@ python examples/ws_metrics_example.py
 python examples/mode_switch_example.py
 python examples/backfill_history_example.py
 python examples/metrics_recorder_example.py
+python examples/recorder_strategy.py
 python examples/parallel_strategies_example.py
 ```
 

--- a/examples/recorder_strategy.py
+++ b/examples/recorder_strategy.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from qmtl.sdk import Strategy, Node, StreamInput, Runner, metrics
+from qmtl.io import QuestDBLoader, QuestDBRecorder
+
+
+class RecorderStrategy(Strategy):
+    def setup(self) -> None:
+        price = StreamInput(
+            interval="60s",
+            period=30,
+            history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
+            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+        )
+
+        def momentum(view) -> pd.DataFrame:
+            df = pd.DataFrame([v for _, v in view[price][60]])
+            mom = df["close"].pct_change().rolling(5).mean()
+            return pd.DataFrame({"momentum": mom})
+
+        mom_node = Node(input=price, compute_fn=momentum, name="momentum")
+        self.add_nodes([price, mom_node])
+
+
+if __name__ == "__main__":
+    metrics.start_metrics_server(port=8000)
+    Runner.dryrun(RecorderStrategy, gateway_url="http://localhost:8000")

--- a/examples/recorder_strategy.py
+++ b/examples/recorder_strategy.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 import pandas as pd
 
-from qmtl.sdk import Strategy, Node, StreamInput, Runner, metrics
-from qmtl.io import QuestDBLoader, QuestDBRecorder
+from qmtl.sdk import (
+    Strategy,
+    Node,
+    StreamInput,
+    Runner,
+    metrics,
+    QuestDBLoader,
+    QuestDBRecorder,
+)
 
 
 class RecorderStrategy(Strategy):

--- a/tests/test_examples_import.py
+++ b/tests/test_examples_import.py
@@ -6,6 +6,7 @@ MODULES = [
     "examples.mode_switch_example",
     "examples.backfill_history_example",
     "examples.metrics_recorder_example",
+    "examples.recorder_strategy",
     "examples.parallel_strategies_example",
 ]
 


### PR DESCRIPTION
## Summary
- add `recorder_strategy.py` example showing event recording and momentum calculation
- document new example in examples README
- test import of the new example

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6865d75b2a2083298a8c9babd60352a2