### PR TITLE
feat(docs): add tag support

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,6 +1,8 @@
 ---
 title: "Architecture"
-tags: []
+tags:
+  - architecture
+  - overview
 author: "QMTL Team"
 last_modified: 2025-08-21
 ---

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -1,6 +1,8 @@
 ---
 title: "QMTL 고급 아키텍처 및 시스템 구현 계획서"
-tags: []
+tags:
+  - architecture
+  - design
 author: "QMTL Team"
 last_modified: 2025-08-21
 ---

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,6 +1,8 @@
 ---
 title: "Guides"
-tags: []
+tags:
+  - guide
+  - overview
 author: "QMTL Team"
 last_modified: 2025-08-21
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 title: "QMTL Documentation"
-tags: []
+tags:
+  - overview
 author: "QMTL Team"
 last_modified: 2025-08-21
 ---

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,6 +1,8 @@
 ---
 title: "Operations"
-tags: []
+tags:
+  - operations
+  - overview
 author: "QMTL Team"
 last_modified: 2025-08-21
 ---

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,6 +1,8 @@
 ---
 title: "Reference"
-tags: []
+tags:
+  - reference
+  - overview
 author: "QMTL Team"
 last_modified: 2025-08-21
 ---

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,21 @@
+---
+title: "Tags"
+tags:
+  - reference
+---
+
+# Tag Usage
+
+This page outlines how to use tags within the documentation and lists common examples.
+
+## Guidelines
+- Use short, lowercase keywords.
+- Apply multiple tags when it improves discoverability.
+- Core tags include `architecture`, `guide`, `operations`, `reference`, and `overview`.
+
+## Examples
+- `docs/architecture/README.md` → `tags: [architecture, overview]`
+- `docs/guides/README.md` → `tags: [guide, overview]`
+- `docs/operations/README.md` → `tags: [operations, overview]`
+
+When the documentation is built, this page will also display a tag index for quick filtering.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,10 +28,13 @@ nav:
       - Lean-like Features: reference/lean_like_features.md
       - Inventory: reference/_inventory.md
       - Changelog: reference/CHANGELOG.md
+  - Tags: tags.md
 plugins:
   - search
   - macros
   - mkdocs-breadcrumbs-plugin
+  - tags:
+      tags_file: tags.md
 theme:
   name: material
   features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "grpcio-tools",
     "pyarrow",
     "xstate",
+    "mkdocs-material",
 ]
 
 ray = ["ray"]


### PR DESCRIPTION
## Summary
- tag key docs with frontmatter metadata
- enable tag filtering plugin in MkDocs and document tag usage

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68a687995f688329b9ceb61d985b6827