### PR TITLE
Remove breaker timeout options

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -45,12 +45,9 @@ Configuration options control the breakers:
 ```yaml
 gateway:
   dagclient_breaker_threshold: 3  # failures before opening
-  dagclient_breaker_timeout: 60.0 # seconds before reset
 dagmanager:
   kafka_breaker_threshold: 3
-  kafka_breaker_timeout: 60.0
   neo4j_breaker_threshold: 3
-  neo4j_breaker_timeout: 60.0
 ```
 
 ## SDK Metrics

--- a/qmtl/config.py
+++ b/qmtl/config.py
@@ -54,6 +54,10 @@ def load_config(path: str) -> UnifiedConfig:
     if not isinstance(dm_data, dict):
         raise TypeError("dagmanager section must be a mapping")
 
+    for key in ("dagclient_breaker_timeout", "kafka_breaker_timeout", "neo4j_breaker_timeout"):
+        gw_data.pop(key, None)
+        dm_data.pop(key, None)
+
     gateway_cfg = GatewayConfig(**gw_data)
     dagmanager_cfg = DagManagerConfig(**dm_data)
     return UnifiedConfig(gateway=gateway_cfg, dagmanager=dagmanager_cfg)

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -16,9 +16,7 @@ class DagManagerConfig:
     memory_repo_path: str = "memrepo.gpickle"
     kafka_dsn: Optional[str] = None
     kafka_breaker_threshold: int = 3
-    kafka_breaker_timeout: float = 60.0
     neo4j_breaker_threshold: int = 3
-    neo4j_breaker_timeout: float = 60.0
     grpc_host: str = "0.0.0.0"
     grpc_port: int = 50051
     http_host: str = "0.0.0.0"
@@ -42,4 +40,7 @@ def load_dagmanager_config(path: str) -> DagManagerConfig:
         raise
     if not isinstance(data, dict):
         raise TypeError("DagManager config must be a mapping")
+    data.pop("dagclient_breaker_timeout", None)
+    data.pop("kafka_breaker_timeout", None)
+    data.pop("neo4j_breaker_timeout", None)
     return DagManagerConfig(**data)

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -16,7 +16,6 @@ class GatewayConfig:
     database_backend: str = "sqlite"
     database_dsn: str = "./qmtl.db"
     dagclient_breaker_threshold: int = 3
-    dagclient_breaker_timeout: float = 60.0
 
 
 def load_gateway_config(path: str) -> GatewayConfig:
@@ -34,5 +33,8 @@ def load_gateway_config(path: str) -> GatewayConfig:
         raise
     if not isinstance(data, dict):
         raise TypeError("Gateway config must be a mapping")
+    data.pop("dagclient_breaker_timeout", None)
+    data.pop("kafka_breaker_timeout", None)
+    data.pop("neo4j_breaker_timeout", None)
     cfg = GatewayConfig(**data)
     return cfg

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -13,16 +13,12 @@ def test_dagmanager_config_custom_values() -> None:
         neo4j_password="pw",
         kafka_dsn="localhost:9092",
         kafka_breaker_threshold=5,
-        kafka_breaker_timeout=2.5,
         neo4j_breaker_threshold=4,
-        neo4j_breaker_timeout=1.5,
     )
     assert cfg.neo4j_dsn == "bolt://db:7687"
     assert cfg.kafka_dsn == "localhost:9092"
     assert cfg.kafka_breaker_threshold == 5
-    assert cfg.kafka_breaker_timeout == 2.5
     assert cfg.neo4j_breaker_threshold == 4
-    assert cfg.neo4j_breaker_timeout == 1.5
 
 
 def test_dagmanager_config_defaults() -> None:
@@ -30,9 +26,9 @@ def test_dagmanager_config_defaults() -> None:
     assert cfg.neo4j_dsn is None
     assert cfg.kafka_dsn is None
     assert cfg.kafka_breaker_threshold == 3
-    assert cfg.kafka_breaker_timeout == 60.0
+    assert not hasattr(cfg, "kafka_breaker_timeout")
     assert cfg.neo4j_breaker_threshold == 3
-    assert cfg.neo4j_breaker_timeout == 60.0
+    assert not hasattr(cfg, "neo4j_breaker_timeout")
 
 
 def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
@@ -42,6 +38,8 @@ def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
         "neo4j_password": "pw",
         "kafka_dsn": "kafka:9092",
         "grpc_port": 6000,
