### PR TITLE
docs: rename WorldManager to WorldService

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -22,7 +22,7 @@ See also: Architecture Glossary (architecture/glossary.md) for canonical terms s
 - [Architecture Overview](architecture.md): High-level system design.
 - [Gateway](gateway.md): Gateway component specification.
 - [DAG Manager](dag-manager.md): DAG Manager design.
-- [WorldManager](worldmanager.md): World policy, decisions, activation.
+- [WorldService](worldservice.md): World policy, decisions, activation.
 - [EventPool](eventpool.md): Internal control bus (opaque to SDK).
 - [Lean Brokerage Model](lean_brokerage_model.md): Brokerage integration details.
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -16,7 +16,7 @@ last_modified: 2025-08-21
 - [Gateway](gateway.md)
 - [DAG Manager](dag-manager.md)
 - [Lean Brokerage Model](lean_brokerage_model.md)
-- [WorldManager](worldmanager.md)
+- [WorldService](worldservice.md)
 - [EventPool](eventpool.md)
 
 ---
@@ -40,7 +40,7 @@ graph LR
     GW[Gateway]
   end
   subgraph Core
-    WM[WorldManager (SSOT Worlds)]
+    WS[WorldService (SSOT Worlds)]
     DM[DAG Manager (SSOT Graph)]
     EP[(EventPool — internal)]
     GDB[(Graph DB)]
@@ -48,19 +48,19 @@ graph LR
   end
 
   SDK -- HTTP submit/queues/worlds --> GW
-  GW -- proxy --> WM
+  GW -- proxy --> WS
   GW -- proxy --> DM
   DM --> GDB
   DM --> KQ
