### PR TITLE
Remove Neo4j breaker configuration

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -47,8 +47,10 @@ gateway:
   dagclient_breaker_threshold: 3  # failures before opening
 dagmanager:
   kafka_breaker_threshold: 3
-  neo4j_breaker_threshold: 3
 ```
+
+The DAG Manager's Neo4j breaker uses a fixed threshold of 3 and cannot be
+configured.
 
 Unlike time-based breakers, QMTL requires an explicit success signal to
 close a tripped breaker. Calls that verify remote health should inspect

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -16,7 +16,6 @@ class DagManagerConfig:
     memory_repo_path: str = "memrepo.gpickle"
     kafka_dsn: Optional[str] = None
     kafka_breaker_threshold: int = 3
-    neo4j_breaker_threshold: int = 3
     grpc_host: str = "0.0.0.0"
     grpc_port: int = 50051
     http_host: str = "0.0.0.0"
@@ -43,5 +42,4 @@ def load_dagmanager_config(path: str) -> DagManagerConfig:
     # Breaker timeouts are deprecated; reset breakers manually on success.
     data.pop("dagclient_breaker_timeout", None)
     data.pop("kafka_breaker_timeout", None)
-    data.pop("neo4j_breaker_timeout", None)
     return DagManagerConfig(**data)

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -13,12 +13,10 @@ def test_dagmanager_config_custom_values() -> None:
         neo4j_password="pw",
         kafka_dsn="localhost:9092",
         kafka_breaker_threshold=5,
-        neo4j_breaker_threshold=4,
     )
     assert cfg.neo4j_dsn == "bolt://db:7687"
     assert cfg.kafka_dsn == "localhost:9092"
     assert cfg.kafka_breaker_threshold == 5
-    assert cfg.neo4j_breaker_threshold == 4
 
 
 def test_dagmanager_config_defaults() -> None:
@@ -27,8 +25,6 @@ def test_dagmanager_config_defaults() -> None:
     assert cfg.kafka_dsn is None
     assert cfg.kafka_breaker_threshold == 3
     assert not hasattr(cfg, "kafka_breaker_timeout")
-    assert cfg.neo4j_breaker_threshold == 3
-    assert not hasattr(cfg, "neo4j_breaker_timeout")
 
 
 def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
@@ -39,7 +35,6 @@ def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
         "kafka_dsn": "kafka:9092",
         "grpc_port": 6000,
         "kafka_breaker_timeout": 2.5,
-        "neo4j_breaker_timeout": 1.5,
     }
     config_file = tmp_path / "dm.yml"
     config_file.write_text(yaml.safe_dump(data))
@@ -48,7 +43,6 @@ def test_load_dagmanager_config_yaml(tmp_path: Path) -> None:
     assert cfg.kafka_dsn == "kafka:9092"
     assert cfg.grpc_port == 6000
     assert not hasattr(cfg, "kafka_breaker_timeout")
-    assert not hasattr(cfg, "neo4j_breaker_timeout")
 
 
 def test_load_dagmanager_config_missing_file() -> None:

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -16,8 +16,6 @@ def test_load_unified_config_yaml(tmp_path: Path) -> None:
         },
         "dagmanager": {
             "neo4j_dsn": "bolt://db:7687",
-            "neo4j_breaker_threshold": 5,
-            "neo4j_breaker_timeout": 2.0,
         },
     }
     config_file = tmp_path / "cfg.yml"
@@ -27,8 +25,6 @@ def test_load_unified_config_yaml(tmp_path: Path) -> None:
     assert config.gateway.dagclient_breaker_threshold == 4
     assert not hasattr(config.gateway, "dagclient_breaker_timeout")
     assert config.dagmanager.neo4j_dsn == data["dagmanager"]["neo4j_dsn"]
-    assert config.dagmanager.neo4j_breaker_threshold == 5
-    assert not hasattr(config.dagmanager, "neo4j_breaker_timeout")
 
 
 def test_load_unified_config_json(tmp_path: Path) -> None:
@@ -40,8 +36,6 @@ def test_load_unified_config_json(tmp_path: Path) -> None:
         },
         "dagmanager": {
             "grpc_port": 1234,
-            "neo4j_breaker_threshold": 2,
-            "neo4j_breaker_timeout": 1.0,
         },
     }
     config_file = tmp_path / "cfg.json"
@@ -51,8 +45,6 @@ def test_load_unified_config_json(tmp_path: Path) -> None:
     assert config.dagmanager.grpc_port == 1234
     assert config.gateway.dagclient_breaker_threshold == 3
     assert not hasattr(config.gateway, "dagclient_breaker_timeout")
-    assert config.dagmanager.neo4j_breaker_threshold == 2
-    assert not hasattr(config.dagmanager, "neo4j_breaker_timeout")
 
 
 def test_load_unified_config_missing_file() -> None:
@@ -92,8 +84,6 @@ def test_load_unified_config_defaults(tmp_path: Path) -> None:
     assert config.dagmanager.grpc_port == 50051
     assert config.gateway.dagclient_breaker_threshold == 3
     assert not hasattr(config.gateway, "dagclient_breaker_timeout")
-    assert config.dagmanager.neo4j_breaker_threshold == 3
-    assert not hasattr(config.dagmanager, "neo4j_breaker_timeout")
 
 
 def test_load_unified_config_bad_gateway(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- drop deprecated Neo4j breaker settings from DAG manager config
- document fixed Neo4j breaker threshold
- update unit tests for new configuration

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_6890c6ac9a1c832988a7cfebde1f4166