### PR TITLE
Simplify alert rules and document monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Run all unit and integration tests with:
 uv run -- pytest
 ```
 
+## Monitoring
+
+Load the sample alert definitions from `alert_rules.yml` into Prometheus to enable basic monitoring. For a full list of available alerts and Grafana dashboards, see [docs/monitoring.md](docs/monitoring.md).
+
 ## Running Services
 
 Start the Gateway and DAG manager using the combined configuration file or rely

--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -1,75 +1,29 @@
-# Example Alertmanager configuration for QMTL metrics
----
-route:
-  group_by: ['job']
-  receiver: 'slack'
-  routes:
-    - match:
-        severity: 'critical'
-      receiver: 'pagerduty'
+# Basic Alertmanager and Prometheus rules for QMTL metrics
+# For a complete list of suggested alerts see docs/monitoring.md
+alertmanager:
+  route:
+    receiver: 'slack'
+  receivers:
+    - name: 'slack'
+      slack_configs:
+        - channel: '#alerts'
+          send_resolved: true
 
-receivers:
-  - name: 'pagerduty'
-    pagerduty_configs:
-      - routing_key: 'dummy'
-  - name: 'slack'
-    slack_configs:
-      - channel: '#alerts'
-        send_resolved: true
-
----
- groups:
-   - name: qmtl
-     rules:
-      - alert: DiffDurationHigh
-        expr: diff_duration_ms_p95 > 200
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: Diff processing slow
-      - alert: NodeCacheMemoryHigh
-        expr: nodecache_resident_bytes > 5e9
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: NodeCache memory usage high
-      - alert: QueueCreateErrors
-         expr: queue_create_error_total > 0
-         for: 15m
-         labels:
-           severity: critical
-         annotations:
-           summary: Queue creation failures detected
-       - alert: SentinelGap
-         expr: sentinel_gap_count >= 1
-         labels:
-           severity: warning
-         annotations:
-           summary: Missing diff sentinel detected
-      - alert: OrphanQueuesGrowing
-        expr: increase(orphan_queue_total[3h]) > 0
-        labels:
-          severity: warning
-        annotations:
-          summary: Orphan queue count rising
-      - alert: GatewayLatencyHigh
-        expr: gateway_e2e_latency_p95 > 150
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: Gateway end-to-end latency high
-      - alert: LostRequests
-        expr: increase(lost_requests_total[1m]) > 0
-        labels:
-          severity: critical
-        annotations:
-          summary: Diff submissions lost
-      - alert: GCSchedulerStall
-        expr: time() - gc_last_run_timestamp > 600
-        labels:
-          severity: warning
-        annotations:
-          summary: Garbage collector has not run for 10 minutes
+prometheus:
+  groups:
+    - name: qmtl
+      rules:
+        - alert: DiffDurationHigh
+          expr: diff_duration_ms_p95 > 200
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Diff processing slow
+        - alert: NodeCacheMemoryHigh
+          expr: nodecache_resident_bytes > 5e9
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: NodeCache memory usage high

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -4,7 +4,20 @@ This document outlines sample Prometheus alerts and Grafana dashboards for QMTL 
 
 ## Alert Rules
 
-Prometheus can load `alert_rules.yml` to activate alerts for the DAG manager and gateway. Additional rules have been added for garbage collection. The file can be mounted into the Prometheus container via its configuration.
+Prometheus can load `alert_rules.yml` to activate alerts for the DAG manager and gateway. The repository ships a minimal example with a couple of core alerts. Mount the file into your Prometheus container and expand it as needed.
+
+### Additional Alert Reference
+
+The following alerts are available for inspiration when extending `alert_rules.yml`:
+
+- **DiffDurationHigh** – triggers when `diff_duration_ms_p95` exceeds 200 ms.
+- **NodeCacheMemoryHigh** – warns if `nodecache_resident_bytes` surpasses 5 GB.
+- **QueueCreateErrors** – fires when `queue_create_error_total` increases.
+- **SentinelGap** – indicates a missing diff sentinel via `sentinel_gap_count`.
+- **OrphanQueuesGrowing** – detects rises in `orphan_queue_total` over a three-hour window.
+- **GatewayLatencyHigh** – alerts when `gateway_e2e_latency_p95` exceeds 150 ms.
+- **LostRequests** – reports lost diff submissions based on `lost_requests_total`.
+- **GCSchedulerStall** – warns if `gc_last_run_timestamp` lags by more than ten minutes.
 
 ## Grafana Dashboards
 


### PR DESCRIPTION
## Summary
- condense Alertmanager and Prometheus rules into single minimal `alert_rules.yml`
- document full alert catalog in `docs/monitoring.md`
- mention sample monitoring files in README

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_689027e94b888329972237d02a4aa09f