### PR TITLE
feat: exit strategy when all nodes already registered

### DIFF
--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -592,6 +592,10 @@ class Runner:
             raise RuntimeError(queue_map["error"])
 
         Runner._apply_queue_map(strategy, queue_map)
+        if not any(n.execute for n in strategy.nodes):
+            logger.info("No executable nodes; exiting strategy")
+            return strategy
+
         offline_mode = offline or not Runner._kafka_available
         await manager.resolve_tags(offline=offline_mode)
         await Runner._ensure_history(strategy, None, None, stop_on_ready=True)
@@ -645,6 +649,10 @@ class Runner:
             raise RuntimeError(queue_map["error"])
 
         Runner._apply_queue_map(strategy, queue_map)
+        if not any(n.execute for n in strategy.nodes):
+            logger.info("No executable nodes; exiting strategy")
+            return strategy
+
         offline_mode = offline or not Runner._kafka_available
         await manager.resolve_tags(offline=offline_mode)
         await Runner._ensure_history(strategy, None, None, stop_on_ready=True)


### PR DESCRIPTION
## Summary
- stop dryrun/live runs when all strategy nodes already exist in the gateway DAG
- test early exit behaviour for dryrun and live modes

## Testing
- `uv run -m pytest tests/test_runner.py::test_dry_run_exits_when_all_nodes_mapped tests/test_runner.py::test_live_exits_when_all_nodes_mapped -W error`

Fixes #415 
------
https://chatgpt.com/codex/tasks/task_e_68af1fbe931c8329ba4c0ddec7bffa25