### PR TITLE
Make Ray execution opt-in

### DIFF
--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -139,7 +139,7 @@ Runner.backtest(
 During backtest and offline runs the SDK **replays** cached history through a
 ``Pipeline``.  Events from each ``StreamInput`` are collected concurrently with
 ``asyncio.gather`` and sorted by timestamp before being fed into the graph.
-If Ray is installed, compute functions may execute in parallel during this
+If Ray execution is enabled, compute functions may execute in parallel during this
 replay phase.
 
 ## Monitoring Progress

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -94,7 +94,7 @@ python -m qmtl.sdk --help
 
 PyArrow 기반 캐시를 사용하려면 환경 변수 `QMTL_ARROW_CACHE=1`을 설정합니다.
 만료 슬라이스 정리는 `QMTL_CACHE_EVICT_INTERVAL`(초) 값에 따라 주기적으로 실행되며
-Ray가 설치되어 있는 경우 Ray Actor에서 동작합니다.
+Ray 실행을 `Runner.enable_ray()` 또는 CLI의 `--with-ray` 옵션으로 활성화한 경우 Ray Actor에서 동작합니다.
 
 ## 백필 작업
 

--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -29,7 +29,15 @@ async def _main(argv: List[str] | None = None) -> None:
         "--gateway-url",
         help="Gateway base URL (required for backtest, dryrun and live modes)",
     )
+    parser.add_argument(
+        "--with-ray",
+        action="store_true",
+        help="Enable Ray-based execution of compute functions",
+    )
     args = parser.parse_args(argv)
+
+    if args.with_ray:
+        Runner.enable_ray()
 
     module_name, class_name = args.strategy.split(":")
     module = importlib.import_module(module_name)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -283,7 +283,8 @@ def test_feed_queue_data_with_ray(monkeypatch):
     import qmtl.sdk.runner as rmod
 
     monkeypatch.setattr(rmod, "ray", dummy_ray)
-    monkeypatch.setattr(rmod.Runner, "_ray_available", True)
+    monkeypatch.setattr(rmod.Runner, "_ray_available", False)
+    rmod.Runner.enable_ray()
 
     calls = []
 
@@ -632,3 +633,32 @@ def test_backtest_on_missing_fail(monkeypatch):
             on_missing="fail",
             gateway_url="http://gw",
         )
+
+
+def test_enable_ray_requires_module(monkeypatch):
+    import qmtl.sdk.runner as rmod
+    monkeypatch.setattr(rmod, "ray", None)
+    monkeypatch.setattr(rmod.Runner, "_ray_available", False)
+    with pytest.raises(RuntimeError):
+        rmod.Runner.enable_ray()
+
+
+def test_cli_with_ray(monkeypatch):
+    import sys
+    from qmtl.sdk.cli import main
+    import qmtl.sdk.runner as rmod
+
+    dummy_ray = object()
+    monkeypatch.setattr(rmod, "ray", dummy_ray)
+    monkeypatch.setattr(rmod.Runner, "_ray_available", False)
+
+    argv = [
+        "qmtl.sdk",
+        "tests.sample_strategy:SampleStrategy",
+        "--mode",
+        "offline",
+        "--with-ray",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    main()
+    assert rmod.Runner._ray_available


### PR DESCRIPTION
## Summary
- make Ray disabled by default and add `Runner.enable_ray()`
- update compute path to check both the flag and the library
- add `--with-ray` option to the CLI
- clarify Ray usage in documentation
- adjust tests and add new coverage for Ray enablement

## Testing
- `uv pip install -e .[dev] > /tmp/pip.log && tail -n 20 /tmp/pip.log`
- `uv run -m pytest -W error > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_686f9d564cc08329b51e6002eb2b93f3