### PR TITLE
Add RiskManager guide and example strategy

### DIFF
--- a/docs/risk_management.md
+++ b/docs/risk_management.md
@@ -1,0 +1,37 @@
+# Risk Management Guide
+
+This guide explains how to configure and use the `RiskManager` to enforce portfolio limits during backtests and simulations.
+
+## Configuration
+
+`RiskManager` supports several parameters to control portfolio risk:
+
+- `max_position_size`: absolute maximum position value.
+- `max_leverage`: maximum allowed leverage ratio.
+- `max_drawdown_pct`: maximum tolerated drawdown as a fraction.
+- `max_concentration_pct`: cap on single position concentration.
+- `max_portfolio_volatility`: annualized volatility threshold.
+- `position_size_limit_pct`: maximum percentage of portfolio per position.
+- `enable_dynamic_sizing`: whether to automatically scale positions to meet limits.
+
+Initialize the manager with the limits appropriate for your strategy:
+
+```python
+from qmtl.sdk.risk_management import RiskManager
+
+risk_mgr = RiskManager(position_size_limit_pct=0.10)
+```
+
+## Enforcing Position Limits
+
+Use `validate_position_size` to check proposed trades. It returns whether the trade is valid, any violation details, and the quantity adjusted to satisfy limits.
+
+```python
+from qmtl.examples.strategies.risk_managed_strategy import enforce_position_limit
+
+is_valid, violation, adjusted_qty = enforce_position_limit(
+    symbol="AAPL", proposed_quantity=20, price=10.0, portfolio_value=1_000.0
+)
+```
+
+If the trade exceeds the configured limits, `is_valid` is `False` and `adjusted_qty` reflects the maximum safe quantity.

--- a/qmtl/examples/strategies/risk_managed_strategy.py
+++ b/qmtl/examples/strategies/risk_managed_strategy.py
@@ -1,0 +1,46 @@
+"""Example strategy demonstrating RiskManager usage."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+from qmtl.sdk.risk_management import PositionInfo, RiskManager, RiskViolation
+
+
+def enforce_position_limit(
+    *,
+    symbol: str,
+    proposed_quantity: float,
+    price: float,
+    portfolio_value: float,
+    current_positions: Optional[Dict[str, PositionInfo]] = None,
+) -> Tuple[bool, Optional[RiskViolation], float]:
+    """Validate a trade against position size limits.
+
+    Parameters
+    ----------
+    symbol : str
+        Asset identifier for the trade.
+    proposed_quantity : float
+        Desired number of units to trade.
+    price : float
+        Current asset price.
+    portfolio_value : float
+        Total value of the portfolio.
+    current_positions : dict, optional
+        Existing positions keyed by symbol.
+
+    Returns
+    -------
+    tuple
+        (is_valid, violation_if_any, adjusted_quantity)
+    """
+    positions = current_positions or {}
+    risk_mgr = RiskManager(position_size_limit_pct=0.10)
+    return risk_mgr.validate_position_size(
+        symbol=symbol,
+        proposed_quantity=proposed_quantity,
+        current_price=price,
+        portfolio_value=portfolio_value,
+        current_positions=positions,
+    )

--- a/qmtl/examples/tests/test_risk_managed_strategy.py
+++ b/qmtl/examples/tests/test_risk_managed_strategy.py
@@ -1,0 +1,21 @@
+from qmtl.examples.strategies.risk_managed_strategy import enforce_position_limit
+from qmtl.sdk.risk_management import RiskViolationType
+
+
+def test_violation_detected_when_exceeding_limit() -> None:
+    is_valid, violation, adjusted = enforce_position_limit(
+        symbol="AAPL", proposed_quantity=20, price=10.0, portfolio_value=1_000.0
+    )
+    assert not is_valid
+    assert violation is not None
+    assert violation.violation_type == RiskViolationType.POSITION_SIZE_LIMIT
+    assert adjusted == 10.0
+
+
+def test_no_violation_within_limit() -> None:
+    is_valid, violation, adjusted = enforce_position_limit(
+        symbol="AAPL", proposed_quantity=5, price=10.0, portfolio_value=1_000.0
+    )
+    assert is_valid
+    assert violation is None
+    assert adjusted == 5


### PR DESCRIPTION
## Summary
- document RiskManager configuration and usage
- add pure example strategy enforcing position size limits
- cover position limit violations with unit tests

## Testing
- `uv run -m pytest -W error` *(fails: AssertionError: assert 1 == 0)*
- `uv run -m pytest qmtl/examples/tests/test_risk_managed_strategy.py -W error`

------
https://chatgpt.com/codex/tasks/task_e_68a65991ddac8329bd43dc20da72bc29