### PR TITLE
Add circuit breakers to alert callbacks

### DIFF
--- a/qmtl/dagmanager/alerts.py
+++ b/qmtl/dagmanager/alerts.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 """Alerting helpers for PagerDuty and Slack."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol
 
 import httpx
+
+from ..common import AsyncCircuitBreaker
+from .callbacks import post_with_backoff
 
 
 class PagerDutySender(Protocol):
@@ -25,30 +28,48 @@ class SlackSender(Protocol):
 @dataclass
 class PagerDutyClient:
     url: str
+    breaker: AsyncCircuitBreaker | None = None
 
     async def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
         async with httpx.AsyncClient() as client:
-            await client.post(self.url, json={"text": message})
+            await post_with_backoff(
+                self.url,
+                {"text": message},
+                client=client,
+                circuit_breaker=self.breaker,
+            )
 
 
 @dataclass
 class SlackClient:
     url: str
+    breaker: AsyncCircuitBreaker | None = None
 
     async def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
         async with httpx.AsyncClient() as client:
-            await client.post(self.url, json={"text": message})
+            await post_with_backoff(
+                self.url,
+                {"text": message},
+                client=client,
+                circuit_breaker=self.breaker,
+            )
 
 
 @dataclass
 class AlertManager:
     pagerduty: PagerDutySender
     slack: SlackSender
+    pagerduty_breaker: AsyncCircuitBreaker = field(default_factory=AsyncCircuitBreaker)
+    slack_breaker: AsyncCircuitBreaker = field(default_factory=AsyncCircuitBreaker)
 
     async def send_pagerduty(self, message: str) -> None:
+        if isinstance(self.pagerduty, PagerDutyClient):
+            self.pagerduty.breaker = self.pagerduty_breaker
         await self.pagerduty.send(message)
 
     async def send_slack(self, message: str) -> None:
+        if isinstance(self.slack, SlackClient):
+            self.slack.breaker = self.slack_breaker
         await self.slack.send(message)
 
 

--- a/tests/dagmanager/test_circuit_breaker_callbacks.py
+++ b/tests/dagmanager/test_circuit_breaker_callbacks.py
@@ -1,0 +1,31 @@
+import asyncio
+import httpx
+import pytest
+
+from qmtl.dagmanager.callbacks import post_with_backoff
+from qmtl.common import AsyncCircuitBreaker
+
+
+@pytest.mark.asyncio
+async def test_post_with_breaker_trips_on_failures(monkeypatch):
+    cb = AsyncCircuitBreaker(max_failures=2, reset_timeout=0.1)
+
+    async def mock_post(self, url, json=None):
+        return httpx.Response(500)
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+
+    async def dummy_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", dummy_sleep)
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError):
+            await post_with_backoff(
+                "http://x", {}, retries=1, circuit_breaker=cb
+            )
+
+    assert cb.is_open
+    with pytest.raises(RuntimeError):
+        await post_with_backoff("http://x", {}, retries=1, circuit_breaker=cb)


### PR DESCRIPTION
## Summary
- extend `post_with_backoff` with optional `AsyncCircuitBreaker`
- wire PagerDuty and Slack clients to use circuit breakers
- instantiate breakers in `AlertManager`
- test that repeated HTTP failures open the breaker

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_687917bd13c4832986464be498effb68