### PR TITLE
feat(dagmanager): add sentinel traffic endpoint

### DIFF
--- a/qmtl/dagmanager/api.py
+++ b/qmtl/dagmanager/api.py
@@ -8,6 +8,7 @@ from .garbage_collector import GarbageCollector
 from .callbacks import post_with_backoff
 from ..common.cloudevents import format_event
 from .dagmanager_health import get_health
+from . import metrics
 
 if TYPE_CHECKING:  # pragma: no cover - optional import for typing
     from neo4j import Driver
@@ -23,11 +24,22 @@ class GcResponse(BaseModel):
     processed: list[str]
 
 
+class WeightUpdate(BaseModel):
+    """Payload to update traffic weight for a version sentinel."""
+
+    version: str = Field(..., description="Version identifier")
+    weight: float = Field(
+        ..., ge=0.0, le=1.0, description="Traffic weight"
+    )
+
+
 def create_app(
     gc: GarbageCollector,
     *,
     callback_url: Optional[str] = None,
     driver: "Driver" | None = None,
+    weights: Optional[dict[str, float]] = None,
+    gateway_url: str | None = None,
 ) -> FastAPI:
     """Return a FastAPI app exposing admin routes."""
     app = FastAPI()
@@ -50,6 +62,29 @@ def create_app(
             await post_with_backoff(callback_url, event)
         return GcResponse(processed=processed)
 
+    store = weights if weights is not None else {}
+
+    @app.post("/callbacks/sentinel-traffic", status_code=status.HTTP_202_ACCEPTED)
+    async def sentinel_traffic(update: WeightUpdate):
+        store[update.version] = update.weight
+        metrics.set_active_version_weight(update.version, update.weight)
+        if driver:
+            with driver.session() as session:
+                session.run(
+                    "MERGE (s:VersionSentinel {version: $version}) "
+                    "SET s.traffic_weight = $weight",
+                    version=update.version,
+                    weight=update.weight,
+                )
+        if gateway_url:
+            event = format_event(
+                "qmtl.dagmanager",
+                "sentinel_weight",
+                {"sentinel_id": update.version, "weight": update.weight},
+            )
+            await post_with_backoff(gateway_url, event)
+        return {"version": update.version, "weight": update.weight}
+
     return app
 
-__all__ = ["GcRequest", "GcResponse", "create_app"]
+__all__ = ["GcRequest", "GcResponse", "WeightUpdate", "create_app"]

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -104,7 +104,12 @@ async def _run(cfg: DagManagerConfig) -> None:
     )
     await grpc_server.start()
 
-    app = create_app(gc, callback_url=cfg.gc_callback, driver=driver)
+    app = create_app(
+        gc,
+        callback_url=cfg.gc_callback,
+        driver=driver,
+        gateway_url=cfg.diff_callback,
+    )
     config = uvicorn.Config(app, host=cfg.http_host, port=cfg.http_port, loop="asyncio", log_level="info")
     http_server = uvicorn.Server(config)
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,7 +2,6 @@ from datetime import datetime, UTC
 from fastapi.testclient import TestClient
 
 from qmtl.gateway.api import create_app as gw_create_app
-from qmtl.dagmanager.http_server import create_app as dag_http_create_app
 from qmtl.dagmanager.api import create_app as dag_api_create_app
 from qmtl.dagmanager.garbage_collector import QueueInfo
 from qmtl.dagmanager.diff_service import StreamSender
@@ -57,17 +56,10 @@ def test_gateway_health(fake_redis):
 
 
 def test_dagmanager_http_health():
-    with TestClient(dag_http_create_app()) as client:
-        resp = client.get("/status")
-        assert resp.status_code == 200
-        assert resp.json()["neo4j"] in {"ok", "error", "unknown"}
-
-
-def test_dagmanager_api_health():
     with TestClient(dag_api_create_app(DummyGC())) as client:
         resp = client.get("/status")
         assert resp.status_code == 200
-        assert "neo4j" in resp.json()
+        assert resp.json()["neo4j"] in {"ok", "error", "unknown"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `/callbacks/sentinel-traffic` to DAG Manager API so weights update metrics, Neo4j, and Gateway
- expose diff callback to HTTP server to forward sentinel weight events
- update tests for new API wiring

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68967a702f148329946c458739e0584a