-  WM -- publish --> EP
+  WS -- publish --> EP
   DM -- publish --> EP
   GW -- subscribe --> EP
   GW -- WS (opaque) --> SDK
 ```
 
 1. **SDK**는 전략을 DAG로 직렬화하고 Gateway에 제출/질의한다. 실행 중에는 Gateway의 WS로부터 불투명(EventPool 기반) 이벤트 스트림을 전달받아 활성/큐 변경을 반영한다.
-2. **Gateway**는 외부 단일 접점으로서 WorldManager/DAG Manager를 프록시하고, 캐시/서킷/관측을 담당한다. 또한 EventPool을 구독하여 SDK로 이벤트를 재전송한다.
-3. **WorldManager**는 월드/정책/결정/활성의 SSOT이며, 결정·활성 업데이트를 EventPool에 발행한다.
+2. **Gateway**는 외부 단일 접점으로서 WorldService/DAG Manager를 프록시하고, 캐시/서킷/관측을 담당한다. 또한 EventPool을 구독하여 SDK로 이벤트를 재전송한다.
+3. **WorldService**는 월드/정책/결정/활성의 SSOT이며, 결정·활성 업데이트를 EventPool에 발행한다.
 4. **DAG Manager**는 그래프/노드/큐의 SSOT이며, Diff와 큐 오케스트레이션을 수행하고 QueueUpdated 이벤트를 EventPool에 발행한다.
 5. **SDK**는 반환된 큐 매핑에 따라 로컬에서 필요한 노드만 실행하며, 활성 게이트(OrderGateNode)로 주문 발동을 제어한다.
 

--- a/docs/architecture/eventpool.md
+++ b/docs/architecture/eventpool.md
@@ -19,7 +19,7 @@ Role
 - Bounded retention with compacted history for late subscribers
 
 Non‑Goals
-- Not a source of truth (SSOT); decisions/activation live in WorldManager, queues in DAG Manager
+- Not a source of truth (SSOT); decisions/activation live in WorldService, queues in DAG Manager
 - Not a general data bus; market/indicator/trade data remain on data topics managed by DAG Manager
 
 ---
@@ -106,13 +106,13 @@ Metrics
 - replay_queue_depth, partition_skew_seconds
 
 Runbooks
-- Recreate consumer groups, increase partitions per world count, backfill via HTTP reconcile endpoints at Gateway/WorldManager/DAG Manager
+- Recreate consumer groups, increase partitions per world count, backfill via HTTP reconcile endpoints at Gateway/WorldService/DAG Manager
 
 ---
 
 ## 6. Integration Pattern
 
-- WorldManager publishes ActivationUpdated/PolicyUpdated.
+- WorldService publishes ActivationUpdated/PolicyUpdated.
 - DAG Manager publishes QueueUpdated.
 - Gateway instances subscribe to EventPool and relay updates to SDK via an opaque WebSocket stream (`/events/subscribe`).
 

--- a/docs/architecture/lean_brokerage_model.md
+++ b/docs/architecture/lean_brokerage_model.md
@@ -12,7 +12,7 @@ last_modified: 2025-08-21
 - [QMTL Architecture](architecture.md)
 - [Gateway](gateway.md)
 - [DAG Manager](dag-manager.md)
-- [WorldManager](worldmanager.md)
+- [WorldService](worldservice.md)
 
 아래는 \*\*Lean의 ‘브로커리지 모델(Brokerage Model)’\*\*을 구현할 때 필요한 핵심 기술과, 이를 **조합**해 “현실적인 체결·거래 제약”을 한 번에 모델링하는 설계 가이드입니다. 마지막에 **QMTL**로 옮겨 담는 방법(모듈 배치/파이프라인)도 제안합니다.
 
@@ -217,7 +217,7 @@ If you want, I can sketch a minimal **IBKR-like BrokerageProfile POC**(파이썬
 
 ## Integration Note: Worlds and Brokerage
 
-- Activation vs. Execution: WorldManager decides whether a strategy/side may trade (activation set). Brokerage models define how orders are validated and executed once allowed.
+- Activation vs. Execution: WorldService decides whether a strategy/side may trade (activation set). Brokerage models define how orders are validated and executed once allowed.
 - Separation of concerns: Gateway/SDK enforce world activation via an order gate before invoking brokerage logic. Brokerage does not determine activation and remains broker‑specific.
 - Safety: If activation is stale/unknown, orders are gated OFF regardless of brokerage model outcomes.
 

--- a/docs/architecture/worldservice.md
+++ b/docs/architecture/worldservice.md
@@ -1,5 +1,5 @@
 ---
-title: "WorldManager — World Policy, Decisions, and Activation"
+title: "WorldService — World Policy, Decisions, and Activation"
 tags: [architecture, world, policy]
 author: "QMTL Team"
 last_modified: 2025-08-29
@@ -7,11 +7,11 @@ last_modified: 2025-08-29
 
 {{ nav_links() }}
 
-# WorldManager — World Policy, Decisions, and Activation
+# WorldService — World Policy, Decisions, and Activation
 
 ## 0. Role & Scope
 
-WorldManager is the system of record (SSOT) for Worlds. It owns:
+WorldService is the system of record (SSOT) for Worlds. It owns:
 - World/Policy registry: CRUD, versioning, defaults, rollback
 - Decision engine: data-currency, sample sufficiency, gates/score/constraints, hysteresis → effective_mode
 - Activation control: per-world activation set for strategies/sides with weights
@@ -130,12 +130,12 @@ Concurrency & Single‑Flight
 
 ## 6. Security & RBAC
 
-- Auth: service‑to‑service tokens (mTLS/JWT); user tokens at Gateway → propagated to WM
-- World‑scope RBAC enforced at WM; Gateway only proxies
+- Auth: service‑to‑service tokens (mTLS/JWT); user tokens at Gateway → propagated to WS
+- World‑scope RBAC enforced at WS; Gateway only proxies
 - Audit: all write ops and evaluations are logged with correlation_id
 
 Clock Discipline
-- Decisions depend on time. WM uses a monotonic server clock and enforces NTP health. Maximum tolerated client skew should be documented (e.g., ≤ 2s).
+- Decisions depend on time. WS uses a monotonic server clock and enforces NTP health. Maximum tolerated client skew should be documented (e.g., ≤ 2s).
 
 ---
 
@@ -156,7 +156,7 @@ Alerts
 
 ## 8. Failure Modes & Recovery
 
-- WM down: Gateway returns cached DecisionEnvelope if fresh; else safe default (offline/backtest). Activation defaults to inactive.
+- WS down: Gateway returns cached DecisionEnvelope if fresh; else safe default (offline/backtest). Activation defaults to inactive.
 - Redis loss: reconstruct activation from latest snapshot; orders remain gated until consistency restored.
 - Policy parse errors: reject version; keep prior default.
 
@@ -166,7 +166,7 @@ Alerts
 
 - Gateway: proxy `/worlds/*`, cache decisions with TTL, enforce `--allow-live` guard
 - DAG Manager: no dependency for decisions; only for queue/graph metadata
-- EventPool: WM publishes ActivationUpdated/PolicyUpdated; Gateway subscribes and relays via WS to SDK
+- EventPool: WS publishes ActivationUpdated/PolicyUpdated; Gateway subscribes and relays via WS to SDK
 
 ---
 

--- a/docs/operations/activation.md
+++ b/docs/operations/activation.md
@@ -15,7 +15,7 @@ last_modified: 2025-08-29
 - Rollback after failed apply
 
 ## Preconditions
-- Confirm NTP health on WorldManager and Gateway nodes
+- Confirm NTP health on WorldService and Gateway nodes
 - Identify `world_id` and current `resource_version`/`etag`
 
 ## Procedures

--- a/docs/reference/api_world.md
+++ b/docs/reference/api_world.md
@@ -9,11 +9,11 @@ last_modified: 2025-08-29
 
 # World API Reference — Proxied via Gateway
 
-Gateway proxies WorldManager endpoints for SDKs and tools. This page lists the key endpoints and normative envelopes. See also: docs/world/world.md §12 for examples.
+Gateway proxies WorldService endpoints for SDKs and tools. This page lists the key endpoints and normative envelopes. See also: docs/world/world.md §12 for examples.
 
 ## Authentication
 
-- External callers authenticate to Gateway (JWT). Gateway authenticates/authorizes to WorldManager using service credentials and forwards identity scopes.
+- External callers authenticate to Gateway (JWT). Gateway authenticates/authorizes to WorldService using service credentials and forwards identity scopes.
 
 ## Endpoints
 

--- a/docs/world/world.md
+++ b/docs/world/world.md
@@ -289,7 +289,7 @@ POST /events/subscribe HTTP/1.1
 
 ## 13. 월드 레지스트리(CRUD & 전역 접근)
 
-월드는 전략 제출과 독립적으로 생성/수정/삭제/조회가 가능해야 하며, 프레임워크 전역에서 동일한 ID로 접근 가능해야 한다. 중앙 진실 원천(SSOT)은 WorldManager의 월드 레지스트리이며, Gateway는 외부 접근을 위한 프록시/캐시 역할을 수행한다. 내부 전파는 Redis 캐시와 EventPool(은닉) 이벤트를 사용하고, 외부에는 Gateway WS/HTTP로 노출한다.
+월드는 전략 제출과 독립적으로 생성/수정/삭제/조회가 가능해야 하며, 프레임워크 전역에서 동일한 ID로 접근 가능해야 한다. 중앙 진실 원천(SSOT)은 WorldService의 월드 레지스트리이며, Gateway는 외부 접근을 위한 프록시/캐시 역할을 수행한다. 내부 전파는 Redis 캐시와 EventPool(은닉) 이벤트를 사용하고, 외부에는 Gateway WS/HTTP로 노출한다.
 
 ### 13.1 데이터 모델(경량)
 
@@ -366,7 +366,7 @@ qmtl world delete crypto_mom_1h --force
 SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이며 외부에 명시적으로 드러나지 않는다. 실행 단계에서 Gateway가 “이벤트 스트림 기술서(EventStreamDescriptor)”를 반환하고, SDK는 이를 사용해 실시간 이벤트를 푸시로 수신한다.
 
 - 역할 분리
-  - SSOT: WorldManager(세계/정책/활성), DAG Manager(그래프/큐)
+  - SSOT: WorldService(세계/정책/활성), DAG Manager(그래프/큐)
   - 배포/팬아웃: EventPool(내부), 외부에는 Gateway가 단일 접점
 - EventStreamDescriptor(불투명)
   - `stream_url`(wss): 게이트웨이 도메인 하의 URL. 내부 구현상 EventPool로 프록시/리다이렉트될 수 있으나 클라이언트는 불문에 부친다.
@@ -384,10 +384,10 @@ SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이�
   - 스트림 실패 시 Gateway WS `fallback_url` 또는 주기적 `GET /worlds/{id}/activation`/`/queues/by_tag`로 보정.
   - 만료 혹은 401/403 발생 시 `POST /events/subscribe`로 재발급.
 - 보안/RBAC
-  - Gateway가 토큰을 발급하고 WorldManager 권한을 대행 검증. 민감 토픽은 world‑scope 권한 요구.
+  - Gateway가 토큰을 발급하고 WorldService 권한을 대행 검증. 민감 토픽은 world‑scope 권한 요구.
 - SLO/관측(권장)
   - `event_subscribe_latency_ms_p95` ≤ 150ms, `event_fanout_lag_ms_p95` ≤ 200ms
-  - 드롭/재연결/스큐 지표와 감사 로그(WorldManager 원본 이벤트 ID 포함) 노출
+  - 드롭/재연결/스큐 지표와 감사 로그(WorldService 원본 이벤트 ID 포함) 노출
 
 실행 흐름(요지)
 1) Runner 시작 → Gateway로 전략 제출/월드 결정 조회
@@ -397,18 +397,18 @@ SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이�
 
 ## 15. 컴포넌트 관계(모듈/인터페이스 명세)
 
-본 절은 sdk, gateway, eventpool(은닉), worldmanager, dagmanager 간의 책임·경계·인터페이스를 모듈 관점에서 명시한다.
+본 절은 sdk, gateway, eventpool(은닉), worldservice, dagmanager 간의 책임·경계·인터페이스를 모듈 관점에서 명시한다.
 
 ### 15.1 소유권(SSOT)과 책임
 
-- WorldManager(SSOT)
+- WorldService(SSOT)
   - 월드/정책 CRUD, 버전 관리, 결정/평가/적용, 활성 테이블 관리, 감사/알림, RBAC
 - DAG Manager(SSOT)
   - 그래프/노드/토픽/태그 쿼리, Diff, 버전/롤백, 큐 메타데이터
 - Gateway(프록시/캐시)
   - SDK 외부 단일 접점; 전략 제출/상태/큐 조회 프록시, 월드 API 프록시, 이벤트 스트림 발급, 캐시/서킷/관측
 - EventPool(배포/팬아웃)
-  - 제어 이벤트의 내부 퍼브/섭 허브(비공개). SSOT 아님. WM/DM의 업데이트를 다수 Gateway 인스턴스로 팬아웃
+  - 제어 이벤트의 내부 퍼브/섭 허브(비공개). SSOT 아님. WS/DM의 업데이트를 다수 Gateway 인스턴스로 팬아웃
 - SDK(클라이언트/런타임)
   - 전략 직렬화/제출, 태그 해석, OrderGateNode로 주문 게이트, 이벤트 스트림 구독/적용
 
@@ -417,17 +417,17 @@ SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이�
 - SDK → Gateway (HTTP)
   - `/strategies`(제출), `/strategies/{id}/status`, `/queues/by_tag`, `/worlds/*`(프록시), `/events/subscribe`
   - 인증: 사용자 토큰(JWT)
-- Gateway → WorldManager (HTTP/gRPC)
+- Gateway → WorldService (HTTP/gRPC)
   - `/worlds` CRUD, `/worlds/{id}/decide|activation|evaluate|apply`, `/worlds/{id}/audit`
   - 인증: 서비스 간 토큰(mTLS/JWT), world‑scope RBAC 위임
 - Gateway → DAG Manager (gRPC/HTTP)
   - `get_queues_by_tag`, Diff/콜백, 센티넬 트래픽 업데이트 수신
-- WorldManager → EventPool (Publish)
+- WorldService → EventPool (Publish)
   - `ActivationUpdated`, `PolicyUpdated`, `WorldUpdated`
 - DAG Manager → EventPool (Publish)
   - `QueueUpdated`
 - Gateway → EventPool (Subscribe)
-  - WM/DM 이벤트를 수신 → SDK로 WS 재전송. 실패 시 HTTP 폴백
+  - WS/DM 이벤트를 수신 → SDK로 WS 재전송. 실패 시 HTTP 폴백
 
 ### 15.3 이벤트 타입(요약)
 
@@ -441,7 +441,7 @@ SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이�
 
 - SDK→Gateway 제출 p95 ≤ 150ms, 큐 조회 p95 ≤ 200ms
 - 이벤트 팬아웃 지연 p95 ≤ 200ms, 최대 스큐(`activation_skew_seconds`) ≤ 2s
-- Gateway 프록시 타임아웃: WM/DM 각각 독립 서킷 브레이커 적용(예: 300ms/500ms)
+- Gateway 프록시 타임아웃: WS/DM 각각 독립 서킷 브레이커 적용(예: 300ms/500ms)
 - 실패 기본값: 월드 결정을 못 받으면 `backtest|offline`으로 폴백, 활성 미확인 시 게이트 OFF
 
 ### 15.5 개발 단위 매핑
@@ -450,7 +450,7 @@ SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이�
   - Runner: `auto_async(world_id)`, `OrderGateNode`, TagQueryManager(WS/폴백)
 - gateway/
   - api: `/worlds/*` 프록시, `/events/subscribe`, EventPool 구독자, 캐시/서킷
-- worldmanager/
+- worldservice/
   - api: CRUD/Policy/Decide/Evaluate/Apply, 감사/알림, RBAC
 - dagmanager/
   - api: get_queues_by_tag, Diff, 센티넬/토픽 관리
@@ -468,15 +468,15 @@ graph LR
     GW[Gateway]
   end
   subgraph Core
-    WM[WorldManager (SSOT Worlds)]
+    WS[WorldService (SSOT Worlds)]
     DM[DAG Manager (SSOT Graph)]
     EP[(EventPool — internal)]
   end
 
   SDK -- HTTP submit/decide/activation --> GW
-  GW -- proxy --> WM
+  GW -- proxy --> WS
   GW -- proxy --> DM
-  WM -- publish --> EP
+  WS -- publish --> EP
   DM -- publish --> EP
   GW -- subscribe --> EP
   GW -- WS (opaque) --> SDK

--- a/docs/world/world_refined.md
+++ b/docs/world/world_refined.md
@@ -94,10 +94,10 @@ F. 운영·관측·감사
 
 3) 정책/아키텍처 보강: 적용 청사진
 
-(1) WorldManager(신규 서비스, 경계 명확화)
+(1) WorldService(신규 서비스, 경계 명확화)
 	•	책임: 정책 파싱/검증 → 평가주기 실행 → 후보 선별(게이트→스코어→제약→Top‑K) → 전환 트랜잭션 발행.
 	•	상태기계(FSM): submitted → backtest → dry-run(evaluating) → live → inactive(←→dry-run)
-	•	Gateway 연결: Gateway는 실행/상태 저장에 집중, WorldManager는 정책·결정에 집중(약결합).
+	•	Gateway 연결: Gateway는 실행/상태 저장에 집중, WorldService는 정책·결정에 집중(약결합).
 	•	기존 Runner/메트릭 수집을 그대로 활용(설계 초안과 호환).  ￼  ￼
 
 (2) API/CLI (외부 제어)
@@ -193,7 +193,7 @@ def hysteresis(prev_state, checks, policy):
 9) 본 설계가 기존 결과와 합치/강화되는 지점
 	•	Runner 모드 전환·PaperTrading↔Brokerage 전환은 그대로 활용하되, 게이트 노드+2‑Phase 전환으로 금융 시스템에 필요한 원자성·안전장치를 부여.  ￼
 	•	월드 정책/Top‑K/히스테리시스·가지치기(Mark‑&‑Sweep) 구상은 유지하되, 데이터 통화성/표본충분성/리스크 총량을 정식 게이트로 승격.  ￼  ￼
-	•	CLI/API는 Gateway를 기본 채널로 하되, WorldManager를 분리해 구조적 명확성 확보(정책 결정은 WorldManager, 실행/상태는 Gateway).  ￼
+	•	CLI/API는 Gateway를 기본 채널로 하되, WorldService를 분리해 구조적 명확성 확보(정책 결정은 WorldService, 실행/상태는 Gateway).  ￼
 
 ⸻
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ nav:
       - Glossary: architecture/glossary.md
       - DAG Manager: architecture/dag-manager.md
       - Gateway: architecture/gateway.md
-      - World Manager: architecture/worldmanager.md
+      - World Service: architecture/worldservice.md
       - EventPool: architecture/eventpool.md
       - Lean Brokerage Model: architecture/lean_brokerage_model.md
   - Guides:


### PR DESCRIPTION
## Summary
- rename WorldManager spec to `worldservice.md` and update terminology
- replace WorldManager references and diagram labels with WorldService across docs
- update MkDocs navigation to World Service

## Testing
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b1885cc77083298b5acd1934680f13