### PR TITLE
Document alpha theories and link transform sources

### DIFF
--- a/docs/alphadocs/ideas/acceptable-price-band-theory.md
+++ b/docs/alphadocs/ideas/acceptable-price-band-theory.md
@@ -1,0 +1,23 @@
+# Acceptable Price Band Theory
+
+An acceptable price band adapts to market conditions using exponential smoothing.
+
+## Band estimation
+
+```
+mu = (1 - lambda_mu) * mu_prev + lambda_mu * price
+resid = price - mu
+sigma = sqrt((1 - lambda_sigma) * sigma_prev**2 + lambda_sigma * resid**2)
+band_lower = mu - k * sigma
+band_upper = mu + k * sigma
+pbx = resid / (k * sigma) if sigma else 0
+```
+
+## Overshoot and volume surprise
+
+```
+overshoot = max(0, abs(resid) - k * sigma) / sigma
+volume_surprise = (volume - volume_hat) / volume_std
+```
+
+These measures flag excursions beyond the band and unexpected volume bursts.

--- a/docs/alphadocs/ideas/dynamic-execution-diffusion-contraction-theory.md
+++ b/docs/alphadocs/ideas/dynamic-execution-diffusion-contraction-theory.md
@@ -1,0 +1,27 @@
+# Dynamic Execution Diffusion-Contraction Theory
+
+Execution diffusion-contraction evaluates how executed prices cluster or disperse and the expected jump from latent depth.
+
+## Concentration scores
+
+```
+entropy, hhi, fano = concentration_scores(exec_prices_ticks, exec_sizes, bins)
+```
+
+Histogram binning of executed prices yields entropy, Herfindahl-Hirschman Index and a Fano-based dispersion ratio.
+
+## Hazard probability
+
+A logistic model maps standardized features ``x`` and coefficients ``eta`` to a diffusion-contraction hazard:
+
+```
+hazard = 1 / (1 + exp(-(eta0 + sum(eta_i * x_i))))
+```
+
+## Expected jump and alpha
+
+Given gap widths and cumulative depth, the expected jump size is accumulated with parameter ``zeta``. The side-specific signal is
+
+```
+edch = hazard * expected_jump
+```

--- a/docs/alphadocs/ideas/latent-liquidity-threshold-reconfiguration.md
+++ b/docs/alphadocs/ideas/latent-liquidity-threshold-reconfiguration.md
@@ -1,0 +1,11 @@
+# Latent Liquidity Threshold Reconfiguration
+
+The Latent Liquidity Threshold Reconfiguration Index (LLRTI) measures how quickly book depth collapses once price moves beyond a tolerance.
+
+Given depth changes over an interval and the absolute price change $\Delta p$, the index is
+
+```
+LLRTI = sum(depth_changes) / delta_t
+```
+
+when $|\Delta p|>\delta$ and the interval duration ``delta_t`` is positive. Otherwise the index is ``0``. The measure captures latent liquidity that vanishes once prices breach a reconfiguration threshold.

--- a/docs/alphadocs/ideas/order-book-clustering-collapse-theory.md
+++ b/docs/alphadocs/ideas/order-book-clustering-collapse-theory.md
@@ -1,0 +1,11 @@
+# Order Book Clustering Collapse Theory
+
+Order book clustering collapse tracks the risk of densely packed orders disintegrating into sparse liquidity.
+
+## Hazard probability
+
+Features $\{C,\text{Cliff},\text{Gap},\text{CH},\text{RL},\text{Shield},\text{QDT\_inv}\}$ feed a logistic hazard model. Feature ``C`` uses a softplus transform and ``Shield`` enters negatively.
+
+## Direction gating and cost
+
+Direction gating supplies a side-aware signal conditioned on imbalance, while execution cost is reused from the generic hazard utilities. Together they describe the likelihood and cost of a clustering collapse.

