### PR TITLE
Add lag and diff duration alerts to DAG monitor

### DIFF
--- a/tests/dagmanager/test_monitor_lag_alerts.py
+++ b/tests/dagmanager/test_monitor_lag_alerts.py
@@ -1,0 +1,68 @@
+import pytest
+
+from qmtl.dagmanager.monitor import Monitor, AckStatus
+from qmtl.dagmanager.alerts import AlertManager
+
+
+class LagMetrics:
+    def __init__(self, lag: float, threshold: float, diff: float):
+        self.lag = lag
+        self.threshold = threshold
+        self.diff = diff
+
+    def neo4j_leader_is_null(self) -> bool:
+        return False
+
+    def kafka_zookeeper_disconnects(self) -> int:
+        return 0
+
+    def queue_lag_seconds(self, topic: str) -> tuple[float, float]:
+        return self.lag, self.threshold
+
+    def diff_duration_ms_p95(self) -> float:
+        return self.diff
+
+
+class NoopCluster:
+    def elect_leader(self) -> None:
+        pass
+
+
+class NoopKafka:
+    def retry(self) -> None:
+        pass
+
+
+class NoopStream:
+    def ack_status(self) -> AckStatus:
+        return AckStatus.OK
+
+    def resume_from_last_offset(self) -> None:
+        pass
+
+
+class DummyPagerDuty:
+    async def send(self, message: str, *, topic: str | None = None, node: str | None = None) -> None:
+        pass
+
+
+class CapturingSlack:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str | None, str | None]] = []
+
+    async def send(self, message: str, *, topic: str | None = None, node: str | None = None) -> None:
+        self.sent.append((message, topic, node))
+
+
+@pytest.mark.asyncio
+async def test_monitor_alerts_on_lag_and_diff_duration():
+    metrics = LagMetrics(lag=15, threshold=10, diff=250)
+    pd = DummyPagerDuty()
+    slack = CapturingSlack()
+    manager = AlertManager(pd, slack)
+    monitor = Monitor(metrics, NoopCluster(), NoopKafka(), NoopStream(), manager, lag_topics=["prices"])
+
+    await monitor.check_once()
+
+    assert ("Queue lag high", "prices", None) in slack.sent
+    assert ("Diff duration high", None, None) in slack.sent

--- a/tests/reliability/test_worker_alerts.py
+++ b/tests/reliability/test_worker_alerts.py
@@ -33,10 +33,14 @@ class DummyAlerts:
     def __init__(self):
         self.slack: list[str] = []
 
-    async def send_slack(self, msg: str) -> None:
+    async def send_slack(
+        self, msg: str, *, topic: str | None = None, node: str | None = None
+    ) -> None:
         self.slack.append(msg)
 
-    async def send_pagerduty(self, msg: str) -> None:
+    async def send_pagerduty(
+        self, msg: str, *, topic: str | None = None, node: str | None = None
+    ) -> None:
         self.slack.append(msg)
 
 


### PR DESCRIPTION
## Summary
- extend MetricsBackend and Monitor to check queue lag and diff stream p95 duration
- allow alert callbacks to accept topic or node identifiers
- test alert dispatch when lag or diff duration exceed thresholds

## Testing
- `uv run -m pytest -W error` *(fails: ModuleNotFoundError: No module named 'strategies')*
- `uv run -m pytest -W error tests/test_monitor.py tests/dagmanager/test_monitor_lag_alerts.py tests/reliability/test_worker_alerts.py`


------
https://chatgpt.com/codex/tasks/task_e_68a29eb445fc8329b1a5db343ad063ee