### PR TITLE
Standardize lookback parameter as period

### DIFF
--- a/qmtl/examples/strategies/extensions_combined_strategy.py
+++ b/qmtl/examples/strategies/extensions_combined_strategy.py
@@ -7,7 +7,7 @@ from qmtl.transforms import rate_of_change
 class CombinedExtensionsStrategy(Strategy):
     def setup(self):
         self.source = GarchInput(interval="60s", period=30, seed=42)
-        self.ema_node = ema(self.source, window=5)
+        self.ema_node = ema(self.source, period=5)
         self.roc_node = rate_of_change(self.ema_node, period=5)
         self.add_nodes([self.source, self.ema_node, self.roc_node])
 

--- a/qmtl/examples/strategies/indicators_strategy.py
+++ b/qmtl/examples/strategies/indicators_strategy.py
@@ -5,7 +5,7 @@ from qmtl.indicators import ema
 class EmaStrategy(Strategy):
     def setup(self):
         self.price = StreamInput(interval="60s", period=20)
-        self.ema_node = ema(self.price, window=10)
+        self.ema_node = ema(self.price, period=10)
         self.add_nodes([self.price, self.ema_node])
 
 if __name__ == "__main__":

--- a/qmtl/examples/templates/multi_indicator.py
+++ b/qmtl/examples/templates/multi_indicator.py
@@ -28,10 +28,10 @@ class MultiIndicatorStrategy(Strategy):
         # Price stream feeding all downstream indicators
         price = StreamInput(interval="60s", period=50)
         # Short and long EMAs computed from the same source
-        fast_ema = ema(price, window=5)
-        slow_ema = ema(price, window=20)
+        fast_ema = ema(price, period=5)
+        slow_ema = ema(price, period=20)
         # Relative strength index from the same price history
-        rsi_node = rsi(price, window=14)
+        rsi_node = rsi(price, period=14)
         # Register all nodes so the DAG manager can schedule them
         self.add_nodes([price, fast_ema, slow_ema, rsi_node])
 

--- a/qmtl/examples/templates/single_indicator.py
+++ b/qmtl/examples/templates/single_indicator.py
@@ -22,7 +22,7 @@ class SingleIndicatorStrategy(Strategy):
         # Source price stream feeding the graph
         price = StreamInput(interval="60s", period=20)
         # Compute an exponential moving average from the price stream
-        ema_node = ema(price, window=10)
+        ema_node = ema(price, period=10)
         # Register nodes with the strategy in execution order
         self.add_nodes([price, ema_node])
 if __name__ == "__main__":

--- a/qmtl/indicators/atr.py
+++ b/qmtl/indicators/atr.py
@@ -4,28 +4,28 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def atr(high: Node, low: Node, close: Node, window: int, *, name: str | None = None) -> Node:
+def atr(high: Node, low: Node, close: Node, period: int, *, name: str | None = None) -> Node:
     """Return a Node computing Average True Range."""
 
     def compute(view: CacheView):
-        highs = view[high][high.interval][-window:]
-        lows = view[low][low.interval][-window:]
-        closes = view[close][close.interval][-(window + 1):]
-        if len(highs) < window or len(lows) < window or len(closes) < window + 1:
+        highs = view[high][high.interval][-period:]
+        lows = view[low][low.interval][-period:]
+        closes = view[close][close.interval][-(period + 1):]
+        if len(highs) < period or len(lows) < period or len(closes) < period + 1:
             return None
         tr_values = []
-        for i in range(1, window + 1):
+        for i in range(1, period + 1):
             h = highs[i - 1][1]
             l = lows[i - 1][1]
             pc = closes[i - 1][1]
             tr = max(h - l, abs(h - pc), abs(l - pc))
             tr_values.append(tr)
-        return sum(tr_values) / window
+        return sum(tr_values) / period
 
     return Node(
         input=[high, low, close],
         compute_fn=compute,
         name=name or "atr",
         interval=close.interval,
-        period=window,
+        period=period,
     )

