### PR TITLE
Add documentation inventory

### DIFF
--- a/docs/_inventory.md
+++ b/docs/_inventory.md
@@ -1,0 +1,42 @@
+# Documentation Inventory
+
+Below is a categorized list of Markdown files located in the repository root and `docs/` directory. Each category includes an owner responsible for maintaining the documents.
+
+## Architecture
+*Owner: Alice*
+
+- `architecture.md`
+- `dag-manager.md`
+- `gateway.md`
+- `docs/lean_brokerage_model.md`
+- `docs/lean_like_features.md`
+- `docs/strategy_workflow.md`
+- `docs/timing_controls.md`
+
+## Operations
+*Owner: Bob*
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `docs/backfill.md`
+- `docs/backtest_validation.md`
+- `docs/canary_rollout.md`
+- `docs/e2e_testing.md`
+- `docs/enhanced_validation.md`
+- `docs/monitoring.md`
+- `docs/risk_management.md`
+
+## Guides
+*Owner: Carol*
+
+- `README.md`
+- `docs/sdk_tutorial.md`
+
+## Reference
+*Owner: Dave*
+
+- `BACKTEST_ENHANCEMENTS_SUMMARY.md`
+- `docs/CHANGELOG.md`
+- `docs/faq.md`
+- `docs/templates.md`
+


### PR DESCRIPTION
## Summary
- inventory all root and docs Markdown files
- categorize documentation into architecture, operations, guides, and reference with owners

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a679450f8083298b4d364e7b48ac60