### PR TITLE
feat: handle explicit stream ack statuses

### DIFF
--- a/dag-manager.md
+++ b/dag-manager.md
@@ -174,7 +174,7 @@ sequenceDiagram
 | --------------------- | --------------- | ----------------------------- | -------------------------------------- | ---------- |
 | Neo4j leader down     | Diff 거절         | `raft_leader_is_null`         | Automat. leader election               | PagerDuty  |
 | Kafka ZK session loss | 토픽 생성 실패        | `kafka_zookeeper_disconnects` | Retry exponential, fallback admin node | Slack #ops |
-| Diff Stream stall     | Gateway timeout | `diff_chunk_ack_timeout`      | Resume from last ACK offset            | Opsgenie   |
+| Diff Stream stall     | Gateway timeout | `ack_status=timeout`          | Resume from last ACK offset            | Opsgenie   |
 
 ---
 

--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -17,6 +17,7 @@ from .diff_service import (
     NodeRecord,
     StreamSender,
 )
+from .monitor import AckStatus
 from .topic import topic_name
 from .neo4j_export import export_schema, connect
 from ..gateway.dagmanager_client import DagManagerClient
@@ -71,10 +72,10 @@ class _PrintStream(StreamSender):
     def send(self, chunk) -> None:
         print(json.dumps({"queue_map": chunk.queue_map, "sentinel_id": chunk.sentinel_id}))
 
-    def wait_for_ack(self) -> None:
-        pass
+    def wait_for_ack(self) -> AckStatus:
+        return AckStatus.OK
 
-    def ack(self) -> None:
+    def ack(self, status: AckStatus = AckStatus.OK) -> None:
         pass
 
 

--- a/qmtl/dagmanager/diff_service.py
+++ b/qmtl/dagmanager/diff_service.py
@@ -20,6 +20,7 @@ from .metrics import (
 from .kafka_admin import KafkaAdmin
 from .topic import TopicConfig, topic_name
 from qmtl.common import AsyncCircuitBreaker
+from .monitor import AckStatus
 
 if TYPE_CHECKING:  # pragma: no cover - optional import for typing
     from neo4j import Driver
@@ -156,11 +157,11 @@ class StreamSender:
     def send(self, chunk: DiffChunk) -> None:
         raise NotImplementedError
 
-    def wait_for_ack(self) -> None:
+    def wait_for_ack(self) -> AckStatus:
         """Block until the client acknowledges the last chunk."""
         raise NotImplementedError
 
-    def ack(self) -> None:
+    def ack(self, status: AckStatus = AckStatus.OK) -> None:
         """Signal that the last chunk was received."""
         raise NotImplementedError
 

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -14,16 +14,17 @@ from ..config import load_config, find_config_file
 from .api import create_app
 from .gc import GarbageCollector, QueueInfo, MetricsProvider, QueueStore
 from .diff_service import StreamSender
+from .monitor import AckStatus
 
 
 class _NullStream(StreamSender):
     def send(self, chunk) -> None:  # pragma: no cover - simple no-op
         pass
 
-    def wait_for_ack(self) -> None:  # pragma: no cover - noop
-        pass
+    def wait_for_ack(self) -> AckStatus:  # pragma: no cover - noop
+        return AckStatus.OK
 
-    def ack(self) -> None:  # pragma: no cover - noop
+    def ack(self, status: AckStatus = AckStatus.OK) -> None:  # pragma: no cover - noop
         pass
 
 

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -14,6 +14,7 @@ from qmtl.gateway.dagmanager_client import DagManagerClient
 from qmtl.dagmanager.grpc_server import serve
 from qmtl.dagmanager.diff_service import StreamSender, Neo4jNodeRepository
 import grpc
+from qmtl.dagmanager.monitor import AckStatus
 
 
 class _FakeSession:
@@ -53,10 +54,10 @@ class _FakeStream(StreamSender):
     def send(self, chunk):
         pass
 
-    def wait_for_ack(self):
-        pass
+    def wait_for_ack(self) -> AckStatus:
+        return AckStatus.OK
 
-    def ack(self):
+    def ack(self, status: AckStatus = AckStatus.OK):
         pass
 
 

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -9,6 +9,7 @@ from qmtl.dagmanager.diff_service import (
     Neo4jNodeRepository,
     KafkaQueueManager,
 )
+from qmtl.dagmanager.monitor import AckStatus
 from qmtl.dagmanager.node_repository import MemoryNodeRepository
 from qmtl.dagmanager.kafka_admin import KafkaAdmin
 from qmtl.dagmanager.topic import topic_name
@@ -59,10 +60,11 @@ class FakeStream(StreamSender):
     def send(self, chunk):
         self.chunks.append(chunk)
 
-    def wait_for_ack(self):
+    def wait_for_ack(self) -> AckStatus:
         self.waits += 1
+        return AckStatus.OK
 
-    def ack(self):
+    def ack(self, status: AckStatus = AckStatus.OK):
         pass
 
 

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -12,6 +12,7 @@ from qmtl.dagmanager.http_server import create_app
 from qmtl.dagmanager import metrics
 from qmtl.dagmanager.gc import GarbageCollector, QueueInfo
 from qmtl.proto import dagmanager_pb2, dagmanager_pb2_grpc
+from qmtl.dagmanager.monitor import AckStatus
 
 
 class FakeSession:
@@ -54,10 +55,10 @@ class FakeStream(StreamSender):
     def send(self, chunk):
         pass
 
-    def wait_for_ack(self):
-        pass
+    def wait_for_ack(self) -> AckStatus:
+        return AckStatus.OK
 
-    def ack(self):
+    def ack(self, status: AckStatus = AckStatus.OK):
         pass
 
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -5,6 +5,8 @@ from qmtl.gateway.api import create_app as gw_create_app
 from qmtl.dagmanager.http_server import create_app as dag_http_create_app
 from qmtl.dagmanager.api import create_app as dag_api_create_app
 from qmtl.dagmanager.gc import QueueInfo
+from qmtl.dagmanager.diff_service import StreamSender
+from qmtl.dagmanager.monitor import AckStatus
 from qmtl.gateway.redis_queue import RedisTaskQueue
 from qmtl.gateway.dagmanager_client import DagManagerClient
 from qmtl.gateway.ws import WebSocketHub
@@ -93,14 +95,14 @@ async def test_grpc_health():
         def create_topic(self, *a, **k):
             pass
 
-    class FakeStream:
+    class FakeStream(StreamSender):
         def send(self, chunk):
             pass
 
-        def wait_for_ack(self):
-            pass
+        def wait_for_ack(self) -> AckStatus:
+            return AckStatus.OK
 
-        def ack(self):
+        def ack(self, status: AckStatus = AckStatus.OK):
             pass
 
     driver = FakeDriver()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,6 +14,7 @@ from qmtl.dagmanager.gc import GarbageCollector, QueueInfo
 import httpx
 import time
 from qmtl.dagmanager import metrics
+from qmtl.dagmanager.monitor import AckStatus
 
 
 class FakeRepo(NodeRepository):
@@ -50,10 +51,10 @@ class FakeStream(StreamSender):
     def send(self, chunk):
         pass
 
-    def wait_for_ack(self):
-        pass
+    def wait_for_ack(self) -> AckStatus:
+        return AckStatus.OK
 
-    def ack(self):
+    def ack(self, status: AckStatus = AckStatus.OK):
         pass
 
 


### PR DESCRIPTION
## Summary
- monitor diff streams using explicit ACK status from stream components
- emit AckStatus results from stream senders/receivers
- document the new ACK-based recovery in DAG manager docs

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6890a7791dec832982765ec16e90ef6c