### PR TITLE
docs: add related document sections and TLDR summary

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,8 +11,12 @@ last_modified: 2025-08-21
 
 # Architecture
 
+!!! abstract "TL;DR"
+    High-level hub for QMTL's architectural components. Use the links below to explore each module.
+
 Design documents describing core QMTL components.
 
+## 관련 문서
 - [Architecture Overview](architecture.md): High-level system design.
 - [Gateway](gateway.md): Gateway component specification.
 - [DAG Manager](dag-manager.md): DAG Manager design.

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -11,6 +11,11 @@ last_modified: 2025-08-21
 
 # QMTL 고급 아키텍처 및 시스템 구현 계획서
 
+## 관련 문서
+- [Architecture Overview](README.md)
+- [Gateway](gateway.md)
+- [DAG Manager](dag-manager.md)
+- [Lean Brokerage Model](lean_brokerage_model.md)
 
 ---
 

--- a/docs/architecture/dag-manager.md
+++ b/docs/architecture/dag-manager.md
@@ -11,6 +11,12 @@ last_modified: 2025-08-21
 
 > **Revision 2025‑06‑04 / v1.1**  — 문서 분량 +75% 확장, 실전 운영 기준 세부 스펙 포함
 
+## 관련 문서
+- [Architecture Overview](README.md)
+- [QMTL Architecture](architecture.md)
+- [Gateway](gateway.md)
+- [Lean Brokerage Model](lean_brokerage_model.md)
+
 ---
 
 ## 0. 역할 요약 & 설계 철학

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -11,6 +11,12 @@ last_modified: 2025-08-21
 
 *Research‑Driven Draft v1.2 — 2025‑06‑10*
 
+## 관련 문서
+- [Architecture Overview](README.md)
+- [QMTL Architecture](architecture.md)
+- [DAG Manager](dag-manager.md)
+- [Lean Brokerage Model](lean_brokerage_model.md)
+
 > This extended edition enlarges the previous document by ≈ 75 % and adopts an explicit, graduate‑level rigor. All threat models, formal API contracts, latency distributions, and CI/CD semantics are fully enumerated.
 > Legend: **Sx** = Section, **Rx** = Requirement, **Ax** = Assumption.
 

--- a/docs/architecture/lean_brokerage_model.md
+++ b/docs/architecture/lean_brokerage_model.md
@@ -7,6 +7,12 @@ last_modified: 2025-08-21
 
 {{ nav_links() }}
 
+## 관련 문서
+- [Architecture Overview](README.md)
+- [QMTL Architecture](architecture.md)
+- [Gateway](gateway.md)
+- [DAG Manager](dag-manager.md)
+
 아래는 \*\*Lean의 ‘브로커리지 모델(Brokerage Model)’\*\*을 구현할 때 필요한 핵심 기술과, 이를 **조합**해 “현실적인 체결·거래 제약”을 한 번에 모델링하는 설계 가이드입니다. 마지막에 **QMTL**로 옮겨 담는 방법(모듈 배치/파이프라인)도 제안합니다.
 
 ---


### PR DESCRIPTION
## Summary
- add TL;DR summary card and related document section to architecture overview
- link cross-references across architecture specs

## Testing
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68a68a586750832989e943be6e21f7b7