### PR TITLE
feat: expose manual arrow cache eviction

### DIFF
--- a/tests/test_arrow_cache.py
+++ b/tests/test_arrow_cache.py
@@ -1,4 +1,5 @@
 import os
+import time
 import pytest
 
 from qmtl.sdk import arrow_cache
@@ -12,10 +13,11 @@ pytestmark = pytest.mark.filterwarnings('ignore::RuntimeWarning')
 @pytest.mark.skipif(not arrow_cache.ARROW_AVAILABLE, reason="pyarrow missing")
 def test_arrow_cache_basic():
     cache = arrow_cache.NodeCacheArrow(period=2)
-    cache.append("u1", 60, 60, {"v": 1})
-    cache.append("u1", 60, 120, {"v": 2})
+    now = int(time.time())
+    cache.append("u1", 60, now, {"v": 1})
+    cache.append("u1", 60, now + 60, {"v": 2})
     view = cache.view()
-    assert view["u1"][60].latest() == (120, {"v": 2})
+    assert view["u1"][60].latest() == (now + 60 - ((now + 60) % 60), {"v": 2})
     assert arrow_cache.pa and isinstance(view["u1"][60].table(), arrow_cache.pa.Table)
 
 
@@ -31,9 +33,10 @@ def test_node_uses_arrow_cache(monkeypatch):
 @pytest.mark.skipif(not arrow_cache.ARROW_AVAILABLE, reason="pyarrow missing")
 def test_drop_upstream_removes_data_and_is_idempotent():
     cache = arrow_cache.NodeCacheArrow(period=2)
-    cache.append("u1", 60, 60, {"v": 1})
+    now = int(time.time())
+    cache.append("u1", 60, now, {"v": 1})
     view = cache.view()
-    assert view["u1"][60].latest() == (60, {"v": 1})
+    assert view["u1"][60].latest() == (now - (now % 60), {"v": 1})
 
     cache.drop_upstream("u1", 60)
     view = cache.view()
@@ -42,3 +45,21 @@ def test_drop_upstream_removes_data_and_is_idempotent():
 
     # second invocation should not raise
     cache.drop_upstream("u1", 60)
+
+
+@pytest.mark.skipif(not arrow_cache.ARROW_AVAILABLE, reason="pyarrow missing")
+def test_explicit_eviction_removes_old_entries():
+    cache = arrow_cache.NodeCacheArrow(period=2)
+    now = int(time.time())
+    cache.append("u1", 60, now - 500, {"v": 1})
+    cache.evict_expired()
+    assert cache.latest("u1", 60) is None
+
+
+@pytest.mark.skipif(not arrow_cache.ARROW_AVAILABLE, reason="pyarrow missing")
+def test_access_triggers_eviction(monkeypatch):
+    cache = arrow_cache.NodeCacheArrow(period=1)
+    now = int(time.time())
+    cache.append("u1", 60, now, {"v": 1})
+    monkeypatch.setattr(arrow_cache.time, "time", lambda: now + 120)
+    assert cache.latest("u1", 60) is None


### PR DESCRIPTION
## Summary
- remove background eviction loops and Ray actor
- document and expose manual eviction via `evict_expired`
- test manual and access-triggered eviction paths

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68908da130088329aa4fb69d9ab4a688