--- a/qmtl/indicators/bollinger_bands.py
+++ b/qmtl/indicators/bollinger_bands.py
@@ -7,12 +7,12 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def bollinger_bands(source: Node, window: int, multiplier: float = 2.0, *, name: str | None = None) -> Node:
+def bollinger_bands(source: Node, period: int, multiplier: float = 2.0, *, name: str | None = None) -> Node:
     """Return a Node computing Bollinger Bands as (mid, upper, lower)."""
 
     def compute(view: CacheView):
-        data = [v for _, v in view[source][source.interval][-window:]]
-        if len(data) < window:
+        data = [v for _, v in view[source][source.interval][-period:]]
+        if len(data) < period:
             return None
         mid = mean(data)
         std = pstdev(data)
@@ -25,5 +25,5 @@ def bollinger_bands(source: Node, window: int, multiplier: float = 2.0, *, name:
         compute_fn=compute,
         name=name or "bollinger_bands",
         interval=source.interval,
-        period=window,
+        period=period,
     )

--- a/qmtl/indicators/chandelier_exit.py
+++ b/qmtl/indicators/chandelier_exit.py
@@ -9,25 +9,25 @@ def chandelier_exit(
     low: Node,
     close: Node,
     *,
-    window: int = 22,
+    period: int = 22,
     multiplier: float = 3.0,
     name: str | None = None,
 ) -> Node:
     """Return a Node computing Chandelier Exit levels."""
 
     def compute(view: CacheView):
-        highs = view[high][high.interval][-window:]
-        lows = view[low][low.interval][-window:]
-        closes = view[close][close.interval][-(window + 1):]
-        if len(highs) < window or len(lows) < window or len(closes) < window + 1:
+        highs = view[high][high.interval][-period:]
+        lows = view[low][low.interval][-period:]
+        closes = view[close][close.interval][-(period + 1):]
+        if len(highs) < period or len(lows) < period or len(closes) < period + 1:
             return None
         tr_values = []
-        for i in range(1, window + 1):
+        for i in range(1, period + 1):
             h = highs[i - 1][1]
             l = lows[i - 1][1]
             pc = closes[i - 1][1]
             tr_values.append(max(h - l, abs(h - pc), abs(l - pc)))
-        atr_val = sum(tr_values) / window
+        atr_val = sum(tr_values) / period
         highest_high = max(v for _, v in highs)
         lowest_low = min(v for _, v in lows)
         long_exit = highest_high - multiplier * atr_val
@@ -39,5 +39,5 @@ def chandelier_exit(
         compute_fn=compute,
         name=name or "chandelier_exit",
         interval=close.interval,
-        period=window,
+        period=period,
     )

--- a/qmtl/indicators/ema.py
+++ b/qmtl/indicators/ema.py
@@ -4,14 +4,14 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def ema(source: Node, window: int, *, name: str | None = None) -> Node:
+def ema(source: Node, period: int, *, name: str | None = None) -> Node:
     """Return a Node computing an exponential moving average."""
 
-    alpha = 2 / (window + 1)
+    alpha = 2 / (period + 1)
 
     def compute(view: CacheView):
-        data = [v for _, v in view[source][source.interval][-window:]]
-        if len(data) < window:
+        data = [v for _, v in view[source][source.interval][-period:]]
+        if len(data) < period:
             return None
         value = data[0]
         for x in data[1:]:
@@ -23,5 +23,5 @@ def ema(source: Node, window: int, *, name: str | None = None) -> Node:
         compute_fn=compute,
         name=name or "ema",
         interval=source.interval,
-        period=window,
+        period=period,
     )

--- a/qmtl/indicators/kdj.py
+++ b/qmtl/indicators/kdj.py
@@ -4,14 +4,14 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def kdj(high: Node, low: Node, close: Node, window: int, *, name: str | None = None) -> Node:
+def kdj(high: Node, low: Node, close: Node, period: int, *, name: str | None = None) -> Node:
     """Return a Node computing a simplified KDJ oscillator."""
 
     def compute(view: CacheView):
