### PR TITLE
Enable host/port parameters for QuestDB IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,11 @@ class BinanceFetcher:
 
 fetcher = BinanceFetcher()
 loader = QuestDBLoader(
-    "postgresql://user:pass@localhost:8812/qdb",
+    host="localhost",
+    port=8812,
+    database="qdb",
+    user="user",
+    password="pass",
     fetcher=fetcher,
 )
 ```

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -31,12 +31,22 @@ The SDK ships with `QuestDBLoader` which reads from a QuestDB instance:
 ```python
 from qmtl.sdk import QuestDBLoader
 
-source = QuestDBLoader("postgresql://user:pass@localhost:8812/qdb")
+source = QuestDBLoader(
+    host="localhost",
+    port=8812,
+    database="qdb",
+    user="user",
+    password="pass",
+)
 
 # with an external fetcher supplying missing rows
 # fetcher = MyFetcher()
 # source = QuestDBLoader(
-#     "postgresql://user:pass@localhost:8812/qdb",
+#     host="localhost",
+#     port=8812,
+#     database="qdb",
+#     user="user",
+#     password="pass",
 #     fetcher=fetcher,
 # )
 ```
@@ -69,7 +79,11 @@ class BinanceFetcher:
 
 fetcher = BinanceFetcher()
 loader = QuestDBLoader(
-    "postgresql://user:pass@localhost:8812/qdb",
+    host="localhost",
+    port=8812,
+    database="qdb",
+    user="user",
+    password="pass",
     fetcher=fetcher,
 )
 ```
