### PR TITLE
Implement BinanceFetcher example and strategy backfill

### DIFF
--- a/qmtl/examples/__init__.py
+++ b/qmtl/examples/__init__.py
@@ -1,0 +1,3 @@
+from .binance_fetcher import BinanceFetcher
+
+__all__ = ["BinanceFetcher"]

--- a/qmtl/examples/backfill_history_example.py
+++ b/qmtl/examples/backfill_history_example.py
@@ -1,31 +1,10 @@
 from __future__ import annotations
 
-import asyncio
-import httpx
 import pandas as pd
 
-from qmtl.sdk import Strategy, Node, StreamInput, Runner, DataFetcher
+from qmtl.sdk import Strategy, Node, StreamInput, Runner
 from qmtl.io import QuestDBLoader
-
-
-class BinanceFetcher:
-    """Simple DataFetcher for Binance kline history."""
-
-    async def fetch(
-        self, start: int, end: int, *, node_id: str, interval: int
-    ) -> pd.DataFrame:
-        url = (
-            "https://api.binance.com/api/v3/klines"
-            f"?symbol={node_id}&interval={interval}m"
-            f"&startTime={start * 1000}&endTime={end * 1000}"
-        )
-        async with httpx.AsyncClient() as client:
-            data = (await client.get(url)).json()
-        rows = [
-            {"ts": int(r[0] / 1000), "open": float(r[1]), "close": float(r[4])}
-            for r in data
-        ]
-        return pd.DataFrame(rows)
+from qmtl.examples import BinanceFetcher
 
 
 fetcher = BinanceFetcher()
@@ -48,17 +27,14 @@ class BackfillHistoryStrategy(Strategy):
         self.add_nodes([self.price, ret_node])
 
 
-async def main() -> None:
-    start = 1700000000
-    end = 1700003600
-
-    strategy = Runner._prepare(BackfillHistoryStrategy)
-    manager = Runner._init_tag_manager(strategy, None)
-    Runner._apply_queue_map(strategy, {})
-    await manager.resolve_tags(offline=True)
-    await Runner._ensure_history(strategy, start, end)
-    await Runner._replay_history(strategy, start, end)
+def main() -> None:
+    Runner.backtest(
+        BackfillHistoryStrategy,
+        start_time=1700000000,
+        end_time=1700003600,
+        gateway_url="http://localhost:8000",
+    )
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/qmtl/examples/binance_fetcher.py
+++ b/qmtl/examples/binance_fetcher.py
@@ -1,0 +1,25 @@
+import httpx
+import pandas as pd
+
+from qmtl.sdk import DataFetcher
+
+
+class BinanceFetcher:
+    """Retrieve kline history from Binance."""
+
+    async def fetch(
+        self, start: int, end: int, *, node_id: str, interval: str
+    ) -> pd.DataFrame:
+        url = (
+            "https://api.binance.com/api/v3/klines"
+            f"?symbol={node_id}&interval={interval}"
+            f"&startTime={start * 1000}&endTime={end * 1000}"
+        )
+        async with httpx.AsyncClient() as client:
+            data = (await client.get(url)).json()
+        return pd.DataFrame(
+            [
+                {"ts": int(r[0] / 1000), "open": float(r[1]), "close": float(r[4])}
+                for r in data
+            ]
+        )

--- a/tests/test_binance_fetcher.py
+++ b/tests/test_binance_fetcher.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import httpx
+import pytest
+
+from qmtl.examples import BinanceFetcher
+
+
+@pytest.mark.asyncio
+async def test_binance_fetcher(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v3/klines"
+        return httpx.Response(200, json=[[1000, "1", None, None, "2"]])
+
+    transport = httpx.MockTransport(handler)
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self._client = httpx.Client(transport=transport)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            self._client.close()
+
+        async def get(self, url):
+            request = httpx.Request("GET", url)
+            resp = handler(request)
+            resp.request = request
+            return resp
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+
+    fetcher = BinanceFetcher()
+    df = await fetcher.fetch(1, 2, node_id="BTCUSDT", interval="1m")
+    expected = pd.DataFrame([{"ts": 1, "open": 1.0, "close": 2.0}])
+    pd.testing.assert_frame_equal(df, expected)


### PR DESCRIPTION
## Summary
- add reusable BinanceFetcher example
- demonstrate backtest in `backfill_history_example`
- export `BinanceFetcher` from examples package
- test BinanceFetcher fetch logic

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6865d76a059883298f18efb39191598d