-        highs = [v for _, v in view[high][high.interval][-window:]]
-        lows = [v for _, v in view[low][low.interval][-window:]]
+        highs = [v for _, v in view[high][high.interval][-period:]]
+        lows = [v for _, v in view[low][low.interval][-period:]]
         closes = [v for _, v in view[close][close.interval][-1:]]
-        if len(highs) < window or len(lows) < window or not closes:
+        if len(highs) < period or len(lows) < period or not closes:
             return None
         highest = max(highs)
         lowest = min(lows)
@@ -27,5 +27,5 @@ def kdj(high: Node, low: Node, close: Node, window: int, *, name: str | None = N
         compute_fn=compute,
         name=name or "kdj",
         interval=close.interval,
-        period=window,
+        period=period,
     )

--- a/qmtl/indicators/keltner_channel.py
+++ b/qmtl/indicators/keltner_channel.py
@@ -11,38 +11,38 @@ def keltner_channel(
     low: Node,
     close: Node,
     *,
-    ema_window: int = 20,
-    atr_window: int = 10,
+    ema_period: int = 20,
+    atr_period: int = 10,
     multiplier: float = 2.0,
     name: str | None = None,
 ) -> Node:
     """Return a Node computing Keltner Channel (mid, upper, lower)."""
 
-    alpha = 2 / (ema_window + 1)
+    alpha = 2 / (ema_period + 1)
 
     def compute(view: CacheView):
-        highs = view[high][high.interval][-atr_window:]
-        lows = view[low][low.interval][-atr_window:]
-        closes = view[close][close.interval][-(max(ema_window, atr_window) + 1):]
+        highs = view[high][high.interval][-atr_period:]
+        lows = view[low][low.interval][-atr_period:]
+        closes = view[close][close.interval][-(max(ema_period, atr_period) + 1):]
         if (
-            len(highs) < atr_window
-            or len(lows) < atr_window
-            or len(closes) < max(ema_window, atr_window) + 1
+            len(highs) < atr_period
+            or len(lows) < atr_period
+            or len(closes) < max(ema_period, atr_period) + 1
         ):
             return None
         # EMA
-        ema_val = closes[-ema_window][1]
-        for _, val in closes[-ema_window + 1 :]:
+        ema_val = closes[-ema_period][1]
+        for _, val in closes[-ema_period + 1 :]:
             ema_val = alpha * val + (1 - alpha) * ema_val
         # ATR
         tr_values = []
-        for i in range(1, atr_window + 1):
+        for i in range(1, atr_period + 1):
             h = highs[i - 1][1]
             l = lows[i - 1][1]
             pc = closes[i - 1][1]
             tr = max(h - l, abs(h - pc), abs(l - pc))
             tr_values.append(tr)
-        atr_val = sum(tr_values) / atr_window
+        atr_val = sum(tr_values) / atr_period
         upper = ema_val + multiplier * atr_val
         lower = ema_val - multiplier * atr_val
         return {"mid": ema_val, "upper": upper, "lower": lower}
@@ -52,5 +52,5 @@ def keltner_channel(
         compute_fn=compute,
         name=name or "keltner_channel",
         interval=close.interval,
-        period=max(ema_window, atr_window),
+        period=max(ema_period, atr_period),
     )

--- a/qmtl/indicators/obv.py
+++ b/qmtl/indicators/obv.py
@@ -4,15 +4,15 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def obv(close: Node, volume: Node, *, name: str | None = None, window: int | None = None) -> Node:
-    """Return a Node computing OBV over ``window`` entries if given."""
+def obv(close: Node, volume: Node, *, name: str | None = None, period: int | None = None) -> Node:
+    """Return a Node computing OBV over ``period`` entries if given."""
 
     def compute(view: CacheView):
         closes = list(view[close][close.interval])
         vols = list(view[volume][volume.interval])
