### PR TITLE
feat: simplify diff stream acknowledgement

### DIFF
--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -70,9 +70,6 @@ class _PrintStream(StreamSender):
     def send(self, chunk) -> None:
         print(json.dumps({"queue_map": chunk.queue_map, "sentinel_id": chunk.sentinel_id}))
 
-    def wait_for_ack(self) -> None:
-        pass
-
     def ack(self) -> None:
         pass
 

--- a/qmtl/dagmanager/diff_service.py
+++ b/qmtl/dagmanager/diff_service.py
@@ -154,10 +154,12 @@ class StreamSender:
     """Interface to send diff results as a stream."""
 
     def send(self, chunk: DiffChunk) -> None:
-        raise NotImplementedError
+        """Send ``chunk`` and wait for receiver acknowledgement.
 
-    def wait_for_ack(self) -> None:
-        """Block until the client acknowledges the last chunk."""
+        Implementations should block until the remote side acknowledges the
+        chunk or raise an exception if the acknowledgement is not received or
+        the stream reports an error.
+        """
         raise NotImplementedError
 
     def ack(self) -> None:
@@ -295,7 +297,6 @@ class DiffService:
                     buffering_nodes=[],
                 )
             )
-            self.stream_sender.wait_for_ack()
             return
         for i in range(0, total, CHUNK_SIZE):
             chunk_new = new_nodes[i:i+CHUNK_SIZE]
@@ -308,7 +309,6 @@ class DiffService:
                     buffering_nodes=chunk_buf,
                 )
             )
-            self.stream_sender.wait_for_ack()
 
     def diff(self, request: DiffRequest) -> DiffChunk:
         start = time.perf_counter()

--- a/qmtl/dagmanager/monitor.py
+++ b/qmtl/dagmanager/monitor.py
@@ -18,9 +18,6 @@ class MetricsBackend(Protocol):
     def kafka_zookeeper_disconnects(self) -> int:
         ...
 
-    def diff_chunk_ack_timeout(self) -> bool:
-        ...
-
 
 class Neo4jCluster(Protocol):
     """Control interface for Neo4j cluster."""
@@ -36,19 +33,11 @@ class KafkaSession(Protocol):
         ...
 
 
-class DiffStream(Protocol):
-    """Interface to resume diff streams."""
-
-    def resume_from_last_offset(self) -> None:
-        ...
-
-
 @dataclass
 class Monitor:
     metrics: MetricsBackend
     neo4j: Neo4jCluster
     kafka: KafkaSession
-    stream: DiffStream
     alerts: AlertManager
 
     async def check_once(self) -> None:
@@ -61,9 +50,6 @@ class Monitor:
             self.kafka.retry()
             await self.alerts.send_slack("Kafka session lost")
 
-        if self.metrics.diff_chunk_ack_timeout():
-            self.stream.resume_from_last_offset()
-            await self.alerts.send_slack("Diff stream stalled")
 
 
 @dataclass
@@ -102,6 +88,5 @@ __all__ = [
     "MetricsBackend",
     "Neo4jCluster",
     "KafkaSession",
-    "DiffStream",
     "MonitorLoop",
 ]

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -20,9 +20,6 @@ class _NullStream(StreamSender):
     def send(self, chunk) -> None:  # pragma: no cover - simple no-op
         pass
 
-    def wait_for_ack(self) -> None:  # pragma: no cover - noop
-        pass
-
     def ack(self) -> None:  # pragma: no cover - noop
         pass
 

--- a/qmtl/gateway/dagmanager_client.py
+++ b/qmtl/gateway/dagmanager_client.py
@@ -80,6 +80,11 @@ class DagManagerClient:
                 queue_map.update(dict(chunk.queue_map))
                 sentinel_id = chunk.sentinel_id
                 buffer_nodes.extend(chunk.buffer_nodes)
+                await self._diff_stub.AckChunk(
+                    dagmanager_pb2.ChunkAck(
+                        sentinel_id=chunk.sentinel_id, chunk_id=0
+                    )
+                )
             return dagmanager_pb2.DiffChunk(
                 queue_map=queue_map,
                 sentinel_id=sentinel_id,

--- a/tests/gateway/test_circuit_breaker_dagclient.py
+++ b/tests/gateway/test_circuit_breaker_dagclient.py
@@ -29,6 +29,9 @@ def make_diff_stub(total_failures: int = 0):
                 raise grpc.RpcError("fail")
             return gen()
 
+        async def AckChunk(self, ack):
+            return ack
+
     return Stub
 
 

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -53,9 +53,6 @@ class _FakeStream(StreamSender):
     def send(self, chunk):
         pass
 
-    def wait_for_ack(self):
-        pass
-
     def ack(self):
         pass
 

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -54,13 +54,9 @@ class FakeQueue(QueueManager):
 class FakeStream(StreamSender):
     def __init__(self):
         self.chunks = []
-        self.waits = 0
 
     def send(self, chunk):
         self.chunks.append(chunk)
-
-    def wait_for_ack(self):
-        self.waits += 1
 
     def ack(self):
         pass
@@ -371,4 +367,3 @@ def test_stream_chunking_and_ack():
     service.diff(DiffRequest(strategy_id="s", dag_json=dag))
 
     assert len(stream.chunks) == 3
-    assert stream.waits == 3

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -53,10 +53,6 @@ class FakeAdmin:
 class FakeStream(StreamSender):
     def send(self, chunk):
         pass
-
-    def wait_for_ack(self):
-        pass
-
     def ack(self):
         pass
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -96,10 +96,6 @@ async def test_grpc_health():
     class FakeStream:
         def send(self, chunk):
             pass
-
-        def wait_for_ack(self):
-            pass
-
         def ack(self):
             pass
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -50,9 +50,6 @@ class FakeStream(StreamSender):
     def send(self, chunk):
         pass
 
-    def wait_for_ack(self):
-        pass
-
     def ack(self):
         pass
 


### PR DESCRIPTION
## Summary
- require diff stream `send` to await acknowledgement instead of calling `wait_for_ack`
- remove diff stream stall checks from Monitor
- update gRPC server/client to use new stream protocol

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_689089bb5b4083298251617a7c5e42b1