### PR TITLE
docs: configure mkdocs with navigation

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Architecture
 
 Design documents describing core QMTL components.
@@ -6,3 +8,6 @@ Design documents describing core QMTL components.
 - [Gateway](gateway.md): Gateway component specification.
 - [DAG Manager](dag-manager.md): DAG Manager design.
 - [Lean Brokerage Model](lean_brokerage_model.md): Brokerage integration details.
+
+{{ nav_links() }}
+

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # QMTL 고급 아키텍처 및 시스템 구현 계획서
 
 > *최종 수정일: 2025년 6월 4일*
@@ -414,4 +416,7 @@ Runner.dryrun(CrossMarketLagStrategy)
     50% 프로모션, 한 줄 롤백 명령으로 이어지는 파이프라인을 구축한다.
 
 위 목록이 모두 충족된 시점을 QMTL v0.9 “Determinism” 마일스톤으로 삼는다.
+
+
+{{ nav_links() }}
 

--- a/docs/architecture/dag-manager.md
+++ b/docs/architecture/dag-manager.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # QMTL DAG Manager — 상세 설계서 (Extended Edition)
 
 > **Revision 2025‑06‑04 / v1.1**  — 문서 분량 +75% 확장, 실전 운영 기준 세부 스펙 포함
@@ -287,3 +289,6 @@ qmtl dagmanager-server --config qmtl/examples/qmtl.yml
 Available flags:
 
 - ``--config`` – optional path to configuration file.
+
+{{ nav_links() }}
+

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # QMTL Gateway — Comprehensive Technical Specification
 
 *Research‑Driven Draft v1.2 — 2025‑06‑10*
@@ -189,3 +191,6 @@ Available flags:
 
 - ``--config`` – optional path to configuration file.
 - ``--no-sentinel`` – disable automatic ``VersionSentinel`` insertion.
+
+{{ nav_links() }}
+

--- a/docs/architecture/lean_brokerage_model.md
+++ b/docs/architecture/lean_brokerage_model.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 아래는 \*\*Lean의 ‘브로커리지 모델(Brokerage Model)’\*\*을 구현할 때 필요한 핵심 기술과, 이를 **조합**해 “현실적인 체결·거래 제약”을 한 번에 모델링하는 설계 가이드입니다. 마지막에 **QMTL**로 옮겨 담는 방법(모듈 배치/파이프라인)도 제안합니다.
 
 ---
