### PR TITLE
refactor: rename queue config to topic

### DIFF
--- a/qmtl/dagmanager/topic.py
+++ b/qmtl/dagmanager/topic.py
@@ -13,7 +13,7 @@ class TopicConfig:
     retention_ms: int
 
 
-_QUEUE_CONFIG = {
+_TOPIC_CONFIG = {
     "raw": TopicConfig(partitions=3, replication_factor=3, retention_ms=7 * 24 * 60 * 60 * 1000),
     "indicator": TopicConfig(partitions=1, replication_factor=2, retention_ms=30 * 24 * 60 * 60 * 1000),
     "trade_exec": TopicConfig(partitions=1, replication_factor=3, retention_ms=90 * 24 * 60 * 60 * 1000),
@@ -48,12 +48,12 @@ def topic_name(
         length += 2
 
 
-def get_config(queue_type: str) -> TopicConfig:
-    """Return :class:`TopicConfig` for the given ``queue_type``."""
+def get_config(topic_type: str) -> TopicConfig:
+    """Return :class:`TopicConfig` for the given ``topic_type``."""
     try:
-        return _QUEUE_CONFIG[queue_type]
+        return _TOPIC_CONFIG[topic_type]
     except KeyError:
-        raise ValueError(f"unknown queue type: {queue_type}")
+        raise ValueError(f"unknown topic type: {topic_type}")
 
 
 __all__ = ["TopicConfig", "topic_name", "get_config"]

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -36,8 +36,7 @@ def test_topic_name_generation():
     )
     assert sim.endswith("_sim")
 
-
-def test_queue_config_values():
+def test_topic_config_values():
     config = get_config("raw")
     assert config == TopicConfig(partitions=3, replication_factor=3, retention_ms=7 * 24 * 60 * 60 * 1000)
     ind = get_config("indicator")


### PR DESCRIPTION
## Summary
- rename internal `_QUEUE_CONFIG` to `_TOPIC_CONFIG`
- rename `queue_type` parameter to `topic_type`
- update tests and docs for topic terminology

## Testing
- `uv run -m pytest -W error tests/test_topic.py`


------
https://chatgpt.com/codex/tasks/task_e_6890bdc6563c832980d9d5df5be14af6