### PR TITLE
feat: add grpc call wrappers without timeout

### DIFF
--- a/qmtl/proto/dagmanager_pb2_grpc.py
+++ b/qmtl/proto/dagmanager_pb2_grpc.py
@@ -2,8 +2,20 @@
 """Client and server classes corresponding to protobuf-defined services."""
 import grpc
 import warnings
+from typing import Any, Callable
 
 import dagmanager_pb2 as dagmanager__pb2
+
+
+def call_without_timeout(call: Callable[..., Any]) -> Callable[..., Any]:
+    """Return an adapter that disallows ``timeout`` for ``call``."""
+
+    def wrapped(request: Any, *args: Any, **kwargs: Any) -> Any:
+        if "timeout" in kwargs:
+            raise TypeError("timeout parameter is not supported")
+        return call(request, *args, **kwargs)
+
+    return wrapped
 
 GRPC_GENERATED_VERSION = '1.73.0'
 GRPC_VERSION = grpc.__version__


### PR DESCRIPTION
## Summary
- add `call_without_timeout` helper that rejects gRPC timeouts
- use wrapped gRPC stub calls in `DagManagerClient`

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68909089418c8329b03dd1ae32e8ac16