@@ -223,3 +225,6 @@ If you want, I can sketch a minimal **IBKR-like BrokerageProfile POC**(파이썬
 [24]: https://www.quantconnect.com/docs/v2/writing-algorithms/reality-modeling/settlement/supported-models?utm_source=chatgpt.com "Supported Models"
 [25]: https://www.quantconnect.com/docs/v2/writing-algorithms/datasets/quantconnect/us-equities-short-availability?utm_source=chatgpt.com "US Equities Short Availability"
 [26]: https://www.quantconnect.com/docs/v2/writing-algorithms/reality-modeling/key-concepts?utm_source=chatgpt.com "Reality Modeling"
+
+{{ nav_links() }}
+

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,6 +1,11 @@
+{{ nav_links() }}
+
 # Guides
 
 Tutorials and workflow guides for using QMTL.
 
 - [SDK Tutorial](sdk_tutorial.md): Build strategies with the SDK.
 - [Strategy Workflow](strategy_workflow.md): Recommended development flow.
+
+{{ nav_links() }}
+

--- a/docs/guides/sdk_tutorial.md
+++ b/docs/guides/sdk_tutorial.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # SDK 사용 가이드
 
 본 문서는 QMTL SDK를 이용해 전략을 구현하고 실행하는 기본 절차를 소개합니다. 보다 상세한 아키텍처 설명과 예시는 [architecture.md](../architecture/architecture.md)와 `qmtl/examples/` 디렉터리를 참고하세요.
@@ -258,4 +260,7 @@ execution backend.
 
 노드 캐시를 과거 데이터로 초기화하는 방법은
 [backfill.md](backfill.md) 문서를 참고하세요.
+
+
+{{ nav_links() }}
 

--- a/docs/guides/strategy_workflow.md
+++ b/docs/guides/strategy_workflow.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Strategy Development and Testing Workflow
 
 > **실무 개발 가이드 및 체크리스트**
@@ -200,3 +202,6 @@ Gateway and DAG Manager using your customized `qmtl.yml`.
 > - [monitoring.md](monitoring.md): 모니터링 및 운영
 > - [canary_rollout.md](canary_rollout.md): 점진적 배포 전략
 > - [qmtl/examples/](../qmtl/examples/): 다양한 전략 예제
+
+{{ nav_links() }}
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+{{ nav_links() }}
+
+# QMTL Documentation
+
+Welcome to the QMTL documentation. Use the navigation links to explore architecture, guides, operations, and reference materials.
+
+{{ nav_links() }}

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Operations
 
 Guidelines for running and maintaining QMTL in production.
@@ -9,3 +11,6 @@ Guidelines for running and maintaining QMTL in production.
 - [Risk Management](risk_management.md): Operational risk controls.
 - [Timing Controls](timing_controls.md): Scheduling safeguards.
 - [Grafana Dashboard](dashboards/gc_dashboard.json): Sample metrics dashboard.
+
+{{ nav_links() }}
+

--- a/docs/operations/backfill.md
+++ b/docs/operations/backfill.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Backfilling Historical Data
 
 This guide explains how to populate node caches with past values before a strategy starts processing live data.
@@ -199,4 +201,7 @@ are retried up to ``max_retries`` times with a short delay. During execution the
 engine emits metrics such as ``backfill_jobs_in_progress``,
 ``backfill_last_timestamp``, ``backfill_retry_total`` and
 ``backfill_failure_total``.
+
+
+{{ nav_links() }}
 

--- a/docs/operations/canary_rollout.md
+++ b/docs/operations/canary_rollout.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Canary Rollout Guide
 
 This document explains how to gradually shift traffic between strategy versions using the `DAG Manager` callback endpoint `/callbacks/sentinel-traffic`. See [dag-manager.md](../architecture/dag-manager.md) for the full API specification and [gateway.md](../architecture/gateway.md) for how Gateway processes `sentinel_weight` events.
@@ -24,3 +26,6 @@ curl -X POST \
 * **Alerts:** alert rules under `alert_rules.yml` trigger if traffic weight deviates from the configured value for more than 5 minutes.
 
 Review Grafana dashboards to visualize canary success rates and error budgets while gradually increasing the traffic weight.
+
+{{ nav_links() }}
+

--- a/docs/operations/e2e_testing.md
+++ b/docs/operations/e2e_testing.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # End-to-End Testing
 
 This guide explains how to spin up the required services and execute the end-to-end test suite.
@@ -60,4 +62,7 @@ python -m qmtl.sdk tests.sample_strategy:SampleStrategy \
 ```
 
 See [backfill.md](backfill.md) for a full overview of the workflow.
+
+
+{{ nav_links() }}
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Monitoring and Alerting
 
 This document outlines sample Prometheus alerts and Grafana dashboards for QMTL services.
@@ -114,4 +116,7 @@ service="gateway"
 
 Selecting a trace shows the relationship between the SDK's HTTP request, the
 Gateway submission and downstream gRPC calls to the DAG Manager.
+
+
+{{ nav_links() }}
 

--- a/docs/operations/risk_management.md
+++ b/docs/operations/risk_management.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Risk Management Guide
 
 This guide explains how to configure and use the `RiskManager` to enforce portfolio limits during backtests and simulations.
@@ -35,3 +37,6 @@ is_valid, violation, adjusted_qty = enforce_position_limit(
 ```
 
 If the trade exceeds the configured limits, `is_valid` is `False` and `adjusted_qty` reflects the maximum safe quantity.
+
+{{ nav_links() }}
+

--- a/docs/operations/timing_controls.md
+++ b/docs/operations/timing_controls.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Timing Controls
 
 This document outlines the timing utilities available in QMTL for managing market sessions and validating timestamp data.
@@ -54,3 +56,6 @@ for node, node_issues in issues.items():
     for issue in node_issues:
         print(issue["reason"], issue["datetime"])
 ```
+
+{{ nav_links() }}
+

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Changelog
 
 ## Unreleased
@@ -28,3 +30,6 @@ PR 본문:
 - 로컬에서 lint/테스트/문서 동기화 체크 후 PR 생성 바랍니다.
 - CI 복구 시 본문/문서에서 안내 예정
 ```
+
+{{ nav_links() }}
+

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Reference
 
 Reference materials and inventories for QMTL.
@@ -9,3 +11,6 @@ Reference materials and inventories for QMTL.
 - [Lean-like Features](lean_like_features.md): Proposed feature alignment with Lean.
 - [Templates](templates.md): Document templates.
 - [Inventory](\_inventory.md): Documentation index.
+
+{{ nav_links() }}
+

--- a/docs/reference/_inventory.md
+++ b/docs/reference/_inventory.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Documentation Inventory
 
 Below is a categorized list of Markdown files located in the repository root and `docs/` directory. Each category includes an owner responsible for maintaining the documents.
@@ -40,3 +42,6 @@ Below is a categorized list of Markdown files located in the repository root and
 - `docs/reference/lean_like_features.md`
 - `docs/reference/templates.md`
 - `docs/reference/_inventory.md`
+
+{{ nav_links() }}
+

--- a/docs/reference/backtest_validation.md
+++ b/docs/reference/backtest_validation.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Backtest Data Validation
 
 `validate_backtest_data` inspects cached history before replay to catch common quality issues. It generates a `DataQualityReport` for each `StreamInput` and can halt execution when data falls below a required threshold.
@@ -25,3 +27,6 @@ Use `validate_backtest_data(strategy, fail_on_quality_threshold=0.8)` to enforce
 ## Example
 
 The script at `qmtl/examples/backtest_validation_example.py` shows how to enable validation before running a backtest. A sample CSV with deliberate gaps is provided at `qmtl/examples/data/backtest_validation_sample.csv` for experimentation.
+
+{{ nav_links() }}
+

--- a/docs/reference/enhanced_validation.md
+++ b/docs/reference/enhanced_validation.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Enhanced Error Handling and Input Validation
 
 This document describes the improvements made to error handling and input validation in the QMTL SDK.
@@ -165,3 +167,6 @@ Run validation tests:
 ```bash
 pytest tests/test_enhanced_validation.py -v
 ```
+
+{{ nav_links() }}
+

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -1,5 +1,10 @@
+{{ nav_links() }}
+
 # FAQ
 
 ## 태그 기반 노드는 각 실행 모드에서 어떻게 동작하나요?
 
 `TagQueryNode`는 Runner가 생성하는 `TagQueryManager`가 Gateway와 통신하여 큐 목록을 갱신합니다. `backtest`, `dryrun`, `live` 모드에서는 `--gateway-url`을 지정하면 태그 기반 노드를 완전히 사용할 수 있습니다. `offline` 모드는 Gateway 없이 로컬에서만 실행하므로 태그 기반 노드는 빈 큐 목록으로 초기화되어 동작이 부분적입니다. 필요한 경우 개별 지표를 `StreamInput`으로 등록하고 과거 데이터를 직접 백필하여 사용하세요.
+
+{{ nav_links() }}
+

--- a/docs/reference/lean_like_features.md
+++ b/docs/reference/lean_like_features.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 Enhancing Backtest Execution Accuracy: Lean Features & QMTL Integration
 Introduction
 Improving the realism of backtest trade execution requires modeling various market mechanics. QuantConnect’s Lean engine provides a rich set of “reality modeling” features that enhance fill accuracy, including diverse order types/policies, slippage and fee models, liquidity constraints, proper timing of fills, and robust position tracking. QMTL – a DAG-based strategy execution framework – currently focuses on signal generation and lacks these detailed execution simulations. This report analyzes how Lean implements each key feature and proposes a design to transplant similar functionality into QMTL. Where possible, we suggest purely DAG-based solutions; if a direct DAG integration is impractical, we outline hybrid approaches (e.g. an external order-matching layer or portfolio state machine) and explain their pros and cons. The goal is to incorporate the following features into QMTL’s architecture to yield more realistic backtest outcomes:
@@ -155,3 +157,6 @@ https://www.quantconnect.com/forum/discussion/17157/how-to-make-set-slippagemode
 [23] [24] [31] Market Order Backtesting Behavior - QuantConnect.com
 https://www.quantconnect.com/forum/discussion/10369/market-order-backtesting-behavior/
 [32] [35] [architecture.md](../architecture/architecture.md)
+
+{{ nav_links() }}
+

--- a/docs/reference/templates.md
+++ b/docs/reference/templates.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Strategy Templates
 
 QMTL ships with starter strategies that can be used when running `qmtl init`.
@@ -105,3 +107,6 @@ qmtl taglint path/to/module.py
 Add `--fix` to normalize intervals and scaffold missing keys. Linting can run in
 parallel with documentation tasks, so teams can update docs while `qmtl taglint`
 checks the code.
+
+{{ nav_links() }}
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,27 @@
+import os
+
+def define_env(env):
+    @env.macro
+    def nav_links():
+        page = env.variables.get('page')
+        if not page or not hasattr(page, 'file'):
+            return ''
+        base_dir = os.path.dirname(page.file.src_uri)
+        def relpath(target):
+            return os.path.relpath(target, base_dir) if base_dir else target
+        parts = []
+        parent = getattr(page, 'parent', None)
+        if parent and hasattr(parent, 'file'):
+            parts.append('**Parent:** [' + parent.title + '](' + relpath(parent.file.src_uri) + ')')
+        children = getattr(page, 'children', None) or []
+        children = [c for c in children if hasattr(c, 'file')]
+        if children:
+            child_links = ', '.join('[' + c.title + '](' + relpath(c.file.src_uri) + ')' for c in children)
+            parts.append('**Children:** ' + child_links)
+        siblings = []
+        if parent and getattr(parent, 'children', None):
+            siblings = [c for c in parent.children if c is not page and hasattr(c, 'file')]
+        if siblings:
+            sibling_links = ', '.join('[' + s.title + '](' + relpath(s.file.src_uri) + ')' for s in siblings)
+            parts.append('**Related:** ' + sibling_links)
+        return '\n\n'.join(parts)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,40 @@
+site_name: QMTL Documentation
+nav:
+  - Home: index.md
+  - Architecture:
+      - Overview: architecture/README.md
+      - Architecture: architecture/architecture.md
+      - DAG Manager: architecture/dag-manager.md
+      - Gateway: architecture/gateway.md
+      - Lean Brokerage Model: architecture/lean_brokerage_model.md
+  - Guides:
+      - Overview: guides/README.md
+      - SDK Tutorial: guides/sdk_tutorial.md
+      - Strategy Workflow: guides/strategy_workflow.md
+  - Operations:
+      - Overview: operations/README.md
+      - Backfill: operations/backfill.md
+      - Canary Rollout: operations/canary_rollout.md
+      - E2E Testing: operations/e2e_testing.md
+      - Monitoring: operations/monitoring.md
+      - Risk Management: operations/risk_management.md
+      - Timing Controls: operations/timing_controls.md
+  - Reference:
+      - Overview: reference/README.md
+      - FAQ: reference/faq.md
+      - Templates: reference/templates.md
+      - Enhanced Validation: reference/enhanced_validation.md
+      - Backtest Validation: reference/backtest_validation.md
+      - Lean-like Features: reference/lean_like_features.md
+      - Inventory: reference/_inventory.md
+      - Changelog: reference/CHANGELOG.md
+plugins:
+  - search
+  - macros
+  - mkdocs-breadcrumbs-plugin
+theme:
+  name: material
+  features:
+    - navigation.top
+    - navigation.expand
+    - navigation.path


### PR DESCRIPTION
## Summary
- add mkdocs configuration and material theme with breadcrumb plugin
- include macro to render parent, child, and related links in each document
- inject navigation macro at top and bottom of documentation pages

## Testing
- `uv run mkdocs build`
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68a67fdcbe2483298811563b8895dbaa