### PR TITLE
Simplify QuestDB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,7 @@ class BinanceFetcher:
 
 fetcher = BinanceFetcher()
 loader = QuestDBLoader(
-    host="localhost",
-    port=8812,
-    database="qdb",
-    user="user",
-    password="pass",
+    dsn="postgresql://user:pass@localhost:8812/qdb",
     fetcher=fetcher,
 )
 ```

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -32,21 +32,13 @@ The SDK ships with `QuestDBLoader` which reads from a QuestDB instance:
 from qmtl.sdk import QuestDBLoader
 
 source = QuestDBLoader(
-    host="localhost",
-    port=8812,
-    database="qdb",
-    user="user",
-    password="pass",
+    dsn="postgresql://user:pass@localhost:8812/qdb",
 )
 
 # with an external fetcher supplying missing rows
 # fetcher = MyFetcher()
 # source = QuestDBLoader(
-#     host="localhost",
-#     port=8812,
-#     database="qdb",
-#     user="user",
-#     password="pass",
+#     dsn="postgresql://user:pass@localhost:8812/qdb",
 #     fetcher=fetcher,
 # )
 ```
@@ -79,11 +71,7 @@ class BinanceFetcher:
 
 fetcher = BinanceFetcher()
 loader = QuestDBLoader(
-    host="localhost",
-    port=8812,
-    database="qdb",
-    user="user",
-    password="pass",
+    dsn="postgresql://user:pass@localhost:8812/qdb",
     fetcher=fetcher,
 )
 ```

--- a/examples/tag_query_aggregation.py
+++ b/examples/tag_query_aggregation.py
@@ -28,9 +28,7 @@ class TagQueryAggregationStrategy(Strategy):
         corr_node = Node(input=indicators, compute_fn=calc_corr, name="indicator_corr")
         # persist correlation matrices if a database is configured
         corr_node.event_recorder = QuestDBRecorder(
-            host="localhost",
-            port=8812,
-            database="qdb",
+            dsn="postgresql://localhost:8812/qdb",
         )
 
         self.add_nodes([indicators, corr_node])

--- a/qmtl/examples/backfill_history_example.py
+++ b/qmtl/examples/backfill_history_example.py
@@ -9,9 +9,7 @@ from qmtl.examples import BinanceFetcher
 
 fetcher = BinanceFetcher()
 loader = QuestDBLoader(
-    host="localhost",
-    port=8812,
-    database="qdb",
+    dsn="postgresql://localhost:8812/qdb",
     fetcher=fetcher,
 )
 

--- a/qmtl/examples/cross_market_lag_strategy.py
+++ b/qmtl/examples/cross_market_lag_strategy.py
@@ -9,14 +9,10 @@ class CrossMarketLagStrategy(Strategy):
             interval="60s",
             period=120,
             history_provider=QuestDBLoader(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
             event_recorder=QuestDBRecorder(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
         )
         mstr_price = StreamInput(
@@ -24,14 +20,10 @@ class CrossMarketLagStrategy(Strategy):
             interval="60s",
             period=120,
             history_provider=QuestDBLoader(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
             event_recorder=QuestDBRecorder(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
         )
         def lagged_corr(view):

--- a/qmtl/examples/general_strategy.py
+++ b/qmtl/examples/general_strategy.py
@@ -9,14 +9,10 @@ class GeneralStrategy(Strategy):
     def setup(self):
         price_stream = StreamInput(
             history_provider=QuestDBLoader(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
             event_recorder=QuestDBRecorder(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
         )
 

--- a/qmtl/examples/metrics_recorder_example.py
+++ b/qmtl/examples/metrics_recorder_example.py
@@ -12,14 +12,10 @@ class RecorderStrategy(Strategy):
             interval="60s",
             period=30,
             history_provider=QuestDBLoader(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
             event_recorder=QuestDBRecorder(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
         )
 

--- a/qmtl/examples/questdb_parallel_example.py
+++ b/qmtl/examples/questdb_parallel_example.py
@@ -14,9 +14,7 @@ class MA1(BaseMA1):
             interval="60s",
             period=30,
             event_recorder=QuestDBRecorder(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
         )
 
@@ -34,9 +32,7 @@ class MA2(BaseMA2):
             interval="60s",
             period=60,
             event_recorder=QuestDBRecorder(
-                host="localhost",
-                port=8812,
-                database="qdb",
+                dsn="postgresql://localhost:8812/qdb",
             ),
         )
 

--- a/qmtl/io/eventrecorder.py
+++ b/qmtl/io/eventrecorder.py
@@ -13,48 +13,18 @@ class QuestDBRecorder(EventRecorder):
 
     def __init__(
         self,
-        dsn: str | None = None,
+        dsn: str,
         *,
-        host: str = "localhost",
-        port: int = 8812,
-        database: str = "qdb",
-        user: str | None = None,
-        password: str | None = None,
         table: str = "node_data",
     ) -> None:
-        self._dsn_provided = dsn is not None
-        self.dsn = dsn or self._make_dsn(host, port, database, user, password)
-        self.host = host
-        self.port = port
-        self.database = database
-        self.user = user
-        self.password = password
+        self.dsn = dsn
         self.table = table
 
-    @staticmethod
-    def _make_dsn(
-        host: str, port: int, database: str, user: str | None, password: str | None
-    ) -> str:
-        auth = ""
-        if user:
-            auth = user
-            if password:
-                auth += f":{password}"
-            auth += "@"
-        return f"postgresql://{auth}{host}:{port}/{database}"
 
     async def persist(
         self, node_id: str, interval: int, timestamp: int, payload: Any
     ) -> None:
-        conn = await asyncpg.connect(
-            **({"dsn": self.dsn} if self._dsn_provided else {
-                "host": self.host,
-                "port": self.port,
-                "database": self.database,
-                "user": self.user,
-                "password": self.password,
-            })
-        )
+        conn = await asyncpg.connect(dsn=self.dsn)
         try:
             columns = ", ".join(payload.keys())
             values = payload.values()


### PR DESCRIPTION
## Summary
- simplify `QuestDBLoader` and `QuestDBRecorder` constructors
- remove host/port settings from docs and examples
- adapt examples and docs to DSN-only connection strings

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_686860ec3d2c8329962e8f4e008b2a72