### PR TITLE
Switch history & event interfaces to ABC

### DIFF
--- a/qmtl/sdk/data_io.py
+++ b/qmtl/sdk/data_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Interfaces for I/O operations and legacy re-exports."""
 
 from typing import Protocol, Any
+from abc import ABC, abstractmethod
 import pandas as pd
 
 
@@ -15,21 +16,24 @@ class DataFetcher(Protocol):
         ...
 
 
-class HistoryProvider(Protocol):
+class HistoryProvider(ABC):
     """Load historical data into node caches."""
 
+    @abstractmethod
     async def fetch(
         self, start: int, end: int, *, node_id: str, interval: int
     ) -> pd.DataFrame:
         """Return data in ``[start, end)`` for ``node_id`` and ``interval``."""
         ...
 
+    @abstractmethod
     async def coverage(
         self, *, node_id: str, interval: int
     ) -> list[tuple[int, int]]:
         """Return timestamp ranges available for ``node_id`` and ``interval``."""
         ...
 
+    @abstractmethod
     async def fill_missing(
         self, start: int, end: int, *, node_id: str, interval: int
     ) -> None:
@@ -37,9 +41,10 @@ class HistoryProvider(Protocol):
         ...
 
 
-class EventRecorder(Protocol):
+class EventRecorder(ABC):
     """Persist processed node data."""
 
+    @abstractmethod
     async def persist(
         self, node_id: str, interval: int, timestamp: int, payload: Any
     ) -> None:


### PR DESCRIPTION
## Summary
- implement `HistoryProvider` and `EventRecorder` as abstract base classes
- import `ABC` and `abstractmethod` where needed

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6868517c35fc8329963184785c46ce22