### PR TITLE
Release worker lock to enable immediate reprocessing

### DIFF
--- a/qmtl/gateway/worker.py
+++ b/qmtl/gateway/worker.py
@@ -105,9 +105,8 @@ class StrategyWorker:
                 await self.ws_hub.send_progress(strategy_id, state)
             return True
         finally:
-            # The lock expires automatically; explicit deletion would allow
-            # another worker to reprocess the same strategy immediately.
-            pass
+            # Explicitly remove the lock so reprocessing isn't delayed.
+            await self.redis.delete(lock_key)
 
     async def run_once(self) -> Optional[str]:
         """Pop and process a single strategy."""


### PR DESCRIPTION
## Summary
- Ensure StrategyWorker deletes its Redis lock after processing to avoid reprocessing delays.
- Add regression tests for immediate reprocessing without stale locks.

## Testing
- `uv run -m pytest tests/gateway/test_worker.py -W error`

------
https://chatgpt.com/codex/tasks/task_e_689090c0564c83299b7f3741c7ddb75a