### PR TITLE
Update docs and tests for new HistoryProvider API

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ injecting `HistoryProvider` instances
 into `StreamInput` nodes. These dependencies must be provided at creation time
 and cannot be reassigned later. The same guide covers persisting data via
 `EventRecorder`.
+
+Example injection:
+
+```python
+from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder
+
+stream = StreamInput(
+    interval="60s",
+    history_provider=QuestDBLoader(dsn="postgresql://user:pass@localhost:8812/qdb"),
+    event_recorder=QuestDBRecorder(dsn="postgresql://user:pass@localhost:8812/qdb"),
+)
+```
+
 [docs/backfill.md](docs/backfill.md).
 
 ### QuestDBLoader with a custom fetcher

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -100,19 +100,11 @@ from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder
 stream = StreamInput(
     interval="60s",
     history_provider=QuestDBLoader(
-        host="localhost",
-        port=8812,
-        database="qdb",
-        user="user",
-        password="pass",
+        dsn="postgresql://user:pass@localhost:8812/qdb",
         fetcher=fetcher,
     ),
     event_recorder=QuestDBRecorder(
-        host="localhost",
-        port=8812,
-        database="qdb",
-        user="user",
-        password="pass",
+        dsn="postgresql://user:pass@localhost:8812/qdb",
     ),
 )
 ```

--- a/tests/dummy_fetcher.py
+++ b/tests/dummy_fetcher.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from qmtl.io import DataFetcher
+from qmtl.sdk import DataFetcher
 
 
 class DummyDataFetcher:


### PR DESCRIPTION
## Summary
- use SDK classes for dummy fetcher and QuestDB tests
- assert `QuestDBLoader`/`QuestDBRecorder` are instances of new base classes
- document dependency injection in README and backfill guide

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68685ce6eb4c8329b64c813b8536746f