### PR TITLE
docs: add maintenance schedule and docs CI workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/docs.yml'
+
+jobs:
+  lint-and-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v15
+        with:
+          globs: |
+            **/*.md
+      - name: Check links
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --no-progress './**/*.md'

--- a/docs/MAINTENANCE_SCHEDULE.md
+++ b/docs/MAINTENANCE_SCHEDULE.md
@@ -1,0 +1,11 @@
+# Documentation Maintenance Schedule
+
+The QMTL documentation structure is reviewed each quarter to keep content organized and up to date.
+
+| Quarter | Review Month | Focus |
+|---------|--------------|-------|
+| Q1      | January      | Audit overall documentation structure and navigation. |
+| Q2      | April        | Incorporate feedback and reorganize new content. |
+| Q3      | July         | Mid-year review of architecture and guides. |
+| Q4      | October      | Year-end cleanup and planning for next year's docs. |
+


### PR DESCRIPTION
## Summary
- document quarterly review cycle in docs/MAINTENANCE_SCHEDULE.md
- add docs CI workflow for markdown linting and link checking

## Testing
- `uv run -m pytest -W error` *(fails: ExceptionGroup: multiple unraisable exception warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a68684cea083299419bda3e8c1f997