### PR TITLE
docs: add maintenance schedule to nav

### DIFF
--- a/docs/MAINTENANCE_SCHEDULE.md
+++ b/docs/MAINTENANCE_SCHEDULE.md
@@ -1,3 +1,5 @@
+{{ nav_links() }}
+
 # Documentation Maintenance Schedule
 
 The QMTL documentation structure is reviewed each quarter to keep content organized and up to date.
@@ -9,3 +11,4 @@ The QMTL documentation structure is reviewed each quarter to keep content organi
 | Q3      | July         | Mid-year review of architecture and guides. |
 | Q4      | October      | Year-end cleanup and planning for next year's docs. |
 
+{{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: QMTL Documentation
 nav:
   - Home: index.md
+  - Maintenance Schedule: MAINTENANCE_SCHEDULE.md
   - Architecture:
       - Overview: architecture/README.md
       - Architecture: architecture/architecture.md


### PR DESCRIPTION
## Summary
- add navigation links to Maintenance Schedule documentation
- include maintenance schedule in site navigation

## Testing
- `uv run mkdocs build`
- `uv run -m pytest -W error`

------
https://chatgpt.com/codex/tasks/task_e_68aac16caf088329a3135e6a91171732