-        if window is not None:
-            closes = closes[-(window + 1):]
-            vols = vols[-(window + 1):]
+        if period is not None:
+            closes = closes[-(period + 1):]
+            vols = vols[-(period + 1):]
         if len(closes) < 2 or len(vols) < 2:
             return None
         total = 0.0
@@ -31,5 +31,5 @@ def obv(close: Node, volume: Node, *, name: str | None = None, window: int | Non
         compute_fn=compute,
         name=name or "obv",
         interval=close.interval,
-        period=window or 2,
+        period=period or 2,
     )

--- a/qmtl/indicators/rough_bergami.py
+++ b/qmtl/indicators/rough_bergami.py
@@ -5,12 +5,12 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def rough_bergami(source: Node, window: int, *, name: str | None = None) -> Node:
+def rough_bergami(source: Node, period: int, *, name: str | None = None) -> Node:
     """Return a Node computing a simple rough volatility estimate."""
 
     def compute(view: CacheView):
-        data = [v for _, v in view[source][source.interval][- (window + 1):]]
-        if len(data) < window + 1:
+        data = [v for _, v in view[source][source.interval][-(period + 1):]]
+        if len(data) < period + 1:
             return None
         returns = [math.log(data[i] / data[i - 1]) for i in range(1, len(data))]
         if not returns:
@@ -24,5 +24,5 @@ def rough_bergami(source: Node, window: int, *, name: str | None = None) -> Node
         compute_fn=compute,
         name=name or "rough_bergami",
         interval=source.interval,
-        period=window + 1,
+        period=period + 1,
     )

--- a/qmtl/indicators/rsi.py
+++ b/qmtl/indicators/rsi.py
@@ -4,12 +4,12 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def rsi(source: Node, window: int, *, name: str | None = None) -> Node:
+def rsi(source: Node, period: int, *, name: str | None = None) -> Node:
     """Return a Node computing the RSI."""
 
     def compute(view: CacheView):
-        data = [v for _, v in view[source][source.interval][-(window + 1):]]
-        if len(data) < window + 1:
+        data = [v for _, v in view[source][source.interval][-(period + 1):]]
+        if len(data) < period + 1:
             return None
         gains = []
         losses = []
@@ -19,8 +19,8 @@ def rsi(source: Node, window: int, *, name: str | None = None) -> Node:
                 gains.append(diff)
             else:
                 losses.append(-diff)
-        avg_gain = sum(gains) / window
-        avg_loss = sum(losses) / window
+        avg_gain = sum(gains) / period
+        avg_loss = sum(losses) / period
         if avg_loss == 0:
             return 100.0
         rs = avg_gain / avg_loss
@@ -31,5 +31,5 @@ def rsi(source: Node, window: int, *, name: str | None = None) -> Node:
         compute_fn=compute,
         name=name or "rsi",
         interval=source.interval,
-        period=window + 1,
+        period=period + 1,
     )

--- a/qmtl/indicators/sma.py
+++ b/qmtl/indicators/sma.py
@@ -4,11 +4,11 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def sma(source: Node, window: int, *, name: str | None = None) -> Node:
-    """Return a Node computing a simple moving average over ``window`` values."""
+def sma(source: Node, period: int, *, name: str | None = None) -> Node:
+    """Return a Node computing a simple moving average over ``period`` values."""
 
     def compute(view: CacheView):
-        data = view[source][source.interval][-window:]
+        data = view[source][source.interval][-period:]
         if not data:
             return None
         values = [v for _, v in data]
@@ -19,5 +19,5 @@ def sma(source: Node, window: int, *, name: str | None = None) -> Node:
         compute_fn=compute,
         name=name or "sma",
         interval=source.interval,
-        period=window,
+        period=period,
     )

--- a/qmtl/indicators/stoch_rsi.py
+++ b/qmtl/indicators/stoch_rsi.py
@@ -5,7 +5,7 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def stoch_rsi(source: Node, window: int, *, name: str | None = None) -> Node:
+def stoch_rsi(source: Node, period: int, *, name: str | None = None) -> Node:
     """Return a Node computing Stochastic RSI."""
 
     def _rsi(values: list[float]) -> float:
