### PR TITLE
Add timing control docs and example strategy

### DIFF
--- a/docs/timing_controls.md
+++ b/docs/timing_controls.md
@@ -1,0 +1,56 @@
+# Timing Controls
+
+This document outlines the timing utilities available in QMTL for managing market sessions and validating timestamp data.
+
+## MarketHours
+
+`MarketHours` describes the boundaries of each trading session. It accepts the start and end times for pre-market, regular, and post-market sessions.
+
+```python
+from qmtl.sdk.timing_controls import MarketHours, MarketSession
+from datetime import datetime, time, timezone
+
+hours = MarketHours(
+    pre_market_start=time(4, 0),
+    regular_start=time(9, 30),
+    regular_end=time(16, 0),
+    post_market_end=time(20, 0)
+)
+
+# Wednesday 10:00 AM UTC
+ts = datetime(2024, 1, 3, 10, 0, tzinfo=timezone.utc)
+session = hours.get_session(ts)
+assert session is MarketSession.REGULAR
+```
+
+## TimingController
+
+`TimingController` coordinates session checks and execution delays.
+
+- `allow_pre_post_market`: permit trading in pre/post-market sessions.
+- `require_regular_hours`: only allow trading during the regular session.
+- `validate_timing(timestamp)`: returns `(is_valid, reason, session)`.
+- `calculate_execution_delay(...)`: estimates realistic execution delay.
+- `get_next_valid_execution_time(...)`: finds the next allowable time if the current timestamp is invalid.
+
+```python
+from qmtl.sdk.timing_controls import TimingController
+
+controller = TimingController(allow_pre_post_market=False)
+valid, reason, session = controller.validate_timing(ts)
+if not valid:
+    print(f"Blocked {session}: {reason}")
+```
+
+## validate_backtest_timing
+
+`validate_backtest_timing` scans all `StreamInput` nodes in a strategy and reports timestamps that fall outside the configured trading sessions. Each issue includes the timestamp, reason, and the detected market session. Set `fail_on_invalid_timing=True` to raise an exception when invalid data is found.
+
+```python
+from qmtl.sdk.timing_controls import validate_backtest_timing
+
+issues = validate_backtest_timing(strategy)
+for node, node_issues in issues.items():
+    for issue in node_issues:
+        print(issue["reason"], issue["datetime"])
+```

--- a/qmtl/examples/strategies/timing_control_strategy.py
+++ b/qmtl/examples/strategies/timing_control_strategy.py
@@ -1,0 +1,37 @@
+"""Example strategy demonstrating pre/post-market restrictions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from qmtl.sdk import Strategy, StreamInput
+from qmtl.sdk.timing_controls import TimingController, validate_backtest_timing
+
+
+class TimingControlStrategy(Strategy):
+    """Strategy that skips data outside regular market hours."""
+
+    def __init__(self) -> None:
+        super().__init__(default_interval="3600s", default_period=10)
+        self.timing_controller = TimingController(allow_pre_post_market=False)
+
+    def setup(self) -> None:
+        price_stream = StreamInput(interval="3600s", period=10)
+        self.add_nodes([price_stream])
+
+    def validate_data(self):
+        """Return timing validation issues for the loaded data."""
+        return validate_backtest_timing(self, self.timing_controller)
+
+
+if __name__ == "__main__":
+    strategy = TimingControlStrategy()
+    strategy.setup()
+
+    # Add example data including a pre-market timestamp
+    stream = strategy.nodes[0]
+    pre_market_ts = int(datetime(2024, 1, 3, 8, 0, tzinfo=timezone.utc).timestamp() * 1000)
+    stream.cache.append("prices", 3600, pre_market_ts, {"close": 100.0})
+
+    issues = strategy.validate_data()
+    print("Timing issues:", issues)


### PR DESCRIPTION
## Summary
- Document MarketHours, TimingController and validate_backtest_timing
- Add timing_control_strategy example demonstrating pre/post-market restrictions
- Test that pre-market timestamps are flagged during validation

## Testing
- `uv run -m pytest -W error` *(fails: tests/test_cli_check_imports.py::test_cli_check_imports, tests/test_runner_trade_execution_service.py::test_runner_trade_execution_service_invoked)*
- `uv run -m pytest tests/test_timing_controls.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_68a65c7c604883298f6aaa2611da89a3