### PR TITLE
Simplify DAG manager CLI configuration

### DIFF
--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -20,7 +20,6 @@ from .topic import topic_name
 from .neo4j_export import export_schema, connect
 from ..gateway.dagmanager_client import DagManagerClient
 from ..proto import dagmanager_pb2, dagmanager_pb2_grpc
-from ..config import load_config, find_config_file
 
 
 class _MemRepo(NodeRepository):
@@ -132,8 +131,7 @@ def _cmd_export_schema(args: argparse.Namespace) -> None:
 
 async def _main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="qmtl dagm")
-    parser.add_argument("--config", help="Path to configuration file")
-    parser.add_argument("--target", help="gRPC service target")
+    parser.add_argument("--target", help="gRPC service target", default="localhost:50051")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p_diff = sub.add_parser("diff", help="Run diff")
@@ -158,13 +156,6 @@ async def _main(argv: list[str] | None = None) -> None:
     p_exp.add_argument("--out")
 
     args = parser.parse_args(argv)
-
-    cfg_path = args.config or find_config_file()
-    if cfg_path and args.target is None:
-        cfg = load_config(cfg_path).dagmanager
-        args.target = f"{cfg.grpc_host}:{cfg.grpc_port}"
-    if args.target is None:
-        args.target = "localhost:50051"
 
     if args.cmd == "diff":
         await _cmd_diff(args)

--- a/tests/test_dagm_cli.py
+++ b/tests/test_dagm_cli.py
@@ -1,5 +1,4 @@
 import json
-import yaml
 from qmtl.dagmanager.cli import main
 from qmtl.proto import dagmanager_pb2, dagmanager_pb2_grpc
 import grpc
@@ -16,13 +15,7 @@ def test_cli_diff_dryrun(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "n1" in out
 
-def test_cli_queue_stats(monkeypatch, capsys, tmp_path):
-    config_path = tmp_path / "qmtl.yml"
-    config_path.write_text(
-        yaml.safe_dump({"dagmanager": {"grpc_host": "h", "grpc_port": 1234}})
-    )
-    monkeypatch.chdir(tmp_path)
-
+def test_cli_queue_stats(monkeypatch, capsys):
     class Stub:
         def __init__(self, channel):
             pass
@@ -40,7 +33,7 @@ def test_cli_queue_stats(monkeypatch, capsys, tmp_path):
     out = capsys.readouterr().out
     data = json.loads(out)
     assert data == {"q": 1}
-    assert captured["target"] == "h:1234"
+    assert captured["target"] == "localhost:50051"
 
 def test_cli_gc(monkeypatch, capsys):
     called = {}

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -1,43 +1,25 @@
-import yaml
-import pytest
-from pathlib import Path
-from qmtl.dagmanager.config import load_dagmanager_config, DagManagerConfig
+from qmtl.dagmanager.config import DagManagerConfig
 
 
-def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
-    data = {
-        "repo_backend": "neo4j",
-        "neo4j_dsn": "bolt://db:7687",
-        "neo4j_user": "neo4j",
-        "neo4j_password": "pw",
-        "queue_backend": "kafka",
-        "kafka_dsn": "localhost:9092",
-        "kafka_breaker_threshold": 5,
-        "kafka_breaker_timeout": 2.5,
-        "neo4j_breaker_threshold": 4,
-        "neo4j_breaker_timeout": 1.5,
-    }
-    config_file = tmp_path / "dm.yml"
-    config_file.write_text(yaml.safe_dump(data))
-    config = load_dagmanager_config(str(config_file))
-    assert config.neo4j_dsn == data["neo4j_dsn"]
-    assert config.kafka_dsn == data["kafka_dsn"]
-    assert config.kafka_breaker_threshold == 5
-    assert config.kafka_breaker_timeout == 2.5
-    assert config.neo4j_breaker_threshold == 4
-    assert config.neo4j_breaker_timeout == 1.5
-
-
-def test_load_dagmanager_config_missing_file():
-    with pytest.raises(FileNotFoundError):
-        load_dagmanager_config("nope.yml")
-
-
-def test_load_dagmanager_config_malformed(tmp_path: Path):
-    f = tmp_path / "bad.yml"
-    f.write_text("- 1")
-    with pytest.raises(TypeError):
-        load_dagmanager_config(str(f))
+def test_dagmanager_config_custom_values() -> None:
+    cfg = DagManagerConfig(
+        repo_backend="neo4j",
+        neo4j_dsn="bolt://db:7687",
+        neo4j_user="neo4j",
+        neo4j_password="pw",
+        queue_backend="kafka",
+        kafka_dsn="localhost:9092",
+        kafka_breaker_threshold=5,
+        kafka_breaker_timeout=2.5,
+        neo4j_breaker_threshold=4,
+        neo4j_breaker_timeout=1.5,
+    )
+    assert cfg.neo4j_dsn == "bolt://db:7687"
+    assert cfg.kafka_dsn == "localhost:9092"
+    assert cfg.kafka_breaker_threshold == 5
+    assert cfg.kafka_breaker_timeout == 2.5
+    assert cfg.neo4j_breaker_threshold == 4
+    assert cfg.neo4j_breaker_timeout == 1.5
 
 
 def test_dagmanager_config_defaults() -> None:


### PR DESCRIPTION
## Summary
- remove admin CLI config file handling and default to a localhost gRPC target
- drop YAML config usage from DAG manager CLI tests
- test DagManagerConfig directly without reading YAML files

## Testing
- `uv run -m pytest -W error tests/test_dagm_cli.py tests/test_dagmanager_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68902b0530b48329a73fcbc21278de6f