### PR TITLE
Remove DagManagerClient retries and propagate errors

### DIFF
--- a/tests/gateway/test_circuit_breaker_dagclient.py
+++ b/tests/gateway/test_circuit_breaker_dagclient.py
@@ -68,7 +68,7 @@ def make_health_stub(total_failures: int = 0):
 
 @pytest.mark.asyncio
 async def test_breaker_opens_and_resets(monkeypatch):
-    DiffStub = make_diff_stub(total_failures=10)
+    DiffStub = make_diff_stub(total_failures=2)
     TagStub = make_tag_stub()
     HealthStub = make_health_stub()
     monkeypatch.setattr(dagmanager_pb2_grpc, "DiffServiceStub", DiffStub)

--- a/tests/gateway/test_diff.py
+++ b/tests/gateway/test_diff.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 import grpc
 
@@ -77,18 +76,16 @@ async def test_diff_returns_buffer_nodes(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_diff_retries(monkeypatch):
+async def test_diff_propagates_error(monkeypatch):
     chunk = dagmanager_pb2.DiffChunk(queue_map={"A": "t"}, sentinel_id="s")
-    Stub, get_calls = make_stub([chunk], fail_times=2)
+    Stub, get_calls = make_stub([chunk], fail_times=1)
     monkeypatch.setattr(dagmanager_pb2_grpc, "DiffServiceStub", Stub)
     monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", lambda c: None)
     monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", lambda c: None)
     monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
-    orig_sleep = asyncio.sleep
-    monkeypatch.setattr(asyncio, "sleep", lambda t: orig_sleep(0))
 
     client = DagManagerClient("127.0.0.1:1")
-    result = await client.diff("sid", "{}")
-    assert result.queue_map == {"A": "t"}
-    assert get_calls() == 3
+    with pytest.raises(grpc.RpcError):
+        await client.diff("sid", "{}")
+    assert get_calls() == 1
     await client.close()


### PR DESCRIPTION
## Summary
- remove retry/backoff loops from DagManagerClient so gRPC failures bubble up
- have API /queues/by_tag surface DagManager failures as HTTP 503
- update gateway tests for explicit failure handling

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_6890861b210483298df7acdaf6165b90