### PR TITLE
Default to in-memory backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,10 @@ uv run -- pytest
 
 ## Running Services
 
-Start the Gateway and DAG manager using the combined configuration file. Each
-service reads its own section from `qmtl.yml`. The default template uses
-lightweight in-memory/SQLite backends for easy local testing. Commented lines in
-the file show how to enable cluster-ready services like Postgres, Neo4j and
-Kafka.
+Start the Gateway and DAG manager using the combined configuration file or rely
+on the built-in defaults. Without ``--config`` both services start in a local
+mode that uses SQLite and in-memory repositories. The sample ``qmtl.yml`` file
+demonstrates how to switch to Postgres, Neo4j and Kafka for production.
 
 ```bash
 

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -273,7 +273,8 @@ qmtl dagmgr-server --config examples/qmtl.yml
 ```
 
 해당 명령은 `examples/qmtl.yml` 의 ``dagmanager`` 섹션을 읽어 서버를 실행한다.
-`examples/qmtl.yml` contains comments showing every available field.
+``--config`` 를 생략하면 기본값으로 메모리 레포지토리와 큐가 사용된다. 샘플
+파일에는 모든 필드를 주석과 함께 설명한다.
 
 Available flags:
 

--- a/gateway.md
+++ b/gateway.md
@@ -156,9 +156,10 @@ qmtl gw --config examples/qmtl.yml
 ```
 
 The command reads the ``gateway`` section of ``examples/qmtl.yml`` for all
-server parameters. The template defaults to a lightweight SQLite database and
-Redis instance. Commented lines illustrate how to switch to a clustered
-Postgres setup. See the file for a fully annotated configuration template.
+server parameters. Omitting ``--config`` starts the service with built-in
+defaults that use SQLite and an in-memory Redis replacement. Commented lines in
+the sample file illustrate how to switch to a clustered Postgres setup. See the
+file for a fully annotated configuration template.
 
 Available flags:
 

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -10,12 +10,12 @@ import yaml
 class DagManagerConfig:
     """Configuration for DAG manager server."""
 
-    repo_backend: str = "neo4j"
+    repo_backend: str = "memory"
     neo4j_dsn: str = "bolt://localhost:7687"
     neo4j_user: str = "neo4j"
     neo4j_password: str = "neo4j"
     memory_repo_path: str = "memrepo.gpickle"
-    queue_backend: str = "kafka"
+    queue_backend: str = "memory"
     kafka_dsn: str = "localhost:9092"
     grpc_host: str = "0.0.0.0"
     grpc_port: int = 50051

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -12,9 +12,9 @@ class GatewayConfig:
     host: str = "0.0.0.0"
     port: int = 8000
     redis_dsn: str = "redis://localhost:6379"
-    database_backend: str = "postgres"
-    database_dsn: str = "postgresql://localhost/qmtl"
-    offline: bool = False
+    database_backend: str = "sqlite"
+    database_dsn: str = "./qmtl.db"
+    offline: bool = True
 
 
 def load_gateway_config(path: str) -> GatewayConfig:

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -31,3 +31,9 @@ def test_load_dagmanager_config_malformed(tmp_path: Path):
     with pytest.raises(TypeError):
         load_dagmanager_config(str(f))
 
+
+def test_dagmanager_config_defaults() -> None:
+    cfg = DagManagerConfig()
+    assert cfg.repo_backend == "memory"
+    assert cfg.queue_backend == "memory"
+

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -47,3 +47,10 @@ def test_load_gateway_config_malformed(tmp_path: Path):
     p.write_text("- 1")
     with pytest.raises(TypeError):
         load_gateway_config(str(p))
+
+
+def test_gateway_config_defaults() -> None:
+    cfg = GatewayConfig()
+    assert cfg.database_backend == "sqlite"
+    assert cfg.database_dsn == "./qmtl.db"
+    assert cfg.offline is True

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -20,8 +20,8 @@ def test_server_defaults(monkeypatch):
 
     monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
     main([])
-    assert captured["repo"] == "neo4j"
-    assert captured["queue"] == "kafka"
+    assert captured["repo"] == "memory"
+    assert captured["queue"] == "memory"
 
 
 def test_server_config_file(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- switch gateway defaults to sqlite/offline
- switch dag-manager defaults to memory
- mention new defaults in README and docs
- test new default values for both configs

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6867b4f6e2f08329b361e8095dc40d21