### PR TITLE
feat: add lean-style brokerage model components

### DIFF
--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -1,0 +1,28 @@
+"""Brokerage model components for QMTL."""
+
+# Source: docs/architecture/lean_brokerage_model.md
+
+from .order import Order, Fill, Account
+from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
+from .simple import (
+    CashBuyingPowerModel,
+    PerShareFeeModel,
+    VolumeShareSlippageModel,
+    ImmediateFillModel,
+)
+from .brokerage_model import BrokerageModel
+
+__all__ = [
+    "Order",
+    "Fill",
+    "Account",
+    "BuyingPowerModel",
+    "FeeModel",
+    "SlippageModel",
+    "FillModel",
+    "CashBuyingPowerModel",
+    "PerShareFeeModel",
+    "VolumeShareSlippageModel",
+    "ImmediateFillModel",
+    "BrokerageModel",
+]

--- a/qmtl/brokerage/brokerage_model.py
+++ b/qmtl/brokerage/brokerage_model.py
@@ -1,0 +1,43 @@
+"""Aggregate brokerage model combining component models."""
+
+# Source: docs/architecture/lean_brokerage_model.md
+
+from __future__ import annotations
+
+from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
+from .order import Account, Order, Fill
+
+
+class BrokerageModel:
+    """Compose buying power, fee, slippage and fill models."""
+
+    def __init__(
+        self,
+        buying_power_model: BuyingPowerModel,
+        fee_model: FeeModel,
+        slippage_model: SlippageModel,
+        fill_model: FillModel,
+    ) -> None:
+        self.buying_power_model = buying_power_model
+        self.fee_model = fee_model
+        self.slippage_model = slippage_model
+        self.fill_model = fill_model
+
+    def can_submit_order(self, account: Account, order: Order) -> bool:
+        """Return ``True`` if the order passes buying power checks."""
+
+        return self.buying_power_model.has_sufficient_buying_power(account, order)
+
+    def execute_order(self, account: Account, order: Order, market_price: float) -> Fill:
+        """Execute ``order`` and update ``account`` cash balance."""
+
+        if not self.can_submit_order(account, order):
+            raise ValueError("Insufficient buying power")
+
+        price_with_slippage = self.slippage_model.apply(order, market_price)
+        fill = self.fill_model.fill(order, price_with_slippage)
+        fee = self.fee_model.calculate(order, fill.price)
+        fill.fee = fee
+        cost = fill.price * order.quantity + fee
+        account.cash -= cost
+        return fill

--- a/qmtl/brokerage/interfaces.py
+++ b/qmtl/brokerage/interfaces.py
@@ -1,0 +1,41 @@
+"""Abstract interfaces for brokerage model components."""
+
+# Source: docs/architecture/lean_brokerage_model.md
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .order import Account, Order, Fill
+
+
+class BuyingPowerModel(ABC):
+    """Determine if an order has sufficient buying power."""
+
+    @abstractmethod
+    def has_sufficient_buying_power(self, account: Account, order: Order) -> bool:
+        """Return ``True`` if the account can cover the order cost."""
+
+
+class FeeModel(ABC):
+    """Calculate transaction fees."""
+
+    @abstractmethod
+    def calculate(self, order: Order, fill_price: float) -> float:
+        """Return the fee for executing ``order`` at ``fill_price``."""
+
+
+class SlippageModel(ABC):
+    """Estimate price impact due to slippage."""
+
+    @abstractmethod
+    def apply(self, order: Order, market_price: float) -> float:
+        """Return price adjusted for slippage from ``market_price``."""
+
+
+class FillModel(ABC):
+    """Determine fill quantity and base price."""
+
+    @abstractmethod
+    def fill(self, order: Order, market_price: float) -> Fill:
+        """Return fill details for ``order`` at ``market_price``."""

--- a/qmtl/brokerage/order.py
+++ b/qmtl/brokerage/order.py
@@ -1,0 +1,39 @@
+"""Order and fill data structures for brokerage models."""
+
+# Source: docs/architecture/lean_brokerage_model.md
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Order:
+    """Simple order representation.
+
+    Attributes:
+        symbol: Trading pair or ticker.
+        quantity: Number of units to buy (>0) or sell (<0).
+        price: Expected execution price used for buying power checks.
+    """
+
+    symbol: str
+    quantity: int
+    price: float
+
+
+@dataclass
+class Fill:
+    """Executed order details."""
+
+    symbol: str
+    quantity: int
+    price: float
+    fee: float = 0.0
+
+
+@dataclass
+class Account:
+    """Account holding cash for trading."""
+
+    cash: float

