### PR TITLE
Handle Redis errors in task queue

### DIFF
--- a/qmtl/gateway/redis_queue.py
+++ b/qmtl/gateway/redis_queue.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+import logging
 import redis.asyncio as redis
 
 
@@ -12,13 +13,25 @@ class RedisTaskQueue:
         self.redis = redis_client
         self.name = name
 
-    async def push(self, item: str) -> None:
-        """Append ``item`` to the queue."""
-        await self.redis.rpush(self.name, item)
+    async def push(self, item: str) -> bool:
+        """Append ``item`` to the queue.
+
+        Returns ``True`` on success, ``False`` otherwise.
+        """
+        try:
+            await self.redis.rpush(self.name, item)
+            return True
+        except Exception as e:  # pragma: no cover - logging
+            logging.error("Redis queue %s push failed: %s", self.name, e)
+            return False
 
     async def pop(self) -> Optional[str]:
-        """Pop the next item from the queue or ``None`` if empty."""
-        data = await self.redis.lpop(self.name)
+        """Pop the next item from the queue or ``None`` if empty or on error."""
+        try:
+            data = await self.redis.lpop(self.name)
+        except Exception as e:  # pragma: no cover - logging
+            logging.error("Redis queue %s pop failed: %s", self.name, e)
+            return None
         if data is None:
             return None
         return data.decode() if isinstance(data, bytes) else data

--- a/tests/gateway/test_redis_queue_errors.py
+++ b/tests/gateway/test_redis_queue_errors.py
@@ -1,0 +1,30 @@
+import logging
+import pytest
+
+from qmtl.gateway.redis_queue import RedisTaskQueue
+
+
+class _FailPushRedis:
+    async def rpush(self, name: str, value: str) -> None:  # pragma: no cover - behaviour is tested
+        raise RuntimeError("fail-push")
+
+
+class _FailPopRedis:
+    async def lpop(self, name: str) -> None:  # pragma: no cover - behaviour is tested
+        raise RuntimeError("fail-pop")
+
+
+@pytest.mark.asyncio
+async def test_push_failure_logs_and_returns_false(caplog):
+    queue = RedisTaskQueue(_FailPushRedis(), "q")
+    caplog.set_level(logging.ERROR)
+    assert await queue.push("x") is False
+    assert any("q" in r.message and "fail-push" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_pop_failure_logs_and_returns_none(caplog):
+    queue = RedisTaskQueue(_FailPopRedis(), "q")
+    caplog.set_level(logging.ERROR)
+    assert await queue.pop() is None
+    assert any("q" in r.message and "fail-pop" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- wrap RedisTaskQueue push/pop calls in try/except and log failures
- return a boolean on push and `None` on pop errors for clearer handling
- add unit tests for RedisTaskQueue error paths

## Testing
- `uv run -m pytest -W error tests/gateway/test_inmemory_redis.py tests/gateway/test_worker.py tests/test_health.py tests/reliability/test_worker_alerts.py tests/gateway/test_redis_queue_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_6890836063f88329a1e10ff341246725