### PR TITLE
docs: add nav links to tags page

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -4,6 +4,8 @@ tags:
   - reference
 ---
 
+{{ nav_links() }}
+
 # Tag Usage
 
 This page outlines how to use tags within the documentation and lists common examples.
@@ -19,3 +21,6 @@ This page outlines how to use tags within the documentation and lists common exa
 - `docs/operations/README.md` → `tags: [operations, overview]`
 
 When the documentation is built, this page will also display a tag index for quick filtering.
+
+{{ nav_links() }}
+


### PR DESCRIPTION
## Summary
- include nav_links macro at the top and bottom of Tags doc
- build documentation to verify navigation links

## Testing
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68aac16e0fc48329901accff9f3fbfa5