### PR TITLE
refactor queue naming to Kafka topic and RedisTaskQueue

### DIFF
--- a/dag-manager.md
+++ b/dag-manager.md
@@ -43,7 +43,7 @@
 ```cypher
 CREATE CONSTRAINT compute_pk IF NOT EXISTS
 ON (c:ComputeNode) ASSERT c.node_id IS UNIQUE;
-CREATE INDEX queue_topic IF NOT EXISTS FOR (q:Queue) ON (q.topic);
+CREATE INDEX kafka_topic IF NOT EXISTS FOR (q:Queue) ON (q.topic);
 ```
 ### 1.3 NodeID Generation
 - NodeID = SHA-256 hash of `(node_type, code_hash, config_hash, schema_hash)`.

--- a/qmtl/dagmanager/neo4j_init.py
+++ b/qmtl/dagmanager/neo4j_init.py
@@ -1,6 +1,6 @@
 SCHEMA_QUERIES = [
     "CREATE CONSTRAINT compute_pk IF NOT EXISTS ON (c:ComputeNode) ASSERT c.node_id IS UNIQUE",
-    "CREATE INDEX queue_topic IF NOT EXISTS FOR (q:Queue) ON (q.topic)",
+    "CREATE INDEX kafka_topic IF NOT EXISTS FOR (q:Queue) ON (q.topic)",
 ]
 
 

--- a/qmtl/gateway/__init__.py
+++ b/qmtl/gateway/__init__.py
@@ -1,5 +1,5 @@
 from .dagmanager_client import DagManagerClient
-from .queue import RedisFIFOQueue
+from .redis_queue import RedisTaskQueue
 from .redis_client import InMemoryRedis
 from .worker import StrategyWorker
 from .api import create_app, StrategySubmit, StrategyAck, StatusResponse
