### PR TITLE
chore: remove unused extras and tidy dev deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,12 @@ uv pip install -e .[dev]
 ```
 
 These commands match the steps in the SDK tutorial
-([docs/sdk_tutorial.md](docs/sdk_tutorial.md)) lines 5&ndash;18, where optional
-extras are also documented:
+([docs/sdk_tutorial.md](docs/sdk_tutorial.md)).
+
+Install the `io` extra if you need additional data modules:
 
 ```bash
-uv pip install -e .[indicators]
 uv pip install -e .[io]
-uv pip install -e .[generators]
-uv pip install -e .[transforms]
 ```
 
 ## Project Initialization
@@ -50,12 +48,7 @@ cd my_qmtl_project
 See [docs/templates.md](docs/templates.md) for a description of each template.
 
 The scaffold includes empty `generators/`, `indicators/` and
-`transforms/` packages. Install their optional extras so Python can
-discover your extensions:
-
-```bash
-uv pip install -e .[generators,indicators,transforms]
-```
+`transforms/` packages for adding your own extensions.
 
 Run the default strategy to verify everything is set up correctly:
 
@@ -98,13 +91,12 @@ Use consistent naming for connection strings across the project. Prefer the `*_d
 
 ## Optional Modules
 
-Install additional functionality on demand. Each entry links to its
-documentation and shows the corresponding extra:
+Install additional functionality on demand:
 
-- [Indicators](qmtl/indicators/README.md) &mdash; `pip install qmtl[indicators]`
+- [Indicators](qmtl/indicators/README.md)
 - [IO](qmtl/io) &mdash; `pip install qmtl[io]`
-- [Generators](qmtl/generators/README.md) &mdash; `pip install qmtl[generators]`
-- [Transforms](qmtl/transforms/README.md) &mdash; `pip install qmtl[transforms]`
+- [Generators](qmtl/generators/README.md)
+- [Transforms](qmtl/transforms/README.md)
 
 
 ## End-to-End Testing

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -9,12 +9,10 @@ uv venv
 uv pip install -e .[dev]
 ```
 
-필요에 따라 선택적 확장 패키지를 설치할 수 있습니다.
+필요에 따라 데이터 IO 모듈을 설치할 수 있습니다.
 
 ```bash
-uv pip install -e .[indicators]  # 기술 지표 노드 모음
-uv pip install -e .[io]         # 데이터 IO 모듈
-uv pip install -e .[generators]  # 시뮬레이션 데이터 생성기
+uv pip install -e .[io]  # 데이터 IO 모듈
 ```
 
 ## 기본 구조

--- a/docs/strategy_workflow.md
+++ b/docs/strategy_workflow.md
@@ -29,16 +29,6 @@ uv venv
 uv pip install -e .[dev]
 ```
 
-Optional extras such as `generators`, `indicators` or `transforms` are installed
-from the repository root (or from PyPI) **before** creating your project
-directory:
-
-```bash
-uv pip install -e .[generators,indicators,transforms]
-```
-
-> **Tip:** 프로젝트 scaffold 내부에서 extras를 설치하면 오류가 발생합니다. 반드시 저장소 루트에서 설치하세요.
-
 ## 1. Initialize a Project
 
 Create a dedicated directory for your strategy and generate the scaffold:
@@ -50,9 +40,7 @@ cd my_qmtl_project
 
 The command copies a sample `strategy.py`, a `qmtl.yml` configuration and empty
 packages for `generators`, `indicators` and `transforms`. These folders let you
-extend the SDK by adding custom nodes. Because the extras were installed in the
-previous step, no additional `pip install` commands are required inside the
-project directory.
+extend the SDK by adding custom nodes.
 
 ## 2. Explore the Scaffold
 
@@ -88,18 +76,7 @@ transforms
 ...
 ```
 
-Attempting to install the optional extras directly fails because the scaffold does not contain
-`pyproject.toml`:
-
-```text
-$ uv pip install -e .[generators,indicators,transforms]
-error: /tmp/my_qmtl_project does not appear to be a Python project, as neither `pyproject.toml` nor `setup.py` are present in the directory
-```
-
-Run the command from the repository root instead (or install from PyPI) to make
-the extras available.
-
-Running the default strategy without a Gateway URL also produces an error:
+Running the default strategy without a Gateway URL produces an error:
 
 ```text
 $ python strategy.py
@@ -109,7 +86,6 @@ RuntimeError: gateway_url is required for backtest mode
 Provide a `--gateway-url` argument or modify the script to use `Runner.offline()` when running locally.
 
 > **자주 발생하는 문제**
-> - `pyproject.toml` 없음: scaffold 내부가 아닌 저장소 루트에서 extras 설치 필요
 > - Gateway URL 미지정: `--gateway-url` 인자 추가 또는 `Runner.offline()` 사용
 > - 의존성 충돌: `uv pip install -e .[dev]`로 재설치 권장
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,33 +21,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-
 dev = [
     "pytest",
     "pytest-asyncio",
-    "httpx",
-    "fastapi",
-    "uvicorn",
     "fakeredis",
-    "asyncpg",
-    "aiosqlite",
-    "xstate",
-    "websockets",
-    "redis",
-    "fakeredis",
-    "grpcio",
-    "PyYAML",
     "grpcio-tools",
-    "pytest-asyncio",
-    "xstate",
     "pyarrow",
+    "xstate",
 ]
 
 ray = ["ray"]
 io = ["pandas", "asyncpg"]
-indicators = []
-generators = []
-transforms = []
 
 [project.scripts]
 qmtl = "qmtl.cli:main"

--- a/qmtl/generators/README.md
+++ b/qmtl/generators/README.md
@@ -5,11 +5,7 @@ Synthetic data generators that extend `qmtl.sdk`.
 - Keep each generator self-contained in line with the Single Responsibility Principle.
 - All generators must have accompanying tests under `tests/`.
 
-Install the extension:
-
-```bash
-pip install qmtl[generators]
-```
+Generators are included with the main package and require no extra installation.
 
 Usage example:
 

--- a/qmtl/indicators/README.md
+++ b/qmtl/indicators/README.md
@@ -5,11 +5,7 @@ Common technical indicator nodes for the QMTL SDK.
 - Modules observe the Single Responsibility Principle and keep dependencies minimal.
 - When adding new indicators, include unit tests under `tests/`.
 
-Install only when needed:
-
-```bash
-pip install qmtl[indicators]
-```
+The indicators module ships with the core package; no extra install is required.
 
 Use with:
 

--- a/qmtl/transforms/README.md
+++ b/qmtl/transforms/README.md
@@ -5,11 +5,7 @@ Derived transformation nodes for the QMTL SDK.
 - Each transform stays focused on a single calculation.
 - Add tests for new transforms under `tests/`.
 
-Install with:
-
-```bash
-pip install qmtl[transforms]
-```
+Transforms ship with the core package and do not require a separate install.
 
 Example:
 


### PR DESCRIPTION
## Summary
- streamline `[project.optional-dependencies].dev` to the minimal set and drop unused extras
- document that indicators, generators, and transforms ship with the core package
- update installation instructions and strategy workflow guide accordingly

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_689027c608108329aaf41db2ef617bda