### PR TITLE
Rename rough Bergomi indicator

### DIFF
--- a/qmtl/indicators/__init__.py
+++ b/qmtl/indicators/__init__.py
@@ -14,7 +14,7 @@ from .obv import obv
 from .vwap import vwap
 from .anchored_vwap import anchored_vwap
 from .kalman_trend import kalman_trend
-from .rough_bergami import rough_bergami
+from .rough_bergomi import rough_bergomi
 from .stoch_rsi import stoch_rsi
 
 __all__ = [
@@ -32,6 +32,6 @@ __all__ = [
     "vwap",
     "anchored_vwap",
     "kalman_trend",
-    "rough_bergami",
+    "rough_bergomi",
     "stoch_rsi",
 ]

--- a/qmtl/indicators/rough_bergomi.py
+++ b/qmtl/indicators/rough_bergomi.py
@@ -5,7 +5,7 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def rough_bergami(source: Node, window: int, *, name: str | None = None) -> Node:
+def rough_bergomi(source: Node, window: int, *, name: str | None = None) -> Node:
     """Return a Node computing a simple rough volatility estimate."""
 
     def compute(view: CacheView):
@@ -22,7 +22,7 @@ def rough_bergami(source: Node, window: int, *, name: str | None = None) -> Node
     return Node(
         input=source,
         compute_fn=compute,
-        name=name or "rough_bergami",
+        name=name or "rough_bergomi",
         interval=source.interval,
         period=window + 1,
     )

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -23,7 +23,7 @@ from qmtl.indicators import (
     supertrend,
     ichimoku_cloud,
     kalman_trend,
-    rough_bergami,
+    rough_bergomi,
     stoch_rsi,
     kdj,
 )
@@ -178,9 +178,9 @@ def test_kalman_trend_compute():
     assert isinstance(result, float)
 
 
-def test_rough_bergami_compute():
+def test_rough_bergomi_compute():
     src = SourceNode(interval="1s", period=4, config={"id": "src"})
-    node = rough_bergami(src, window=3)
+    node = rough_bergomi(src, window=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 1), (3, 2)]}}
     view = CacheView(data)
     assert round(node.compute_fn(view), 4) > 0


### PR DESCRIPTION
## Summary
- rename rough_bergami indicator to rough_bergomi and adjust default node name
- update indicator exports and associated tests

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68907ebde8e883299f937ecb8d698537