### PR TITLE
Introduce queue_backend option for Gateway

### DIFF
--- a/gateway.md
+++ b/gateway.md
@@ -157,9 +157,10 @@ qmtl gw --config examples/qmtl.yml
 
 The command reads the ``gateway`` section of ``examples/qmtl.yml`` for all
 server parameters. Omitting ``--config`` starts the service with built-in
-defaults that use SQLite and an in-memory Redis replacement. Commented lines in
-the sample file illustrate how to switch to a clustered Postgres setup. See the
-file for a fully annotated configuration template.
+defaults that use SQLite and ``queue_backend: memory`` for an in-memory Redis
+replacement. Commented lines in the sample file illustrate how to set
+``queue_backend: redis`` and point ``redis_dsn`` to a real cluster. See the file
+for a fully annotated configuration template.
 
 Available flags:
 

--- a/qmtl/examples/qmtl.yml
+++ b/qmtl/examples/qmtl.yml
@@ -5,6 +5,7 @@ gateway:
   # Lightweight local store for quick testing
   database_backend: sqlite
   database_dsn: ./qmtl.db
+  queue_backend: memory
   # To use Postgres in a production cluster uncomment below
   # database_backend: postgres
   # database_dsn: postgresql://user:pass@db/qmtl

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -22,7 +22,7 @@ async def _main(argv: list[str] | None = None) -> None:
     if args.config:
         config = load_config(args.config).gateway
 
-    if config.offline:
+    if config.queue_backend == "memory":
         redis_client = InMemoryRedis()
     else:
         redis_client = redis.from_url(config.redis_dsn, decode_responses=True)

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -14,7 +14,7 @@ class GatewayConfig:
     redis_dsn: str = "redis://localhost:6379"
     database_backend: str = "sqlite"
     database_dsn: str = "./qmtl.db"
-    offline: bool = True
+    queue_backend: str = "memory"
 
 
 def load_gateway_config(path: str) -> GatewayConfig:
@@ -23,4 +23,7 @@ def load_gateway_config(path: str) -> GatewayConfig:
         data = yaml.safe_load(fh) or {}
     if not isinstance(data, dict):
         raise TypeError("Gateway config must be a mapping")
-    return GatewayConfig(**data)
+    cfg = GatewayConfig(**data)
+    if cfg.queue_backend not in {"memory", "redis"}:
+        raise ValueError("queue_backend must be 'memory' or 'redis'")
+    return cfg

--- a/qmtl/gateway/redis_client.py
+++ b/qmtl/gateway/redis_client.py
@@ -5,7 +5,7 @@ import asyncio
 
 
 class InMemoryRedis:
-    """Minimal in-memory Redis clone used for offline mode."""
+    """Minimal in-memory Redis clone used when ``queue_backend`` is ``memory``."""
 
     def __init__(self) -> None:
         self._values: Dict[str, Any] = {}

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -1,5 +1,5 @@
-import json
 from pathlib import Path
+import json
 import pytest
 import yaml
 
@@ -11,7 +11,7 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
         "redis_dsn": "redis://test:6379",
         "database_backend": "postgres",
         "database_dsn": "postgresql://db/test",
-        "offline": True,
+        "queue_backend": "memory",
     }
     config_file = tmp_path / "gw.yaml"
     config_file.write_text(yaml.safe_dump(data))
@@ -19,7 +19,7 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
     assert config.redis_dsn == data["redis_dsn"]
     assert config.database_backend == "postgres"
     assert config.database_dsn == data["database_dsn"]
-    assert config.offline is True
+    assert config.queue_backend == "memory"
 
 
 def test_load_gateway_config_json(tmp_path: Path) -> None:
@@ -27,14 +27,14 @@ def test_load_gateway_config_json(tmp_path: Path) -> None:
         "redis_dsn": "redis://j:6379",
         "database_backend": "memory",
         "database_dsn": "sqlite:///:memory:",
-        "offline": False,
+        "queue_backend": "redis",
     }
     config_file = tmp_path / "gw.json"
     config_file.write_text(json.dumps(data))
     config = load_gateway_config(str(config_file))
     assert config.database_backend == "memory"
     assert config.database_dsn == data["database_dsn"]
-    assert config.offline is False
+    assert config.queue_backend == "redis"
 
 
 def test_load_gateway_config_missing_file():
@@ -53,4 +53,4 @@ def test_gateway_config_defaults() -> None:
     cfg = GatewayConfig()
     assert cfg.database_backend == "sqlite"
     assert cfg.database_dsn == "./qmtl.db"
-    assert cfg.offline is True
+    assert cfg.queue_backend == "memory"


### PR DESCRIPTION
## Summary
- add `queue_backend` setting to gateway configuration
- instantiate InMemoryRedis only when using memory backend
- update sample config and docs
- refactor gateway tests for the new option

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6868529519288329aa819e998d6dba85