### PR TITLE
feat: track queue lag by topic

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -27,3 +27,10 @@ prometheus:
             severity: warning
           annotations:
             summary: NodeCache memory usage high
+        - alert: QueueLagHigh
+          expr: queue_lag_seconds > queue_lag_threshold_seconds
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Kafka consumer lag above threshold

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -15,6 +15,7 @@ The following alerts are available for inspiration when extending `alert_rules.y
 - **QueueCreateErrors** – fires when `queue_create_error_total` increases.
 - **SentinelGap** – indicates a missing diff sentinel via `sentinel_gap_count`.
 - **OrphanQueuesGrowing** – detects rises in `orphan_queue_total` over a three-hour window.
+- **QueueLagHigh** – triggers when `queue_lag_seconds` exceeds `queue_lag_threshold_seconds` for a topic.
 - **GatewayLatencyHigh** – alerts when `gateway_e2e_latency_p95` exceeds 150 ms.
 - **LostRequests** – reports lost diff submissions based on `lost_requests_total`.
 - **GCSchedulerStall** – warns if `gc_last_run_timestamp` lags by more than ten minutes.
@@ -42,6 +43,8 @@ Both services expose a Prometheus endpoint. Circuit breaker activity is tracked 
 
 Both breakers open after three consecutive failures and are not configurable.
 The DAG Manager's Neo4j breaker also uses a fixed threshold of 3.
+
+Kafka consumer lag per topic is exported via `queue_lag_seconds{topic}` along with `queue_lag_threshold_seconds{topic}` to express the configured alert boundary.
 
 Unlike time-based breakers, QMTL requires an explicit success signal to
 close a tripped breaker. Calls that verify remote health should inspect

--- a/qmtl/dagmanager/__init__.py
+++ b/qmtl/dagmanager/__init__.py
@@ -41,6 +41,7 @@ from .monitor import Monitor, MonitorLoop
 from .completion import QueueCompletionMonitor
 from .metrics import start_metrics_server
 from .api import create_app
+from .lag_monitor import LagMonitor, LagMonitorLoop, QueueLagInfo
 
 __all__ = [
     "compute_node_id",
@@ -59,6 +60,9 @@ __all__ = [
     "Monitor",
     "MonitorLoop",
     "QueueCompletionMonitor",
+    "LagMonitor",
+    "LagMonitorLoop",
+    "QueueLagInfo",
     "start_metrics_server",
     "create_app",
 ]

--- a/qmtl/dagmanager/lag_monitor.py
+++ b/qmtl/dagmanager/lag_monitor.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Background task recording Kafka consumer lag per topic."""
+
+from dataclasses import dataclass
+from typing import Iterable, Protocol, Dict, Optional
+import asyncio
+
+from .kafka_admin import KafkaAdmin
+from . import metrics
+
+
+@dataclass(frozen=True)
+class QueueLagInfo:
+    topic: str
+    committed_offset: int
+    lag_alert_threshold: int
+
+
+class LagStore(Protocol):
+    """Provides queue lag metadata from Neo4j."""
+
+    def list_queues(self) -> Iterable[QueueLagInfo]:
+        ...
+
+
+@dataclass
+class LagMonitor:
+    admin: KafkaAdmin
+    store: LagStore
+
+    def record_lag(self) -> Dict[str, int]:
+        """Fetch lag for all queues and update metrics."""
+        infos = list(self.store.list_queues())
+        committed = {i.topic: i.committed_offset for i in infos}
+        lags = self.admin.topic_lag(committed)
+        for info in infos:
+            lag = lags.get(info.topic, 0)
+            metrics.observe_queue_lag(info.topic, lag, info.lag_alert_threshold)
+        return lags
+
+
+@dataclass
+class LagMonitorLoop:
+    monitor: LagMonitor
+    interval: float = 30.0
+    _task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                self.monitor.record_lag()
+                await asyncio.sleep(self.interval)
+        except asyncio.CancelledError:  # pragma: no cover - background task
+            pass
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            finally:
+                self._task = None
+
+
+__all__ = ["LagMonitor", "LagMonitorLoop", "QueueLagInfo", "LagStore"]

--- a/tests/dagmanager/test_lag_monitor.py
+++ b/tests/dagmanager/test_lag_monitor.py
@@ -1,0 +1,40 @@
+import pytest
+
+from qmtl.dagmanager.kafka_admin import KafkaAdmin, InMemoryAdminClient
+from qmtl.dagmanager.lag_monitor import LagMonitor, QueueLagInfo
+from qmtl.dagmanager import metrics
+
+
+class DummyStore:
+    def __init__(self, infos):
+        self._infos = infos
+
+    def list_queues(self):
+        return self._infos
+
+
+def test_kafka_admin_topic_lag():
+    client = InMemoryAdminClient()
+    client.create_topic("t1", num_partitions=1, replication_factor=1)
+    client.set_offsets("t1", high=100, low=0)
+    admin = KafkaAdmin(client)
+
+    lags = admin.topic_lag({"t1": 90})
+    assert lags["t1"] == 10
+
+
+def test_lag_monitor_records_metrics():
+    client = InMemoryAdminClient()
+    client.create_topic("q1", num_partitions=1, replication_factor=1)
+    client.set_offsets("q1", high=15, low=0)
+    admin = KafkaAdmin(client)
+
+    store = DummyStore([QueueLagInfo(topic="q1", committed_offset=5, lag_alert_threshold=10)])
+
+    metrics.reset_metrics()
+    monitor = LagMonitor(admin, store)
+    lags = monitor.record_lag()
+
+    assert lags["q1"] == 10
+    assert metrics.queue_lag_seconds._vals["q1"] == 10
+    assert metrics.queue_lag_threshold_seconds._vals["q1"] == 10


### PR DESCRIPTION
## Summary
- expose `queue_lag_seconds` and `queue_lag_threshold_seconds` metrics
- add KafkaAdmin helpers and LagMonitor to compute and record lag
- add alert rule and docs for lag monitoring

## Testing
- `uv run -m pytest -W error` *(fails: ModuleNotFoundError: No module named 'strategies')*


------
https://chatgpt.com/codex/tasks/task_e_68a291eff5bc8329bb39b6bf0d26bbf5