### PR TITLE
feat: auto-enable ray by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ python -m qmtl.examples.generators_example
 python -m qmtl.examples.extensions_combined_strategy
 ```
 
-Append `--with-ray` to enable Ray-based execution:
+Ray is used automatically when installed. Append `--no-ray` to disable Ray-based execution:
 
 ```bash
-python -m qmtl.examples.general_strategy --with-ray
+python -m qmtl.examples.general_strategy --no-ray
 ```
 
 See [qmtl/examples/README.md](qmtl/examples/README.md) for additional scripts such as `tag_query_strategy.py` or `ws_metrics_example.py`.

--- a/architecture.md
+++ b/architecture.md
@@ -77,8 +77,8 @@ Strategy SDK ──▶ Gateway ──▶ DAG Manager ──▶ Graph DB (Neo4j)
   Actor로 분리 스케줄링한다.
 * **Arrow 캐시 백엔드 옵션**: 환경 변수 `QMTL_ARROW_CACHE=1`을 설정하면 PyArrow 기반
   캐시가 활성화됩니다. `QMTL_CACHE_EVICT_INTERVAL` 값으로 만료 슬라이스를 검사하는
-  주기를 조정하며, Ray 실행을 `Runner.enable_ray()` 또는 CLI의 `--with-ray` 옵션으로
-  활성화한 경우 eviction 로직은 Ray Actor로 실행됩니다.
+  주기를 조정하며, Ray가 설치되어 있으면 eviction 로직이 Ray Actor로 실행됩니다.
+  CLI의 `--no-ray` 옵션으로 비활성화할 수 있습니다.
 * **다중 인터벌·다중 업스트림 지원**: `u` 축 (업스트림)과 `i` 축 (인터벌)을 분리함으로써 1m·5m·1h 등 다양한 간격과 여러 태그 큐를 동시에 저장·검색 가능.
 * **캐시 채우기 규칙**: 노드는 `∀(u,i) : |C[u,i]| ≥ Pᵢ` 조건을 만족할 때에만 프로세싱 함수가 호출된다.
 * **타임스탬프 정렬 예시**: interval = 1 m, period = 10, 시스템 UTC = 10:10:30 ⇒ `f="t"` 슬롯에는 10:01 … 10:10(10개 캔들)이 저장된다.

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -105,7 +105,7 @@ python -m qmtl.sdk --help
 
 PyArrow 기반 캐시를 사용하려면 환경 변수 `QMTL_ARROW_CACHE=1`을 설정합니다.
 만료 슬라이스 정리는 `QMTL_CACHE_EVICT_INTERVAL`(초) 값에 따라 주기적으로 실행되며
-Ray 실행을 `Runner.enable_ray()` 또는 CLI의 `--with-ray` 옵션으로 활성화한 경우 Ray Actor에서 동작합니다.
+Ray가 설치되어 있으면 Ray Actor에서 동작합니다. CLI의 `--no-ray` 옵션으로 비활성화할 수 있습니다.
 
 ## Cache Backends
 

--- a/qmtl/examples/README.md
+++ b/qmtl/examples/README.md
@@ -31,10 +31,10 @@ python -m qmtl.examples.strategies.general_strategy
 python -m qmtl.examples.parallel.questdb_parallel_example
 ```
 
-Ray 기반 병렬 실행을 사용하려면 다음과 같이 `--with-ray` 옵션을 추가하세요.
+Ray가 설치되어 있으면 자동으로 사용됩니다. 비활성화하려면 `--no-ray` 옵션을 추가하세요.
 
 ```bash
-python -m qmtl.examples.strategies.general_strategy --with-ray
+python -m qmtl.examples.strategies.general_strategy --no-ray
 ```
 
 백테스트가 필요한 경우 `Runner.backtest()`에 시작/종료 타임스탬프를 지정하세요.

--- a/qmtl/examples/strategies/general_strategy.py
+++ b/qmtl/examples/strategies/general_strategy.py
@@ -45,8 +45,6 @@ if __name__ == "__main__":
     start = args.start_time or defaults.get("start_time")
     end = args.end_time or defaults.get("end_time")
     on_missing = args.on_missing or defaults.get("on_missing", "skip")
-
-    Runner.enable_ray()
     if args.backtest:
         Runner.backtest(
             GeneralStrategy,

--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -30,14 +30,14 @@ async def _main(argv: List[str] | None = None) -> None:
         help="Gateway base URL (required for backtest, dryrun and live modes)",
     )
     parser.add_argument(
-        "--with-ray",
+        "--no-ray",
         action="store_true",
-        help="Enable Ray-based execution of compute functions",
+        help="Disable Ray-based execution of compute functions",
     )
     args = parser.parse_args(argv)
 
-    if args.with_ray:
-        Runner.enable_ray()
+    if args.no_ray:
+        Runner._ray_available = False
 
     module_name, class_name = args.strategy.split(":")
     module = importlib.import_module(module_name)

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -26,21 +26,9 @@ except Exception:  # pragma: no cover - Ray not installed
 
 class Runner:
     """Execute strategies in various modes."""
-
-    _ray_available = False
+    _ray_available = ray is not None
     _kafka_available = AIOKafkaConsumer is not None
     _gateway_cb: AsyncCircuitBreaker | None = None
-
-    @classmethod
-    def enable_ray(cls, enable: bool = True) -> None:
-        """Toggle Ray-based execution explicitly."""
-        if enable and ray is None:
-            raise RuntimeError("Ray not installed")
-        cls._ray_available = enable
-
-    @classmethod
-    def disable_ray(cls) -> None:
-        cls.enable_ray(False)
 
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- enable Ray automatically when installed
- add `--no-ray` CLI flag to disable Ray and remove old enable/disable APIs
- update docs and examples for automatic Ray usage

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6890c6bbfe8883298ad2199b70000bc5