@@ -11,7 +11,7 @@ from .watch import QueueWatchHub
 
 __all__ = [
     "DagManagerClient",
-    "RedisFIFOQueue",
+    "RedisTaskQueue",
     "InMemoryRedis",
     "StrategyWorker",
     "StrategyFSM",

--- a/qmtl/gateway/redis_queue.py
+++ b/qmtl/gateway/redis_queue.py
@@ -5,8 +5,8 @@ from typing import Optional
 import redis.asyncio as redis
 
 
-class RedisFIFOQueue:
-    """Simple FIFO queue backed by Redis."""
+class RedisTaskQueue:
+    """Simple FIFO task queue backed by Redis."""
 
     def __init__(self, redis_client: redis.Redis, name: str = "strategy_queue") -> None:
         self.redis = redis_client
@@ -32,4 +32,4 @@ class RedisFIFOQueue:
             return False
 
 
-__all__ = ["RedisFIFOQueue"]
+__all__ = ["RedisTaskQueue"]

--- a/qmtl/gateway/worker.py
+++ b/qmtl/gateway/worker.py
@@ -9,7 +9,7 @@ from .database import Database
 from .dagmanager_client import DagManagerClient
 from .ws import WebSocketHub
 from .fsm import StrategyFSM
-from .queue import RedisFIFOQueue
+from .redis_queue import RedisTaskQueue
 from ..dagmanager.alerts import AlertManager
 
 
@@ -21,7 +21,7 @@ class StrategyWorker:
         redis_client: redis.Redis,
         database: Database,
         fsm: StrategyFSM,
-        queue: RedisFIFOQueue,
+        queue: RedisTaskQueue,
         dag_client: DagManagerClient,
         ws_hub: Optional[WebSocketHub] = None,
         worker_id: Optional[str] = None,

--- a/qmtl/pipeline/pipeline.py
+++ b/qmtl/pipeline/pipeline.py
@@ -20,9 +20,9 @@ class Pipeline:
 
     # ------------------------------------------------------------------
     def _publish(self, node: Node, interval: int, timestamp: int, payload: Any) -> None:
-        if self.producer and node.queue_topic:
+        if self.producer and node.kafka_topic:
             self.producer.produce(
-                node.queue_topic, {"interval": interval, "timestamp": timestamp, "payload": payload}
+                node.kafka_topic, {"interval": interval, "timestamp": timestamp, "payload": payload}
             )
 
     def _propagate(

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -416,7 +416,7 @@ class Node:
         self.config = config or {}
         self.schema = schema or {}
         self.execute = True
-        self.queue_topic: str | None = None
+        self.kafka_topic: str | None = None
         if arrow_cache.ARROW_AVAILABLE and os.getenv("QMTL_ARROW_CACHE") == "1":
             self.cache = arrow_cache.NodeCacheArrow(period_val or 0)
         else:

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -126,10 +126,10 @@ class Runner:
             else:
                 if mapping:
                     node.execute = False
-                    node.queue_topic = mapping  # type: ignore[assignment]
+                    node.kafka_topic = mapping  # type: ignore[assignment]
                 else:
                     node.execute = True
-                    node.queue_topic = None
+                    node.kafka_topic = None
 
             if node.execute != old_execute:
                 logger.debug(
@@ -311,7 +311,7 @@ class Runner:
         if not Runner._kafka_available:
             raise RuntimeError("aiokafka not available")
         consumer = AIOKafkaConsumer(
-            node.queue_topic,
+            node.kafka_topic,
             bootstrap_servers=bootstrap_servers,
             enable_auto_commit=True,
         )
@@ -325,7 +325,7 @@ class Runner:
                 ts = int(msg.timestamp / 1000)
                 Runner.feed_queue_data(
                     node,
-                    node.queue_topic,
+                    node.kafka_topic,
                     node.interval,
                     ts,
                     payload,
@@ -342,10 +342,10 @@ class Runner:
         bootstrap_servers: str,
         stop_event: asyncio.Event,
     ) -> list[asyncio.Task]:
-        """Spawn Kafka consumer tasks for nodes with ``queue_topic``."""
+        """Spawn Kafka consumer tasks for nodes with a ``kafka_topic``."""
         tasks = []
         for n in strategy.nodes:
-            if n.queue_topic:
+            if n.kafka_topic:
                 tasks.append(
                     asyncio.create_task(
                         Runner._consume_node(

--- a/tests/gateway/test_inmemory_redis.py
+++ b/tests/gateway/test_inmemory_redis.py
@@ -1,7 +1,7 @@
 import pytest
 
 from qmtl.gateway.redis_client import InMemoryRedis
-from qmtl.gateway.queue import RedisFIFOQueue
+from qmtl.gateway.redis_queue import RedisTaskQueue
 from qmtl.gateway.fsm import StrategyFSM
 from qmtl.gateway.api import Database
 
@@ -27,7 +27,7 @@ class FakeDB(Database):
 @pytest.mark.asyncio
 async def test_queue_push_pop_order():
     redis = InMemoryRedis()
-    queue = RedisFIFOQueue(redis, "q")
+    queue = RedisTaskQueue(redis, "q")
 
     await queue.push("a")
     await queue.push("b")

--- a/tests/gateway/test_worker.py
+++ b/tests/gateway/test_worker.py
@@ -4,7 +4,7 @@ import pytest
 
 from types import SimpleNamespace
 
-from qmtl.gateway.queue import RedisFIFOQueue
+from qmtl.gateway.redis_queue import RedisTaskQueue
 from qmtl.gateway.worker import StrategyWorker
 from qmtl.gateway.database import Database
 from qmtl.gateway.fsm import StrategyFSM
@@ -35,7 +35,7 @@ class FakeDB(Database):
 @pytest.mark.asyncio
 async def test_worker_locking_single_processing(fake_redis):
     redis = fake_redis
-    queue = RedisFIFOQueue(redis, "strategy_queue")
+    queue = RedisTaskQueue(redis, "strategy_queue")
     db = FakeDB()
     fsm = StrategyFSM(redis, db)
 
@@ -76,7 +76,7 @@ class DummyHub(WebSocketHub):
 @pytest.mark.asyncio
 async def test_worker_diff_success_broadcasts(fake_redis):
     redis = fake_redis
-    queue = RedisFIFOQueue(redis, "strategy_queue")
+    queue = RedisTaskQueue(redis, "strategy_queue")
     db = FakeDB()
     fsm = StrategyFSM(redis, db)
 
@@ -105,7 +105,7 @@ async def test_worker_diff_success_broadcasts(fake_redis):
 @pytest.mark.asyncio
 async def test_worker_diff_failure_sets_failed_and_broadcasts(fake_redis):
     redis = fake_redis
-    queue = RedisFIFOQueue(redis, "strategy_queue")
+    queue = RedisTaskQueue(redis, "strategy_queue")
     db = FakeDB()
     fsm = StrategyFSM(redis, db)
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -31,8 +31,8 @@ def test_basic_flow():
     n2 = ProcessingNode(input=n1, compute_fn=add1, name="n2", interval="1s", period=1)
 
     prod = DummyProducer()
-    n1.queue_topic = "n1"
-    n2.queue_topic = "n2"
+    n1.kafka_topic = "n1"
+    n2.kafka_topic = "n2"
 
     pipe = Pipeline([src, n1, n2], producer=prod)
 

--- a/tests/reliability/test_worker_alerts.py
+++ b/tests/reliability/test_worker_alerts.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 
 from qmtl.gateway.worker import StrategyWorker
-from qmtl.gateway.queue import RedisFIFOQueue
+from qmtl.gateway.redis_queue import RedisTaskQueue
 from qmtl.gateway.fsm import StrategyFSM
 from qmtl.gateway.database import Database
 
@@ -43,7 +43,7 @@ class DummyAlerts:
 @pytest.mark.asyncio
 async def test_worker_alerts_after_repeated_failures(fake_redis):
     redis = fake_redis
-    queue = RedisFIFOQueue(redis, "strategy_queue")
+    queue = RedisTaskQueue(redis, "strategy_queue")
     db = FakeDB()
     fsm = StrategyFSM(redis, db)
     alerts = DummyAlerts()

--- a/tests/runner/test_kafka_consumers.py
+++ b/tests/runner/test_kafka_consumers.py
@@ -20,14 +20,14 @@ async def test_single_node_consumption(monkeypatch):
 
     src = StreamInput(interval="60s", period=2)
     node = ProcessingNode(input=src, compute_fn=compute, name="n1", interval="60s", period=2)
-    node.queue_topic = "t1"
+    node.kafka_topic = "t1"
     strategy = DummyStrategy([src, node])
 
     stop_event = asyncio.Event()
 
     async def fake_consume(n, *, bootstrap_servers, stop_event):
-        Runner.feed_queue_data(n, n.queue_topic, 60, 60, {"v": 1})
-        Runner.feed_queue_data(n, n.queue_topic, 60, 120, {"v": 2})
+        Runner.feed_queue_data(n, n.kafka_topic, 60, 60, {"v": 1})
+        Runner.feed_queue_data(n, n.kafka_topic, 60, 120, {"v": 2})
         stop_event.set()
 
     monkeypatch.setattr(Runner, "_consume_node", fake_consume)
@@ -51,11 +51,11 @@ async def test_multi_node_consumption(monkeypatch):
 
     src1 = StreamInput(interval="60s", period=2)
     node1 = ProcessingNode(input=src1, compute_fn=compute1, name="n1", interval="60s", period=2)
-    node1.queue_topic = "t1"
+    node1.kafka_topic = "t1"
 
     src2 = StreamInput(interval="60s", period=2)
     node2 = ProcessingNode(input=src2, compute_fn=compute2, name="n2", interval="60s", period=2)
-    node2.queue_topic = "t2"
+    node2.kafka_topic = "t2"
 
     strategy = DummyStrategy([src1, node1, src2, node2])
 
@@ -63,8 +63,8 @@ async def test_multi_node_consumption(monkeypatch):
     counter = {"c": 0}
 
     async def fake_consume(n, *, bootstrap_servers, stop_event):
-        Runner.feed_queue_data(n, n.queue_topic, 60, 60, {"v": 1})
-        Runner.feed_queue_data(n, n.queue_topic, 60, 120, {"v": 2})
+        Runner.feed_queue_data(n, n.kafka_topic, 60, 60, {"v": 1})
+        Runner.feed_queue_data(n, n.kafka_topic, 60, 120, {"v": 2})
         counter["c"] += 1
         if counter["c"] == 2:
             stop_event.set()

--- a/tests/test_dagmanager.py
+++ b/tests/test_dagmanager.py
@@ -22,4 +22,4 @@ def test_compute_node_id_sha3_fallback():
 def test_schema_queries():
     queries = get_schema_queries()
     assert "compute_pk" in queries[0]
-    assert "queue_topic" in queries[1]
+    assert "kafka_topic" in queries[1]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -5,7 +5,7 @@ from qmtl.gateway.api import create_app as gw_create_app
 from qmtl.dagmanager.http_server import create_app as dag_http_create_app
 from qmtl.dagmanager.api import create_app as dag_api_create_app
 from qmtl.dagmanager.gc import QueueInfo
-from qmtl.gateway.queue import RedisFIFOQueue
+from qmtl.gateway.redis_queue import RedisTaskQueue
 from qmtl.gateway.dagmanager_client import DagManagerClient
 from qmtl.gateway.ws import WebSocketHub
 from qmtl.gateway.worker import StrategyWorker
@@ -121,7 +121,7 @@ async def test_grpc_status():
 @pytest.mark.asyncio
 async def test_queue_healthy(fake_redis):
     redis = fake_redis
-    queue = RedisFIFOQueue(redis)
+    queue = RedisTaskQueue(redis)
     assert await queue.healthy() is True
 
 
@@ -150,7 +150,7 @@ async def test_worker_healthy(monkeypatch, fake_redis):
 
     db = FakeDB()
     fsm = StrategyFSM(redis, db)
-    queue = RedisFIFOQueue(redis)
+    queue = RedisTaskQueue(redis)
     client = DagManagerClient("127.0.0.1:1")
     async def status():
         return True

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -158,7 +158,7 @@ def test_gateway_queue_mapping(monkeypatch):
 
     strategy = Runner.dryrun(SampleStrategy, gateway_url="http://gw")
     first_node = strategy.nodes[0]
-    assert first_node.queue_topic == "topic1"
+    assert first_node.kafka_topic == "topic1"
     assert not first_node.execute
 
 
@@ -188,7 +188,7 @@ def test_gateway_error(monkeypatch):
 def test_offline_mode():
     strategy = Runner.offline(SampleStrategy)
     assert all(n.execute for n in strategy.nodes)
-    assert all(n.queue_topic is None for n in strategy.nodes)
+    assert all(n.kafka_topic is None for n in strategy.nodes)
 
 
 def test_connection_failure(monkeypatch):


### PR DESCRIPTION
## Summary
- rename Node.queue_topic attribute to kafka_topic and update Runner and Pipeline logic
- rename gateway queue module to redis_queue.py with RedisTaskQueue class
- adjust docs, schema, and tests for new topic/queue terminology

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68907ebc99a08329a17e175bb3f5f584