### PR TITLE
Handle gateway circuit breaker resets

### DIFF
--- a/tests/sdk/test_circuit_breaker_runner.py
+++ b/tests/sdk/test_circuit_breaker_runner.py
@@ -1,12 +1,11 @@
 import httpx
 import pytest
-import httpx
 
-from qmtl.sdk.runner import Runner
 from qmtl.common import AsyncCircuitBreaker
+from qmtl.sdk.runner import Runner
 
 
-class DummyClient:
+class FailingClient:
     def __init__(self, *a, **k):
         pass
 
@@ -20,48 +19,108 @@ class DummyClient:
         raise httpx.RequestError("fail", request=httpx.Request("POST", url))
 
 
+class FlakyClient:
+    calls = 0
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None):
+        type(self).calls += 1
+        if type(self).calls == 1:
+            raise httpx.RequestError("fail", request=httpx.Request("POST", url))
+        return httpx.Response(202, json={"queue_map": {"n": "t"}})
+
+
+class TrackingCircuitBreaker(AsyncCircuitBreaker):
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.reset_calls = 0
+
+    def reset(self) -> None:  # type: ignore[override]
+        self.reset_calls += 1
+        super().reset()
+
+
 @pytest.mark.asyncio
 async def test_post_gateway_circuit_breaker(monkeypatch):
-    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+    monkeypatch.setattr(httpx, "AsyncClient", FailingClient)
     cb = AsyncCircuitBreaker(max_failures=1)
 
-    with pytest.raises(httpx.RequestError):
-        await Runner._post_gateway_async(
-            gateway_url="http://gw",
-            dag={},
-            meta=None,
-            run_type="x",
-            circuit_breaker=cb,
-        )
+    res = await Runner._post_gateway_async(
+        gateway_url="http://gw",
+        dag={},
+        meta=None,
+        run_type="x",
+        circuit_breaker=cb,
+    )
+    assert "error" in res and "fail" in res["error"]
+    assert cb.is_open
 
-    with pytest.raises(RuntimeError):
-        await Runner._post_gateway_async(
-            gateway_url="http://gw",
-            dag={},
-            meta=None,
-            run_type="x",
-            circuit_breaker=cb,
-        )
+    res = await Runner._post_gateway_async(
+        gateway_url="http://gw",
+        dag={},
+        meta=None,
+        run_type="x",
+        circuit_breaker=cb,
+    )
+    assert res["error"] == "circuit open"
+
+
 @pytest.mark.asyncio
 async def test_default_circuit_breaker(monkeypatch):
-    monkeypatch.setattr(httpx, "AsyncClient", DummyClient)
+    monkeypatch.setattr(httpx, "AsyncClient", FailingClient)
     Runner.set_gateway_circuit_breaker(None)
 
     for _ in range(3):
-        with pytest.raises(httpx.RequestError):
-            await Runner._post_gateway_async(
-                gateway_url="http://gw",
-                dag={},
-                meta=None,
-                run_type="x",
-            )
-
-    with pytest.raises(RuntimeError):
-        await Runner._post_gateway_async(
+        res = await Runner._post_gateway_async(
             gateway_url="http://gw",
             dag={},
             meta=None,
             run_type="x",
         )
+        assert "error" in res
+
+    res = await Runner._post_gateway_async(
+        gateway_url="http://gw",
+        dag={},
+        meta=None,
+        run_type="x",
+    )
+    assert res["error"] == "circuit open"
     Runner.set_gateway_circuit_breaker(None)
+
+
+@pytest.mark.asyncio
+async def test_breaker_resets_on_success(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", FlakyClient)
+    cb = TrackingCircuitBreaker(max_failures=2)
+
+    first = await Runner._post_gateway_async(
+        gateway_url="http://gw",
+        dag={},
+        meta=None,
+        run_type="x",
+        circuit_breaker=cb,
+    )
+    assert "error" in first
+    assert cb.failures == 1
+
+    second = await Runner._post_gateway_async(
+        gateway_url="http://gw",
+        dag={},
+        meta=None,
+        run_type="x",
+        circuit_breaker=cb,
+    )
+    assert second == {"n": "t"}
+    assert cb.reset_calls == 1
+    assert cb.failures == 0
+    assert not cb.is_open
 


### PR DESCRIPTION
## Summary
- handle gateway circuit breaker resets explicitly
- return error objects from `_post_gateway_async`
- test circuit breaker reset behavior

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6890a76f8fd483298cc13aee93d92243