--- a/qmtl/brokerage/simple.py
+++ b/qmtl/brokerage/simple.py
@@ -1,0 +1,44 @@
+"""Simple brokerage model implementations."""
+
+# Source: docs/architecture/lean_brokerage_model.md
+
+from __future__ import annotations
+
+from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
+from .order import Account, Order, Fill
+
+
+class CashBuyingPowerModel(BuyingPowerModel):
+    """Buying power limited by available cash."""
+
+    def has_sufficient_buying_power(self, account: Account, order: Order) -> bool:
+        required = order.price * order.quantity
+        return account.cash >= required
+
+
+class PerShareFeeModel(FeeModel):
+    """Charge a fixed fee per share."""
+
+    def __init__(self, fee_per_share: float = 0.01) -> None:
+        self.fee_per_share = fee_per_share
+
+    def calculate(self, order: Order, fill_price: float) -> float:
+        return abs(order.quantity) * self.fee_per_share
+
+
+class VolumeShareSlippageModel(SlippageModel):
+    """Apply slippage proportional to price."""
+
+    def __init__(self, slippage_rate: float = 0.0005) -> None:
+        self.slippage_rate = slippage_rate
+
+    def apply(self, order: Order, market_price: float) -> float:
+        direction = 1 if order.quantity > 0 else -1
+        return market_price + direction * market_price * self.slippage_rate
+
+
+class ImmediateFillModel(FillModel):
+    """Fill the entire order at the given price."""
+
+    def fill(self, order: Order, market_price: float) -> Fill:
+        return Fill(symbol=order.symbol, quantity=order.quantity, price=market_price)

--- a/tests/test_brokerage_model.py
+++ b/tests/test_brokerage_model.py
@@ -1,0 +1,57 @@
+"""Tests for simple brokerage model components."""
+
+import pytest
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashBuyingPowerModel,
+    ImmediateFillModel,
+    Order,
+    PerShareFeeModel,
+    VolumeShareSlippageModel,
+)
+
+
+def test_can_submit_order_based_on_buying_power():
+    account = Account(cash=1000)
+    order = Order(symbol="AAPL", quantity=5, price=100)
+    brokerage = BrokerageModel(
+        CashBuyingPowerModel(),
+        PerShareFeeModel(),
+        VolumeShareSlippageModel(),
+        ImmediateFillModel(),
+    )
+    assert brokerage.can_submit_order(account, order)
+    account.cash = 100
+    assert not brokerage.can_submit_order(account, order)
+
+
+def test_execute_order_applies_slippage_and_fee():
+    account = Account(cash=1000)
+    order = Order(symbol="AAPL", quantity=5, price=100)
+    brokerage = BrokerageModel(
+        CashBuyingPowerModel(),
+        PerShareFeeModel(fee_per_share=0.5),
+        VolumeShareSlippageModel(slippage_rate=0.01),
+        ImmediateFillModel(),
+    )
+    fill = brokerage.execute_order(account, order, market_price=100)
+    expected_price = 100 * (1 + 0.01)
+    expected_fee = 5 * 0.5
+    assert fill.price == expected_price
+    assert fill.fee == expected_fee
+    assert account.cash == 1000 - (expected_price * 5 + expected_fee)
+
+
+def test_execute_order_rejects_when_insufficient_cash():
+    account = Account(cash=10)
+    order = Order(symbol="AAPL", quantity=1, price=100)
+    brokerage = BrokerageModel(
+        CashBuyingPowerModel(),
+        PerShareFeeModel(),
+        VolumeShareSlippageModel(),
+        ImmediateFillModel(),
+    )
+    with pytest.raises(ValueError):
+        brokerage.execute_order(account, order, market_price=100)


### PR DESCRIPTION
## Summary
- add order, fill, and account dataclasses for brokerage modeling
- define interfaces and simple implementations for buying power, fees, slippage, and fills
- compose models into a BrokerageModel with tests

## Testing
- `uv run -m pytest -W error`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68a6a6c333c08329a34e0f4c920c6069