### PR TITLE
Use event driven scheduling

### DIFF
--- a/tests/buffer/test_buffer_scheduler.py
+++ b/tests/buffer/test_buffer_scheduler.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 
 from qmtl.dagmanager.buffer_scheduler import BufferingScheduler
@@ -54,7 +53,7 @@ async def test_scheduler_reprocesses_old_nodes():
     diff = FakeDiff()
     sched = BufferingScheduler(repo, diff, interval=0.01, delay_days=7)
     await sched.start()
-    await asyncio.sleep(0.03)
+    await sched.trigger()
     await sched.stop()
     assert diff.calls and diff.calls[0].strategy_id == "A"
     assert repo.cleared == ["A"]

--- a/tests/gc/test_scheduler.py
+++ b/tests/gc/test_scheduler.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 
 from qmtl.dagmanager.gc_scheduler import GCScheduler
@@ -18,6 +17,7 @@ async def test_gc_scheduler_runs_collect():
     gc = DummyGC()
     sched = GCScheduler(gc, interval=0.01)
     await sched.start()
-    await asyncio.sleep(0.03)
+    await sched.trigger()
+    await sched.trigger()
     await sched.stop()
-    assert gc.calls >= 2
+    assert gc.calls == 2

--- a/tests/test_completion_monitor.py
+++ b/tests/test_completion_monitor.py
@@ -72,8 +72,10 @@ async def test_completion_emits_event(monkeypatch):
     )
 
     monitor = QueueCompletionMonitor(repo, admin, "http://gw/cb", threshold=1)
-    await monitor.check_once()
-    await monitor.check_once()
+    await monitor.start()
+    await monitor.trigger()
+    await monitor.trigger()
+    await monitor.stop()
 
     assert events
     evt = events[0]

--- a/tests/test_monitor_loop.py
+++ b/tests/test_monitor_loop.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 
 from qmtl.dagmanager.monitor import MonitorLoop
@@ -17,6 +16,7 @@ async def test_monitor_loop_runs_periodically():
     mon = DummyMonitor()
     loop = MonitorLoop(mon, interval=0.01)  # type: ignore[arg-type]
     await loop.start()
-    await asyncio.sleep(0.03)
+    await loop.trigger()
+    await loop.trigger()
     await loop.stop()
-    assert mon.called >= 2
+    assert mon.called == 2


### PR DESCRIPTION
## Summary
- replace scheduler sleep loops with event-triggered queues and `trigger` interfaces
- allow degradation monitoring to react to explicit health check events
- add tests for new trigger-based scheduling

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68908d9afa9483298fdaab66a8ffdceb