### PR TITLE
docs: document strategy templates and init options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ uv pip install -e .[transforms]
 
 Create a new working directory with `qmtl init`. The command generates a
 project scaffold containing extension packages and a sample strategy.
-Use `--strategy` to select from the built-in templates:
+Use `--strategy` to select from the built-in templates, `--list-templates` to
+see the choices and `--with-sample-data` to copy an example OHLCV CSV and
+notebook:
 
 ```bash
 qmtl init --path my_qmtl_project
@@ -44,6 +46,8 @@ qmtl init --list-templates
 
 # create project with the branching template
 qmtl init --path my_qmtl_project --strategy branching
+# include sample data
+qmtl init --path my_qmtl_project --with-sample-data
 cd my_qmtl_project
 ```
 

--- a/docs/strategy_workflow.md
+++ b/docs/strategy_workflow.md
@@ -41,18 +41,25 @@ uv pip install -e .[generators,indicators,transforms]
 
 ## 1. Initialize a Project
 
-Create a dedicated directory for your strategy and generate the scaffold:
+Create a dedicated directory for your strategy and generate the scaffold. List
+available templates, then initialize the project with a chosen template and
+optional sample data:
 
 ```bash
-qmtl init --path my_qmtl_project
+qmtl init --list-templates
+qmtl init --path my_qmtl_project --strategy branching --with-sample-data
 cd my_qmtl_project
 ```
 
-The command copies a sample `strategy.py`, a `qmtl.yml` configuration and empty
-packages for `generators`, `indicators` and `transforms`. These folders let you
-extend the SDK by adding custom nodes. Because the extras were installed in the
-previous step, no additional `pip install` commands are required inside the
-project directory.
+`--strategy` selects from the built-in templates (see
+[templates.md](templates.md)). `--with-sample-data` copies an example OHLCV CSV
+and a notebook into the new project.
+
+The command also copies a sample `strategy.py`, a `qmtl.yml` configuration and
+empty packages for `generators`, `indicators` and `transforms`. These folders
+let you extend the SDK by adding custom nodes. Because the extras were
+installed in the previous step, no additional `pip install` commands are
+required inside the project directory.
 
 ## 2. Explore the Scaffold
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,24 +1,89 @@
 # Strategy Templates
 
-QMTL includes several starter strategies that can be copied when running `qmtl init`.
+QMTL ships with starter strategies that can be used when running `qmtl init`.
 List them with:
 
 ```bash
 qmtl init --list-templates
 ```
 
-Available templates are:
+Add sample data and an analysis notebook with `--with-sample-data`:
 
-- **general** – basic example used by default
-- **single_indicator** – single EMA indicator
-- **multi_indicator** – multiple indicators on one stream
-- **branching** – two computation branches from the same input
-- **state_machine** – maintains a simple trend state
+```bash
+qmtl init --path my_proj --with-sample-data
+```
 
-Each template is implemented in `qmtl/examples/templates/` and ends with a short
-`Runner` invocation so you can execute the file directly. Choose a template
-with the `--strategy` option when initializing your project:
+Choose a template using the `--strategy` option. Each template below shows the
+node flow and offers quick usage notes.
+
+## general
+
+```mermaid
+graph LR
+    price-->momentum_signal
+```
+
+*Basic example used by default.* Demonstrates a minimal momentum signal
+calculation and serves as a starting point for new projects.
+
+```bash
+qmtl init --path my_proj --strategy general
+```
+
+## single_indicator
+
+```mermaid
+graph LR
+    price-->ema
+```
+
+*Single EMA indicator.* Shows how to attach one indicator to a price stream.
+
+```bash
+qmtl init --path my_proj --strategy single_indicator
+```
+
+## multi_indicator
+
+```mermaid
+graph LR
+    price-->fast_ema
+    price-->slow_ema
+    price-->rsi
+```
+
+*Multiple indicators from one stream.* Useful when comparing different
+indicators over the same data source.
+
+```bash
+qmtl init --path my_proj --strategy multi_indicator
+```
+
+## branching
+
+```mermaid
+graph LR
+    price-->momentum
+    price-->volatility
+```
+
+*Two computation branches from one input.* Demonstrates branching logic within a
+strategy.
 
 ```bash
 qmtl init --path my_proj --strategy branching
+```
+
+## state_machine
+
+```mermaid
+graph LR
+    price-->trend_state
+```
+
+*Keeps track of trend direction between runs.* Shows how to maintain simple
+state inside a strategy.
+
+```bash
+qmtl init --path my_proj --strategy state_machine
 ```

--- a/qmtl/cli.py
+++ b/qmtl/cli.py
@@ -11,24 +11,27 @@ def main(argv: List[str] | None = None) -> None:
     sub.add_parser("dagm", help="Dag manager admin CLI", add_help=False)
     sub.add_parser("dagmgr-server", help="Run DAG manager servers", add_help=False)
     sub.add_parser("sdk", help="Run strategy via SDK", add_help=False)
-    p_init = sub.add_parser("init", help="Initialize new project")
+    p_init = sub.add_parser(
+        "init",
+        help="Initialize new project (see docs/strategy_workflow.md)",
+    )
     p_init.add_argument(
         "--path", required=True, help="Project directory to create scaffolding"
     )
     p_init.add_argument(
         "--strategy",
         default="general",
-        help="Strategy template to use",
+        help="Strategy template to use (see docs/templates.md)",
     )
     p_init.add_argument(
         "--list-templates",
         action="store_true",
-        help="List available templates and exit",
+        help="List available templates and exit (see docs/templates.md)",
     )
     p_init.add_argument(
         "--with-sample-data",
         action="store_true",
-        help="Include sample OHLCV CSV in project",
+        help="Include sample OHLCV CSV and notebook (see docs/strategy_workflow.md)",
     )
 
     args, rest = parser.parse_known_args(argv)

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -26,3 +26,13 @@ def test_cli_list_templates(capsys):
     out = capsys.readouterr().out.strip().splitlines()
     assert "branching" in out
     assert "general" in out
+
+
+def test_cli_help_contains_doc_links(capsys):
+    try:
+        qmtl.cli.main(["init", "--help"])
+    except SystemExit:
+        pass
+    out = capsys.readouterr().out
+    assert "docs/templates.md" in out
+    assert "docs/strategy_workflow.md" in out


### PR DESCRIPTION
## Summary
- explain strategy templates with diagrams and usage examples
- document `--strategy`, `--list-templates`, and `--with-sample-data` in README and workflow guide
- link CLI `qmtl init` help text to relevant docs and test help output

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_688fc94fff208329886675bf53324dae