### PR TITLE
feat: auto-detect config in CLIs

### DIFF
--- a/qmtl/config.py
+++ b/qmtl/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 import yaml
 
 from .gateway.config import GatewayConfig
@@ -13,6 +14,17 @@ class UnifiedConfig:
 
     gateway: GatewayConfig = field(default_factory=GatewayConfig)
     dagmanager: DagManagerConfig = field(default_factory=DagManagerConfig)
+
+
+def find_config_file(cwd: Path | None = None) -> str | None:
+    """Return path to ``qmtl.yml``/``qmtl.yaml`` in ``cwd`` if present."""
+
+    base = Path.cwd() if cwd is None else cwd
+    for name in ("qmtl.yml", "qmtl.yaml"):
+        candidate = base / name
+        if candidate.is_file():
+            return str(candidate)
+    return None
 
 
 def load_config(path: str) -> UnifiedConfig:

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 import argparse
 import asyncio
 from dataclasses import dataclass
@@ -11,7 +10,7 @@ import uvicorn
 
 from .grpc_server import serve
 from .config import DagManagerConfig
-from ..config import load_config
+from ..config import load_config, find_config_file
 from .api import create_app
 from .gc import GarbageCollector, QueueInfo, MetricsProvider, QueueStore
 from .diff_service import StreamSender
@@ -123,9 +122,10 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--config", help="Path to configuration file")
     args = parser.parse_args(argv)
 
+    cfg_path = args.config or find_config_file()
     cfg = DagManagerConfig()
-    if args.config:
-        cfg = load_config(args.config).dagmanager
+    if cfg_path:
+        cfg = load_config(cfg_path).dagmanager
 
     asyncio.run(_run(cfg))
 

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -9,7 +9,7 @@ from .redis_client import InMemoryRedis
 
 from .api import create_app
 from .config import GatewayConfig
-from ..config import load_config
+from ..config import load_config, find_config_file
 
 
 async def _main(argv: list[str] | None = None) -> None:
@@ -18,9 +18,10 @@ async def _main(argv: list[str] | None = None) -> None:
     parser.add_argument("--config", help="Path to configuration file")
     args = parser.parse_args(argv)
 
+    cfg_path = args.config or find_config_file()
     config = GatewayConfig()
-    if args.config:
-        config = load_config(args.config).gateway
+    if cfg_path:
+        config = load_config(cfg_path).gateway
 
     if config.queue_backend == "memory":
         redis_client = InMemoryRedis()

--- a/tests/test_gateway_cli.py
+++ b/tests/test_gateway_cli.py
@@ -9,7 +9,7 @@ def test_gateway_cli_help():
 
 
 def test_gateway_cli_config_file(monkeypatch, tmp_path):
-    config_path = tmp_path / "cfg.yml"
+    config_path = tmp_path / "qmtl.yml"
     config_path.write_text(
         "\n".join(
             [
@@ -45,8 +45,9 @@ def test_gateway_cli_config_file(monkeypatch, tmp_path):
 
     fake_uvicorn = SimpleNamespace(run=lambda app, host, port: captured.update({"host": host, "port": port}))
     monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.chdir(tmp_path)
 
-    cli.main(["--config", str(config_path)])
+    cli.main([])
 
     assert captured["host"] == "127.0.0.1"
     assert captured["port"] == 12345
@@ -56,7 +57,7 @@ def test_gateway_cli_config_file(monkeypatch, tmp_path):
 
 
 def test_gateway_cli_redis_backend(monkeypatch, tmp_path):
-    config_path = tmp_path / "cfg.yml"
+    config_path = tmp_path / "qmtl.yml"
     config_path.write_text(
         "\n".join(
             [
@@ -91,8 +92,9 @@ def test_gateway_cli_redis_backend(monkeypatch, tmp_path):
     monkeypatch.setattr(cli.redis, "from_url", fake_from_url)
     monkeypatch.setattr(cli, "create_app", fake_create_app)
     monkeypatch.setitem(sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None))
+    monkeypatch.chdir(tmp_path)
 
-    cli.main(["--config", str(config_path)])
+    cli.main([])
 
     assert isinstance(captured["redis"], DummyRedis)
     assert captured["dsn"] == "redis://x:6379"

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -11,7 +11,7 @@ def test_server_help(capsys):
     assert "--config" in out
 
 
-def test_server_defaults(monkeypatch):
+def test_server_defaults(monkeypatch, tmp_path):
     captured = {}
 
     async def fake_run(config):
@@ -19,13 +19,14 @@ def test_server_defaults(monkeypatch):
         captured["queue"] = config.queue_backend
 
     monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
+    monkeypatch.chdir(tmp_path)
     main([])
     assert captured["repo"] == "memory"
     assert captured["queue"] == "memory"
 
 
 def test_server_config_file(monkeypatch, tmp_path):
-    config_path = tmp_path / "cfg.yml"
+    config_path = tmp_path / "qmtl.yml"
     config_path.write_text(
         yaml.safe_dump({"dagmanager": {"neo4j_dsn": "bolt://test:7687"}})
     )
@@ -36,5 +37,6 @@ def test_server_config_file(monkeypatch, tmp_path):
         captured["uri"] = config.neo4j_dsn
 
     monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
-    main(["--config", str(config_path)])
+    monkeypatch.chdir(tmp_path)
+    main([])
     assert captured["uri"] == "bolt://test:7687"


### PR DESCRIPTION
## Summary
- allow gateway and dagmanager CLIs to auto-detect qmtl.yml configuration
- reuse auto-detected config in dag manager server
- verify default config discovery in CLI tests

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_689027c8455483299f93ee0387a5b836