### PR TITLE
Remove dagclient breaker options

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -40,11 +40,10 @@ Both services expose a Prometheus endpoint. Circuit breaker activity is tracked 
 - `dagclient_breaker_open_total` — increments each time the Gateway's gRPC client trips open.
 - `kafka_breaker_open_total` — increments each time the DAG Manager's Kafka admin breaker opens.
 
-Configuration options control the breakers:
+The Gateway's DAG client breaker opens after three consecutive failures and
+is not configurable. The DAG Manager still allows configuring breaker thresholds:
 
 ```yaml
-gateway:
-  dagclient_breaker_threshold: 3  # failures before opening
 dagmanager:
   kafka_breaker_threshold: 3
   neo4j_breaker_threshold: 3

--- a/qmtl/config.py
+++ b/qmtl/config.py
@@ -56,7 +56,7 @@ def load_config(path: str) -> UnifiedConfig:
 
     # Breaker timeouts were removed; services now reset breakers manually
     # based on explicit success signals.
-    for key in ("dagclient_breaker_timeout", "kafka_breaker_timeout", "neo4j_breaker_timeout"):
+    for key in ("kafka_breaker_timeout", "neo4j_breaker_timeout"):
         gw_data.pop(key, None)
         dm_data.pop(key, None)
 

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -41,7 +41,6 @@ def load_dagmanager_config(path: str) -> DagManagerConfig:
     if not isinstance(data, dict):
         raise TypeError("DAG Manager config must be a mapping")
     # Breaker timeouts are deprecated; reset breakers manually on success.
-    data.pop("dagclient_breaker_timeout", None)
     data.pop("kafka_breaker_timeout", None)
     data.pop("neo4j_breaker_timeout", None)
     return DagManagerConfig(**data)

--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -15,7 +15,6 @@ class GatewayConfig:
     redis_dsn: Optional[str] = None
     database_backend: str = "sqlite"
     database_dsn: str = "./qmtl.db"
-    dagclient_breaker_threshold: int = 3
 
 
 def load_gateway_config(path: str) -> GatewayConfig:
@@ -33,9 +32,5 @@ def load_gateway_config(path: str) -> GatewayConfig:
         raise
     if not isinstance(data, dict):
         raise TypeError("Gateway config must be a mapping")
-    # Breaker timeouts are deprecated; reset breakers manually on success.
-    data.pop("dagclient_breaker_timeout", None)
-    data.pop("kafka_breaker_timeout", None)
-    data.pop("neo4j_breaker_timeout", None)
     cfg = GatewayConfig(**data)
     return cfg

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -12,8 +12,6 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
         "redis_dsn": "redis://test:6379",
         "database_backend": "postgres",
         "database_dsn": "postgresql://db/test",
-        "dagclient_breaker_threshold": 5,
-        "dagclient_breaker_timeout": 2.5,
     }
     config_file = tmp_path / "gw.yaml"
     config_file.write_text(yaml.safe_dump(data))
@@ -21,8 +19,6 @@ def test_load_gateway_config_yaml(tmp_path: Path) -> None:
     assert config.redis_dsn == data["redis_dsn"]
     assert config.database_backend == "postgres"
     assert config.database_dsn == data["database_dsn"]
-    assert config.dagclient_breaker_threshold == 5
-    assert not hasattr(config, "dagclient_breaker_timeout")
 
 
 def test_load_gateway_config_json(tmp_path: Path) -> None:
@@ -30,8 +26,6 @@ def test_load_gateway_config_json(tmp_path: Path) -> None:
         "redis_dsn": "redis://j:6379",
         "database_backend": "memory",
         "database_dsn": "sqlite:///:memory:",
-        "dagclient_breaker_threshold": 4,
-        "dagclient_breaker_timeout": 1.0,
     }
     config_file = tmp_path / "gw.json"
     config_file.write_text(json.dumps(data))
@@ -39,8 +33,6 @@ def test_load_gateway_config_json(tmp_path: Path) -> None:
     assert config.redis_dsn == data["redis_dsn"]
     assert config.database_backend == "memory"
     assert config.database_dsn == data["database_dsn"]
-    assert config.dagclient_breaker_threshold == 4
-    assert not hasattr(config, "dagclient_breaker_timeout")
 
 
 def test_load_gateway_config_missing_file():
@@ -75,5 +67,3 @@ def test_gateway_config_defaults() -> None:
     assert cfg.redis_dsn is None
     assert cfg.database_backend == "sqlite"
     assert cfg.database_dsn == "./qmtl.db"
-    assert cfg.dagclient_breaker_threshold == 3
-    assert not hasattr(cfg, "dagclient_breaker_timeout")

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -1,5 +1,5 @@
-import json
 from pathlib import Path
+import json
 import logging
 import pytest
 import yaml
@@ -11,8 +11,6 @@ def test_load_unified_config_yaml(tmp_path: Path) -> None:
     data = {
         "gateway": {
             "redis_dsn": "redis://test:6379",
-            "dagclient_breaker_threshold": 4,
-            "dagclient_breaker_timeout": 1.0,
         },
         "dagmanager": {
             "neo4j_dsn": "bolt://db:7687",
@@ -24,8 +22,6 @@ def test_load_unified_config_yaml(tmp_path: Path) -> None:
     config_file.write_text(yaml.safe_dump(data))
     config = load_config(str(config_file))
     assert config.gateway.redis_dsn == data["gateway"]["redis_dsn"]
-    assert config.gateway.dagclient_breaker_threshold == 4
-    assert not hasattr(config.gateway, "dagclient_breaker_timeout")
     assert config.dagmanager.neo4j_dsn == data["dagmanager"]["neo4j_dsn"]
     assert config.dagmanager.neo4j_breaker_threshold == 5
     assert not hasattr(config.dagmanager, "neo4j_breaker_timeout")
@@ -35,8 +31,6 @@ def test_load_unified_config_json(tmp_path: Path) -> None:
     data = {
         "gateway": {
             "host": "127.0.0.1",
-            "dagclient_breaker_threshold": 3,
-            "dagclient_breaker_timeout": 5.0,
         },
         "dagmanager": {
             "grpc_port": 1234,
@@ -49,8 +43,6 @@ def test_load_unified_config_json(tmp_path: Path) -> None:
     config = load_config(str(config_file))
     assert config.gateway.host == "127.0.0.1"
     assert config.dagmanager.grpc_port == 1234
-    assert config.gateway.dagclient_breaker_threshold == 3
-    assert not hasattr(config.gateway, "dagclient_breaker_timeout")
     assert config.dagmanager.neo4j_breaker_threshold == 2
     assert not hasattr(config.dagmanager, "neo4j_breaker_timeout")
 
@@ -90,8 +82,6 @@ def test_load_unified_config_defaults(tmp_path: Path) -> None:
     assert isinstance(config, UnifiedConfig)
     assert config.gateway.redis_dsn is None
     assert config.dagmanager.grpc_port == 50051
-    assert config.gateway.dagclient_breaker_threshold == 3
-    assert not hasattr(config.gateway, "dagclient_breaker_timeout")
     assert config.dagmanager.neo4j_breaker_threshold == 3
     assert not hasattr(config.dagmanager, "neo4j_breaker_timeout")
 


### PR DESCRIPTION
## Summary
- drop deprecated `dagclient_breaker_threshold` option and stop accepting `dagclient_breaker_timeout`
- simplify config loaders and documentation to reflect fixed breaker behaviour
- update configuration tests to match new defaults

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6890c67e4cd08329956dcbab05d0c073