### PR TITLE
docs: expose archive page

### DIFF
--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,4 +1,9 @@
+{{ nav_links() }}
+
 # Archived Documentation
 
 | Version | Status |
 |--------|--------|
+| _None yet_ | - |
+
+{{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - Lean-like Features: reference/lean_like_features.md
       - Inventory: reference/_inventory.md
       - Changelog: reference/CHANGELOG.md
+  - Archive: archive/README.md
   - Tags: tags.md
 plugins:
   - search


### PR DESCRIPTION
## Summary
- surface archive documentation in site navigation
- add navigation links scaffold to archive index

## Testing
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68aac16f003c8329abcb95b7edd0fe3c