### PR TITLE
Add circuit breaker to DagManagerClient

### DIFF
--- a/qmtl/gateway/dagmanager_client.py
+++ b/qmtl/gateway/dagmanager_client.py
@@ -6,12 +6,14 @@ from typing import Dict
 import grpc
 
 from ..proto import dagmanager_pb2, dagmanager_pb2_grpc
+from ..common import AsyncCircuitBreaker
+from . import metrics as gw_metrics
 
 
 class DagManagerClient:
     """gRPC client for DAG‑Manager services using a persistent channel."""
 
-    def __init__(self, target: str) -> None:
+    def __init__(self, target: str, *, breaker_max_failures: int = 3, breaker_reset_timeout: float = 60.0) -> None:
         self._target = target
         try:
             asyncio.get_running_loop()
@@ -21,41 +23,74 @@ class DagManagerClient:
         self._health_stub = dagmanager_pb2_grpc.HealthCheckStub(self._channel)
         self._diff_stub = dagmanager_pb2_grpc.DiffServiceStub(self._channel)
         self._tag_stub = dagmanager_pb2_grpc.TagQueryStub(self._channel)
+        self._breaker = AsyncCircuitBreaker(
+            max_failures=breaker_max_failures,
+            reset_timeout=breaker_reset_timeout,
+            on_open=lambda: gw_metrics.dagclient_breaker_state.set(1),
+            on_close=lambda: (
+                gw_metrics.dagclient_breaker_state.set(0),
+                gw_metrics.dagclient_breaker_failures.set(0),
+            ),
+            on_failure=lambda c: gw_metrics.dagclient_breaker_failures.set(c),
+        )
+        gw_metrics.dagclient_breaker_state.set(0)
+        gw_metrics.dagclient_breaker_failures.set(0)
 
     async def close(self) -> None:
         """Close the underlying gRPC channel."""
         await self._channel.close()
 
+    @property
+    def breaker(self) -> AsyncCircuitBreaker:
+        """Return the circuit breaker instance."""
+        return self._breaker
+
     async def status(self) -> bool:
         """Return ``True`` if the remote DAG manager reports healthy status."""
-        try:
+        @self._breaker
+        async def _call() -> bool:
             reply = await self._health_stub.Status(dagmanager_pb2.StatusRequest())
             return reply.neo4j == "ok" and reply.state == "running"
+
+        try:
+            result = await _call()
+            gw_metrics.dagclient_breaker_failures.set(self._breaker.failures)
+            return result
         except Exception:
             return False
 
     async def diff(self, strategy_id: str, dag_json: str) -> dagmanager_pb2.DiffChunk:
         """Call ``DiffService.Diff`` with retries and collect the stream."""
         request = dagmanager_pb2.DiffRequest(strategy_id=strategy_id, dag_json=dag_json)