--- a/docs/alphadocs/ideas/resiliency.md
+++ b/docs/alphadocs/ideas/resiliency.md
@@ -1,0 +1,19 @@
+# Resiliency
+
+Resiliency quantifies how quickly markets absorb trades and revert to equilibrium.
+
+## Impact
+
+A simplified impact model scales trade volume by typical size and book depth:
+
+```
+impact = beta * (volume / avg_volume) / depth
+```
+
+## Alpha
+
+The resiliency alpha rewards markets that recover after impact and penalizes volatility and order book imbalance derivatives:
+
+```
+alpha = gamma * impact - volatility + obi_derivative
+```

--- a/docs/alphadocs/ideas/tactical-liquidity-bifurcation-theory.md
+++ b/docs/alphadocs/ideas/tactical-liquidity-bifurcation-theory.md
@@ -1,0 +1,23 @@
+# Tactical Liquidity Bifurcation Theory
+
+Tactical liquidity bifurcation models the chance that order book conditions split into competing liquidity regimes and shapes order placement.
+
+## Hazard probability
+
+Given standardized features $Z=\{\text{SkewDot},\text{CancelDot},\text{Gap},\text{Cliff},\text{Shield},\text{QDT\_inv},\text{RequoteLag}\}$ and coefficients $\beta$, the hazard is
+computed with a logistic transform. ``SkewDot`` and ``CancelDot`` pass through a softplus
+while ``Shield`` enters with a negative sign.
+
+## Direction signal
+
+A side-aware direction signal weights aggregated flow by order flow imbalance using coefficients $\eta$.
+
+## Alpha
+
+The trading signal combines hazard, direction and execution cost:
+
+```
+alpha = max(hazard**gamma - tau, 0) * direction * pi * exp(-phi * cost)
+```
+
+where $\gamma$ controls curvature, $\tau$ is an activation threshold, ``pi`` reflects position incentive and ``cost`` is expected execution cost.

--- a/docs/alphadocs_registry.yml
+++ b/docs/alphadocs_registry.yml
@@ -4,11 +4,11 @@
 #   status: draft|implemented
 #   modules: []
 
-- doc: ../docs/alphadocs/ideas/gpt5pro/tactical-liquidity-bifurcation-theory.md
+- doc: ../docs/alphadocs/ideas/tactical-liquidity-bifurcation-theory.md
   status: implemented
   modules:
     - qmtl/transforms/tactical_liquidity_bifurcation.py
-- doc: ../docs/alphadocs/ideas/gpt5pro/latent-liquidity-threshold-reconfiguration.md
+- doc: ../docs/alphadocs/ideas/latent-liquidity-threshold-reconfiguration.md
   status: implemented
   modules:
     - qmtl/transforms/llrti.py
@@ -16,11 +16,11 @@
   status: implemented
   modules:
     - qmtl/transforms/resiliency.py
-- doc: "../docs/alphadocs/ideas/gpt5pro/Acceptable Price Band Theory.md"
+- doc: ../docs/alphadocs/ideas/acceptable-price-band-theory.md
   status: implemented
   modules:
     - qmtl/transforms/acceptable_price_band.py
-- doc: "../docs/alphadocs/ideas/gpt5pro/Dynamic Execution Diffusion-Contraction Theory.md"
+- doc: ../docs/alphadocs/ideas/dynamic-execution-diffusion-contraction-theory.md
   status: implemented
   modules:
     - qmtl/transforms/execution_diffusion_contraction.py
@@ -31,7 +31,7 @@
     - qmtl/examples/nodes/generators/sequence.py
     - qmtl/examples/nodes/transforms/scale.py
     - qmtl/examples/nodes/indicators/average.py
-- doc: ../docs/alphadocs/ideas/gpt5pro/order-book-clustering-collapse-theory.md
+- doc: ../docs/alphadocs/ideas/order-book-clustering-collapse-theory.md
   status: implemented
   modules:
     - qmtl/transforms/order_book_clustering_collapse.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,13 @@ nav:
       - Lean-like Features: reference/lean_like_features.md
       - Inventory: reference/_inventory.md
       - Changelog: reference/CHANGELOG.md
