### PR TITLE
Implement stream binding for I/O backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ stream = StreamInput(
 )
 ```
 
+``QuestDBLoader`` and ``QuestDBRecorder`` will default to using
+``stream.node_id`` as the table name if ``table`` is not provided.
+
 [docs/backfill.md](docs/backfill.md).
 
 ### QuestDBLoader with a custom fetcher

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -97,6 +97,10 @@ stream = StreamInput(
 )
 ```
 
+When the QuestDB loader or recorder is created without a ``table`` argument it
+automatically uses ``stream.node_id`` as the table name.  Pass ``table="name"``
+explicitly to override this behaviour.
+
 ``StreamInput`` treats these dependencies as immutable. Attempting to modify
 ``history_provider`` or ``event_recorder`` after creation will raise an
 ``AttributeError``.

--- a/qmtl/io/eventrecorder.py
+++ b/qmtl/io/eventrecorder.py
@@ -15,10 +15,17 @@ class QuestDBRecorder(EventRecorder):
         self,
         dsn: str,
         *,
-        table: str = "node_data",
+        table: str | None = None,
     ) -> None:
         self.dsn = dsn
-        self.table = table
+        self._table = table
+
+    @property
+    def table(self) -> str:
+        tbl = self._table or getattr(self, "_stream_id", None)
+        if tbl is None:
+            raise RuntimeError("table not specified and stream not bound")
+        return tbl
 
 
     async def persist(

--- a/qmtl/io/historyprovider.py
+++ b/qmtl/io/historyprovider.py
@@ -15,12 +15,19 @@ class QuestDBLoader(HistoryProvider):
         self,
         dsn: str,
         *,
-        table: str = "node_data",
+        table: str | None = None,
         fetcher: DataFetcher | None = None,
     ) -> None:
         self.dsn = dsn
-        self.table = table
+        self._table = table
         self.fetcher = fetcher
+
+    @property
+    def table(self) -> str:
+        tbl = self._table or getattr(self, "_stream_id", None)
+        if tbl is None:
+            raise RuntimeError("table not specified and stream not bound")
+        return tbl
 
 
     async def fetch(

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -569,7 +569,11 @@ class StreamInput(SourceNode):
             tags=tags or [],
         )
         self._history_provider = history_provider
+        if history_provider and hasattr(history_provider, "bind_stream"):
+            history_provider.bind_stream(self)
         self._event_recorder = event_recorder
+        if event_recorder and hasattr(event_recorder, "bind_stream"):
+            event_recorder.bind_stream(self)
 
     @property
     def history_provider(self) -> "HistoryProvider" | None:

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -33,7 +33,7 @@ async def dummy_connect(*_args, **_kwargs):
 @pytest.mark.asyncio
 async def test_questdb_fetch(monkeypatch):
     monkeypatch.setattr("qmtl.io.historyprovider.asyncpg.connect", dummy_connect)
-    src = QuestDBLoader("db")
+    src = QuestDBLoader("db", table="node_data")
     assert isinstance(src, HistoryProvider)
     df = await src.fetch(1, 3, node_id="n1", interval=60)
     expected = pd.DataFrame([{"ts": 1, "value": 10}, {"ts": 2, "value": 20}])
@@ -61,7 +61,7 @@ async def test_questdb_coverage(monkeypatch):
         return DummyConn()
 
     monkeypatch.setattr("qmtl.io.historyprovider.asyncpg.connect", _connect)
-    src = QuestDBLoader("db")
+    src = QuestDBLoader("db", table="node_data")
     assert isinstance(src, HistoryProvider)
     ranges = await src.coverage(node_id="n", interval=60)
     assert ranges == [(60, 120), (240, 300)]
@@ -85,7 +85,7 @@ async def test_questdb_fill_missing_no_fetcher(monkeypatch):
         return DummyConn()
 
     monkeypatch.setattr("qmtl.io.historyprovider.asyncpg.connect", _connect)
-    src = QuestDBLoader("db")
+    src = QuestDBLoader("db", table="node_data")
     assert isinstance(src, HistoryProvider)
     with pytest.raises(RuntimeError):
         await src.fill_missing(60, 180, node_id="n", interval=60)
@@ -107,7 +107,7 @@ async def test_fill_missing_without_fetcher_raises(monkeypatch):
         return DummyConn()
 
     monkeypatch.setattr("qmtl.io.historyprovider.asyncpg.connect", _connect)
-    loader = QuestDBLoader("db")
+    loader = QuestDBLoader("db", table="node_data")
     assert isinstance(loader, HistoryProvider)
     with pytest.raises(RuntimeError):
         await loader.fill_missing(0, 0, node_id="n", interval=60)
@@ -132,7 +132,7 @@ async def test_questdb_fill_missing(monkeypatch):
         return DummyConn()
 
     monkeypatch.setattr("qmtl.io.historyprovider.asyncpg.connect", _connect)
-    src = QuestDBLoader("db", fetcher=fetcher)
+    src = QuestDBLoader("db", table="node_data", fetcher=fetcher)
     assert isinstance(src, HistoryProvider)
     await src.fill_missing(60, 180, node_id="n", interval=60)
 

--- a/tests/test_stream_binding.py
+++ b/tests/test_stream_binding.py
@@ -1,0 +1,27 @@
+import pytest
+from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder
+
+
+def test_questdb_table_defaults_to_node_id():
+    stream = StreamInput(
+        interval="60s",
+        period=1,
+        history_provider=QuestDBLoader("db"),
+        event_recorder=QuestDBRecorder("db"),
+    )
+    assert stream.history_provider.table == stream.node_id
+    assert stream.event_recorder.table == stream.node_id
+
+
+def test_questdb_explicit_table_override():
+    loader = QuestDBLoader("db", table="t")
+    recorder = QuestDBRecorder("db", table="t")
+    stream = StreamInput(
+        interval="60s",
+        period=1,
+        history_provider=loader,
+        event_recorder=recorder,
+    )
+    assert loader.table == "t"
+    assert recorder.table == "t"
+


### PR DESCRIPTION
## Summary
- allow HistoryProvider and EventRecorder instances to bind to StreamInput
- automatically bind QuestDB implementations and expose resolved table names
- update StreamInput to bind dependencies on construction
- document automatic table naming for QuestDB backends
- add regression tests

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6869c8b0758c8329ab44fc59cf842a8f