### PR TITLE
docs: add template to nav and remove nav links

### DIFF
--- a/docs/templates/template.md
+++ b/docs/templates/template.md
@@ -5,10 +5,7 @@ author: "Author Name"
 last_modified: 2025-08-21
 ---
 
-{{ nav_links() }}
-
 # Document Title
 
 Write your content here.
 
-{{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - Inventory: reference/_inventory.md
       - Changelog: reference/CHANGELOG.md
   - Tags: tags.md
+  - Template: templates/template.md
 plugins:
   - search
   - macros


### PR DESCRIPTION
## Summary
- expose template page via mkdocs navigation
- drop nav_links macro calls from template document

## Testing
- `uv run -m pytest -W error`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68aac17022148329afc2217dc646c968