-        backoff = 0.5
-        retries = 5
-        for attempt in range(retries):
-            try:
-                queue_map: Dict[str, str] = {}
-                sentinel_id = ""
-                buffer_nodes: list[dagmanager_pb2.BufferInstruction] = []
-                async for chunk in self._diff_stub.Diff(request):
-                    queue_map.update(dict(chunk.queue_map))
-                    sentinel_id = chunk.sentinel_id
-                    buffer_nodes.extend(chunk.buffer_nodes)
-                return dagmanager_pb2.DiffChunk(
-                    queue_map=queue_map, sentinel_id=sentinel_id, buffer_nodes=buffer_nodes
-                )
-            except Exception:
-                if attempt == retries - 1:
-                    raise
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 4)
+
+        @self._breaker
+        async def _call() -> dagmanager_pb2.DiffChunk:
+            backoff = 0.5
+            retries = 5
+            for attempt in range(retries):
+                try:
+                    queue_map: Dict[str, str] = {}
+                    sentinel_id = ""
+                    buffer_nodes: list[dagmanager_pb2.BufferInstruction] = []
+                    async for chunk in self._diff_stub.Diff(request):
+                        queue_map.update(dict(chunk.queue_map))
+                        sentinel_id = chunk.sentinel_id
+                        buffer_nodes.extend(chunk.buffer_nodes)
+                    return dagmanager_pb2.DiffChunk(
+                        queue_map=queue_map,
+                        sentinel_id=sentinel_id,
+                        buffer_nodes=buffer_nodes,
+                    )
+                except Exception:
+                    if attempt == retries - 1:
+                        raise
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, 4)
+            raise RuntimeError("unreachable")
+
+        result = await _call()
+        gw_metrics.dagclient_breaker_failures.set(self._breaker.failures)
+        return result
 
     async def get_queues_by_tag(
         self, tags: list[str], interval: int, match_mode: str = "any"
@@ -79,18 +114,25 @@ class DagManagerClient:
         request = dagmanager_pb2.TagQueryRequest(
             tags=tags, interval=interval, match_mode=match_mode
         )
-        backoff = 0.5
-        retries = 5
-        for attempt in range(retries):
-            try:
-                response = await self._tag_stub.GetQueues(request)
-                return list(response.queues)
-            except Exception:
-                if attempt == retries - 1:
-                    raise
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 4)
-        return []
+        
+        @self._breaker
+        async def _call() -> list[str]:
+            backoff = 0.5
+            retries = 5
+            for attempt in range(retries):
+                try:
+                    response = await self._tag_stub.GetQueues(request)
+                    return list(response.queues)
+                except Exception:
+                    if attempt == retries - 1:
+                        raise
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, 4)
+            return []
+
+        result = await _call()
+        gw_metrics.dagclient_breaker_failures.set(self._breaker.failures)
+        return result
 
 
 __all__ = ["DagManagerClient"]

--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -22,6 +22,18 @@ lost_requests_total = Counter(
     registry=global_registry,
 )
 
+dagclient_breaker_state = Gauge(
+    "dagclient_breaker_state",
+    "DAG manager circuit breaker state (1=open, 0=closed)",
+    registry=global_registry,
+)
+
+dagclient_breaker_failures = Gauge(
+    "dagclient_breaker_failures",
+    "Consecutive failures recorded by the DAG manager circuit breaker",
+    registry=global_registry,
+)
+
 
 # Track the percentage of traffic routed to each sentinel version
 if "gateway_sentinel_traffic_ratio" in global_registry._names_to_collectors:
@@ -74,4 +86,8 @@ def reset_metrics() -> None:
     gateway_sentinel_traffic_ratio._vals = {}  # type: ignore[attr-defined]
     if hasattr(gateway_sentinel_traffic_ratio, "_metrics"):
         gateway_sentinel_traffic_ratio._metrics.clear()
+    dagclient_breaker_state.set(0)
+    dagclient_breaker_state._val = 0  # type: ignore[attr-defined]
+    dagclient_breaker_failures.set(0)
+    dagclient_breaker_failures._val = 0  # type: ignore[attr-defined]
 

