### PR TITLE
Remove gateway circuit breaker options

### DIFF
--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import argparse
 import importlib
-import os
 
 import asyncio
 from typing import List
@@ -35,34 +34,10 @@ async def _main(argv: List[str] | None = None) -> None:
         action="store_true",
         help="Enable Ray-based execution of compute functions",
     )
-    parser.add_argument(
-        "--gateway-cb-max-failures",
-        type=int,
-        default=os.getenv("QMTL_GW_CB_MAX_FAILURES"),
-        help="Max failures before Gateway circuit opens",
-    )
-    parser.add_argument(
-        "--gateway-cb-reset-timeout",
-        type=float,
-        default=os.getenv("QMTL_GW_CB_RESET_TIMEOUT"),
-        help="Reset timeout for Gateway circuit breaker",
-    )
     args = parser.parse_args(argv)
 
     if args.with_ray:
         Runner.enable_ray()
-
-    if args.gateway_cb_max_failures is not None or args.gateway_cb_reset_timeout is not None:
-        mf = args.gateway_cb_max_failures
-        rt = args.gateway_cb_reset_timeout
-        if mf is None:
-            mf = 3
-        if rt is None:
-            rt = 60.0
-        from qmtl.common import AsyncCircuitBreaker
-        Runner.set_gateway_circuit_breaker(
-            AsyncCircuitBreaker(max_failures=int(mf), reset_timeout=float(rt))
-        )
 
     module_name, class_name = args.strategy.split(":")
     module = importlib.import_module(module_name)

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -4,7 +4,6 @@ import base64
 import json
 import asyncio
 import time
-import os
 from typing import Optional, Iterable
 import logging
 import httpx
@@ -53,15 +52,9 @@ class Runner:
         cls._gateway_cb = cb
 
     @classmethod
-    def _get_gateway_circuit_breaker(cls) -> AsyncCircuitBreaker | None:
+    def _get_gateway_circuit_breaker(cls) -> AsyncCircuitBreaker:
         if cls._gateway_cb is None:
-            max_failures = os.getenv("QMTL_GW_CB_MAX_FAILURES")
-            reset_timeout = os.getenv("QMTL_GW_CB_RESET_TIMEOUT")
-            if max_failures or reset_timeout:
-                cls._gateway_cb = AsyncCircuitBreaker(
-                    max_failures=int(max_failures or 3),
-                    reset_timeout=float(reset_timeout or 60.0),
-                )
+            cls._gateway_cb = AsyncCircuitBreaker(max_failures=3, reset_timeout=60.0)
         return cls._gateway_cb
 
     # ------------------------------------------------------------------

--- a/tests/sdk/test_circuit_breaker_runner.py
+++ b/tests/sdk/test_circuit_breaker_runner.py
@@ -41,23 +41,19 @@ async def test_post_gateway_circuit_breaker(monkeypatch):
             run_type="x",
             circuit_breaker=cb,
         )
-
-
-
 @pytest.mark.asyncio
-async def test_env_config(monkeypatch):
+async def test_default_circuit_breaker(monkeypatch):
     monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
-    monkeypatch.setenv("QMTL_GW_CB_MAX_FAILURES", "1")
-    monkeypatch.setenv("QMTL_GW_CB_RESET_TIMEOUT", "60")
     Runner.set_gateway_circuit_breaker(None)
 
-    with pytest.raises(httpx.RequestError):
-        await Runner._post_gateway_async(
-            gateway_url="http://gw",
-            dag={},
-            meta=None,
-            run_type="x",
-        )
+    for _ in range(3):
+        with pytest.raises(httpx.RequestError):
+            await Runner._post_gateway_async(
+                gateway_url="http://gw",
+                dag={},
+                meta=None,
+                run_type="x",
+            )
 
     with pytest.raises(RuntimeError):
         await Runner._post_gateway_async(


### PR DESCRIPTION
## Summary
- drop `--gateway-cb-max-failures` and `--gateway-cb-reset-timeout` from the SDK CLI
- always use a default AsyncCircuitBreaker in Runner regardless of environment variables
- adjust circuit breaker tests to match new defaults

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68907c2173148329bdb70f233bd97045