### PR TITLE
docs: add documentation management guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,13 @@
 - For any code changes, run `uv run -m pytest -W error` locally and ensure the command completes without warnings. CI must also run this command without warnings.
 - Ensure proper resource cleanup (e.g., closing Redis connections) to avoid `ResourceWarning`.
 
+# Documentation Management
+
+- Store documentation in the `docs/` directory with descriptive filenames.
+- Each Markdown file should start with a single `#` heading and use relative links to other docs.
+- Update `mkdocs.yml` navigation when adding or moving files.
+- Validate docs with `uv run mkdocs build` before committing. Ensure `mkdocs-macros-plugin` and `mkdocs-breadcrumbs-plugin` are installed via `uv pip install -e .[dev]`.
+
 # Prioritizing external alpha ideas
 
 - The top-level docs directory `docs/alphadocs/ideas/gpt5pro/` contains alpha ideas rewritten by a stronger model (GPT-5-Pro). These files should be treated as higher-priority implementation targets by agents and maintainers working within the `qmtl` project.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dev = [
     "pyarrow",
     "xstate",
     "mkdocs-material",
+    "mkdocs-macros-plugin",
+    "mkdocs-breadcrumbs-plugin",
 ]
 
 ray = ["ray"]


### PR DESCRIPTION
## Summary
- add repo-wide documentation management guidelines to AGENTS.md
- include missing MkDocs plugins in dev dependencies so docs build cleanly

## Testing
- `uv run mkdocs build`
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68a6a22e92cc832981a3b5900df6d07a