+        "kafka_breaker_timeout": 2.5,
+        "neo4j_breaker_timeout": 1.5,
     }
     config_file = tmp_path / "dm.yml"
     config_file.write_text(yaml.safe_dump(data))
@@ -49,6 +47,8 @@ def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
     assert cfg.neo4j_dsn == data["neo4j_dsn"]
     assert cfg.kafka_dsn == "kafka:9092"
     assert cfg.grpc_port == 6000
+    assert not hasattr(cfg, "kafka_breaker_timeout")
+    assert not hasattr(cfg, "neo4j_breaker_timeout")
 
 
 def test_load_dagmanager_config_missing_file() -> None:

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -22,7 +22,7 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
     assert config.database_backend == "postgres"
     assert config.database_dsn == data["database_dsn"]
     assert config.dagclient_breaker_threshold == 5
-    assert config.dagclient_breaker_timeout == 2.5
+    assert not hasattr(config, "dagclient_breaker_timeout")
 
 
 def test_load_gateway_config_json(tmp_path: Path) -> None:
@@ -40,7 +40,7 @@ def test_load_gateway_config_json(tmp_path: Path) -> None:
     assert config.database_backend == "memory"
     assert config.database_dsn == data["database_dsn"]
     assert config.dagclient_breaker_threshold == 4
-    assert config.dagclient_breaker_timeout == 1.0
+    assert not hasattr(config, "dagclient_breaker_timeout")
 
 
 def test_load_gateway_config_missing_file():
@@ -76,4 +76,4 @@ def test_gateway_config_defaults() -> None:
     assert cfg.database_backend == "sqlite"
     assert cfg.database_dsn == "./qmtl.db"
     assert cfg.dagclient_breaker_threshold == 3
-    assert cfg.dagclient_breaker_timeout == 60.0
+    assert not hasattr(cfg, "dagclient_breaker_timeout")

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -25,10 +25,10 @@ def test_load_unified_config_yaml(tmp_path: Path) -> None:
     config = load_config(str(config_file))
     assert config.gateway.redis_dsn == data["gateway"]["redis_dsn"]
     assert config.gateway.dagclient_breaker_threshold == 4
-    assert config.gateway.dagclient_breaker_timeout == 1.0
+    assert not hasattr(config.gateway, "dagclient_breaker_timeout")
     assert config.dagmanager.neo4j_dsn == data["dagmanager"]["neo4j_dsn"]
     assert config.dagmanager.neo4j_breaker_threshold == 5
-    assert config.dagmanager.neo4j_breaker_timeout == 2.0
+    assert not hasattr(config.dagmanager, "neo4j_breaker_timeout")
 
 
 def test_load_unified_config_json(tmp_path: Path) -> None:
@@ -50,9 +50,9 @@ def test_load_unified_config_json(tmp_path: Path) -> None:
     assert config.gateway.host == "127.0.0.1"
     assert config.dagmanager.grpc_port == 1234
     assert config.gateway.dagclient_breaker_threshold == 3
-    assert config.gateway.dagclient_breaker_timeout == 5.0
+    assert not hasattr(config.gateway, "dagclient_breaker_timeout")
     assert config.dagmanager.neo4j_breaker_threshold == 2
-    assert config.dagmanager.neo4j_breaker_timeout == 1.0
+    assert not hasattr(config.dagmanager, "neo4j_breaker_timeout")
 
 
 def test_load_unified_config_missing_file() -> None:
@@ -91,9 +91,9 @@ def test_load_unified_config_defaults(tmp_path: Path) -> None:
     assert config.gateway.redis_dsn is None
     assert config.dagmanager.grpc_port == 50051
     assert config.gateway.dagclient_breaker_threshold == 3
-    assert config.gateway.dagclient_breaker_timeout == 60.0
+    assert not hasattr(config.gateway, "dagclient_breaker_timeout")
     assert config.dagmanager.neo4j_breaker_threshold == 3
-    assert config.dagmanager.neo4j_breaker_timeout == 60.0
+    assert not hasattr(config.dagmanager, "neo4j_breaker_timeout")
 
 
 def test_load_unified_config_bad_gateway(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- drop deprecated breaker timeout fields from gateway and dagmanager configs
- ignore removed timeout options when loading unified config
- update tests and docs for timeout removal

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_6890a4ce270483298ea805872a9e473e