@@ -25,11 +25,11 @@ def stoch_rsi(source: Node, window: int, *, name: str | None = None) -> Node:
         return 100 - (100 / (1 + rs))
 
     def compute(view: CacheView):
-        values = [v for _, v in view[source][source.interval][-(window * 2):]]
-        if len(values) < window * 2:
+        values = [v for _, v in view[source][source.interval][-(period * 2):]]
+        if len(values) < period * 2:
             return None
         rsi_vals = [
-            _rsi(values[i : i + window + 1]) for i in range(len(values) - window)
+            _rsi(values[i : i + period + 1]) for i in range(len(values) - period)
         ]
         current = rsi_vals[-1]
         lowest = min(rsi_vals)
@@ -43,5 +43,5 @@ def stoch_rsi(source: Node, window: int, *, name: str | None = None) -> Node:
         compute_fn=compute,
         name=name or "stoch_rsi",
         interval=source.interval,
-        period=window * 2,
+        period=period * 2,
     )

--- a/qmtl/indicators/supertrend.py
+++ b/qmtl/indicators/supertrend.py
@@ -9,25 +9,25 @@ def supertrend(
     low: Node,
     close: Node,
     *,
-    window: int = 10,
+    period: int = 10,
     multiplier: float = 3.0,
     name: str | None = None,
 ) -> Node:
     """Return a Node computing a simplified Supertrend value."""
 
     def compute(view: CacheView):
-        highs = view[high][high.interval][-window:]
-        lows = view[low][low.interval][-window:]
-        closes = view[close][close.interval][-(window + 1):]
-        if len(highs) < window or len(lows) < window or len(closes) < window + 1:
+        highs = view[high][high.interval][-period:]
+        lows = view[low][low.interval][-period:]
+        closes = view[close][close.interval][-(period + 1):]
+        if len(highs) < period or len(lows) < period or len(closes) < period + 1:
             return None
         tr_values = []
-        for i in range(1, window + 1):
+        for i in range(1, period + 1):
             h = highs[i - 1][1]
             l = lows[i - 1][1]
             pc = closes[i - 1][1]
             tr_values.append(max(h - l, abs(h - pc), abs(l - pc)))
-        atr_val = sum(tr_values) / window
+        atr_val = sum(tr_values) / period
         mid = (highs[-1][1] + lows[-1][1]) / 2
         upper = mid + multiplier * atr_val
         lower = mid - multiplier * atr_val
@@ -43,5 +43,5 @@ def supertrend(
         compute_fn=compute,
         name=name or "supertrend",
         interval=close.interval,
-        period=window,
+        period=period,
     )

--- a/qmtl/indicators/vwap.py
+++ b/qmtl/indicators/vwap.py
@@ -4,13 +4,13 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def vwap(price: Node, volume: Node, window: int, *, name: str | None = None) -> Node:
+def vwap(price: Node, volume: Node, period: int, *, name: str | None = None) -> Node:
     """Return a Node computing VWAP."""
 
     def compute(view: CacheView):
-        prices = view[price][price.interval][-window:]
-        vols = view[volume][volume.interval][-window:]
-        if len(prices) < window or len(vols) < window:
+        prices = view[price][price.interval][-period:]
+        vols = view[volume][volume.interval][-period:]
+        if len(prices) < period or len(vols) < period:
             return None
         num = sum(p[1] * v[1] for p, v in zip(prices, vols))
         den = sum(v[1] for v in vols)
@@ -23,5 +23,5 @@ def vwap(price: Node, volume: Node, window: int, *, name: str | None = None) -> 
         compute_fn=compute,
         name=name or "vwap",
         interval=price.interval,
-        period=window,
+        period=period,
     )

--- a/qmtl/transforms/angle.py
+++ b/qmtl/transforms/angle.py
@@ -8,15 +8,15 @@ from qmtl.sdk.cache_view import CacheView
 
 def angle(
     source: Node,
-    window: int,
+    period: int,
     *,
     radians: bool = False,
     name: str | None = None,
 ) -> Node:
