### PR TITLE
standardize dry_run flag across dag manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ QMTL orchestrates trading strategies as directed acyclic graphs (DAGs). The gate
 Use the DAG Manager CLI to preview DAG structures:
 
 ```bash
-qmtl dagmanager diff --file dag.json --dry-run
+qmtl dagmanager diff --file dag.json --dry_run
 ```
 
 Every subcommand now exposes its own help message. For example:

--- a/dag-manager.md
+++ b/dag-manager.md
@@ -113,10 +113,10 @@ CREATE INDEX kafka_topic IF NOT EXISTS FOR (q:Queue) ON (q.topic);
 ### 3.1 토픽 이름 컨벤션
 
 ```
-{asset}_{node_type}_{short_hash}_{version}{_dryrun?}
+{asset}_{node_type}_{short_hash}_{version}{_dry_run?}
 ```
 
-* **dry‑run** 플래그가 붙으면 `*_sim` 접미사.
+* **dry_run** 플래그가 붙으면 `*_sim` 접미사.
 * `short_hash = first 6 code_hash` → 충돌 시 길이+2.
 * 기본 토픽 설정은 코드의 ``_TOPIC_CONFIG`` 에서 관리되며 ``get_config(topic_type)`` 으로 조회한다.
 
@@ -236,8 +236,8 @@ sequenceDiagram
 ## 11. Admin CLI Snippets (예)
 
 ```shell
-# diff dry‑run
-qmtl dagmanager diff --file dag.json --dry-run
+# diff dry_run
+qmtl dagmanager diff --file dag.json --dry_run
 # queue stats
 qmtl dagmanager queue-stats --tag indicator --interval 1h
 # trigger GC for a sentinel

--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -58,12 +58,12 @@ class _MemQueue(QueueManager):
         code_hash: str,
         version: str,
         *,
-        dryrun: bool = False,
+        dry_run: bool = False,
     ) -> str:
-        key = (asset, node_type, code_hash, version, dryrun)
+        key = (asset, node_type, code_hash, version, dry_run)
         topic = self.topics.get(key)
         if not topic:
-            topic = topic_name(asset, node_type, code_hash, version, dryrun=dryrun)
+            topic = topic_name(asset, node_type, code_hash, version, dry_run=dry_run)
             self.topics[key] = topic
         return topic
 
@@ -163,7 +163,7 @@ async def _main(argv: list[str] | None = None) -> None:
 
     p_diff = sub.add_parser("diff", help="Run diff")
     p_diff.add_argument("--file", required=True)
-    p_diff.add_argument("--dry-run", action="store_true")
+    p_diff.add_argument("--dry_run", action="store_true")
 
     p_stats = sub.add_parser("queue-stats", help="Get queue statistics")
     p_stats.add_argument("--tag", default="")

--- a/qmtl/dagmanager/diff_service.py
+++ b/qmtl/dagmanager/diff_service.py
@@ -146,7 +146,7 @@ class QueueManager:
         code_hash: str,
         version: str,
         *,
-        dryrun: bool = False,
+        dry_run: bool = False,
     ) -> str:
         raise NotImplementedError
 
@@ -510,7 +510,7 @@ class KafkaQueueManager(QueueManager):
         code_hash: str,
         version: str,
         *,
-        dryrun: bool = False,
+        dry_run: bool = False,
     ) -> str:
         existing = self.admin.client.list_topics().keys()
         topic = topic_name(
@@ -518,7 +518,7 @@ class KafkaQueueManager(QueueManager):
             node_type,
             code_hash,
             version,
-            dryrun=dryrun,
+            dry_run=dry_run,
             existing=existing,
         )
         self.admin.create_topic_if_needed(topic, self.config)

--- a/qmtl/dagmanager/topic.py
+++ b/qmtl/dagmanager/topic.py
@@ -26,7 +26,7 @@ def topic_name(
     code_hash: str,
     version: str,
     *,
-    dryrun: bool = False,
+    dry_run: bool = False,
     existing: Iterable[str] | None = None,
 ) -> str:
     """Return unique topic name per spec.
@@ -38,7 +38,7 @@ def topic_name(
 
     taken = set(existing or [])
     length = 6
-    suffix = "_sim" if dryrun else ""
+    suffix = "_sim" if dry_run else ""
 
     while True:
         short_hash = code_hash[:length]

--- a/tests/runner/test_run_pipeline.py
+++ b/tests/runner/test_run_pipeline.py
@@ -52,7 +52,7 @@ def _make_strategy(calls, results):
     return Strat
 
 
-def test_dryrun_offline_pipeline(monkeypatch):
+def test_dry_run_offline_pipeline(monkeypatch):
     _mock_gateway(monkeypatch)
     monkeypatch.setattr(Runner, "_kafka_available", True)
     calls, results = [], []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ def test_cli_help():
     assert "usage: qmtl sdk" in result.stdout
 
 
-def test_cli_dryrun():
+def test_cli_dry_run():
     result = subprocess.run([
         sys.executable,
         "-m",

--- a/tests/test_dagmanager_cli.py
+++ b/tests/test_dagmanager_cli.py
@@ -17,11 +17,11 @@ class DummyRpcError(grpc.RpcError):
     def __str__(self) -> str:  # pragma: no cover - simple string
         return self._msg
 
-def test_cli_diff_dryrun(tmp_path, capsys):
+def test_cli_diff_dry_run(tmp_path, capsys):
     dag = {"nodes": [{"node_id": "n1", "code_hash": "c", "schema_hash": "s"}]}
     path = tmp_path / "dag.json"
     path.write_text(json.dumps(dag))
-    main(["diff", "--file", str(path), "--dry-run"])
+    main(["diff", "--file", str(path), "--dry_run"])
     out = capsys.readouterr().out
     assert "n1" in out
 
@@ -129,7 +129,7 @@ def test_cli_export_schema(monkeypatch, tmp_path):
 
 def test_cli_diff_file_error(capsys):
     with pytest.raises(SystemExit):
-        main(["diff", "--file", "missing.json", "--dry-run"])
+        main(["diff", "--file", "missing.json", "--dry_run"])
     err = capsys.readouterr().err
     assert "Failed to read file" in err
 

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -47,9 +47,9 @@ class FakeQueue(QueueManager):
     def __init__(self):
         self.calls = []
 
-    def upsert(self, asset, node_type, code_hash, version, *, dryrun=False):
-        self.calls.append((asset, node_type, code_hash, version, dryrun))
-        return topic_name(asset, node_type, code_hash, version, dryrun=dryrun)
+    def upsert(self, asset, node_type, code_hash, version, *, dry_run=False):
+        self.calls.append((asset, node_type, code_hash, version, dry_run))
+        return topic_name(asset, node_type, code_hash, version, dry_run=dry_run)
 
 
 class FakeStream(StreamSender):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -38,12 +38,12 @@ class FakeRepo(NodeRepository):
 
 
 class FakeQueue(QueueManager):
-    def upsert(self, asset, node_type, code_hash, version, *, dryrun=False):
-        return topic_name(asset, node_type, code_hash, version, dryrun=dryrun)
+    def upsert(self, asset, node_type, code_hash, version, *, dry_run=False):
+        return topic_name(asset, node_type, code_hash, version, dry_run=dry_run)
 
 
 class FailingQueue(QueueManager):
-    def upsert(self, asset, node_type, code_hash, version, *, dryrun=False):
+    def upsert(self, asset, node_type, code_hash, version, *, dry_run=False):
         raise RuntimeError("fail")
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -77,7 +77,7 @@ def test_backtest_requires_start_and_end(monkeypatch):
         )
 
 
-def test_dryrun(caplog, monkeypatch):
+def test_dry_run(caplog, monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(202, json={"strategy_id": "s"})
 

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -32,7 +32,7 @@ def test_topic_name_generation():
         "Indicator",
         "abcdef123456",
         "v1",
-        dryrun=True,
+        dry_run=True,
     )
     assert sim.endswith("_sim")
 


### PR DESCRIPTION
## Summary
- rename dag manager dryrun parameter to dry_run
- switch CLI flag to `--dry_run`
- update docs and tests for new dry_run naming

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6890c0ebbec48329ad3e34cf4ca6a8df