### PR TITLE
Add AsyncCircuitBreaker

### DIFF
--- a/qmtl/common/__init__.py
+++ b/qmtl/common/__init__.py
@@ -11,9 +11,11 @@ def crc32_of_list(items: Iterable[str]) -> int:
 
 
 from .reconnect import ReconnectingRedis, ReconnectingNeo4j
+from .circuit_breaker import AsyncCircuitBreaker
 
 __all__ = [
     "crc32_of_list",
     "ReconnectingRedis",
     "ReconnectingNeo4j",
+    "AsyncCircuitBreaker",
 ]

--- a/qmtl/common/circuit_breaker.py
+++ b/qmtl/common/circuit_breaker.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Asynchronous circuit breaker utility."""
+
+import time
+from typing import Any, Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+class AsyncCircuitBreaker:
+    """Simple circuit breaker for async callables."""
+
+    def __init__(
+        self,
+        max_failures: int = 3,
+        reset_timeout: float = 60.0,
+        *,
+        on_open: Callable[[], None] | None = None,
+        on_close: Callable[[], None] | None = None,
+        on_failure: Callable[[int], None] | None = None,
+    ) -> None:
+        self._max_failures = max_failures
+        self._reset_timeout = reset_timeout
+        self._on_open = on_open
+        self._on_close = on_close
+        self._on_failure = on_failure
+        self._failures = 0
+        self._opened_at: float | None = None
+
+    # --- internal helpers -------------------------------------------------
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def _maybe_close(self) -> None:
+        if self._opened_at is None:
+            return
+        if self._now() - self._opened_at >= self._reset_timeout:
+            self._opened_at = None
+            self._failures = 0
+            if self._on_close:
+                self._on_close()
+
+    # --- public API -------------------------------------------------------
+    @property
+    def is_open(self) -> bool:
+        self._maybe_close()
+        return self._opened_at is not None
+
+    @property
+    def failures(self) -> int:
+        return self._failures
+
+    def __call__(
+        self, func: Callable[..., Awaitable[T]]
+    ) -> Callable[..., Awaitable[T]]:
+        async def wrapper(*args: Any, **kwargs: Any) -> T:
+            if self.is_open:
+                raise RuntimeError("circuit open")
+            try:
+                result = await func(*args, **kwargs)
+            except Exception:
+                self._failures += 1
+                if self._on_failure:
+                    self._on_failure(self._failures)
+                if self._failures >= self._max_failures:
+                    if self._opened_at is None:
+                        self._opened_at = self._now()
+                        if self._on_open:
+                            self._on_open()
+                raise
+            else:
+                if self._failures:
+                    self._failures = 0
+                return result
+        return wrapper
+
+
+__all__ = ["AsyncCircuitBreaker"]

--- a/tests/common/test_circuit_breaker.py
+++ b/tests/common/test_circuit_breaker.py
@@ -1,0 +1,61 @@
+import asyncio
+import pytest
+
+from qmtl.common import AsyncCircuitBreaker
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_basic():
+    cb = AsyncCircuitBreaker(max_failures=2, reset_timeout=0.1)
+    calls = 0
+
+    @cb
+    async def flaky():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("boom")
+
+    for expected_failures in (1, 2):
+        with pytest.raises(RuntimeError):
+            await flaky()
+        assert cb.failures == expected_failures
+
+    assert cb.is_open
+    with pytest.raises(RuntimeError):
+        await flaky()
+    assert cb.failures == 2
+
+    await asyncio.sleep(0.11)
+    assert not cb.is_open
+
+    with pytest.raises(RuntimeError):
+        await flaky()
+    assert cb.failures == 1
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_callbacks():
+    events = []
+    cb = AsyncCircuitBreaker(
+        max_failures=1,
+        reset_timeout=0.05,
+        on_open=lambda: events.append("open"),
+        on_close=lambda: events.append("close"),
+        on_failure=lambda count: events.append(f"fail{count}"),
+    )
+
+    @cb
+    async def func():
+        raise RuntimeError("x")
+
+    with pytest.raises(RuntimeError):
+        await func()
+
+    assert events == ["fail1", "open"]
+    assert cb.is_open
+
+    await asyncio.sleep(0.06)
+    # Access property to trigger state refresh
+    assert not cb.is_open
+    assert events[-1] == "close"


### PR DESCRIPTION
## Summary
- implement `AsyncCircuitBreaker` helper for async functions
- export in `qmtl.common`
- unit tests for circuit breaker

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_687915189c5083299fc7ac4de4a12cb9