### PR TITLE
Implement gateway degradation manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "websockets",
     "grpcio",
     "PyYAML",
+    "psutil",
 ]
 
 [project.optional-dependencies]

--- a/qmtl/gateway/__init__.py
+++ b/qmtl/gateway/__init__.py
@@ -3,6 +3,7 @@ from .queue import RedisFIFOQueue
 from .redis_client import InMemoryRedis
 from .worker import StrategyWorker
 from .api import create_app, StrategySubmit, StrategyAck, StatusResponse
+from .degradation import DegradationManager, DegradationLevel
 from .database import Database
 from .fsm import StrategyFSM
 from .ws import WebSocketHub
@@ -19,6 +20,8 @@ __all__ = [
     "StrategySubmit",
     "StrategyAck",
     "StatusResponse",
+    "DegradationManager",
+    "DegradationLevel",
     "WebSocketHub",
     "QueueWatchHub",
 ]

--- a/qmtl/gateway/degradation.py
+++ b/qmtl/gateway/degradation.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+from enum import IntEnum
+from typing import Optional
+
+from .database import Database
+
+import psutil
+
+from . import metrics
+
+
+class DegradationLevel(IntEnum):
+    NORMAL = 0
+    PARTIAL = 1
+    MINIMAL = 2
+    STATIC = 3
+
+
+class DegradationManager:
+    """Monitor dependency health and expose degradation level."""
+
+    def __init__(
+        self,
+        redis_client,
+        database,
+        dag_client,
+        *,
+        check_interval: float = 5.0,
+    ) -> None:
+        self.redis = redis_client
+        self.database = database
+        self.dag_client = dag_client
+        self.check_interval = check_interval
+        self.level = DegradationLevel.NORMAL
+        self.redis_ok = True
+        self.db_ok = True
+        self.dag_ok = True
+        self.local_queue: list[str] = []
+        self._task: Optional[asyncio.Task] = None
+        self._gauge = metrics.degrade_level.labels(service="gateway")
+        self._gauge.set(self.level.value)
+
+    async def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _check_dependencies(self) -> None:
+        try:
+            self.redis_ok = await self.redis.ping()
+        except Exception:
+            self.redis_ok = False
+        self.db_ok = True
+        healthy_attr = getattr(self.database, "healthy", None)
+        func = getattr(healthy_attr, "__func__", None)
+        if healthy_attr is not None and func is not Database.healthy:
+            try:
+                self.db_ok = await healthy_attr()
+            except Exception:
+                self.db_ok = False
+        try:
+            self.dag_ok = await self.dag_client.status()
+        except Exception:
+            self.dag_ok = False
+
+    async def evaluate(self) -> DegradationLevel:
+        await self._check_dependencies()
+        cpu = psutil.cpu_percent(interval=None)
+        failures = sum(not f for f in (self.redis_ok, self.db_ok, self.dag_ok))
+        if cpu > 95 or failures == 3:
+            return DegradationLevel.STATIC
+        if cpu > 85 or failures >= 2:
+            return DegradationLevel.MINIMAL
+        if failures >= 1:
+            return DegradationLevel.PARTIAL
+        return DegradationLevel.NORMAL
+
+    async def update(self) -> None:
+        new_level = await self.evaluate()
+        if new_level != self.level:
+            self.level = new_level
+            self._gauge.set(new_level.value)
+
+    async def _loop(self) -> None:
+        try:
+            while True:
+                await self.update()
+                await asyncio.sleep(self.check_interval)
+        except asyncio.CancelledError:
+            pass
+
+
+__all__ = ["DegradationManager", "DegradationLevel"]

--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -47,6 +47,14 @@ else:
     )
 gateway_sentinel_traffic_ratio._vals = {}  # type: ignore[attr-defined]
 
+# Degradation level of the Gateway service
+degrade_level = Gauge(
+    "degrade_level",
+    "Current degradation level",
+    ["service"],
+    registry=global_registry,
+)
+
 
 def set_sentinel_traffic_ratio(sentinel_id: str, ratio: float) -> None:
     """Update the live traffic ratio for a sentinel version."""
@@ -90,4 +98,5 @@ def reset_metrics() -> None:
     dagclient_breaker_state._val = 0  # type: ignore[attr-defined]
     dagclient_breaker_failures.set(0)
     dagclient_breaker_failures._val = 0  # type: ignore[attr-defined]
