### PR TITLE
Add multi_asset_lag_strategy example

### DIFF
--- a/qmtl/examples/multi_asset_lag_strategy.py
+++ b/qmtl/examples/multi_asset_lag_strategy.py
@@ -1,0 +1,43 @@
+from qmtl.sdk import Strategy, Node, StreamInput, Runner
+from qmtl.io import QuestDBLoader, QuestDBRecorder
+import pandas as pd
+
+class MultiAssetLagStrategy(Strategy):
+    def setup(self):
+        btc_price = StreamInput(
+            tags=["BTC", "price", "binance"],
+            interval="60s",
+            period=120,
+            history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
+            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+        )
+        mstr_price = StreamInput(
+            tags=["MSTR", "price", "nasdaq"],
+            interval="60s",
+            period=120,
+            history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
+            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+        )
+        def lagged_corr(view):
+            btc = pd.DataFrame([v for _, v in view[btc_price][60]])
+            mstr = pd.DataFrame([v for _, v in view[mstr_price][60]])
+            btc_shift = btc["close"].shift(90)
+            corr = btc_shift.corr(mstr["close"])
+            return pd.DataFrame({"lag_corr": [corr]})
+
+        corr_node = Node(
+            input=[btc_price, mstr_price],
+            compute_fn=lagged_corr,
+            name="btc_mstr_corr",
+        )
+
+        self.add_nodes([btc_price, mstr_price, corr_node])
+
+
+if __name__ == "__main__":
+    # For backtesting provide explicit start and end timestamps
+    Runner.backtest(
+        MultiAssetLagStrategy,
+        start_time="2024-01-01T00:00:00Z",
+        end_time="2024-02-01T00:00:00Z",
+    )


### PR DESCRIPTION
## Summary
- provide a MultiAssetLagStrategy example inside the packaged `qmtl.examples`

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6865dd7b7e708329862f69ba3e047e5d