-    """Return a Node computing the slope angle over ``window`` values."""
+    """Return a Node computing the slope angle over ``period`` values."""
 
     def compute(view: CacheView):
-        values = [v for _, v in view[source][source.interval][-window:]]
+        values = [v for _, v in view[source][source.interval][-period:]]
         if len(values) < 2:
             return None
         n = len(values)
@@ -39,5 +39,5 @@ def angle(
         compute_fn=compute,
         name=name or ("angle_rad" if radians else "angle"),
         interval=source.interval,
-        period=window,
+        period=period,
     )

--- a/qmtl/transforms/stochastic.py
+++ b/qmtl/transforms/stochastic.py
@@ -4,12 +4,12 @@ from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def stochastic(source: Node, window: int, *, name: str | None = None) -> Node:
-    """Return a Node computing stochastic oscillator over ``window`` values."""
+def stochastic(source: Node, period: int, *, name: str | None = None) -> Node:
+    """Return a Node computing stochastic oscillator over ``period`` values."""
 
     def compute(view: CacheView):
-        values = [v for _, v in view[source][source.interval][-window:]]
-        if len(values) < window:
+        values = [v for _, v in view[source][source.interval][-period:]]
+        if len(values) < period:
             return None
         current = values[-1]
         lowest = min(values)
@@ -23,5 +23,5 @@ def stochastic(source: Node, window: int, *, name: str | None = None) -> Node:
         compute_fn=compute,
         name=name or "stochastic",
         interval=source.interval,
-        period=window,
+        period=period,
     )

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -5,7 +5,7 @@ from qmtl.sdk.cache_view import CacheView
 
 def test_sma_compute():
     src = SourceNode(interval="1s", period=3)
-    node = sma(src, window=2)
+    node = sma(src, period=2)
     data = {src.node_id: {1: [(0, 1), (1, 3)]}}
     view = CacheView(data)
     assert node.compute_fn(view) == 2
