### PR TITLE
Fix StreamInput injection semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ See [docs/faq.md](docs/faq.md) for common questions such as using `TagQueryNode`
 
 [docs/backfill.md](docs/backfill.md) explains how to preload historical data by
 injecting `HistoryProvider` instances
-into `StreamInput` nodes. This also covers persisting data via `EventRecorder`.
+into `StreamInput` nodes. These dependencies must be provided at creation time
+and cannot be reassigned later. The same guide covers persisting data via
+`EventRecorder`.
 [docs/backfill.md](docs/backfill.md).
 
 ### QuestDBLoader with a custom fetcher

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -117,6 +117,10 @@ stream = StreamInput(
 )
 ```
 
+``StreamInput`` treats these dependencies as immutable. Attempting to modify
+``history_provider`` or ``event_recorder`` after creation will raise an
+``AttributeError``.
+
 ## Running a Backfill
 
 Backfills can be triggered when executing a strategy through the CLI or the

--- a/qmtl/examples/questdb_parallel_example.py
+++ b/qmtl/examples/questdb_parallel_example.py
@@ -1,34 +1,51 @@
 from __future__ import annotations
 
 import asyncio
+import pandas as pd
 
 from qmtl.io import QuestDBRecorder
-from qmtl.sdk import StreamInput, Runner, metrics
+from qmtl.sdk import StreamInput, Node, Runner, metrics
 from qmtl.examples.parallel_strategies_example import MA1 as BaseMA1, MA2 as BaseMA2
 
 
 class MA1(BaseMA1):
     def setup(self) -> None:
-        super().setup()
-        for node in self.nodes:
-            if isinstance(node, StreamInput):
-                node.event_recorder = QuestDBRecorder(
-                    host="localhost",
-                    port=8812,
-                    database="qdb",
-                )
+        price = StreamInput(
+            interval="60s",
+            period=30,
+            event_recorder=QuestDBRecorder(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
+        )
+
+        def avg(view) -> pd.DataFrame:
+            df = pd.DataFrame([v for _, v in view[price][60]])
+            return pd.DataFrame({"ma_short": df["close"].rolling(5).mean()})
+
+        ma_node = Node(input=price, compute_fn=avg, name="ma_short")
+        self.add_nodes([price, ma_node])
 
 
 class MA2(BaseMA2):
     def setup(self) -> None:
-        super().setup()
-        for node in self.nodes:
-            if isinstance(node, StreamInput):
-                node.event_recorder = QuestDBRecorder(
-                    host="localhost",
-                    port=8812,
-                    database="qdb",
-                )
+        price = StreamInput(
+            interval="60s",
+            period=60,
+            event_recorder=QuestDBRecorder(
+                host="localhost",
+                port=8812,
+                database="qdb",
+            ),
+        )
+
+        def avg(view) -> pd.DataFrame:
+            df = pd.DataFrame([v for _, v in view[price][60]])
+            return pd.DataFrame({"ma_long": df["close"].rolling(20).mean()})
+
+        ma_node = Node(input=price, compute_fn=avg, name="ma_long")
+        self.add_nodes([price, ma_node])
 
 
 async def main() -> None:

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -544,7 +544,12 @@ class ProcessingNode(Node):
 
 
 class StreamInput(SourceNode):
-    """Represents an upstream data stream placeholder."""
+    """Represents an upstream data stream placeholder.
+
+    ``history_provider`` and ``event_recorder`` must be supplied when the
+    instance is created. These dependencies are immutable for the lifetime of
+    the node and attempts to reassign them will raise ``AttributeError``.
+    """
 
     def __init__(
         self,
@@ -563,8 +568,26 @@ class StreamInput(SourceNode):
             period=period,
             tags=tags or [],
         )
-        self.history_provider = history_provider
-        self.event_recorder = event_recorder
+        self._history_provider = history_provider
+        self._event_recorder = event_recorder
+
+    @property
+    def history_provider(self) -> "HistoryProvider" | None:
+        """Return the configured history provider."""
+        return self._history_provider
+
+    @history_provider.setter
+    def history_provider(self, value: "HistoryProvider" | None) -> None:
+        raise AttributeError("history_provider is read-only and must be provided via __init__")
+
+    @property
+    def event_recorder(self) -> "EventRecorder" | None:
+        """Return the configured event recorder."""
+        return self._event_recorder
+
+    @event_recorder.setter
+    def event_recorder(self, value: "EventRecorder" | None) -> None:
+        raise AttributeError("event_recorder is read-only and must be provided via __init__")
 
     async def load_history(self, start: int, end: int) -> None:
         """Load historical data if a provider was configured."""

--- a/tests/test_streaminput_immutability.py
+++ b/tests/test_streaminput_immutability.py
@@ -1,0 +1,10 @@
+import pytest
+from qmtl.sdk import StreamInput
+
+
+def test_streaminput_dependencies_readonly():
+    s = StreamInput(interval="1s", period=1)
+    with pytest.raises(AttributeError):
+        s.history_provider = object()
+    with pytest.raises(AttributeError):
+        s.event_recorder = object()


### PR DESCRIPTION
## Summary
- make StreamInput `history_provider` and `event_recorder` immutable
- update docs and README for new behaviour
- adjust questdb parallel example
- test immutability of StreamInput dependencies

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_686859aad9208329bf72e4a9bbd8accc