### PR TITLE
feat: add match mode enum

### DIFF
--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -21,6 +21,7 @@ from .fsm import StrategyFSM
 from . import metrics as gw_metrics
 from .degradation import DegradationManager, DegradationLevel
 from .watch import QueueWatchHub
+from qmtl.sdk.node import MatchMode
 from .ws import WebSocketHub
 from .status import get_status as gateway_status
 from .database import Database, PostgresDatabase, MemoryDatabase, SQLiteDatabase
@@ -272,12 +273,16 @@ def create_app(
                 except (TypeError, ValueError):
                     interval = None
             if tags and interval is not None:
+                try:
+                    mode = MatchMode(match_mode)
+                except ValueError:
+                    return {"ok": True}
                 await watch_hub_local.broadcast(
-                    tags, interval, list(queues), match_mode
+                    tags, interval, list(queues), mode
                 )
                 if ws_hub_local:
                     await ws_hub_local.send_queue_update(
-                        tags, interval, list(queues), match_mode
+                        tags, interval, list(queues), mode
                     )
         elif event_type == "sentinel_weight":
             gateway = getattr(app.state, "gateway", None)
@@ -303,11 +308,15 @@ def create_app(
         tags: str, interval: int, match: str = "any", match_mode: str | None = None
     ):
         tag_list = [t for t in tags.split(",") if t]
-        mode = match_mode or match
+        mode_str = match_mode or match
+        try:
+            mode = MatchMode(mode_str)
+        except ValueError:
+            mode = MatchMode.ANY
 
         async def streamer():
             try:
-                initial = await dag_manager.get_queues_by_tag(tag_list, interval, mode)
+                initial = await dag_manager.get_queues_by_tag(tag_list, interval, mode.value)
             except grpc.RpcError as e:  # Or grpc.aio.AioRpcError if using grpc.aio explicitly
                 # It's good practice to log this error for observability
                 # import logging

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -5,6 +5,8 @@ import json
 import logging
 from typing import Optional
 
+from qmtl.sdk.node import MatchMode
+
 from ..common.cloudevents import format_event
 
 import websockets
@@ -113,9 +115,12 @@ class WebSocketHub:
         tags: list[str],
         interval: int,
         queues: list[str],
-        match_mode: str = "any",
+        match_mode: MatchMode = MatchMode.ANY,
     ) -> None:
-        """Broadcast queue update events."""
+        """Broadcast queue update events.
+
+        ``match_mode`` must be ``MatchMode.ANY`` or ``MatchMode.ALL``.
+        """
         event = format_event(
             "qmtl.gateway",
             "queue_update",
@@ -123,7 +128,7 @@ class WebSocketHub:
                 "tags": tags,
                 "interval": interval,
                 "queues": queues,
-                "match_mode": match_mode,
+                "match_mode": match_mode.value,
             },
         )
         await self.broadcast(event)

--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -7,6 +7,7 @@ from .node import (
     StreamInput,
     TagQueryNode,
     NodeCache,
+    MatchMode,
 )
 from .arrow_cache import NodeCacheArrow
 from .backfill_state import BackfillState
