### PR TITLE
Add QuestDB parallel example and docs

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -10,3 +10,13 @@ Prometheus can load `alert_rules.yml` to activate alerts for the DAG manager and
 
 Example Grafana dashboards are provided in `docs/dashboards/`. Import the JSON file into Grafana to visualise queue counts and garbage collector activity. The dashboard uses the `orphan_queue_total` metric exposed by the DAG manager.
 
+## QuestDB Recorder Demo
+
+The script `examples/questdb_parallel_example.py` runs two moving-average strategies in parallel while persisting every `StreamInput` payload to QuestDB. It starts the metrics server on port `8000` and prints aggregated Prometheus metrics when finished. Execute it as follows:
+
+```bash
+python examples/questdb_parallel_example.py
+```
+
+Monitor `http://localhost:8000/metrics` during execution or check the printed output. Key counters include `node_processed_total` for processed events and `event_recorder_errors_total` when the recorder fails to persist rows.
+

--- a/qmtl/examples/README.md
+++ b/qmtl/examples/README.md
@@ -17,6 +17,7 @@ Gateway와 DAG manager 실행을 위한 예시 설정은 `qmtl.yml` 파일에 �
 - `backfill_history_example.py`: QuestDBLoader를 이용한 캐시 백필 예제
 - `metrics_recorder_example.py`: EventRecorder와 메트릭 저장 예제
 - `parallel_strategies_example.py`: 멀티 스트래티지 병렬 실행 예제
+- `questdb_parallel_example.py`: QuestDBRecorder를 활용한 병렬 실행 예제
 
 ## 예제 실행 방법
 
@@ -33,6 +34,7 @@ python examples/ws_metrics_example.py
 python examples/mode_switch_example.py
 python examples/backfill_history_example.py
 python examples/metrics_recorder_example.py
+python examples/questdb_parallel_example.py
 python examples/parallel_strategies_example.py
 ```
 

--- a/qmtl/examples/questdb_parallel_example.py
+++ b/qmtl/examples/questdb_parallel_example.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+
+from qmtl.io import QuestDBRecorder
+from qmtl.sdk import StreamInput, Runner, metrics
+from qmtl.examples.parallel_strategies_example import MA1 as BaseMA1, MA2 as BaseMA2
+
+
+class MA1(BaseMA1):
+    def setup(self) -> None:
+        super().setup()
+        for node in self.nodes:
+            if isinstance(node, StreamInput):
+                node.event_recorder = QuestDBRecorder("postgresql://localhost:8812/qdb")
+
+
+class MA2(BaseMA2):
+    def setup(self) -> None:
+        super().setup()
+        for node in self.nodes:
+            if isinstance(node, StreamInput):
+                node.event_recorder = QuestDBRecorder("postgresql://localhost:8812/qdb")
+
+
+async def main() -> None:
+    metrics.start_metrics_server(port=8000)
+    task1 = asyncio.create_task(
+        Runner.backtest_async(
+            MA1,
+            start_time=1700000000,
+            end_time=1700003600,
+            gateway_url="http://localhost:8000",
+        )
+    )
+    task2 = asyncio.create_task(
+        Runner.backtest_async(
+            MA2,
+            start_time=1700000000,
+            end_time=1700003600,
+            gateway_url="http://localhost:8000",
+        )
+    )
+    await asyncio.gather(task1, task2)
+    print(metrics.collect_metrics())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- extend monitoring docs with demo instructions
- document questdb_parallel_example in examples/README
- provide questdb_parallel_example.py to run two MA strategies in parallel with QuestDBRecorder

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6865d76cc1a88329a39c1d850d4d1e58