### PR TITLE
refactor: rename status modules to health

### DIFF
--- a/qmtl/dagmanager/api.py
+++ b/qmtl/dagmanager/api.py
@@ -7,7 +7,7 @@ from typing import Optional, TYPE_CHECKING
 from .gc import GarbageCollector
 from .callbacks import post_with_backoff
 from ..common.cloudevents import format_event
-from .status import get_status
+from .dagmanager_health import get_health
 
 if TYPE_CHECKING:  # pragma: no cover - optional import for typing
     from neo4j import Driver
@@ -34,8 +34,8 @@ def create_app(
 
     @app.get("/status")
     async def status_endpoint() -> dict[str, str]:
-        """Return system status including Neo4j connectivity."""
-        return get_status(driver)
+        """Return system health including Neo4j connectivity."""
+        return get_health(driver)
 
     @app.post("/admin/gc-trigger", status_code=status.HTTP_202_ACCEPTED)
     async def trigger_gc(payload: GcRequest) -> GcResponse:

--- a/qmtl/dagmanager/dagmanager_health.py
+++ b/qmtl/dagmanager/dagmanager_health.py
@@ -6,8 +6,8 @@ if TYPE_CHECKING:  # pragma: no cover - optional import for typing
     from neo4j import Driver
 
 
-def get_status(driver: "Driver" | None = None) -> dict[str, str]:
-    """Return status information about DAG manager and dependencies."""
+def get_health(driver: "Driver" | None = None) -> dict[str, str]:
+    """Return health information about DAG manager and dependencies."""
     neo4j_status = "unknown"
     if driver is not None:
         try:

--- a/qmtl/dagmanager/grpc_server.py
+++ b/qmtl/dagmanager/grpc_server.py
@@ -22,7 +22,7 @@ from .callbacks import post_with_backoff
 from ..common.cloudevents import format_event
 from .gc import GarbageCollector
 from ..proto import dagmanager_pb2, dagmanager_pb2_grpc
-from .status import get_status
+from .dagmanager_health import get_health
 
 
 class _GrpcStream(StreamSender):
@@ -225,7 +225,7 @@ class HealthServicer(dagmanager_pb2_grpc.HealthCheckServicer):
         request: dagmanager_pb2.StatusRequest,
         context: grpc.aio.ServicerContext,
     ) -> dagmanager_pb2.StatusReply:
-        info = get_status(self._driver)
+        info = get_health(self._driver)
         return dagmanager_pb2.StatusReply(
             neo4j=info.get("neo4j", "unknown"),
             state=info.get("dag_manager", "unknown"),

--- a/qmtl/dagmanager/http_server.py
+++ b/qmtl/dagmanager/http_server.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from .callbacks import post_with_backoff
 from ..common.cloudevents import format_event
 from . import metrics
-from .status import get_status
+from .dagmanager_health import get_health
 
 
 class WeightUpdate(BaseModel):
@@ -30,8 +30,8 @@ def create_app(
 
     @app.get("/status")
     async def status_endpoint() -> dict[str, str]:
-        """Return system status including Neo4j connectivity."""
-        return get_status(driver)
+        """Return system health including Neo4j connectivity."""
+        return get_health(driver)
 
     store = weights if weights is not None else {}
 

--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -22,7 +22,7 @@ from . import metrics as gw_metrics
 from .degradation import DegradationManager, DegradationLevel
 from .watch import QueueWatchHub
 from .ws import WebSocketHub
-from .status import get_status as gateway_status
+from .gateway_health import get_health as gateway_health
 from .database import Database, PostgresDatabase, MemoryDatabase, SQLiteDatabase
 
 logger = logging.getLogger(__name__)
@@ -171,14 +171,14 @@ def create_app(
 
     @app.get("/status")
     async def status_endpoint() -> dict[str, str]:
-        status_data = await gateway_status(redis_conn, database_obj, dag_manager)
-        status_data["degrade_level"] = degradation.level.name
-        return status_data
+        health_data = await gateway_health(redis_conn, database_obj, dag_manager)
+        health_data["degrade_level"] = degradation.level.name
+        return health_data
 
     @app.get("/health")
     async def health() -> dict[str, str]:
         """Deprecated health check; alias for ``/status``."""
-        return await gateway_status(redis_conn, database_obj, dag_manager)
+        return await gateway_health(redis_conn, database_obj, dag_manager)
 
     class Gateway:
         def __init__(self, ws_hub: Optional[WebSocketHub] = None):

--- a/qmtl/gateway/gateway_health.py
+++ b/qmtl/gateway/gateway_health.py
@@ -17,12 +17,12 @@ _STATUS_CACHE_TTL = 2.0  # seconds
 _STATUS_LOCK = asyncio.Lock()
 
 
-async def get_status(
+async def get_health(
     redis_client: Optional[redis.Redis] = None,
     database: Optional[Database] = None,
     dag_client: Optional[DagManagerClient] = None,
 ) -> dict[str, str]:
-    """Return status information for gateway and dependencies.
+    """Return health information for gateway and dependencies.
 
     Results are cached for a short time to avoid spamming external
     dependencies with health checks when multiple requests arrive
@@ -77,4 +77,4 @@ async def get_status(
         _STATUS_CACHE_TS = now
         return result
 
-__all__ = ["get_status"]
+__all__ = ["get_health"]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -40,7 +40,7 @@ class FakeDB(PostgresDatabase):
         return True
 
 
-def test_gateway_status(fake_redis):
+def test_gateway_health(fake_redis):
     redis_client = fake_redis
     db = FakeDB()
     with TestClient(
@@ -54,14 +54,14 @@ def test_gateway_status(fake_redis):
         assert data["dag_manager"] == "ok"
 
 
-def test_dagmanager_http_status():
+def test_dagmanager_http_health():
     with TestClient(dag_http_create_app()) as client:
         resp = client.get("/status")
         assert resp.status_code == 200
         assert resp.json()["neo4j"] in {"ok", "error", "unknown"}
 
 
-def test_dagmanager_api_status():
+def test_dagmanager_api_health():
     with TestClient(dag_api_create_app(DummyGC())) as client:
         resp = client.get("/status")
         assert resp.status_code == 200
@@ -69,7 +69,7 @@ def test_dagmanager_api_status():
 
 
 @pytest.mark.asyncio
-async def test_grpc_status():
+async def test_grpc_health():
     from qmtl.dagmanager.grpc_server import serve
 
     class FakeDriver:


### PR DESCRIPTION
## Summary
- rename gateway status module to `gateway_health` and provide `get_health`
- replace DAG manager status module with `dagmanager_health`
- update imports, endpoints, and tests to use new health helpers

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68907ec0d8748329a37a5731865c3606