### PR TITLE
docs: clarify optional config usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,16 +143,20 @@ Load the sample alert definitions from `alert_rules.yml` into Prometheus to enab
 ## Running Services
 
 Start the Gateway and DAG manager using the combined configuration file or rely
-on the built-in defaults. Without ``--config`` both services start in a local
-mode that uses SQLite and in-memory repositories. The sample ``qmtl.yml`` file
+on the built-in defaults. The ``--config`` flag is optional; without it both
+services start in a local mode that uses SQLite and in-memory repositories. The
+sample ``qmtl.yml`` file
 demonstrates how to switch to Postgres, Neo4j and Kafka for production.
 
 ```bash
+# start the gateway HTTP server with defaults
+qmtl gw
 
-# start the gateway HTTP server
+# start the DAG manager with defaults
+qmtl dagmgr-server
+
+# use a custom configuration file
 qmtl gw --config qmtl/examples/qmtl.yml
-
-# start the DAG manager
 qmtl dagmgr-server --config qmtl/examples/qmtl.yml
 
 # submit a DAG diff

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -251,7 +251,7 @@ For canary deployment steps see
 ## 12. 서버 설정 파일 사용법
 
 `qmtl dagmgr-server` 서브커맨드는 YAML 형식의 설정 파일 하나만 받는다.
-아래 예시와 같이 모든 서버 옵션을 YAML에 작성하고 ``--config`` 로 경로를 지정한다.
+아래 예시와 같이 모든 서버 옵션을 YAML에 작성하고 필요하다면 ``--config`` 옵션으로 경로를 지정한다.
 
 예시:
 
@@ -269,13 +269,17 @@ repositories and queues for local development. Commented lines show the above
 cluster configuration ready to be enabled.
 
 ```
+# 기본값으로 실행
+qmtl dagmgr-server
+
+# YAML 설정 파일로 실행
 qmtl dagmgr-server --config qmtl/examples/qmtl.yml
 ```
 
 해당 명령은 `qmtl/examples/qmtl.yml` 의 ``dagmanager`` 섹션을 읽어 서버를 실행한다.
-``--config`` 를 생략하면 기본값으로 메모리 레포지토리와 큐가 사용된다. 샘플
+``--config`` 옵션을 생략하면 기본값으로 메모리 레포지토리와 큐가 사용된다. 샘플
 파일에는 모든 필드를 주석과 함께 설명한다.
 
 Available flags:
 
-- ``--config`` – path to configuration file.
+- ``--config`` – optional path to configuration file.

--- a/docs/strategy_workflow.md
+++ b/docs/strategy_workflow.md
@@ -120,9 +120,15 @@ python -m qmtl.sdk mypkg.strategy:MyStrategy --mode backtest \
 ```
 
 Available modes are `backtest`, `dryrun`, `live` and `offline`. The first three
-require a running Gateway and DAG manager. Start them in separate terminals:
+require a running Gateway and DAG manager. Start them in separate terminals. The
+``--config`` flag is optional:
 
 ```bash
+# start with built-in defaults
+qmtl gw
+qmtl dagmgr-server
+
+# or load a custom configuration
 qmtl gw --config qmtl/examples/qmtl.yml
 qmtl dagmgr-server --config qmtl/examples/qmtl.yml
 ```

--- a/gateway.md
+++ b/gateway.md
@@ -149,19 +149,24 @@ Gateway also listens for `sentinel_weight` CloudEvents emitted by DAG‑Manager.
 
 ### Gateway CLI Options
 
-Run the Gateway service using the combined configuration file:
+Run the Gateway service. The ``--config`` flag is optional:
 
 ```bash
+# start with built-in defaults
+qmtl gw
+
+# specify a configuration file
 qmtl gw --config qmtl/examples/qmtl.yml
 ```
 
-The command reads the ``gateway`` section of ``qmtl/examples/qmtl.yml`` for all
-server parameters. Omitting ``--config`` starts the service with built-in
-defaults that use SQLite and ``queue_backend: memory`` for an in-memory Redis
-replacement. Commented lines in the sample file illustrate how to set
-``queue_backend: redis`` and point ``redis_dsn`` to a real cluster. See the file
-for a fully annotated configuration template.
+When provided, the command reads the ``gateway`` section of
+``qmtl/examples/qmtl.yml`` for all server parameters. Omitting ``--config``
+starts the service with built-in defaults that use SQLite and
+``queue_backend: memory`` for an in-memory Redis replacement. Commented lines in
+the sample file illustrate how to set ``queue_backend: redis`` and point
+``redis_dsn`` to a real cluster. See the file for a fully annotated configuration
+template.
 
 Available flags:
 
-- ``--config`` – path to configuration file.
+- ``--config`` – optional path to configuration file.

--- a/qmtl/examples/README.md
+++ b/qmtl/examples/README.md
@@ -4,7 +4,16 @@
 각 예제는 `architecture.md` 문서의 설계를 따르며, 실전 전략 구현 시 참고용으로 활용할 수 있습니다.
 
 예시 Gateway와 DAG manager 설정은 `qmtl.yml`에 포함되어 있습니다. 환경에 맞게 수정한 뒤
-CLI 실행 시 `--config` 인자로 전달하세요.
+CLI 실행 시 필요하다면 `--config` 인자로 전달하세요. 이 옵션을 생략하면 기본 로컬
+설정이 사용됩니다.
+
+```bash
+# 기본값으로 실행
+qmtl gw
+
+# 설정 파일을 사용하는 경우
+qmtl gw --config qmtl/examples/qmtl.yml
+```
 
 ## 구조
 


### PR DESCRIPTION
## Summary
- document that `--config` is optional and show how to run Gateway and DAG manager with built-in defaults
- add no-config examples to strategy workflow and example docs

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_6890752454548329957bb67a05d98f84