### PR TITLE
refactor: simplify gateway redis configuration

### DIFF
--- a/qmtl/examples/qmtl.yml
+++ b/qmtl/examples/qmtl.yml
@@ -5,7 +5,6 @@ gateway:
   # Lightweight local store for quick testing
   database_backend: sqlite
   database_dsn: ./qmtl.db
-  queue_backend: memory
   # To use Postgres in a production cluster uncomment below
   # database_backend: postgres
   # database_dsn: postgresql://user:pass@db/qmtl

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -23,10 +23,10 @@ async def _main(argv: list[str] | None = None) -> None:
     if cfg_path:
         config = load_config(cfg_path).gateway
 
-    if config.queue_backend == "memory":
-        redis_client = InMemoryRedis()
-    else:
+    if config.redis_dsn:
         redis_client = redis.from_url(config.redis_dsn, decode_responses=True)
+    else:
+        redis_client = InMemoryRedis()
     app = create_app(
         redis_client=redis_client,
         database_backend=config.database_backend,

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any
+from typing import Optional
 
 import yaml
 
@@ -11,10 +11,9 @@ class GatewayConfig:
 
     host: str = "0.0.0.0"
     port: int = 8000
-    redis_dsn: str = "redis://localhost:6379"
+    redis_dsn: Optional[str] = None
     database_backend: str = "sqlite"
     database_dsn: str = "./qmtl.db"
-    queue_backend: str = "memory"
     dagclient_breaker_threshold: int = 3
     dagclient_breaker_timeout: float = 60.0
 
@@ -26,6 +25,4 @@ def load_gateway_config(path: str) -> GatewayConfig:
     if not isinstance(data, dict):
         raise TypeError("Gateway config must be a mapping")
     cfg = GatewayConfig(**data)
-    if cfg.queue_backend not in {"memory", "redis"}:
-        raise ValueError("queue_backend must be 'memory' or 'redis'")
     return cfg

--- a/qmtl/gateway/redis_client.py
+++ b/qmtl/gateway/redis_client.py
@@ -5,7 +5,7 @@ import asyncio
 
 
 class InMemoryRedis:
-    """Minimal in-memory Redis clone used when ``queue_backend`` is ``memory``."""
+    """Minimal in-memory Redis clone used when no ``redis_dsn`` is configured."""
 
     def __init__(self) -> None:
         self._values: Dict[str, Any] = {}

--- a/tests/test_gateway_cli.py
+++ b/tests/test_gateway_cli.py
@@ -18,7 +18,6 @@ def test_gateway_cli_config_file(monkeypatch, tmp_path):
                 "gateway:",
                 "  host: 127.0.0.1",
                 "  port: 12345",
-                "  queue_backend: memory",
                 "  database_backend: memory",
                 "  database_dsn: 'sqlite:///:memory:'",
             ]
@@ -66,7 +65,6 @@ def test_gateway_cli_redis_backend(monkeypatch, tmp_path):
                 "gateway:",
                 "  host: 127.0.0.1",
                 "  port: 12345",
-                "  queue_backend: redis",
                 "  redis_dsn: redis://x:6379",
                 "  database_backend: memory",
                 "  database_dsn: 'sqlite:///:memory:'",

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -11,7 +11,6 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
         "redis_dsn": "redis://test:6379",
         "database_backend": "postgres",
         "database_dsn": "postgresql://db/test",
-        "queue_backend": "memory",
         "dagclient_breaker_threshold": 5,
         "dagclient_breaker_timeout": 2.5,
     }
@@ -21,7 +20,6 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
     assert config.redis_dsn == data["redis_dsn"]
     assert config.database_backend == "postgres"
     assert config.database_dsn == data["database_dsn"]
-    assert config.queue_backend == "memory"
     assert config.dagclient_breaker_threshold == 5
     assert config.dagclient_breaker_timeout == 2.5
 
@@ -31,16 +29,15 @@ def test_load_gateway_config_json(tmp_path: Path) -> None:
         "redis_dsn": "redis://j:6379",
         "database_backend": "memory",
         "database_dsn": "sqlite:///:memory:",
-        "queue_backend": "redis",
         "dagclient_breaker_threshold": 4,
         "dagclient_breaker_timeout": 1.0,
     }
     config_file = tmp_path / "gw.json"
     config_file.write_text(json.dumps(data))
     config = load_gateway_config(str(config_file))
+    assert config.redis_dsn == data["redis_dsn"]
     assert config.database_backend == "memory"
     assert config.database_dsn == data["database_dsn"]
-    assert config.queue_backend == "redis"
     assert config.dagclient_breaker_threshold == 4
     assert config.dagclient_breaker_timeout == 1.0
 
@@ -59,8 +56,8 @@ def test_load_gateway_config_malformed(tmp_path: Path):
 
 def test_gateway_config_defaults() -> None:
     cfg = GatewayConfig()
+    assert cfg.redis_dsn is None
     assert cfg.database_backend == "sqlite"
     assert cfg.database_dsn == "./qmtl.db"
-    assert cfg.queue_backend == "memory"
     assert cfg.dagclient_breaker_threshold == 3
     assert cfg.dagclient_breaker_timeout == 60.0

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -72,7 +72,7 @@ def test_load_unified_config_defaults(tmp_path: Path) -> None:
     config_file.write_text("{}")
     config = load_config(str(config_file))
     assert isinstance(config, UnifiedConfig)
-    assert config.gateway.redis_dsn == "redis://localhost:6379"
+    assert config.gateway.redis_dsn is None
     assert config.dagmanager.grpc_port == 50051
     assert config.gateway.dagclient_breaker_threshold == 3
     assert config.gateway.dagclient_breaker_timeout == 60.0


### PR DESCRIPTION
## Summary
- drop `queue_backend` from GatewayConfig and make `redis_dsn` optional
- use `redis_dsn` to choose between real Redis and `InMemoryRedis`
- align tests and sample config with new gateway behaviour

## Testing
- `uv run -m pytest tests/test_gateway_config.py tests/test_gateway_cli.py tests/test_unified_config.py -W error`
- `uv run -m pytest tests/test_server_cli.py tests/test_dagmanager_config.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_68907c22a7e883298a712bd7419650a3