@@ -86,10 +100,20 @@ from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder
 stream = StreamInput(
     interval="60s",
     history_provider=QuestDBLoader(
-        "postgresql://user:pass@localhost:8812/qdb",
+        host="localhost",
+        port=8812,
+        database="qdb",
+        user="user",
+        password="pass",
         fetcher=fetcher,
     ),
-    event_recorder=QuestDBRecorder("postgresql://user:pass@localhost:8812/qdb"),
+    event_recorder=QuestDBRecorder(
+        host="localhost",
+        port=8812,
+        database="qdb",
+        user="user",
+        password="pass",
+    ),
 )
 ```
 

--- a/examples/tag_query_aggregation.py
+++ b/examples/tag_query_aggregation.py
@@ -27,7 +27,11 @@ class TagQueryAggregationStrategy(Strategy):
 
         corr_node = Node(input=indicators, compute_fn=calc_corr, name="indicator_corr")
         # persist correlation matrices if a database is configured
-        corr_node.event_recorder = QuestDBRecorder("postgresql://localhost:8812/qdb")
+        corr_node.event_recorder = QuestDBRecorder(
+            host="localhost",
+            port=8812,
+            database="qdb",
+        )
 
         self.add_nodes([indicators, corr_node])
 

--- a/qmtl/examples/backfill_history_example.py
+++ b/qmtl/examples/backfill_history_example.py
@@ -8,7 +8,12 @@ from qmtl.examples import BinanceFetcher
 
 
 fetcher = BinanceFetcher()
-loader = QuestDBLoader("postgresql://localhost:8812/qdb", fetcher=fetcher)
+loader = QuestDBLoader(
+    host="localhost",
+    port=8812,
+    database="qdb",
+    fetcher=fetcher,
+)
 
 
 class BackfillHistoryStrategy(Strategy):

--- a/qmtl/examples/cross_market_lag_strategy.py
+++ b/qmtl/examples/cross_market_lag_strategy.py
@@ -8,15 +8,31 @@ class CrossMarketLagStrategy(Strategy):
             tags=["BTC", "price", "binance"],
             interval="60s",
             period=120,
-            history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+            history_provider=QuestDBLoader(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
+            event_recorder=QuestDBRecorder(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
         )
         mstr_price = StreamInput(
             tags=["MSTR", "price", "nasdaq"],
             interval="60s",
             period=120,
-            history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+            history_provider=QuestDBLoader(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
+            event_recorder=QuestDBRecorder(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
         )
         def lagged_corr(view):
             btc = pd.DataFrame([v for _, v in view[btc_price][60]])

--- a/qmtl/examples/general_strategy.py
+++ b/qmtl/examples/general_strategy.py
@@ -8,8 +8,16 @@ class GeneralStrategy(Strategy):
 
     def setup(self):
         price_stream = StreamInput(
-            history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+            history_provider=QuestDBLoader(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
+            event_recorder=QuestDBRecorder(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
         )
 
         def generate_signal(view):

--- a/qmtl/examples/metrics_recorder_example.py
+++ b/qmtl/examples/metrics_recorder_example.py
@@ -11,8 +11,16 @@ class RecorderStrategy(Strategy):
         price = StreamInput(
             interval="60s",
             period=30,
-            history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+            history_provider=QuestDBLoader(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
+            event_recorder=QuestDBRecorder(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
         )
 
         def momentum(view) -> pd.DataFrame:

--- a/qmtl/examples/questdb_parallel_example.py
+++ b/qmtl/examples/questdb_parallel_example.py
@@ -12,7 +12,11 @@ class MA1(BaseMA1):
         super().setup()
         for node in self.nodes:
             if isinstance(node, StreamInput):
-                node.event_recorder = QuestDBRecorder("postgresql://localhost:8812/qdb")
+                node.event_recorder = QuestDBRecorder(
+                    host="localhost",
+                    port=8812,
+                    database="qdb",
+                )
 
 
 class MA2(BaseMA2):
@@ -20,7 +24,11 @@ class MA2(BaseMA2):
         super().setup()
         for node in self.nodes:
             if isinstance(node, StreamInput):
-                node.event_recorder = QuestDBRecorder("postgresql://localhost:8812/qdb")
+                node.event_recorder = QuestDBRecorder(
+                    host="localhost",
+                    port=8812,
+                    database="qdb",
+                )
 
 
 async def main() -> None:

--- a/qmtl/io/eventrecorder.py
+++ b/qmtl/io/eventrecorder.py
@@ -11,14 +11,50 @@ from qmtl.sdk.data_io import EventRecorder
 class QuestDBRecorder:
     """EventRecorder implementation that writes records to QuestDB."""
 
-    def __init__(self, dsn: str, table: str = "node_data") -> None:
-        self.dsn = dsn
+    def __init__(
+        self,
+        dsn: str | None = None,
+        *,
+        host: str = "localhost",
+        port: int = 8812,
+        database: str = "qdb",
+        user: str | None = None,
+        password: str | None = None,
+        table: str = "node_data",
+    ) -> None:
+        self._dsn_provided = dsn is not None
+        self.dsn = dsn or self._make_dsn(host, port, database, user, password)
+        self.host = host
+        self.port = port
+        self.database = database
+        self.user = user
+        self.password = password
         self.table = table
+
+    @staticmethod
+    def _make_dsn(
+        host: str, port: int, database: str, user: str | None, password: str | None
+    ) -> str:
+        auth = ""
+        if user:
+            auth = user
+            if password:
+                auth += f":{password}"
+            auth += "@"
+        return f"postgresql://{auth}{host}:{port}/{database}"
 
     async def persist(
         self, node_id: str, interval: int, timestamp: int, payload: dict
     ) -> None:
-        conn = await asyncpg.connect(self.dsn)
+        conn = await asyncpg.connect(
+            **({"dsn": self.dsn} if self._dsn_provided else {
+                "host": self.host,
+                "port": self.port,
+                "database": self.database,
+                "user": self.user,
+                "password": self.password,
+            })
+        )
         try:
             columns = ", ".join(payload.keys())
             values = payload.values()

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -17,7 +17,7 @@ class DummyConn:
         self.closed = True
 
 
-async def dummy_connect(_):
+async def dummy_connect(*_args, **_kwargs):
     rows = [
         {"ts": 1, "value": 10},
         {"ts": 2, "value": 20},
@@ -51,7 +51,7 @@ async def test_questdb_coverage(monkeypatch):
         async def close(self):
             self.closed = True
 
-    async def _connect(_):
+    async def _connect(*_args, **_kwargs):
         return DummyConn()
 
     monkeypatch.setattr("qmtl.io.historyprovider.asyncpg.connect", _connect)
@@ -74,7 +74,7 @@ async def test_questdb_fill_missing_no_fetcher(monkeypatch):
         async def close(self):
             pass
 
-    async def _connect(_):
+    async def _connect(*_args, **_kwargs):
         return DummyConn()
 
     monkeypatch.setattr("qmtl.io.historyprovider.asyncpg.connect", _connect)
@@ -95,7 +95,7 @@ async def test_fill_missing_without_fetcher_raises(monkeypatch):
         async def close(self):
             pass
 
-    async def _connect(_):
+    async def _connect(*_args, **_kwargs):
         return DummyConn()
 
     monkeypatch.setattr("qmtl.io.historyprovider.asyncpg.connect", _connect)
@@ -119,7 +119,7 @@ async def test_questdb_fill_missing(monkeypatch):
         async def close(self):
             pass
 
-    async def _connect(_):
+    async def _connect(*_args, **_kwargs):
         return DummyConn()
 
     monkeypatch.setattr("qmtl.io.historyprovider.asyncpg.connect", _connect)
@@ -145,8 +145,8 @@ async def test_questdb_persist(monkeypatch):
         async def close(self):
             record["closed"] = True
 
-    async def _connect(dsn):
-        record["dsn"] = dsn
+    async def _connect(*args, **kwargs):
+        record["dsn"] = kwargs.get("dsn") or (args[0] if args else None)
         return DummyConn()
 
     monkeypatch.setattr("qmtl.io.eventrecorder.asyncpg.connect", _connect)


### PR DESCRIPTION
## Summary
- allow `QuestDBLoader` and `QuestDBRecorder` to accept either a DSN or host/port connection options
- update asyncpg connection logic to handle DSN or connection params
- update tests for new constructor signature
- update documentation and examples to demonstrate new usage

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6865db23c6dc8329b5bb4d60ad1a6446