### PR TITLE
feat: track node cache memory usage

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -21,7 +21,7 @@ prometheus:
           annotations:
             summary: Diff processing slow
         - alert: NodeCacheMemoryHigh
-          expr: nodecache_resident_bytes > 5e9
+          expr: nodecache_resident_bytes{node_id="all",scope="total"} > 5e9
           for: 5m
           labels:
             severity: warning

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -11,7 +11,7 @@ Prometheus can load `alert_rules.yml` to activate alerts for the DAG Manager and
 The following alerts are available for inspiration when extending `alert_rules.yml`:
 
 - **DiffDurationHigh** – triggers when `diff_duration_ms_p95` exceeds 200 ms.
-- **NodeCacheMemoryHigh** – warns if `nodecache_resident_bytes` surpasses 5 GB.
+- **NodeCacheMemoryHigh** – warns if total `nodecache_resident_bytes` (scope="total") exceeds 5 GB.
 - **QueueCreateErrors** – fires when `queue_create_error_total` increases.
 - **SentinelGap** – indicates a missing diff sentinel via `sentinel_gap_count`.
 - **OrphanQueuesGrowing** – detects rises in `orphan_queue_total` over a three-hour window.

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -19,6 +19,7 @@ from .cache_view import CacheView
 from .backfill_state import BackfillState
 from .util import parse_interval, parse_period
 from . import arrow_cache
+from . import metrics as sdk_metrics
 
 if TYPE_CHECKING:  # pragma: no cover - type checking import
     from qmtl.io import HistoryProvider, EventRecorder
@@ -518,6 +519,9 @@ class Node:
         ``compute_fn``. The function **never** triggers execution directly.
         """
         self.cache.append(upstream_id, interval, timestamp, payload)
+        sdk_metrics.observe_nodecache_resident_bytes(
+            self.node_id, self.cache.resident_bytes
+        )
 
         recorder = getattr(self, "event_recorder", None)
         if recorder is not None:


### PR DESCRIPTION
## Summary
- add nodecache_resident_bytes gauge for SDK and DAG manager metrics
- update Node.feed to publish cache memory usage
- document and alert on total node cache memory

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68967a3853108329b0be2ea6f67b2b2f