+    degrade_level.clear()
 

--- a/tests/gateway/test_degradation.py
+++ b/tests/gateway/test_degradation.py
@@ -1,0 +1,120 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from qmtl.gateway.api import create_app, StrategySubmit
+from qmtl.gateway.database import Database
+from qmtl.gateway.degradation import DegradationManager, DegradationLevel
+from qmtl.common import crc32_of_list
+
+
+class FakeDB(Database):
+    def __init__(self, ok: bool = True) -> None:
+        self.ok = ok
+
+    async def insert_strategy(self, strategy_id: str, meta=None) -> None:  # pragma: no cover - not used
+        pass
+
+    async def set_status(self, strategy_id: str, status: str) -> None:  # pragma: no cover - not used
+        pass
+
+    async def get_status(self, strategy_id: str):  # pragma: no cover - not used
+        return "queued"
+
+    async def append_event(self, strategy_id: str, event: str) -> None:  # pragma: no cover - not used
+        pass
+
+    async def healthy(self) -> bool:
+        return self.ok
+
+
+class DummyDag:
+    def __init__(self, ok: bool = True) -> None:
+        self.ok = ok
+
+    async def status(self) -> bool:
+        return self.ok
+
+
+class DummyRedis:
+    def __init__(self, ok: bool = True) -> None:
+        self.ok = ok
+
+    async def ping(self) -> bool:
+        if not self.ok:
+            raise RuntimeError("fail")
+        return True
+
+    async def rpush(self, *a, **k):
+        pass
+
+    async def hset(self, *a, **k):
+        pass
+
+    async def set(self, *a, **k):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_level_transitions(monkeypatch):
+    redis = DummyRedis()
+    db = FakeDB()
+    dag = DummyDag()
+    mgr = DegradationManager(redis, db, dag, check_interval=0.01)
+    monkeypatch.setattr("psutil.cpu_percent", lambda interval=None: 10)
+    await mgr.update()
+    assert mgr.level == DegradationLevel.NORMAL
+
+    dag.ok = False
+    await mgr.update()
+    assert mgr.level == DegradationLevel.PARTIAL
+
+    db.ok = False
+    await mgr.update()
+    assert mgr.level == DegradationLevel.MINIMAL
+
+    redis.ok = False
+    monkeypatch.setattr("psutil.cpu_percent", lambda interval=None: 96)
+    await mgr.update()
+    assert mgr.level == DegradationLevel.STATIC
+
+
+def make_app(fake_redis):
+    db = FakeDB()
+    app = create_app(redis_client=fake_redis, database=db, dag_client=DummyDag())
+    async def nop():
+        return None
+
+    app.state.degradation.start = nop
+    app.state.degradation.stop = nop
+    return app
+
+
+def test_status_includes_level(fake_redis):
+    app = make_app(fake_redis)
+    with TestClient(app) as client:
+        resp = client.get("/status")
+        assert resp.status_code == 200
+        assert resp.json()["degrade_level"] == "NORMAL"
+
+
+def test_minimal_blocks_submission(fake_redis):
+    app = make_app(fake_redis)
+    app.state.degradation.level = DegradationLevel.MINIMAL
+    payload = StrategySubmit(
+        dag_json="{}",
+        meta=None,
+        run_type="dry-run",
+        node_ids_crc32=crc32_of_list([]),
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/strategies", json=payload.model_dump())
+        assert resp.status_code == 503
+
+
+def test_static_returns_204(fake_redis):
+    app = make_app(fake_redis)
+    app.state.degradation.level = DegradationLevel.STATIC
+    with TestClient(app) as client:
+        resp = client.get("/status")
+        assert resp.status_code == 204
+        assert resp.headers.get("Retry-After") == "30"


### PR DESCRIPTION
## Summary
- add DegradationManager to monitor dependencies and CPU load
- expose degradation level in gateway status endpoint
- update metrics with a `degrade_level` gauge
- route behavior according to degradation level
- include unit tests for degradation states

## Testing
- `uv run -m pytest -W error` *(fails: Exception ignored in BaseEventLoop.__del__)*

------
https://chatgpt.com/codex/tasks/task_e_6879236596308329b152b75b70816f41