### PR TITLE
Add Kafka circuit breaker

### DIFF
--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -17,6 +17,8 @@ class DagManagerConfig:
     memory_repo_path: str = "memrepo.gpickle"
     queue_backend: str = "memory"
     kafka_dsn: str = "localhost:9092"
+    kafka_breaker_threshold: int = 3
+    kafka_breaker_timeout: float = 60.0
     grpc_host: str = "0.0.0.0"
     grpc_port: int = 50051
     http_host: str = "0.0.0.0"

--- a/tests/dagmanager/test_circuit_breaker_kafka.py
+++ b/tests/dagmanager/test_circuit_breaker_kafka.py
@@ -1,0 +1,65 @@
+import time
+import asyncio
+import pytest
+
+from qmtl.common import AsyncCircuitBreaker
+from qmtl.dagmanager.kafka_admin import KafkaAdmin, TopicExistsError
+from qmtl.dagmanager.topic import TopicConfig
+
+
+class FailingAdmin:
+    def __init__(self, fail_times: int) -> None:
+        self.fail_times = fail_times
+        self.calls = 0
+        self.topics = {}
+
+    def list_topics(self):
+        return self.topics
+
+    def create_topic(self, name, *, num_partitions, replication_factor, config=None):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise RuntimeError("boom")
+        if name in self.topics:
+            raise TopicExistsError
+        self.topics[name] = {}
+
+
+class ExistsAdmin:
+    def __init__(self) -> None:
+        self.topics = {"t": {}}
+
+    def list_topics(self):
+        return self.topics
+
+    def create_topic(self, name, *, num_partitions, replication_factor, config=None):
+        if name in self.topics:
+            raise TopicExistsError
+        self.topics[name] = {}
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_opens_on_failures():
+    client = FailingAdmin(fail_times=2)
+    admin = KafkaAdmin(client, breaker=AsyncCircuitBreaker(max_failures=2, reset_timeout=0.05))
+    cfg = TopicConfig(1, 1, 1000)
+
+    with pytest.raises(RuntimeError):
+        await asyncio.to_thread(admin.create_topic_if_needed, "t", cfg)
+    with pytest.raises(RuntimeError):
+        await asyncio.to_thread(admin.create_topic_if_needed, "t", cfg)
+    assert admin.breaker.is_open
+    with pytest.raises(RuntimeError):
+        await asyncio.to_thread(admin.create_topic_if_needed, "t", cfg)
+    await asyncio.sleep(0.06)
+    assert not admin.breaker.is_open
+
+
+@pytest.mark.asyncio
+async def test_topic_exists_does_not_trip_breaker():
+    client = ExistsAdmin()
+    admin = KafkaAdmin(client, breaker=AsyncCircuitBreaker(max_failures=1, reset_timeout=0.01))
+    cfg = TopicConfig(1, 1, 1000)
+
+    await asyncio.to_thread(admin.create_topic_if_needed, "t", cfg)
+    assert admin.breaker.failures == 0

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -12,12 +12,16 @@ def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
         "neo4j_password": "pw",
         "queue_backend": "kafka",
         "kafka_dsn": "localhost:9092",
+        "kafka_breaker_threshold": 5,
+        "kafka_breaker_timeout": 2.5,
     }
     config_file = tmp_path / "dm.yml"
     config_file.write_text(yaml.safe_dump(data))
     config = load_dagmanager_config(str(config_file))
     assert config.neo4j_dsn == data["neo4j_dsn"]
     assert config.kafka_dsn == data["kafka_dsn"]
+    assert config.kafka_breaker_threshold == 5
+    assert config.kafka_breaker_timeout == 2.5
 
 
 def test_load_dagmanager_config_missing_file():
@@ -36,4 +40,6 @@ def test_dagmanager_config_defaults() -> None:
     cfg = DagManagerConfig()
     assert cfg.repo_backend == "memory"
     assert cfg.queue_backend == "memory"
+    assert cfg.kafka_breaker_threshold == 3
+    assert cfg.kafka_breaker_timeout == 60.0
 


### PR DESCRIPTION
## Summary
- use AsyncCircuitBreaker in KafkaAdmin
- expose breaker parameters in DagManagerConfig
- allow gRPC server to pass breaker options
- test loading of breaker config
- add Kafka Admin circuit breaker tests

## Testing
- `uv run -m pytest -W error --deselect tests/e2e/test_sentinel_weight_integration.py::test_sentinel_traffic_triggers_ws`

------
https://chatgpt.com/codex/tasks/task_e_6879179e8eb88329963fc202ef207abb