--- a/tests/gateway/test_circuit_breaker_dagclient.py
+++ b/tests/gateway/test_circuit_breaker_dagclient.py
@@ -1,0 +1,145 @@
+import asyncio
+import pytest
+import grpc
+
+from qmtl.gateway.dagmanager_client import DagManagerClient
+from qmtl.gateway import metrics
+from qmtl.proto import dagmanager_pb2, dagmanager_pb2_grpc
+
+
+class DummyChannel:
+    async def close(self):
+        pass
+
+
+def make_diff_stub(total_failures: int = 0):
+    call_count = 0
+
+    async def gen():
+        yield dagmanager_pb2.DiffChunk()
+
+    class Stub:
+        def __init__(self, channel):
+            pass
+
+        def Diff(self, request):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= total_failures:
+                raise grpc.RpcError("fail")
+            return gen()
+
+    return Stub
+
+
+def make_tag_stub(total_failures: int = 0):
+    call_count = 0
+
+    class Stub:
+        def __init__(self, channel):
+            pass
+
+        async def GetQueues(self, request):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= total_failures:
+                raise grpc.RpcError("fail")
+            return dagmanager_pb2.TagQueryReply(queues=["q"])
+
+    return Stub
+
+
+def make_health_stub(total_failures: int = 0):
+    call_count = 0
+
+    class Stub:
+        def __init__(self, channel):
+            pass
+
+        async def Status(self, request):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= total_failures:
+                raise grpc.RpcError("fail")
+            return dagmanager_pb2.StatusReply(neo4j="ok", state="running")
+
+    return Stub
+
+
+@pytest.mark.asyncio
+async def test_breaker_opens_and_resets(monkeypatch):
+    DiffStub = make_diff_stub(total_failures=10)
+    TagStub = make_tag_stub()
+    HealthStub = make_health_stub()
+    monkeypatch.setattr(dagmanager_pb2_grpc, "DiffServiceStub", DiffStub)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", TagStub)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", HealthStub)
+    monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
+
+    metrics.reset_metrics()
+    client = DagManagerClient("dummy", breaker_max_failures=2, breaker_reset_timeout=0.05)
+
+    for _ in range(2):
+        with pytest.raises(grpc.RpcError):
+            await client.diff("s", "{}")
+    assert client.breaker.is_open
+    assert metrics.dagclient_breaker_state._value.get() == 1
+    assert metrics.dagclient_breaker_failures._value.get() == 2
+
+    with pytest.raises(RuntimeError):
+        await client.diff("s", "{}")
+
+    await asyncio.sleep(0.06)
+    assert not client.breaker.is_open
+    result = await client.diff("s", "{}")
+    assert isinstance(result, dagmanager_pb2.DiffChunk)
+    assert metrics.dagclient_breaker_state._value.get() == 0
+    assert metrics.dagclient_breaker_failures._value.get() == 0
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_queues_uses_breaker(monkeypatch):
+    DiffStub = make_diff_stub()
+    TagStub = make_tag_stub(total_failures=10)
+    HealthStub = make_health_stub()
+    monkeypatch.setattr(dagmanager_pb2_grpc, "DiffServiceStub", DiffStub)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", TagStub)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", HealthStub)
+    monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
+
+    metrics.reset_metrics()
+    client = DagManagerClient("dummy", breaker_max_failures=2, breaker_reset_timeout=0.05)
+
+    for _ in range(2):
+        with pytest.raises(grpc.RpcError):
+            await client.get_queues_by_tag(["t"], 60)
+    with pytest.raises(RuntimeError):
+        await client.get_queues_by_tag(["t"], 60)
+    assert metrics.dagclient_breaker_state._value.get() == 1
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_status_uses_breaker(monkeypatch):
+    DiffStub = make_diff_stub()
+    TagStub = make_tag_stub()
+    HealthStub = make_health_stub(total_failures=2)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "DiffServiceStub", DiffStub)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", TagStub)
+    monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", HealthStub)
+    monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
+
+    metrics.reset_metrics()
+    client = DagManagerClient("dummy", breaker_max_failures=2, breaker_reset_timeout=0.05)
+
+    assert await client.status() is False
+    assert await client.status() is False
+    assert client.breaker.is_open
+    assert metrics.dagclient_breaker_state._value.get() == 1
+    assert await client.status() is False
+    await asyncio.sleep(0.06)
+    assert await client.status() is True
+    assert metrics.dagclient_breaker_state._value.get() == 0
+    assert metrics.dagclient_breaker_failures._value.get() == 0
+    await client.close()


### PR DESCRIPTION
## Summary
- embed `AsyncCircuitBreaker` in `DagManagerClient`
- add breaker metrics and expose them
- wrap `diff`, `status`, and `get_queues_by_tag` with the breaker
- test gRPC circuit breaking behaviour using stubbed stubs

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_687917b75b4883298c537fd676dc79fd