### PR TITLE
Handle errors in DAG manager CLI

### DIFF
--- a/tests/test_dagmanager_cli.py
+++ b/tests/test_dagmanager_cli.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 from qmtl.dagmanager.cli import main
 from qmtl.proto import dagmanager_pb2, dagmanager_pb2_grpc
 import grpc
@@ -6,6 +7,15 @@ import grpc
 class DummyChannel:
     async def close(self):
         pass
+
+
+class DummyRpcError(grpc.RpcError):
+    def __init__(self, msg="boom"):
+        super().__init__()
+        self._msg = msg
+
+    def __str__(self) -> str:  # pragma: no cover - simple string
+        return self._msg
 
 def test_cli_diff_dryrun(tmp_path, capsys):
     dag = {"nodes": [{"node_id": "n1", "code_hash": "c", "schema_hash": "s"}]}
@@ -115,4 +125,55 @@ def test_cli_export_schema(monkeypatch, tmp_path):
     assert out.read_text().strip() == "CREATE CONSTRAINT c"
     assert captured["uri"] == "bolt://db"
     assert captured["closed"]
+
+
+def test_cli_diff_file_error(capsys):
+    with pytest.raises(SystemExit):
+        main(["diff", "--file", "missing.json", "--dry-run"])
+    err = capsys.readouterr().err
+    assert "Failed to read file" in err
+
+
+def test_cli_redo_diff_file_error(capsys):
+    with pytest.raises(SystemExit):
+        main(["redo-diff", "--sentinel", "s", "--file", "missing.json"])
+    err = capsys.readouterr().err
+    assert "Failed to read file" in err
+
+
+def test_cli_diff_grpc_error(monkeypatch, tmp_path, capsys):
+    path = tmp_path / "dag.json"
+    path.write_text("{}")
+
+    class DummyClient:
+        def __init__(self, target):
+            pass
+
+        async def diff(self, strategy_id, dag_json):
+            raise DummyRpcError("fail")
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("qmtl.dagmanager.cli.DagManagerClient", DummyClient)
+    with pytest.raises(SystemExit):
+        main(["diff", "--file", str(path)])
+    err = capsys.readouterr().err
+    assert "gRPC error" in err
+
+
+def test_cli_queue_stats_grpc_error(monkeypatch, capsys):
+    class Stub:
+        def __init__(self, channel):
+            pass
+
+        async def GetQueueStats(self, request):
+            raise DummyRpcError("fail")
+
+    monkeypatch.setattr(dagmanager_pb2_grpc, "AdminServiceStub", Stub)
+    monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
+    with pytest.raises(SystemExit):
+        main(["queue-stats"])
+    err = capsys.readouterr().err
+    assert "gRPC error" in err
 


### PR DESCRIPTION
## Summary
- add helpers to show friendly messages for file read failures and gRPC errors
- use helpers across dagmanager CLI commands and ensure channels are closed
- test file and network error handling paths

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6890836293c883299e29bd163c844c9e