### PR TITLE
Add Dockerfile and update compose for gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir uv && \
+    uv pip install -e .[dev]
+

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -20,13 +20,17 @@ uv pip install -e .[dev]
 
 ## Bringing up the stack
 
-Start all services using Docker Compose:
+Start all services using Docker Compose. The DAG Manager and Gateway images
+are built from the repository's `Dockerfile`, which installs the local package
+so the `qmtl` entrypoint is available:
 
 ```bash
-docker compose -f tests/docker-compose.e2e.yml up -d
+docker compose -f tests/docker-compose.e2e.yml up --build -d
 ```
 
-This launches Redis, Postgres, Neo4j, Kafka, Zookeeper and the `qmtl gw` and `qmtl dagmanager` containers. The gateway exposes port `8000` and the DAG Manager gRPC endpoint is available on `50051`.
+This launches Redis, Postgres, Neo4j, Kafka, Zookeeper and the `qmtl gw` and
+`qmtl dagmanager` containers. The gateway exposes port `8000` and the DAG
+Manager gRPC endpoint is available on `50051`.
 
 ## Running the tests
 

--- a/tests/docker-compose.e2e.yml
+++ b/tests/docker-compose.e2e.yml
@@ -39,7 +39,7 @@ services:
       - "9092:9092"
 
   dagmanager:
-    image: python:3
+    build: ..
     command: ["qmtl", "dagmanager-server"]
     depends_on:
       - kafka
@@ -48,8 +48,8 @@ services:
       - "50051:50051"
 
   gateway:
-    image: python:3
-    command: ["qmtl", "gw", "serve"]
+    build: ..
+    command: ["qmtl", "gw"]
     depends_on:
       - dagmanager
       - redis


### PR DESCRIPTION
## Summary
- add Dockerfile that installs the project so the `qmtl` CLI is available in containers
- build gateway and dagmanager services from the repo and run gateway with `qmtl gw`
- document how to build and start the stack for end-to-end tests

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_6895efbbffd883298d2244dcbde1cd1a