@@ -35,6 +36,7 @@ __all__ = [
     "StreamInput",
     "TagQueryNode",
     "NodeCache",
+    "MatchMode",
     "NodeCacheArrow",
     "BackfillState",
     "CacheView",

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from typing import Any, TYPE_CHECKING
 import logging
+from enum import Enum
 
 import numpy as np
 import xarray as xr
@@ -25,6 +26,17 @@ if TYPE_CHECKING:  # pragma: no cover - type checking import
 from qmtl.dagmanager import compute_node_id
 
 logger = logging.getLogger(__name__)
+
+
+class MatchMode(str, Enum):
+    """Tag matching behaviour for :class:`TagQueryNode`.
+
+    ``MatchMode.ANY`` selects queues containing any of the requested tags,
+    while ``MatchMode.ALL`` requires every tag to be present.
+    """
+
+    ANY = "any"
+    ALL = "all"
 
 
 class _RingBuffer:
@@ -626,7 +638,20 @@ class StreamInput(SourceNode):
 
 
 class TagQueryNode(SourceNode):
-    """Node that selects upstream queues by tag and interval."""
+    """Node that selects upstream queues by tag and interval.
+
+    Parameters
+    ----------
+    query_tags:
+        Tags to subscribe to.
+    interval:
+        Bar interval in seconds or string shorthand.
+    period:
+        Number of bars to retain in the cache.
+    match_mode:
+        Tag matching mode. ``MatchMode.ANY`` subscribes to queues containing
+        any of ``query_tags`` while ``MatchMode.ALL`` requires every tag.
+    """
 
     def __init__(
         self,
@@ -634,7 +659,7 @@ class TagQueryNode(SourceNode):
         *,
         interval: int | str,
         period: int,
-        match_mode: str = "any",
+        match_mode: MatchMode = MatchMode.ANY,
         compute_fn=None,
         name: str | None = None,
     ) -> None:

--- a/tests/gateway/test_queue_update_ws_execution.py
+++ b/tests/gateway/test_queue_update_ws_execution.py
@@ -4,7 +4,7 @@ import pytest
 
 from qmtl.gateway.api import create_app
 from qmtl.gateway.ws import WebSocketHub
-from qmtl.sdk import TagQueryNode, Runner
+from qmtl.sdk import TagQueryNode, Runner, MatchMode
 from qmtl.sdk.ws_client import WebSocketClient
 from qmtl.sdk.tagquery_manager import TagQueryManager
 from qmtl.common.cloudevents import format_event
@@ -20,14 +20,14 @@ class DummyHub(WebSocketHub):
         super().__init__()
         self.client = client
 
-    async def send_queue_update(self, tags, interval, queues, match_mode="any"):  # type: ignore[override]
+    async def send_queue_update(self, tags, interval, queues, match_mode: MatchMode = MatchMode.ANY):  # type: ignore[override]
         await self.client._handle({
             "type": "queue_update",
             "data": {
                 "tags": tags,
                 "interval": interval,
                 "queues": queues,
-                "match_mode": match_mode,
+                "match_mode": match_mode.value,
             },
         })
 

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 import asyncio
 
 from qmtl.gateway.watch import QueueWatchHub
+from qmtl.sdk import MatchMode
 
 from qmtl.gateway.api import create_app, Database
 from qmtl.common import crc32_of_list
@@ -187,7 +188,7 @@ async def test_watch_hub_broadcast():
     hub = QueueWatchHub()
 
     async def listen():
-        gen = hub.subscribe(["t1"], 60, "any")
+        gen = hub.subscribe(["t1"], 60, MatchMode.ANY)
         try:
             return await gen.__anext__()
         finally:
@@ -195,7 +196,7 @@ async def test_watch_hub_broadcast():
 
     task = asyncio.create_task(listen())
     await asyncio.sleep(0)
-    await hub.broadcast(["t1"], 60, ["q3"], "any")
+    await hub.broadcast(["t1"], 60, ["q3"], MatchMode.ANY)
     try:
         result = await task
         assert result == ["q3"]
@@ -210,7 +211,7 @@ async def test_watch_hub_broadcast_only_on_change():
     ready = asyncio.Event()
 
     async def listener() -> None:
-        gen = hub.subscribe(["t1"], 60, "any")
+        gen = hub.subscribe(["t1"], 60, MatchMode.ANY)
         ready.set()
         async for data in gen:
             results.append(data)
@@ -218,11 +219,11 @@ async def test_watch_hub_broadcast_only_on_change():
     task = asyncio.create_task(listener())
     await ready.wait()
 
-    await hub.broadcast(["t1"], 60, ["q3"], "any")
+    await hub.broadcast(["t1"], 60, ["q3"], MatchMode.ANY)
     await asyncio.sleep(0)
-    await hub.broadcast(["t1"], 60, ["q3"], "any")
+    await hub.broadcast(["t1"], 60, ["q3"], MatchMode.ANY)
     await asyncio.sleep(0)
-    await hub.broadcast(["t1"], 60, ["q4"], "any")
+    await hub.broadcast(["t1"], 60, ["q4"], MatchMode.ANY)
     await asyncio.sleep(0)
 
     task.cancel()

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -3,7 +3,7 @@ import json
 import httpx
 import pytest
 
-from qmtl.sdk import Strategy, TagQueryNode, Runner
+from qmtl.sdk import Strategy, TagQueryNode, Runner, MatchMode
 from qmtl.gateway.api import create_app, Database
 from qmtl.gateway.ws import WebSocketHub
 from qmtl.common.cloudevents import format_event
@@ -55,14 +55,14 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
             super().__init__()
             self.client = client
 
-        async def send_queue_update(self, tags, interval, queues, match_mode="any"):  # type: ignore[override]
+        async def send_queue_update(self, tags, interval, queues, match_mode: MatchMode = MatchMode.ANY):  # type: ignore[override]
             await self.client._handle({
                 "type": "queue_update",
                 "data": {
                     "tags": tags,
                     "interval": interval,
                     "queues": queues,
-                    "match_mode": match_mode,
+                    "match_mode": match_mode.value,
                 },
             })
 

--- a/tests/test_tagquery_manager.py
+++ b/tests/test_tagquery_manager.py
@@ -2,7 +2,7 @@ import asyncio
 import httpx
 import pytest
 
-from qmtl.sdk import TagQueryNode
+from qmtl.sdk import TagQueryNode, MatchMode
 from qmtl.sdk.tagquery_manager import TagQueryManager
 
 
@@ -93,8 +93,8 @@ async def test_resolve_handles_empty(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_match_mode_routes_updates():
-    node_any = TagQueryNode(["t1"], interval="60s", period=1, match_mode="any")
-    node_all = TagQueryNode(["t1"], interval="60s", period=1, match_mode="all")
+    node_any = TagQueryNode(["t1"], interval="60s", period=1, match_mode=MatchMode.ANY)
+    node_all = TagQueryNode(["t1"], interval="60s", period=1, match_mode=MatchMode.ALL)
     manager = TagQueryManager()
     manager.register(node_any)
     manager.register(node_all)


### PR DESCRIPTION
## Summary
- add `MatchMode` enum to tag query SDK
- propagate enum usage through gateway and SDK components
- update tests for enum-based match mode

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68907ebeed048329a5cfb94ec1f3b211