### PR TITLE
docs: add documentation dashboard

### DIFF
--- a/.github/workflows/docs-dashboard.yml
+++ b/.github/workflows/docs-dashboard.yml
@@ -1,0 +1,28 @@
+name: Docs Dashboard
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Update dashboard
+        run: python scripts/update_dashboard.py
+      - name: Commit changes
+        run: |
+          if [[ "$(git status --porcelain)" ]]; then
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git add docs/dashboard.json
+            git commit -m "ci: update docs dashboard" || exit 0
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ Here’s a short workflow summary based on the repository’s guidelines:
 
 For additional rules—such as adhering to architecture documents or managing distributable wheels—refer to [AGENTS.md](AGENTS.md) in the project root for the full guidelines.
 
+## Documentation Dashboard
+
+Document progress is tracked in [`docs/dashboard.json`](docs/dashboard.json). Each entry records the document's status (`draft`, `review`, or `complete`) and the responsible owner. The file's `last_updated` and `generated` timestamps are refreshed automatically by a scheduled workflow (`.github/workflows/docs-dashboard.yml`). Run the update script manually if needed:
+
+```bash
+python scripts/update_dashboard.py
+```
+
+Open the JSON directly or import it into a spreadsheet to review documentation status.
+
 ## Coding Style
 
 Use consistent naming for connection strings across the project. Prefer the `*_dsn` suffix for all connection parameters (for example `redis_dsn`, `database_dsn`, `neo4j_dsn`, `kafka_dsn`). Avoid one-letter variable names except in short loops; use descriptive names like `redis_client` or `dagmanager`.

--- a/docs/dashboard.json
+++ b/docs/dashboard.json
@@ -1,0 +1,23 @@
+{
+  "documents": [
+    {
+      "path": "docs/index.md",
+      "status": "complete",
+      "owner": "core",
+      "last_updated": "2025-08-21T03:22:01.482610+00:00"
+    },
+    {
+      "path": "docs/guides/sdk_tutorial.md",
+      "status": "review",
+      "owner": "docs-team",
+      "last_updated": "2025-08-21T03:22:01.482610+00:00"
+    },
+    {
+      "path": "docs/architecture/architecture.md",
+      "status": "draft",
+      "owner": "alice",
+      "last_updated": "2025-08-21T03:22:01.478610+00:00"
+    }
+  ],
+  "generated": "2025-08-21T03:24:59.683324+00:00"
+}

--- a/scripts/update_dashboard.py
+++ b/scripts/update_dashboard.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Update document dashboard with last modified timestamps.
+
+The script reads ``docs/dashboard.json`` and updates the ``last_updated`` field
+for each document based on the file's modification time. A ``generated``
+timestamp records when the dashboard was last refreshed.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def update_dashboard(root: Path = ROOT, dashboard: Path | None = None) -> dict:
+    """Update dashboard JSON file and return its data."""
+    dashboard = dashboard or root / "docs" / "dashboard.json"
+
+    if dashboard.exists():
+        data = json.loads(dashboard.read_text())
+    else:  # pragma: no cover - defensive path
+        data = {"documents": []}
+
+    for doc in data.get("documents", []):
+        doc_path = root / doc["path"]
+        if doc_path.exists():
+            mtime = datetime.fromtimestamp(doc_path.stat().st_mtime, tz=timezone.utc)
+            doc["last_updated"] = mtime.isoformat()
+        else:
+            doc["last_updated"] = None
+            doc["status"] = "missing"
+
+    data["generated"] = datetime.now(timezone.utc).isoformat()
+
+    dashboard.write_text(json.dumps(data, indent=2) + "\n")
+    return data
+
+
+def main() -> int:
+    update_dashboard()
+    print("Dashboard updated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_update_dashboard.py
+++ b/tests/test_update_dashboard.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.update_dashboard import update_dashboard
+
+
+def test_update_dashboard(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+
+    sample = docs_dir / "sample.md"
+    sample.write_text("# Sample\n")
+
+    dashboard = docs_dir / "dashboard.json"
+    dashboard.write_text(
+        json.dumps(
+            {
+                "documents": [
+                    {
+                        "path": "docs/sample.md",
+                        "status": "draft",
+                        "owner": "alice",
+                        "last_updated": None,
+                    }
+                ],
+                "generated": None,
+            }
+        )
+    )
+
+    update_dashboard(root=tmp_path)
+
+    data = json.loads(dashboard.read_text())
+    doc = data["documents"][0]
+    assert doc["last_updated"] is not None
+    assert data["generated"] is not None


### PR DESCRIPTION
## Summary
- track document status and ownership in `docs/dashboard.json`
- auto-refresh dashboard via `scripts/update_dashboard.py` and scheduled workflow
- document dashboard access and usage in README

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68a690c3855883298fa4d4bd68400bfe