### PR TITLE
feat: configure backends via DSN presence

### DIFF
--- a/dag-manager.md
+++ b/dag-manager.md
@@ -256,17 +256,15 @@ For canary deployment steps see
 예시:
 
 ```yaml
-repo_backend: neo4j
 neo4j_dsn: bolt://db:7687
 neo4j_user: neo4j
 neo4j_password: secret
-queue_backend: kafka
 kafka_dsn: localhost:9092
 ```
 
 The sample file installed by ``qmtl init`` instead defaults to in-memory
-repositories and queues for local development. Commented lines show the above
-cluster configuration ready to be enabled.
+repositories and queues for local development. Uncommenting the DSN lines above
+enables Neo4j and Kafka integrations respectively.
 
 ```
 # 기본값으로 실행
@@ -277,8 +275,8 @@ qmtl dagmgr-server --config qmtl/examples/qmtl.yml
 ```
 
 해당 명령은 `qmtl/examples/qmtl.yml` 의 ``dagmanager`` 섹션을 읽어 서버를 실행한다.
-``--config`` 옵션을 생략하면 기본값으로 메모리 레포지토리와 큐가 사용된다. 샘플
-파일에는 모든 필드를 주석과 함께 설명한다.
+``--config`` 옵션을 생략하면 DSN이 제공되지 않으므로 메모리 레포지토리와 큐가
+사용된다. 샘플 파일에는 모든 필드를 주석과 함께 설명한다.
 
 Available flags:
 

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -9,14 +9,11 @@ import yaml
 @dataclass
 class DagManagerConfig:
     """Configuration for DAG manager server."""
-
-    repo_backend: str = "memory"
-    neo4j_dsn: str = "bolt://localhost:7687"
+    neo4j_dsn: Optional[str] = None
     neo4j_user: str = "neo4j"
     neo4j_password: str = "neo4j"
     memory_repo_path: str = "memrepo.gpickle"
-    queue_backend: str = "memory"
-    kafka_dsn: str = "localhost:9092"
+    kafka_dsn: Optional[str] = None
     kafka_breaker_threshold: int = 3
     kafka_breaker_timeout: float = 60.0
     neo4j_breaker_threshold: int = 3

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -59,18 +59,19 @@ async def _run(cfg: DagManagerConfig) -> None:
     admin_client = None
     queue = None
 
-    if cfg.repo_backend == "neo4j":
+    if cfg.neo4j_dsn:
         from neo4j import GraphDatabase  # pragma: no cover - external dependency
 
         driver = GraphDatabase.driver(
             cfg.neo4j_dsn, auth=(cfg.neo4j_user, cfg.neo4j_password)
         )
         repo = None
-    elif cfg.repo_backend == "memory":
+    else:
         from .node_repository import MemoryNodeRepository
 
         repo = MemoryNodeRepository(cfg.memory_repo_path)
-    if cfg.queue_backend == "kafka":
+
+    if cfg.kafka_dsn:
         from .kafka_admin import KafkaAdmin
         from .diff_service import KafkaQueueManager
 
@@ -80,7 +81,7 @@ async def _run(cfg: DagManagerConfig) -> None:
             reset_timeout=cfg.kafka_breaker_timeout,
         )
         queue = KafkaQueueManager(KafkaAdmin(admin_client, breaker=breaker))
-    elif cfg.queue_backend == "memory":
+    else:
         from .kafka_admin import InMemoryAdminClient, KafkaAdmin
         from .diff_service import KafkaQueueManager
 

--- a/qmtl/examples/qmtl.yml
+++ b/qmtl/examples/qmtl.yml
@@ -11,15 +11,11 @@ gateway:
   # database_dsn: postgresql://user:pass@db/qmtl
 
 dagmanager:
-  repo_backend: memory
   memory_repo_path: memrepo.gpickle
-  queue_backend: memory
   # Example cluster configuration using Neo4j and Kafka
-  # repo_backend: neo4j
   # neo4j_dsn: bolt://localhost:7687
   # neo4j_user: neo4j
   # neo4j_password: neo4j
-  # queue_backend: kafka
   # kafka_dsn: localhost:9092
   grpc_host: 0.0.0.0
   grpc_port: 50051

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -3,11 +3,9 @@ from qmtl.dagmanager.config import DagManagerConfig
 
 def test_dagmanager_config_custom_values() -> None:
     cfg = DagManagerConfig(
-        repo_backend="neo4j",
         neo4j_dsn="bolt://db:7687",
         neo4j_user="neo4j",
         neo4j_password="pw",
-        queue_backend="kafka",
         kafka_dsn="localhost:9092",
         kafka_breaker_threshold=5,
         kafka_breaker_timeout=2.5,
@@ -24,8 +22,8 @@ def test_dagmanager_config_custom_values() -> None:
 
 def test_dagmanager_config_defaults() -> None:
     cfg = DagManagerConfig()
-    assert cfg.repo_backend == "memory"
-    assert cfg.queue_backend == "memory"
+    assert cfg.neo4j_dsn is None
+    assert cfg.kafka_dsn is None
     assert cfg.kafka_breaker_threshold == 3
     assert cfg.kafka_breaker_timeout == 60.0
     assert cfg.neo4j_breaker_threshold == 3

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -15,14 +15,14 @@ def test_server_defaults(monkeypatch, tmp_path):
     captured = {}
 
     async def fake_run(config):
-        captured["repo"] = config.repo_backend
-        captured["queue"] = config.queue_backend
+        captured["neo4j"] = config.neo4j_dsn
+        captured["kafka"] = config.kafka_dsn
 
     monkeypatch.setattr("qmtl.dagmanager.server._run", fake_run)
     monkeypatch.chdir(tmp_path)
     main([])
-    assert captured["repo"] == "memory"
-    assert captured["queue"] == "memory"
+    assert captured["neo4j"] is None
+    assert captured["kafka"] is None
 
 
 def test_server_config_file(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- simplify DAG manager config: drop backend fields and switch to DSN-based selection
- infer Neo4j and Kafka use in server via DSN presence
- update docs, examples, and tests for new config flow

## Testing
- `uv run -m pytest -W error tests/test_dagmanager_config.py tests/test_server_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68907c2370788329aa424cb03e13af24