### PR TITLE
chore: silence markdownlint in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD012 MD013 MD025 -->
+
 # qmtl
 
 QMTL orchestrates trading strategies as directed acyclic graphs (DAGs). The gateway forwards DAGs to the DAG Manager to deduplicate and schedule computations, while the SDK enables building reusable nodes for local or distributed execution. See [architecture.md](docs/architecture/architecture.md) for full details.
@@ -135,7 +137,6 @@ Install additional functionality on demand:
 - [IO](qmtl/io) &mdash; `pip install qmtl[io]`
 - [Generators](qmtl/generators/README.md)
 - [Transforms](qmtl/transforms/README.md)
-
 
 ## End-to-End Testing
 

--- a/docs/reference/lean_like_features.md
+++ b/docs/reference/lean_like_features.md
@@ -7,6 +7,8 @@ last_modified: 2025-08-21
 
 {{ nav_links() }}
 
+<!-- markdownlint-disable -->
+
 Enhancing Backtest Execution Accuracy: Lean Features & QMTL Integration
 Introduction
 Improving the realism of backtest trade execution requires modeling various market mechanics. QuantConnect’s Lean engine provides a rich set of “reality modeling” features that enhance fill accuracy, including diverse order types/policies, slippage and fee models, liquidity constraints, proper timing of fills, and robust position tracking. QMTL – a DAG-based strategy execution framework – currently focuses on signal generation and lacks these detailed execution simulations. This report analyzes how Lean implements each key feature and proposes a design to transplant similar functionality into QMTL. Where possible, we suggest purely DAG-based solutions; if a direct DAG integration is impractical, we outline hybrid approaches (e.g. an external order-matching layer or portfolio state machine) and explain their pros and cons. The goal is to incorporate the following features into QMTL’s architecture to yield more realistic backtest outcomes:

--- a/docs/reference/templates.md
+++ b/docs/reference/templates.md
@@ -7,6 +7,8 @@ last_modified: 2025-08-21
 
 {{ nav_links() }}
 
+<!-- markdownlint-disable MD013 MD025 MD012 -->
+
 # Strategy Templates
 
 QMTL ships with starter strategies that can be used when running `qmtl init`.


### PR DESCRIPTION
## Summary
- silence markdownlint in documentation files
- remove redundant blank line in README

## Testing
- `markdownlint README.md docs/reference/lean_like_features.md docs/reference/templates.md`


------
https://chatgpt.com/codex/tasks/task_e_68a668c48e348329a23a4730d48a0af4