### PR TITLE
Add Ray execution usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ python -m qmtl.examples.generators_example
 python -m qmtl.examples.extensions_combined_strategy
 ```
 
+Append `--with-ray` to enable Ray-based execution:
+
+```bash
+python -m qmtl.examples.general_strategy --with-ray
+```
+
 See [qmtl/examples/README.md](qmtl/examples/README.md) for additional scripts such as `tag_query_strategy.py` or `ws_metrics_example.py`.
 
 ## TagQuery Node Resolution

--- a/architecture.md
+++ b/architecture.md
@@ -77,7 +77,8 @@ Strategy SDK ──▶ Gateway ──▶ DAG-Manager ──▶ Graph DB (Neo4j)
   Actor로 분리 스케줄링한다.
 * **Arrow 캐시 백엔드 옵션**: 환경 변수 `QMTL_ARROW_CACHE=1`을 설정하면 PyArrow 기반
   캐시가 활성화됩니다. `QMTL_CACHE_EVICT_INTERVAL` 값으로 만료 슬라이스를 검사하는
-  주기를 조정하며, Ray가 설치되어 있는 경우 eviction 로직은 Ray Actor로 실행됩니다.
+  주기를 조정하며, Ray 실행을 `Runner.enable_ray()` 또는 CLI의 `--with-ray` 옵션으로
+  활성화한 경우 eviction 로직은 Ray Actor로 실행됩니다.
 * **다중 인터벌·다중 업스트림 지원**: `u` 축 (업스트림)과 `i` 축 (인터벌)을 분리함으로써 1m·5m·1h 등 다양한 간격과 여러 태그 큐를 동시에 저장·검색 가능.
 * **캐시 채우기 규칙**: 노드는 `∀(u,i) : |C[u,i]| ≥ Pᵢ` 조건을 만족할 때에만 프로세싱 함수가 호출된다.
 * **타임스탬프 정렬 예시**: interval = 1 m, period = 10, 시스템 UTC = 10:10:30 ⇒ `f="t"` 슬롯에는 10:01 … 10:10(10개 캔들)이 저장된다.

--- a/qmtl/examples/README.md
+++ b/qmtl/examples/README.md
@@ -22,4 +22,10 @@ python -m qmtl.examples.strategies.general_strategy
 python -m qmtl.examples.parallel.questdb_parallel_example
 ```
 
+Ray 기반 병렬 실행을 사용하려면 다음과 같이 `--with-ray` 옵션을 추가하세요.
+
+```bash
+python -m qmtl.examples.strategies.general_strategy --with-ray
+```
+
 백테스트가 필요한 경우 `Runner.backtest()`에 시작/종료 타임스탬프를 지정하세요.

--- a/qmtl/examples/strategies/general_strategy.py
+++ b/qmtl/examples/strategies/general_strategy.py
@@ -31,6 +31,8 @@ class GeneralStrategy(Strategy):
 
 
 if __name__ == "__main__":
+    # Enable Ray execution when available
+    Runner.enable_ray()
     # The backfill range is provided via Runner.backtest
     Runner.backtest(
         GeneralStrategy,


### PR DESCRIPTION
## Summary
- clarify how to enable Ray-based actor in `architecture.md`
- update example README with `--with-ray` usage
- show Ray enabling in `general_strategy` example
- mention Ray CLI option in project README

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68703ed681f08329a37ca8fb25ccafc7