### PR TITLE
Add circuit breaker to Neo4j access

### DIFF
--- a/tests/dagmanager/test_circuit_breaker_neo4j.py
+++ b/tests/dagmanager/test_circuit_breaker_neo4j.py
@@ -1,0 +1,96 @@
+import sys
+import types
+import time
+
+import pytest
+
+from qmtl.common import AsyncCircuitBreaker
+from qmtl.common.reconnect import ReconnectingNeo4j
+from qmtl.dagmanager.diff_service import Neo4jNodeRepository
+
+
+class DummySession:
+    def __init__(self, fail=True):
+        self.fail = fail
+        self.calls = 0
+
+    def run(self, query, **params):
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("fail")
+        return []
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyDriver:
+    def __init__(self, fail=True):
+        self.fail = fail
+        self.session_created = 0
+        self.sessions = []
+
+    def session(self):
+        self.session_created += 1
+        sess = DummySession(self.fail)
+        self.sessions.append(sess)
+        return sess
+
+    def close(self):
+        pass
+
+
+def _patch_driver(monkeypatch, drivers):
+    class FakeGraphDB:
+        @staticmethod
+        def driver(uri, auth):
+            return drivers.pop(0)
+
+    monkeypatch.setitem(sys.modules, 'neo4j', types.SimpleNamespace(GraphDatabase=FakeGraphDB))
+
+
+def test_breaker_opens(monkeypatch):
+    driver1 = DummyDriver(True)
+    driver2 = DummyDriver(True)
+    drivers = [driver1, driver2]
+    _patch_driver(monkeypatch, drivers)
+
+    client = ReconnectingNeo4j('bolt://', 'u', 'p')
+    repo = Neo4jNodeRepository(client)
+    breaker = AsyncCircuitBreaker(max_failures=1, reset_timeout=0.05)
+
+    with pytest.raises(RuntimeError):
+        repo.get_nodes(['A'], breaker=breaker)
+
+    assert breaker.is_open
+    assert driver1.sessions[0].calls == 1
+    assert driver2.sessions[0].calls == 0
+
+
+def test_breaker_resets(monkeypatch):
+    driver1 = DummyDriver(True)
+    driver2 = DummyDriver(False)
+    drivers = [driver1, driver2]
+    _patch_driver(monkeypatch, drivers)
+
+    client = ReconnectingNeo4j('bolt://', 'u', 'p')
+    repo = Neo4jNodeRepository(client)
+    breaker = AsyncCircuitBreaker(max_failures=1, reset_timeout=0.05)
+
+    with pytest.raises(RuntimeError):
+        repo.get_nodes(['A'], breaker=breaker)
+
+    assert breaker.is_open
+    time.sleep(0.06)
+
+    records = repo.get_nodes(['A'], breaker=breaker)
+    assert records == {}
+    assert not breaker.is_open
+    assert driver2.sessions[-1].calls == 1
+


### PR DESCRIPTION
## Summary
- inject `AsyncCircuitBreaker` through `Neo4jNodeRepository` methods
- route `ReconnectingNeo4j.session().run()` via circuit breaker
- test circuit breaker behaviour with Neo4j repository

## Testing
- `uv run -m pytest -W error tests/dagmanager/test_circuit_breaker_neo4j.py tests/dagmanager/test_in_memory_admin.py tests/common/test_circuit_breaker.py tests/reliability/test_reconnect.py`

------
https://chatgpt.com/codex/tasks/task_e_6879179ce504832983f436ae99a4a2cf