### PR TITLE
Add recorder strategy example

### DIFF
--- a/qmtl/examples/README.md
+++ b/qmtl/examples/README.md
@@ -17,6 +17,7 @@ Gateway와 DAG manager 실행을 위한 예시 설정은 `qmtl.yml` 파일에 �
 - `mode_switch_example.py`: 모드별 실행 방법 예제
 - `backfill_history_example.py`: QuestDBLoader를 이용한 캐시 백필 예제
 - `metrics_recorder_example.py`: EventRecorder와 메트릭 저장 예제
+- `recorder_strategy.py`: QuestDBRecorder 사용 예제
 - `parallel_strategies_example.py`: 멀티 스트래티지 병렬 실행 예제
 - `questdb_parallel_example.py`: QuestDBRecorder를 활용한 병렬 실행 예제
 
@@ -36,6 +37,7 @@ python examples/ws_metrics_example.py
 python examples/mode_switch_example.py
 python examples/backfill_history_example.py
 python examples/metrics_recorder_example.py
+python examples/recorder_strategy.py
 python examples/questdb_parallel_example.py
 python examples/parallel_strategies_example.py
 ```

--- a/qmtl/examples/recorder_strategy.py
+++ b/qmtl/examples/recorder_strategy.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from qmtl.sdk import Strategy, Node, StreamInput, Runner, metrics
+from qmtl.io import QuestDBLoader, QuestDBRecorder
+
+
+class RecorderStrategy(Strategy):
+    def setup(self) -> None:
+        price = StreamInput(
+            interval="60s",
+            period=30,
+            history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
+            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+        )
+
+        def momentum(view) -> pd.DataFrame:
+            df = pd.DataFrame([v for _, v in view[price][60]])
+            mom = df["close"].pct_change().rolling(5).mean()
+            return pd.DataFrame({"momentum": mom})
+
+        mom_node = Node(input=price, compute_fn=momentum, name="momentum")
+        self.add_nodes([price, mom_node])
+
+
+if __name__ == "__main__":
+    metrics.start_metrics_server(port=8000)
+    Runner.dryrun(RecorderStrategy, gateway_url="http://localhost:8000")

--- a/tests/test_examples_import.py
+++ b/tests/test_examples_import.py
@@ -6,6 +6,7 @@ MODULES = [
     "qmtl.examples.mode_switch_example",
     "qmtl.examples.backfill_history_example",
     "qmtl.examples.metrics_recorder_example",
+    "qmtl.examples.recorder_strategy",
     "qmtl.examples.parallel_strategies_example",
     "qmtl.examples.multi_asset_lag_strategy",
 ]


### PR DESCRIPTION
## Summary
- add `recorder_strategy.py` example showing QuestDB recorder usage
- document the new example in `examples/README.md`
- ensure the module imports in tests

## Testing
- `uv pip install --system -e .[dev]`
- `uv run -- pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6865f2fe612c83298616a464eae2d06e