### PR TITLE
chore: clean up io extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 ]
 
 ray = ["ray"]
-io = ["pandas", "asyncpg"]
+io = ["pandas"]
 
 [project.scripts]
 qmtl = "qmtl.cli:main"


### PR DESCRIPTION
## Summary
- remove asyncpg from optional `io` extra, keeping only pandas
- verified optional `ray` and `io` extras are still used by runner and I/O modules

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_6890751ffd7c832984d53afd7033eaa7