### PR TITLE
build: add Dockerfile for e2e

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY . /app
 RUN pip install --no-cache-dir uv && \
-    uv pip install -e .[dev]
+    uv pip install .
 

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -20,9 +20,10 @@ uv pip install -e .[dev]
 
 ## Bringing up the stack
 
-Start all services using Docker Compose. The DAG Manager and Gateway images
-are built from the repository's `Dockerfile`, which installs the local package
-so the `qmtl` entrypoint is available:
+Start all services using Docker Compose. Both the DAG Manager and Gateway
+services build from the repository's top-level `Dockerfile`, which installs
+QMTL via `uv pip install .` and mounts the project source so the `qmtl`
+entrypoint is available:
 
 ```bash
 docker compose -f tests/docker-compose.e2e.yml up --build -d

--- a/tests/docker-compose.e2e.yml
+++ b/tests/docker-compose.e2e.yml
@@ -39,7 +39,11 @@ services:
       - "9092:9092"
 
   dagmanager:
-    build: ..
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/app
     command: ["qmtl", "dagmanager-server"]
     depends_on:
       - kafka
@@ -48,7 +52,11 @@ services:
       - "50051:50051"
 
   gateway:
-    build: ..
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/app
     command: ["qmtl", "gw"]
     depends_on:
       - dagmanager


### PR DESCRIPTION
## Summary
- install QMTL inside Docker image with uv
- mount repo and build e2e services from Dockerfile
- document running e2e stack

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68967b02e9088329b27a2b622aba90c0