### PR TITLE
docs: clarify match_mode usage and update examples

### DIFF
--- a/gateway.md
+++ b/gateway.md
@@ -80,6 +80,12 @@ paths:
         - in: query
           name: interval
           schema: { type: integer }
+        - in: query
+          name: match_mode
+          schema: { type: string, enum: [any, all] }
+          description: |
+            Preferred tag matching mode. ``match`` is accepted as a deprecated alias
+            for backwards compatibility.
       responses:
         '200':
           description: Queue list
@@ -92,6 +98,8 @@ paths:
                     type: array
                     items: { type: string }
 ```
+``match_mode`` should be used by new clients. ``match`` remains available for
+older integrations.
 
 **Example Request (compressed 32 KiB DAG JSON omitted)**
 
@@ -105,6 +113,13 @@ Content‑Type: application/json
   "meta": { "user": "quant.alice", "desc": "BTC scalper" },
   "run_type": "dry-run"
 }
+```
+
+**Example Queue Lookup**
+
+```http
+GET /queues/by_tag?tags=t1,t2&interval=60&match_mode=any HTTP/1.1
+Authorization: Bearer <jwt>
 ```
 
 | HTTP Status         | Meaning                                 | Typical Cause      |

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -97,11 +97,22 @@ def client(fake_redis):
 def test_queues_by_tag_route(client):
     c, dag = client
     resp = c.get(
-        "/queues/by_tag", params={"tags": "t1,t2", "interval": "60", "match": "any"}
+        "/queues/by_tag",
+        params={"tags": "t1,t2", "interval": "60", "match_mode": "any"},
     )
     assert resp.status_code == 200
     assert resp.json()["queues"] == ["q1", "q2"]
     assert dag.called_with == (["t1", "t2"], 60, "any")
+
+
+def test_queues_by_tag_route_match_alias(client):
+    c, dag = client
+    resp = c.get(
+        "/queues/by_tag", params={"tags": "t1,t2", "interval": "60", "match": "all"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["queues"] == ["q1", "q2"]
+    assert dag.called_with == (["t1", "t2"], 60, "all")
 
 
 def test_submit_tag_query_node(client):


### PR DESCRIPTION
## Summary
- document preferred `match_mode` query parameter with legacy `match` alias
- update docs and tests to demonstrate `match_mode`

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_6895f043bac48329aac9d17c516bdc34