@@ -31,7 +31,7 @@ from qmtl.indicators import (
 
 def test_ema_compute():
     src = SourceNode(interval="1s", period=3)
-    node = ema(src, window=3)
+    node = ema(src, period=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
     assert node.compute_fn(view) == 2.25
@@ -39,7 +39,7 @@ def test_ema_compute():
 
 def test_rsi_compute():
     src = SourceNode(interval="1s", period=15)
-    node = rsi(src, window=14)
+    node = rsi(src, period=14)
     data = {src.node_id: {1: [(i, float(i)) for i in range(15)]}}
     view = CacheView(data)
     assert node.compute_fn(view) == 100.0
@@ -47,7 +47,7 @@ def test_rsi_compute():
 
 def test_bollinger_bands_compute():
     src = SourceNode(interval="1s", period=3)
-    node = bollinger_bands(src, window=3)
+    node = bollinger_bands(src, period=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
     result = node.compute_fn(view)
@@ -60,7 +60,7 @@ def test_atr_compute():
     h = SourceNode(interval="1s", period=3, config={"id": "h"})
     l = SourceNode(interval="1s", period=3, config={"id": "l"})
     c = SourceNode(interval="1s", period=4, config={"id": "c"})
-    node = atr(h, l, c, window=3)
+    node = atr(h, l, c, period=3)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
         l.node_id: {1: [(0, 0), (1, 1), (2, 2)]},
@@ -74,7 +74,7 @@ def test_chandelier_exit_compute():
     h = SourceNode(interval="1s", period=3, config={"id": "h"})
     l = SourceNode(interval="1s", period=3, config={"id": "l"})
     c = SourceNode(interval="1s", period=4, config={"id": "c"})
-    node = chandelier_exit(h, l, c, window=3, multiplier=3)
+    node = chandelier_exit(h, l, c, period=3, multiplier=3)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
         l.node_id: {1: [(0, 0), (1, 1), (2, 2)]},
@@ -89,7 +89,7 @@ def test_chandelier_exit_compute():
 def test_vwap_compute():
     p = SourceNode(interval="1s", period=3, config={"id": "p"})
     v = SourceNode(interval="1s", period=3, config={"id": "v"})
-    node = vwap(p, v, window=3)
+    node = vwap(p, v, period=3)
     data = {
         p.node_id: {1: [(0, 1), (1, 2), (2, 3)]},
         v.node_id: {1: [(0, 1), (1, 1), (2, 2)]},
@@ -114,7 +114,7 @@ def test_keltner_channel_compute():
     h = SourceNode(interval="1s", period=3, config={"id": "h"})
     l = SourceNode(interval="1s", period=3, config={"id": "l"})
     c = SourceNode(interval="1s", period=4, config={"id": "c"})
-    node = keltner_channel(h, l, c, ema_window=3, atr_window=3, multiplier=2)
+    node = keltner_channel(h, l, c, ema_period=3, atr_period=3, multiplier=2)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
         l.node_id: {1: [(0, 0), (1, 1), (2, 2)]},
@@ -143,7 +143,7 @@ def test_supertrend_compute():
     h = SourceNode(interval="1s", period=3, config={"id": "h"})
     l = SourceNode(interval="1s", period=3, config={"id": "l"})
     c = SourceNode(interval="1s", period=4, config={"id": "c"})
-    node = supertrend(h, l, c, window=3, multiplier=2)
+    node = supertrend(h, l, c, period=3, multiplier=2)
     data = {
         h.node_id: {1: [(0, 2), (1, 3), (2, 4)]},
         l.node_id: {1: [(0, 0), (1, 1), (2, 2)]},
@@ -180,7 +180,7 @@ def test_kalman_trend_compute():
 
 def test_rough_bergami_compute():
     src = SourceNode(interval="1s", period=4, config={"id": "src"})
-    node = rough_bergami(src, window=3)
+    node = rough_bergami(src, period=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 1), (3, 2)]}}
     view = CacheView(data)
     assert round(node.compute_fn(view), 4) > 0
@@ -188,7 +188,7 @@ def test_rough_bergami_compute():
 
 def test_stoch_rsi_compute():
     src = SourceNode(interval="1s", period=30, config={"id": "src"})
-    node = stoch_rsi(src, window=14)
+    node = stoch_rsi(src, period=14)
     values = [(i, float(i % 5)) for i in range(30)]
     data = {src.node_id: {1: values}}
     view = CacheView(data)
@@ -200,7 +200,7 @@ def test_kdj_compute():
     h = SourceNode(interval="1s", period=3, config={"id": "h"})
     l = SourceNode(interval="1s", period=3, config={"id": "l"})
     c = SourceNode(interval="1s", period=3, config={"id": "c"})
-    node = kdj(h, l, c, window=3)
+    node = kdj(h, l, c, period=3)
     data = {
         h.node_id: {1: [(0, 3), (1, 4), (2, 5)]},
         l.node_id: {1: [(0, 1), (1, 1), (2, 2)]},

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -13,7 +13,7 @@ def test_rate_of_change_compute():
 
 def test_stochastic_compute():
     src = SourceNode(interval="1s", period=3)
-    node = stochastic(src, window=3)
+    node = stochastic(src, period=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
     assert node.compute_fn(view) == 100.0
@@ -21,7 +21,7 @@ def test_stochastic_compute():
 
 def test_angle_compute():
     src = SourceNode(interval="1s", period=3)
-    node = angle(src, window=3)
+    node = angle(src, period=3)
     data = {src.node_id: {1: [(0, 1), (1, 2), (2, 3)]}}
     view = CacheView(data)
     assert round(node.compute_fn(view), 2) == 45.0


### PR DESCRIPTION
## Summary
- Replace `window` parameter with `period` across transforms and indicators
- Update examples and tests to use `period`
- Adjust Keltner Channel to use `ema_period` and `atr_period`

## Testing
- `uv run --extra dev -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68907ebfc1f8832983ae346ca49986db