### PR TITLE
feat: add manual circuit breaker reset

### DIFF
--- a/qmtl/dagmanager/grpc_server.py
+++ b/qmtl/dagmanager/grpc_server.py
@@ -244,13 +244,11 @@ def serve(
     repo: NodeRepository | None = None,
     queue: QueueManager | None = None,
     breaker_threshold: int = 3,
-    breaker_timeout: float = 60.0,
 ) -> tuple[grpc.aio.Server, int]:
     admin = None
     if kafka_admin_client is not None:
         breaker = AsyncCircuitBreaker(
             max_failures=breaker_threshold,
-            reset_timeout=breaker_timeout,
         )
         admin = KafkaAdmin(kafka_admin_client, breaker=breaker)
     if repo is None:

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -78,7 +78,6 @@ async def _run(cfg: DagManagerConfig) -> None:
         admin_client = _KafkaAdminClient(cfg.kafka_dsn)
         breaker = AsyncCircuitBreaker(
             max_failures=cfg.kafka_breaker_threshold,
-            reset_timeout=cfg.kafka_breaker_timeout,
         )
         queue = KafkaQueueManager(KafkaAdmin(admin_client, breaker=breaker))
     else:
@@ -88,7 +87,6 @@ async def _run(cfg: DagManagerConfig) -> None:
         admin_client = InMemoryAdminClient()
         breaker = AsyncCircuitBreaker(
             max_failures=cfg.kafka_breaker_threshold,
-            reset_timeout=cfg.kafka_breaker_timeout,
         )
         queue = KafkaQueueManager(KafkaAdmin(admin_client, breaker=breaker))
 
@@ -105,7 +103,6 @@ async def _run(cfg: DagManagerConfig) -> None:
         repo=repo,
         queue=queue,
         breaker_threshold=cfg.kafka_breaker_threshold,
-        breaker_timeout=cfg.kafka_breaker_timeout,
     )
     await grpc_server.start()
 

--- a/qmtl/gateway/dagmanager_client.py
+++ b/qmtl/gateway/dagmanager_client.py
@@ -13,7 +13,7 @@ from . import metrics as gw_metrics
 class DagManagerClient:
     """gRPC client for DAG‑Manager services using a persistent channel."""
 
-    def __init__(self, target: str, *, breaker_max_failures: int = 3, breaker_reset_timeout: float = 60.0) -> None:
+    def __init__(self, target: str, *, breaker_max_failures: int = 3) -> None:
         self._target = target
         self._created_loop = None
         try:
@@ -27,7 +27,6 @@ class DagManagerClient:
         self._tag_stub = dagmanager_pb2_grpc.TagQueryStub(self._channel)
         self._breaker = AsyncCircuitBreaker(
             max_failures=breaker_max_failures,
-            reset_timeout=breaker_reset_timeout,
             on_open=lambda: (
                 gw_metrics.dagclient_breaker_state.set(1),
                 gw_metrics.dagclient_breaker_open_total.inc(),
@@ -61,6 +60,8 @@ class DagManagerClient:
 
         try:
             result = await _call()
+            if result:
+                self._breaker.reset()
             gw_metrics.dagclient_breaker_failures.set(self._breaker.failures)
             return result
         except Exception:

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -54,7 +54,7 @@ class Runner:
     @classmethod
     def _get_gateway_circuit_breaker(cls) -> AsyncCircuitBreaker:
         if cls._gateway_cb is None:
-            cls._gateway_cb = AsyncCircuitBreaker(max_failures=3, reset_timeout=60.0)
+            cls._gateway_cb = AsyncCircuitBreaker(max_failures=3)
         return cls._gateway_cb
 
     # ------------------------------------------------------------------

--- a/tests/dagmanager/test_circuit_breaker_callbacks.py
+++ b/tests/dagmanager/test_circuit_breaker_callbacks.py
@@ -8,7 +8,7 @@ from qmtl.common import AsyncCircuitBreaker
 
 @pytest.mark.asyncio
 async def test_post_with_breaker_trips_on_failures(monkeypatch):
-    cb = AsyncCircuitBreaker(max_failures=2, reset_timeout=0.1)
+    cb = AsyncCircuitBreaker(max_failures=2)
 
     async def mock_post(self, url, json=None):
         return httpx.Response(500)

--- a/tests/dagmanager/test_circuit_breaker_neo4j.py
+++ b/tests/dagmanager/test_circuit_breaker_neo4j.py
@@ -1,7 +1,5 @@
 import sys
 import types
-import time
-
 import pytest
 
 from qmtl.common import AsyncCircuitBreaker
@@ -63,7 +61,7 @@ def test_breaker_opens(monkeypatch):
 
     client = ReconnectingNeo4j('bolt://', 'u', 'p')
     repo = Neo4jNodeRepository(client)
-    breaker = AsyncCircuitBreaker(max_failures=1, reset_timeout=0.05)
+    breaker = AsyncCircuitBreaker(max_failures=1)
 
     with pytest.raises(RuntimeError):
         repo.get_nodes(['A'], breaker=breaker)
@@ -81,13 +79,13 @@ def test_breaker_resets(monkeypatch):
 
     client = ReconnectingNeo4j('bolt://', 'u', 'p')
     repo = Neo4jNodeRepository(client)
-    breaker = AsyncCircuitBreaker(max_failures=1, reset_timeout=0.05)
+    breaker = AsyncCircuitBreaker(max_failures=1)
 
     with pytest.raises(RuntimeError):
         repo.get_nodes(['A'], breaker=breaker)
 
     assert breaker.is_open
-    time.sleep(0.06)
+    breaker.reset()
 
     records = repo.get_nodes(['A'], breaker=breaker)
     assert records == {}

--- a/tests/sdk/test_circuit_breaker_runner.py
+++ b/tests/sdk/test_circuit_breaker_runner.py
@@ -1,5 +1,6 @@
 import httpx
 import pytest
+import httpx
 
 from qmtl.sdk.runner import Runner
 from qmtl.common import AsyncCircuitBreaker
@@ -22,7 +23,7 @@ class DummyClient:
 @pytest.mark.asyncio
 async def test_post_gateway_circuit_breaker(monkeypatch):
     monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
-    cb = AsyncCircuitBreaker(max_failures=1, reset_timeout=60)
+    cb = AsyncCircuitBreaker(max_failures=1)
 
     with pytest.raises(httpx.RequestError):
         await Runner._post_gateway_async(


### PR DESCRIPTION
## Summary
- replace timeout-based reset with manual `AsyncCircuitBreaker.reset`
- update DagManager client and other call sites to new API
- cover manual reset behaviour with tests

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68909c2f10cc8329abae37d9cc0d8fbe