### PR TITLE
Add gateway circuit breaker

### DIFF
--- a/tests/sdk/test_circuit_breaker_runner.py
+++ b/tests/sdk/test_circuit_breaker_runner.py
@@ -1,0 +1,70 @@
+import httpx
+import pytest
+
+from qmtl.sdk.runner import Runner
+from qmtl.common import AsyncCircuitBreaker
+
+
+class DummyClient:
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None):
+        raise httpx.RequestError("fail", request=httpx.Request("POST", url))
+
+
+@pytest.mark.asyncio
+async def test_post_gateway_circuit_breaker(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+    cb = AsyncCircuitBreaker(max_failures=1, reset_timeout=60)
+
+    with pytest.raises(httpx.RequestError):
+        await Runner._post_gateway_async(
+            gateway_url="http://gw",
+            dag={},
+            meta=None,
+            run_type="x",
+            circuit_breaker=cb,
+        )
+
+    with pytest.raises(RuntimeError):
+        await Runner._post_gateway_async(
+            gateway_url="http://gw",
+            dag={},
+            meta=None,
+            run_type="x",
+            circuit_breaker=cb,
+        )
+
+
+
+@pytest.mark.asyncio
+async def test_env_config(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+    monkeypatch.setenv("QMTL_GW_CB_MAX_FAILURES", "1")
+    monkeypatch.setenv("QMTL_GW_CB_RESET_TIMEOUT", "60")
+    Runner.set_gateway_circuit_breaker(None)
+
+    with pytest.raises(httpx.RequestError):
+        await Runner._post_gateway_async(
+            gateway_url="http://gw",
+            dag={},
+            meta=None,
+            run_type="x",
+        )
+
+    with pytest.raises(RuntimeError):
+        await Runner._post_gateway_async(
+            gateway_url="http://gw",
+            dag={},
+            meta=None,
+            run_type="x",
+        )
+    Runner.set_gateway_circuit_breaker(None)
+


### PR DESCRIPTION
## Summary
- add optional circuit breaker usage to Runner._post_gateway_async
- configure circuit breaker thresholds via CLI or environment variables
- add coverage for circuit breaker behavior in runner

## Testing
- `uv run -m pytest tests/sdk/test_circuit_breaker_runner.py -W error`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_687917c935548329aaac544f44bfc694