### PR TITLE
chore: centralize pytest configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Here’s a short workflow summary based on the repository’s guidelines:
 2. **Testing** – Run the tests via `uv` before committing:
 
    ```bash
-   uv run -- pytest
+   uv run -m pytest
    ```
 
    Commit only after tests pass.
@@ -118,7 +118,7 @@ docker compose -f tests/docker-compose.e2e.yml up -d
 Run the tests using uv:
 
 ```bash
-uv run -- pytest tests/e2e
+uv run -m pytest tests/e2e
 ```
 
 See [docs/e2e_testing.md](docs/e2e_testing.md) for the full guide.
@@ -128,7 +128,7 @@ See [docs/e2e_testing.md](docs/e2e_testing.md) for the full guide.
 Run all unit and integration tests with:
 
 ```bash
-uv run -- pytest
+uv run -m pytest
 ```
 
 ## Running Services

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -33,13 +33,13 @@ This launches Redis, Postgres, Neo4j, Kafka, Zookeeper and the `qmtl gw` and `qm
 Execute the end-to-end tests within the uv environment:
 
 ```bash
-uv run -- pytest tests/e2e
+uv run -m pytest tests/e2e
 ```
 
 To execute the entire test suite run:
 
 ```bash
-uv run pytest -q tests
+uv run -m pytest -q tests
 ```
 
 ## Backfills

--- a/docs/strategy_workflow.md
+++ b/docs/strategy_workflow.md
@@ -170,7 +170,7 @@ End‑to‑end tests require Docker. Start the stack and execute the tests:
 
 ```bash
 docker compose -f tests/docker-compose.e2e.yml up -d
-uv run -- pytest tests/e2e
+uv run -m pytest tests/e2e
 ```
 
 For details on the test environment refer to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,8 @@ include = ["qmtl*"]
 "qmtl.examples" = [
     "*.py",
     "*.yml",
-    "README.md",
-    "data/*.csv",
-    "*.csv",
-    "notebooks/*.ipynb",
+"README.md",
+"data/*.csv",
+"*.csv",
+"notebooks/*.ipynb",
 ]
-
-[tool.pytest.ini_options]
-addopts = "-p pytest_asyncio"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -p pytest_asyncio


### PR DESCRIPTION
## Summary
- remove legacy `pytest.ini`
- drop `pytest_asyncio` addopts from `pyproject.toml`
- document running tests via `uv run -m pytest`

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_689027bf30cc83298c8e8ead259315cc