### PR TITLE
Improve config loading error handling

### DIFF
--- a/qmtl/config.py
+++ b/qmtl/config.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+import logging
 import yaml
 
 from .gateway.config import GatewayConfig
 from .dagmanager.config import DagManagerConfig
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -29,8 +32,16 @@ def find_config_file(cwd: Path | None = None) -> str | None:
 
 def load_config(path: str) -> UnifiedConfig:
     """Parse YAML/JSON and populate :class:`UnifiedConfig`."""
-    with open(path, "r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            try:
+                data = yaml.safe_load(fh) or {}
+            except yaml.YAMLError as exc:
+                logger.error("Failed to parse configuration file %s: %s", path, exc)
+                raise ValueError(f"Failed to parse configuration file {path}") from exc
+    except (FileNotFoundError, OSError) as exc:
+        logger.error("Unable to open configuration file %s: %s", path, exc)
+        raise
 
     if not isinstance(data, dict):
         raise TypeError("Unified config must be a mapping")

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+import logging
 import yaml
 
 
@@ -20,8 +21,17 @@ class GatewayConfig:
 
 def load_gateway_config(path: str) -> GatewayConfig:
     """Load configuration from YAML or JSON file."""
-    with open(path, "r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
+    logger = logging.getLogger(__name__)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            try:
+                data = yaml.safe_load(fh) or {}
+            except yaml.YAMLError as exc:
+                logger.error("Failed to parse configuration file %s: %s", path, exc)
+                raise ValueError(f"Failed to parse configuration file {path}") from exc
+    except (FileNotFoundError, OSError) as exc:
+        logger.error("Unable to open configuration file %s: %s", path, exc)
+        raise
     if not isinstance(data, dict):
         raise TypeError("Gateway config must be a mapping")
     cfg = GatewayConfig(**data)

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import logging
 import pytest
 import yaml
 
@@ -47,11 +48,26 @@ def test_load_gateway_config_missing_file():
         load_gateway_config("nope.yml")
 
 
+def test_load_gateway_config_directory(tmp_path: Path) -> None:
+    d = tmp_path / "dir"
+    d.mkdir()
+    with pytest.raises(OSError):
+        load_gateway_config(str(d))
+
+
 def test_load_gateway_config_malformed(tmp_path: Path):
     p = tmp_path / "bad.yml"
     p.write_text("- 1")
     with pytest.raises(TypeError):
         load_gateway_config(str(p))
+
+
+def test_load_gateway_config_yaml_error(tmp_path: Path, caplog):
+    p = tmp_path / "bad_syntax.yml"
+    p.write_text(":\n  -")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match="Failed to parse configuration file"):
+            load_gateway_config(str(p))
 
 
 def test_gateway_config_defaults() -> None:

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import logging
 import pytest
 import yaml
 
@@ -59,11 +60,26 @@ def test_load_unified_config_missing_file() -> None:
         load_config("missing.yml")
 
 
+def test_load_unified_config_directory(tmp_path: Path) -> None:
+    d = tmp_path / "dir"
+    d.mkdir()
+    with pytest.raises(OSError):
+        load_config(str(d))
+
+
 def test_load_unified_config_malformed(tmp_path: Path) -> None:
     config_file = tmp_path / "bad.yml"
     config_file.write_text("- 1")
     with pytest.raises(TypeError):
         load_config(str(config_file))
+
+
+def test_load_unified_config_yaml_error(tmp_path: Path, caplog) -> None:
+    config_file = tmp_path / "bad.yml"
+    config_file.write_text(":\n  -")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match="Failed to parse configuration file"):
+            load_config(str(config_file))
 
 
 def test_load_unified_config_defaults(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- wrap config file reads in try/except to log and raise clear errors
- add tests covering missing files, directory paths, and YAML parse failures

## Testing
- `uv run -m pytest -W error` *(fails: ExceptionGroup: multiple unraisable exception warnings (3 unraisable exception warnings were omitted))*
- `uv run -m pytest tests/test_gateway_config.py tests/test_unified_config.py tests/test_dagmanager_config.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_6890835fd9dc8329bc169fc3a31dcb39