### PR TITLE
Fix fast shutdown of WebSocket client

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -50,6 +50,15 @@ dagmanager:
   neo4j_breaker_threshold: 3
 ```
 
+Unlike time-based breakers, QMTL requires an explicit success signal to
+close a tripped breaker. Calls that verify remote health should inspect
+their return value and invoke `reset()` when appropriate:
+
+```python
+if await client.status():
+    client.breaker.reset()
+```
+
 ## SDK Metrics
 
 The SDK's cache layer provides a small set of Prometheus metrics. Any service can

--- a/qmtl/config.py
+++ b/qmtl/config.py
@@ -54,6 +54,8 @@ def load_config(path: str) -> UnifiedConfig:
     if not isinstance(dm_data, dict):
         raise TypeError("dagmanager section must be a mapping")
 
+    # Breaker timeouts were removed; services now reset breakers manually
+    # based on explicit success signals.
     for key in ("dagclient_breaker_timeout", "kafka_breaker_timeout", "neo4j_breaker_timeout"):
         gw_data.pop(key, None)
         dm_data.pop(key, None)

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -40,6 +40,7 @@ def load_dagmanager_config(path: str) -> DagManagerConfig:
         raise
     if not isinstance(data, dict):
         raise TypeError("DagManager config must be a mapping")
+    # Breaker timeouts are deprecated; reset breakers manually on success.
     data.pop("dagclient_breaker_timeout", None)
     data.pop("kafka_breaker_timeout", None)
     data.pop("neo4j_breaker_timeout", None)

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -33,6 +33,7 @@ def load_gateway_config(path: str) -> GatewayConfig:
         raise
     if not isinstance(data, dict):
         raise TypeError("Gateway config must be a mapping")
+    # Breaker timeouts are deprecated; reset breakers manually on success.
     data.pop("dagclient_breaker_timeout", None)
     data.pop("kafka_breaker_timeout", None)
     data.pop("neo4j_breaker_timeout", None)

--- a/qmtl/sdk/ws_client.py
+++ b/qmtl/sdk/ws_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import contextlib
 from typing import Awaitable, Callable, Optional, TYPE_CHECKING
 
 import websockets
@@ -79,8 +80,11 @@ class WebSocketClient:
         """Stop the background listener."""
         self._stop_event.set()
         if self._ws is not None:
+            self._ws.close_timeout = 0
             await self._ws.close()
             self._ws = None
         if self._task is not None:
-            await self._task
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
             self._task = None

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -59,7 +59,9 @@ async def test_ws_client_stop_closes_session():
         client = WebSocketClient(url)
         await client.start()
         await asyncio.sleep(0.1)
-        await asyncio.wait_for(client.stop(), timeout=0.5)
+        start = asyncio.get_running_loop().time()
+        await client.stop()
+        assert asyncio.get_running_loop().time() - start < 0.5
     finally:
         server.close()
         await server.wait_closed()


### PR DESCRIPTION
## Summary
- ensure WebSocket client shutdown cancels the listener and closes connections immediately
- document manual circuit breaker reset via explicit success signals
- clarify in config loaders that breaker timeouts have been removed

## Testing
- `uv run -m pytest -W error tests/test_ws_client.py tests/test_gateway_config.py tests/test_dagmanager_config.py tests/test_unified_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6890a77db0e08329b2dad4e171060779