+  - AlphaDocs:
+      - Tactical Liquidity Bifurcation Theory: alphadocs/ideas/tactical-liquidity-bifurcation-theory.md
+      - Latent Liquidity Threshold Reconfiguration: alphadocs/ideas/latent-liquidity-threshold-reconfiguration.md
+      - Resiliency: alphadocs/ideas/resiliency.md
+      - Acceptable Price Band Theory: alphadocs/ideas/acceptable-price-band-theory.md
+      - Dynamic Execution Diffusion-Contraction Theory: alphadocs/ideas/dynamic-execution-diffusion-contraction-theory.md
+      - Order Book Clustering Collapse Theory: alphadocs/ideas/order-book-clustering-collapse-theory.md
   - Archive: archive/README.md
   - Tags: tags.md
   - Template: templates/template.md

--- a/qmtl/indicators/__init__.py
+++ b/qmtl/indicators/__init__.py
@@ -17,7 +17,6 @@ from .kalman_trend import kalman_trend
 from .rough_bergomi import rough_bergomi
 from .stoch_rsi import stoch_rsi
 from .volatility import volatility_node, volatility
-from .gap_amplification_alpha import gap_amplification_node
 from .helpers import alpha_indicator_with_history
 
 __all__ = [
@@ -39,6 +38,5 @@ __all__ = [
     "stoch_rsi",
     "volatility_node",
     "volatility",
-    "gap_amplification_node",
     "alpha_indicator_with_history",
 ]

--- a/qmtl/transforms/acceptable_price_band.py
+++ b/qmtl/transforms/acceptable_price_band.py
@@ -1,7 +1,6 @@
 """Acceptable price band transform utilities."""
 
-# Source: ../docs/alphadocs/ideas/gpt5pro/Acceptable Price Band Theory.md
-# Priority: gpt5pro
+# Source: ../docs/alphadocs/ideas/acceptable-price-band-theory.md
 
 from __future__ import annotations
 

--- a/qmtl/transforms/execution_diffusion_contraction.py
+++ b/qmtl/transforms/execution_diffusion_contraction.py
@@ -1,7 +1,6 @@
 """Execution diffusion–contraction hazard transforms."""
 
-# Source: ../docs/alphadocs/ideas/gpt5pro/Dynamic Execution Diffusion-Contraction Theory.md
-# Priority: gpt5pro
+# Source: ../docs/alphadocs/ideas/dynamic-execution-diffusion-contraction-theory.md
 
 from __future__ import annotations
 

--- a/qmtl/transforms/llrti.py
+++ b/qmtl/transforms/llrti.py
@@ -1,6 +1,5 @@
 """LLRTI transform computing liquidity loss rate triggered by price movement."""
-# Source: ../docs/alphadocs/ideas/gpt5pro/latent-liquidity-threshold-reconfiguration.md
-# Priority: gpt5pro
+# Source: ../docs/alphadocs/ideas/latent-liquidity-threshold-reconfiguration.md
 
 from __future__ import annotations
 

--- a/qmtl/transforms/order_book_clustering_collapse.py
+++ b/qmtl/transforms/order_book_clustering_collapse.py
@@ -1,7 +1,6 @@
 """Order book clustering collapse transforms."""
 
-# Source: ../docs/alphadocs/ideas/gpt5pro/order-book-clustering-collapse-theory.md
-# Priority: gpt5pro
+# Source: ../docs/alphadocs/ideas/order-book-clustering-collapse-theory.md
 
 from __future__ import annotations
 

--- a/qmtl/transforms/tactical_liquidity_bifurcation.py
+++ b/qmtl/transforms/tactical_liquidity_bifurcation.py
@@ -1,7 +1,6 @@
 """Tactical Liquidity Bifurcation transforms."""
 
-# Source: ../docs/alphadocs/ideas/gpt5pro/tactical-liquidity-bifurcation-theory.md
-# Priority: gpt5pro
+# Source: ../docs/alphadocs/ideas/tactical-liquidity-bifurcation-theory.md
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- Add theory documents for Tactical Liquidity Bifurcation, LLRTI, Resiliency, Acceptable Price Band, Dynamic Execution Diffusion-Contraction, and Order Book Clustering Collapse
- Link transform modules to their docs via `# Source` headers and update alpha registry & MkDocs navigation
- Drop stale gap amplification indicator to restore clean test run

## Testing
- `uv run mkdocs build`
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68ab14812cf88329bebbd71f1ae587c3