### PR TITLE
refactor: simplify callback posting

### DIFF
--- a/qmtl/dagmanager/alerts.py
+++ b/qmtl/dagmanager/alerts.py
@@ -8,7 +8,7 @@ from typing import Protocol
 import httpx
 
 from ..common import AsyncCircuitBreaker
-from .callbacks import post_with_backoff
+from .callbacks import post
 
 
 class PagerDutySender(Protocol):
@@ -32,7 +32,7 @@ class PagerDutyClient:
 
     async def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
         async with httpx.AsyncClient() as client:
-            await post_with_backoff(
+            await post(
                 self.url,
                 {"text": message},
                 client=client,
@@ -47,7 +47,7 @@ class SlackClient:
 
     async def send(self, message: str) -> None:  # pragma: no cover - simple wrapper
         async with httpx.AsyncClient() as client:
-            await post_with_backoff(
+            await post(
                 self.url,
                 {"text": message},
                 client=client,

--- a/qmtl/dagmanager/callbacks.py
+++ b/qmtl/dagmanager/callbacks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from typing import Any, Optional
 
 import httpx
@@ -8,19 +7,14 @@ import httpx
 from ..common import AsyncCircuitBreaker
 
 
-async def post_with_backoff(
+async def post(
     url: str,
     payload: Any,
     *,
-    retries: int = 3,
-    base: float = 1.0,
-    factor: float = 2.0,
-    max_delay: float = 8.0,
     client: Optional[httpx.AsyncClient] = None,
     circuit_breaker: "AsyncCircuitBreaker" | None = None,
 ) -> httpx.Response:
-    """Send HTTP POST with exponential backoff."""
-    delay = base
+    """Send a single HTTP POST and raise on non-202 responses."""
     async with (client if client is not None else httpx.AsyncClient()) as c:
         async def send() -> httpx.Response:
             resp = await c.post(url, json=payload)
@@ -29,14 +23,5 @@ async def post_with_backoff(
             return resp
 
         wrapped = circuit_breaker(send) if circuit_breaker else send
-
-        for attempt in range(retries):
-            try:
-                return await wrapped()
-            except Exception:
-                if attempt < retries - 1:
-                    await asyncio.sleep(delay)
-                    delay = min(delay * factor, max_delay)
-                else:
-                    raise
+        return await wrapped()
 

--- a/tests/dagmanager/test_circuit_breaker_callbacks.py
+++ b/tests/dagmanager/test_circuit_breaker_callbacks.py
@@ -2,7 +2,7 @@ import asyncio
 import httpx
 import pytest
 
-from qmtl.dagmanager.callbacks import post_with_backoff
+from qmtl.dagmanager.callbacks import post
 from qmtl.common import AsyncCircuitBreaker
 
 
@@ -15,17 +15,10 @@ async def test_post_with_breaker_trips_on_failures(monkeypatch):
 
     monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
 
-    async def dummy_sleep(_):
-        return None
-
-    monkeypatch.setattr(asyncio, "sleep", dummy_sleep)
-
     for _ in range(2):
         with pytest.raises(RuntimeError):
-            await post_with_backoff(
-                "http://x", {}, retries=1, circuit_breaker=cb
-            )
+            await post("http://x", {}, circuit_breaker=cb)
 
     assert cb.is_open
     with pytest.raises(RuntimeError):
-        await post_with_backoff("http://x", {}, retries=1, circuit_breaker=cb)
+        await post("http://x", {}, circuit_breaker=cb)

--- a/tests/e2e/test_sentinel_weight_integration.py
+++ b/tests/e2e/test_sentinel_weight_integration.py
@@ -23,7 +23,7 @@ async def test_sentinel_traffic_triggers_ws(monkeypatch):
             path = url.replace("http://gw", "")
             return await client.post(path, json=json)
 
-    monkeypatch.setattr("qmtl.dagmanager.http_server.post_with_backoff", post_to_gateway)
+    monkeypatch.setattr("qmtl.dagmanager.http_server.post", post_to_gateway)
 
     dag_app = dag_create_app(gateway_url="http://gw/callbacks/dag-event")
     dag_transport = httpx.ASGITransport(dag_app)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,27 +1,26 @@
-import asyncio
-
 import httpx
 import pytest
 
-from qmtl.dagmanager.callbacks import post_with_backoff
+from qmtl.dagmanager.callbacks import post
 
 
 @pytest.mark.asyncio
-async def test_post_with_backoff(monkeypatch):
-    calls = []
-
+async def test_post_success(monkeypatch):
     async def mock_post(self, url, json):
-        calls.append(json)
-        status = 500 if len(calls) < 2 else 202
-        return httpx.Response(status)
+        return httpx.Response(202)
 
     monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
 
-    async def dummy_sleep(_):
-        return None
-
-    monkeypatch.setattr(asyncio, "sleep", dummy_sleep)
-
-    resp = await post_with_backoff("http://gw/cb", {"x": 1})
+    resp = await post("http://gw/cb", {"x": 1})
     assert resp.status_code == 202
-    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_post_failure(monkeypatch):
+    async def mock_post(self, url, json):
+        return httpx.Response(500)
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+
+    with pytest.raises(RuntimeError):
+        await post("http://gw/cb", {"x": 1})

--- a/tests/test_completion_monitor.py
+++ b/tests/test_completion_monitor.py
@@ -67,7 +67,7 @@ async def test_completion_emits_event(monkeypatch):
         return httpx.Response(202)
 
     monkeypatch.setattr(
-        "qmtl.dagmanager.completion.post_with_backoff",
+        "qmtl.dagmanager.completion.post",
         fake_post,
     )
 

--- a/tests/test_gc_endpoint.py
+++ b/tests/test_gc_endpoint.py
@@ -33,7 +33,7 @@ def test_gc_route_emits_callback(monkeypatch):
         events.append((url, payload))
         return httpx.Response(202)
 
-    monkeypatch.setattr("qmtl.dagmanager.api.post_with_backoff", fake_post)
+    monkeypatch.setattr("qmtl.dagmanager.api.post", fake_post)
 
     app = create_app(gc, callback_url="http://gw/cb")
     with TestClient(app) as client:

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -175,7 +175,7 @@ async def test_grpc_diff_callback_sends_cloudevent(monkeypatch):
         return httpx.Response(202)
 
     monkeypatch.setattr(
-        "qmtl.dagmanager.grpc_server.post_with_backoff",
+        "qmtl.dagmanager.grpc_server.post",
         mock_post,
     )
 
@@ -329,7 +329,7 @@ async def test_http_sentinel_traffic(monkeypatch):
         return httpx.Response(202)
 
     monkeypatch.setattr(
-        "qmtl.dagmanager.http_server.post_with_backoff",
+        "qmtl.dagmanager.http_server.post",
         mock_post,
     )
 


### PR DESCRIPTION
## Summary
- replace backoff-based callback helper with single-shot `post`
- let API, HTTP, gRPC servers and queue monitors handle their own retries
- update tests for new posting behavior

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_689089b865108329907bac75b9e96f2e