### PR TITLE
Add execution model strategy and cost-adjusted metrics docs

### DIFF
--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -171,6 +171,49 @@ signal = TradeSignalGeneratorNode(
 )
 ```
 
+## ExecutionModel과 비용 조정 성과 지표
+
+`ExecutionModel`은 커미션, 슬리피지, 시장 임팩트 등 현실적인 체결 비용을 추정합니다.
+생성된 `ExecutionFill` 목록을 `alpha_performance_node`에 전달하면 비용을 반영한 성과 지표를 계산할 수 있습니다.
+
+```python
+from qmtl.sdk.execution_modeling import (
+    ExecutionModel, OrderSide, OrderType, create_market_data_from_ohlcv,
+)
+from qmtl.transforms import TradeSignalGeneratorNode, alpha_history_node
+from qmtl.transforms.alpha_performance import alpha_performance_node
+
+history = alpha_history_node(alpha, window=30)
+signal = TradeSignalGeneratorNode(history, long_threshold=0.5, short_threshold=-0.5)
+
+model = ExecutionModel(commission_rate=0.0005, base_slippage_bps=2.0)
+market = create_market_data_from_ohlcv(
+    timestamp=0,
+    open_price=100,
+    high=101,
+    low=99,
+    close=100,
+    volume=10_000,
+)
+
+fill = model.simulate_execution(
+    order_id="demo",
+    symbol="TEST",
+    side=OrderSide.BUY,
+    quantity=100,
+    order_type=OrderType.MARKET,
+    requested_price=100.0,
+    market_data=market,
+    timestamp=0,
+)
+
+metrics = alpha_performance_node(
+    returns,
+    execution_fills=[fill],
+    use_realistic_costs=True,
+)
+```
+
 ## Order Results and External Executors
 
 `TradeOrderPublisherNode` turns trade signals into standardized order

--- a/qmtl/examples/strategies/execution_model_strategy.py
+++ b/qmtl/examples/strategies/execution_model_strategy.py
@@ -1,0 +1,117 @@
+"""Example strategy demonstrating execution cost modeling."""
+
+from qmtl.sdk import Strategy, StreamInput, Node, Runner
+from qmtl.transforms import alpha_history_node, TradeSignalGeneratorNode
+from qmtl.transforms.alpha_performance import alpha_performance_node
+from qmtl.sdk.execution_modeling import (
+    ExecutionModel,
+    OrderSide,
+    OrderType,
+    create_market_data_from_ohlcv,
+)
+
+
+class ExecutionModelStrategy(Strategy):
+    """Strategy combining trade signals with execution cost modeling."""
+
+    def setup(self) -> None:
+        price_stream = StreamInput(interval="60s", period=5)
+
+        def compute_return(view):
+            data = [v for _, v in view[price_stream][60]]
+            if len(data) < 2:
+                return 0.0
+            prev, last = data[-2]["close"], data[-1]["close"]
+            return (last - prev) / prev
+
+        returns = Node(
+            input=price_stream,
+            compute_fn=compute_return,
+            name="returns",
+        )
+
+        history = alpha_history_node(returns, window=30)
+        signal = TradeSignalGeneratorNode(
+            history, long_threshold=0.0, short_threshold=0.0
+        )
+
+        model = ExecutionModel()
+
+        def simulate_fill(view):
+            sig_data = view[signal][signal.interval]
+            price_data = view[price_stream][price_stream.interval]
+            if not sig_data or not price_data:
+                return None
+
+            sig = sig_data[-1][1]
+            if sig["action"] == "HOLD":
+                return None
+
+            bar_time, bar = price_data[-1]
+            market = create_market_data_from_ohlcv(
+                timestamp=bar_time,
+                open_price=bar["open"],
+                high=bar["high"],
+                low=bar["low"],
+                close=bar["close"],
+                volume=bar["volume"],
+            )
+            side = OrderSide.BUY if sig["action"] == "BUY" else OrderSide.SELL
+            return model.simulate_execution(
+                order_id=f"order_{bar_time}",
+                symbol="ASSET",
+                side=side,
+                quantity=sig["size"],
+                order_type=OrderType.MARKET,
+                requested_price=bar["close"],
+                market_data=market,
+                timestamp=bar_time,
+            )
+
+        fill_node = Node(
+            input=[signal, price_stream],
+            compute_fn=simulate_fill,
+            name="execution_fill",
+            interval=price_stream.interval,
+            period=1,
+        )
+
+        fills = alpha_history_node(fill_node, window=100, name="execution_fills")
+
+        def compute_performance(view):
+            hist_data = view[history][history.interval]
+            fill_data = view[fills][fills.interval]
+            if not hist_data:
+                return None
+            returns_series = hist_data[-1][1]
+            exec_fills = [f for f in (fill_data[-1][1] if fill_data else []) if f]
+            return alpha_performance_node(
+                returns_series,
+                execution_fills=exec_fills,
+                use_realistic_costs=True,
+            )
+
+        performance = Node(
+            input=[history, fills],
+            compute_fn=compute_performance,
+            name="performance",
+            interval=history.interval,
+            period=1,
+        )
+
+        self.add_nodes(
+            [
+                price_stream,
+                returns,
+                history,
+                signal,
+                fill_node,
+                fills,
+                performance,
+            ]
+        )
+
+
+if __name__ == "__main__":
+    Runner.offline(ExecutionModelStrategy)
+


### PR DESCRIPTION
## Summary
- document ExecutionModel and cost-adjusted metrics in SDK tutorial
- add execution_model_strategy example combining trade signals and execution costs
- test ExecutionModel commission and slippage calculations

## Testing
- `uv run -m pytest -W error` (fails: `ModuleNotFoundError: No module named 'scripts.check_no_strategies_import'`)
- `uv run -m pytest tests/test_execution_modeling.py::TestExecutionModel::test_commission_and_slippage_values -W error`


------
https://chatgpt.com/codex/tasks/task_e_68a6683c5fd08329b13e7ce05d41156d