### PR TITLE
Fix breaker hook metrics

### DIFF
--- a/qmtl/dagmanager/kafka_admin.py
+++ b/qmtl/dagmanager/kafka_admin.py
@@ -69,10 +69,15 @@ class KafkaAdmin:
     breaker: AsyncCircuitBreaker = field(default_factory=AsyncCircuitBreaker)
 
     def __post_init__(self) -> None:
-        # Track how often the circuit breaker opens
-        self.breaker._on_open = (
-            lambda: metrics.kafka_breaker_open_total.inc()
-        )
+        """Attach metric callbacks without overriding existing hooks."""
+        prev_on_open = self.breaker._on_open
+
+        def _on_open() -> None:
+            if prev_on_open is not None:
+                prev_on_open()
+            metrics.kafka_breaker_open_total.inc()
+
+        self.breaker._on_open = _on_open
 
     def create_topic_if_needed(self, name: str, config: TopicConfig) -> None:
         """Create topic idempotently using a circuit breaker."""

--- a/tests/dagmanager/test_circuit_breaker_kafka.py
+++ b/tests/dagmanager/test_circuit_breaker_kafka.py
@@ -59,6 +59,30 @@ async def test_circuit_breaker_opens_on_failures():
 
 
 @pytest.mark.asyncio
+async def test_custom_on_open_preserved():
+    triggered = False
+
+    def custom_hook() -> None:
+        nonlocal triggered
+        triggered = True
+
+    breaker = AsyncCircuitBreaker(
+        max_failures=1,
+        reset_timeout=0.01,
+        on_open=custom_hook,
+    )
+    admin = KafkaAdmin(FailingAdmin(fail_times=1), breaker=breaker)
+    cfg = TopicConfig(1, 1, 1000)
+    metrics.reset_metrics()
+
+    with pytest.raises(RuntimeError):
+        await asyncio.to_thread(admin.create_topic_if_needed, "t", cfg)
+
+    assert triggered
+    assert metrics.kafka_breaker_open_total._value.get() == 1  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_topic_exists_does_not_trip_breaker():
     client = ExistsAdmin()
     admin = KafkaAdmin(client, breaker=AsyncCircuitBreaker(max_failures=1, reset_timeout=0.01))


### PR DESCRIPTION
## Summary
- keep existing callbacks when tracking Kafka admin circuit breaker events
- add regression test

## Testing
- `uv run -m pytest tests/dagmanager/test_circuit_breaker_kafka.py -W error`
- `uv run -m pytest -W error` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687926c506f883299e31b4a5ff53a436