### PR TITLE
docs: rename EventPool to ControlBus

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,14 +16,14 @@ last_modified: 2025-08-21
 
 Design documents describing core QMTL components.
 
-See also: Architecture Glossary (architecture/glossary.md) for canonical terms such as DecisionEnvelope, ActivationEnvelope, EventPool, and EventStreamDescriptor.
+See also: Architecture Glossary (architecture/glossary.md) for canonical terms such as DecisionEnvelope, ActivationEnvelope, ControlBus, and EventStreamDescriptor.
 
 ## 관련 문서
 - [Architecture Overview](architecture.md): High-level system design.
 - [Gateway](gateway.md): Gateway component specification.
 - [DAG Manager](dag-manager.md): DAG Manager design.
 - [WorldService](worldservice.md): World policy, decisions, activation.
-- [EventPool](eventpool.md): Internal control bus (opaque to SDK).
+- [ControlBus](controlbus.md): Internal control bus (opaque to SDK).
 - [Lean Brokerage Model](lean_brokerage_model.md): Brokerage integration details.
 
 {{ nav_links() }}

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -17,7 +17,7 @@ last_modified: 2025-08-21
 - [DAG Manager](dag-manager.md)
 - [Lean Brokerage Model](lean_brokerage_model.md)
 - [WorldService](worldservice.md)
-- [EventPool](eventpool.md)
+- [ControlBus](controlbus.md)
 
 ---
 
@@ -42,7 +42,7 @@ graph LR
   subgraph Core
     WS[WorldService (SSOT Worlds)]
     DM[DAG Manager (SSOT Graph)]
-    EP[(EventPool — internal)]
+    CB[(ControlBus — internal)]
     GDB[(Graph DB)]
     KQ[(Kafka/Redpanda)]
   end
@@ -52,16 +52,16 @@ graph LR
   GW -- proxy --> DM
   DM --> GDB
   DM --> KQ
-  WS -- publish --> EP
-  DM -- publish --> EP
-  GW -- subscribe --> EP
+  WS -- publish --> CB
+  DM -- publish --> CB
+  GW -- subscribe --> CB
   GW -- WS (opaque) --> SDK
 ```
 
-1. **SDK**는 전략을 DAG로 직렬화하고 Gateway에 제출/질의한다. 실행 중에는 Gateway의 WS로부터 불투명(EventPool 기반) 이벤트 스트림을 전달받아 활성/큐 변경을 반영한다.
-2. **Gateway**는 외부 단일 접점으로서 WorldService/DAG Manager를 프록시하고, 캐시/서킷/관측을 담당한다. 또한 EventPool을 구독하여 SDK로 이벤트를 재전송한다.
-3. **WorldService**는 월드/정책/결정/활성의 SSOT이며, 결정·활성 업데이트를 EventPool에 발행한다.
-4. **DAG Manager**는 그래프/노드/큐의 SSOT이며, Diff와 큐 오케스트레이션을 수행하고 QueueUpdated 이벤트를 EventPool에 발행한다.
+1. **SDK**는 전략을 DAG로 직렬화하고 Gateway에 제출/질의한다. 실행 중에는 Gateway의 WS로부터 불투명(ControlBus 기반) 이벤트 스트림을 전달받아 활성/큐 변경을 반영한다.
+2. **Gateway**는 외부 단일 접점으로서 WorldService/DAG Manager를 프록시하고, 캐시/서킷/관측을 담당한다. 또한 ControlBus를 구독하여 SDK로 이벤트를 재전송한다.
+3. **WorldService**는 월드/정책/결정/활성의 SSOT이며, 결정·활성 업데이트를 ControlBus에 발행한다.
+4. **DAG Manager**는 그래프/노드/큐의 SSOT이며, Diff와 큐 오케스트레이션을 수행하고 QueueUpdated 이벤트를 ControlBus에 발행한다.
 5. **SDK**는 반환된 큐 매핑에 따라 로컬에서 필요한 노드만 실행하며, 활성 게이트(OrderGateNode)로 주문 발동을 제어한다.
 
 이 구조는 DAG의 구성요소 단위 재사용을 통해 시간복잡도와 자원 소비를 최소화하며, DAG 전체가 아닌 부분 연산 재활용을 통해 글로벌 최적화를 달성한다.

--- a/docs/architecture/controlbus.md
+++ b/docs/architecture/controlbus.md
@@ -1,5 +1,5 @@
 ---
-title: "EventPool — Internal Control Bus (Opaque to SDK)"
+title: "ControlBus — Internal Control Bus (Opaque to SDK)"
 tags: [architecture, events, control]
 author: "QMTL Team"
 last_modified: 2025-08-29
@@ -7,9 +7,9 @@ last_modified: 2025-08-29
 
 {{ nav_links() }}
 
-# EventPool — Internal Control Bus
+# ControlBus — Internal Control Bus
 
-EventPool distributes control‑plane updates (not data) from core services to Gateways. It is an internal component and not a public API; SDKs never connect directly in the default deployment. All control events are versioned envelopes and include `type` and `version` fields.
+ControlBus distributes control‑plane updates (not data) from core services to Gateways. It is an internal component and not a public API; SDKs never connect directly in the default deployment. All control events are versioned envelopes and include `type` and `version` fields.
 
 ## 0. Role & Non‑Goals
 
@@ -102,7 +102,7 @@ PolicyUpdated (versioned)
 ## 5. Observability
 
 Metrics
-- eventpool_publish_latency_ms, fanout_lag_ms, dropped_subscribers_total
+- controlbus_publish_latency_ms, fanout_lag_ms, dropped_subscribers_total
 - replay_queue_depth, partition_skew_seconds
 
 Runbooks
@@ -114,15 +114,15 @@ Runbooks
 
 - WorldService publishes ActivationUpdated/PolicyUpdated.
 - DAG Manager publishes QueueUpdated.
-- Gateway instances subscribe to EventPool and relay updates to SDK via an opaque WebSocket stream (`/events/subscribe`).
+- Gateway instances subscribe to ControlBus and relay updates to SDK via an opaque WebSocket stream (`/events/subscribe`).
 
 ---
 
 ## 7. Initial Snapshot & Delegated WS (Optional)
 
 - Initial snapshot: first message per topic SHOULD be a full snapshot or include a `state_hash` so clients can confirm convergence without a full GET.
-- Delegated WS (feature‑flagged): Gateway may return an alternate `alt_stream_url` that points to a dedicated event streamer tier sitting in front of EventPool.
-  - Tokens are short‑lived JWTs with claims: `aud=eventpool`, `sub=<user|svc>`, `world_id`, `strategy_id`, `topics`, `jti`, `iat`, `exp`, `kid`.
-  - Streamer verifies JWKS/claims and bridges to EventPool; default deployment keeps this disabled.
+- Delegated WS (feature‑flagged): Gateway may return an alternate `alt_stream_url` that points to a dedicated event streamer tier sitting in front of ControlBus.
+  - Tokens are short‑lived JWTs with claims: `aud=controlbus`, `sub=<user|svc>`, `world_id`, `strategy_id`, `topics`, `jti`, `iat`, `exp`, `kid`.
+  - Streamer verifies JWKS/claims and bridges to ControlBus; default deployment keeps this disabled.
 
 {{ nav_links() }}

--- a/docs/architecture/dag-manager.md
+++ b/docs/architecture/dag-manager.md
@@ -160,7 +160,7 @@ CREATE INDEX kafka_topic IF NOT EXISTS FOR (q:Queue) ON (q.topic);
 
 DAG Manager publishes control‑plane updates about queue availability and tag resolution so that Gateways can update SDKs in real time without polling.
 
-- Publisher: DAG Manager → EventPool (internal)
+- Publisher: DAG Manager → ControlBus (internal)
 - Event: ``QueueUpdated`` with schema
 
 ```json
@@ -190,7 +190,7 @@ sequenceDiagram
 
 ---
 
-Note: In the current architecture, control updates (e.g., queue/tag changes, traffic weights) are also published to the internal EventPool and consumed by Gateways for WebSocket relay to SDKs. The callback interface above remains for backward compatibility and operational tooling.
+Note: In the current architecture, control updates (e.g., queue/tag changes, traffic weights) are also published to the internal ControlBus and consumed by Gateways for WebSocket relay to SDKs. The callback interface above remains for backward compatibility and operational tooling.
 
 ## 4. Garbage Collection (Orphan Queue GC) (확장)
 

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -11,7 +11,7 @@ last_modified: 2025-08-29
 
 - DecisionEnvelope: World decision result containing `world_id`, `policy_version`, `effective_mode`, `reason`, `as_of`, `ttl`, `etag`.
 - ActivationEnvelope: Activation state for a `(world_id, strategy_id, side)` with `active`, `weight`, `etag`, `run_id`, `ts` and optional `state_hash`.
-- EventPool: Internal control bus (Kafka/Redpanda) carrying versioned control events (ActivationUpdated, QueueUpdated, PolicyUpdated); not a public API.
+- ControlBus: Internal control bus (Kafka/Redpanda) carrying versioned control events (ActivationUpdated, QueueUpdated, PolicyUpdated); not a public API.
 - EventStreamDescriptor: Opaque WS descriptor from Gateway (`stream_url`, `token`, `topics`, `expires_at`, optional `fallback_url`, `alt_stream_url`).
 - etag: Monotonic version identifier used for deduplication and concurrent update checks.
 - run_id: Idempotency token for 2‑phase apply operations.

--- a/docs/architecture/worldservice.md
+++ b/docs/architecture/worldservice.md
@@ -17,7 +17,7 @@ WorldService is the system of record (SSOT) for Worlds. It owns:
 - Activation control: per-world activation set for strategies/sides with weights
 - 2‑Phase apply: Freeze/Drain → Switch → Unfreeze, idempotent with run_id
 - Audit & RBAC: every policy/update/decision/apply event is logged and authorized
-- Events: emits activation/policy updates to the internal EventPool
+- Events: emits activation/policy updates to the internal ControlBus
 
 Non-goals: Strategy ingest, DAG diff, queue/tag discovery (owned by Gateway/DAG Manager). Order I/O is not handled here.
 
@@ -166,7 +166,7 @@ Alerts
 
 - Gateway: proxy `/worlds/*`, cache decisions with TTL, enforce `--allow-live` guard
 - DAG Manager: no dependency for decisions; only for queue/graph metadata
-- EventPool: WS publishes ActivationUpdated/PolicyUpdated; Gateway subscribes and relays via WS to SDK
+- ControlBus: WS publishes ActivationUpdated/PolicyUpdated; Gateway subscribes and relays via WS to SDK
 
 ---
 

--- a/docs/world/world.md
+++ b/docs/world/world.md
@@ -269,13 +269,13 @@ POST /worlds/{world}/apply HTTP/1.1
 → { "ok": true, "run_id": "..." }
 ```
 
-이벤트 구독(은닉 EventPool 핸드오버)
+이벤트 구독(은닉 ControlBus 핸드오버)
 
 ```http
 POST /events/subscribe HTTP/1.1
 { "world_id": "crypto_mom_1h", "strategy_id": "...", "topics": ["activation", "queues"] }
 → {
-  "stream_url": "wss://gateway.example/ws/evt?ticket=...",  # Opaque; 내부적으로 EventPool일 수 있음
+  "stream_url": "wss://gateway.example/ws/evt?ticket=...",  # Opaque; 내부적으로 ControlBus일 수 있음
   "token": "<jwt>",              # scope: world:*, strategy:*, topics
   "topics": ["activation"],      # 서버가 정규화한 구독 목록
   "expires_at": "2025-08-28T09:30:00Z",
@@ -289,7 +289,7 @@ POST /events/subscribe HTTP/1.1
 
 ## 13. 월드 레지스트리(CRUD & 전역 접근)
 
-월드는 전략 제출과 독립적으로 생성/수정/삭제/조회가 가능해야 하며, 프레임워크 전역에서 동일한 ID로 접근 가능해야 한다. 중앙 진실 원천(SSOT)은 WorldService의 월드 레지스트리이며, Gateway는 외부 접근을 위한 프록시/캐시 역할을 수행한다. 내부 전파는 Redis 캐시와 EventPool(은닉) 이벤트를 사용하고, 외부에는 Gateway WS/HTTP로 노출한다.
+월드는 전략 제출과 독립적으로 생성/수정/삭제/조회가 가능해야 하며, 프레임워크 전역에서 동일한 ID로 접근 가능해야 한다. 중앙 진실 원천(SSOT)은 WorldService의 월드 레지스트리이며, Gateway는 외부 접근을 위한 프록시/캐시 역할을 수행한다. 내부 전파는 Redis 캐시와 ControlBus(은닉) 이벤트를 사용하고, 외부에는 Gateway WS/HTTP로 노출한다.
 
 ### 13.1 데이터 모델(경량)
 
@@ -361,15 +361,15 @@ qmtl world delete crypto_mom_1h --force
 - 롤백: 정책 버전은 언제든 `set-default`로 롤백. `apply` 실패 시 활성 테이블은 이전 스냅샷으로 복원.
 - 가시성: Grafana에 World 대시보드(정책 버전, 활성 세트, 서킷 상태, 최근 알림) 제공.
 
-## 14. 이벤트 스트림(은닉 EventPool) 핸드오버
+## 14. 이벤트 스트림(은닉 ControlBus) 핸드오버
 
-SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이며 외부에 명시적으로 드러나지 않는다. 실행 단계에서 Gateway가 “이벤트 스트림 기술서(EventStreamDescriptor)”를 반환하고, SDK는 이를 사용해 실시간 이벤트를 푸시로 수신한다.
+SDK는 오직 Gateway와만 통신한다. ControlBus는 내부 제어 버스이며 외부에 명시적으로 드러나지 않는다. 실행 단계에서 Gateway가 “이벤트 스트림 기술서(EventStreamDescriptor)”를 반환하고, SDK는 이를 사용해 실시간 이벤트를 푸시로 수신한다.
 
 - 역할 분리
   - SSOT: WorldService(세계/정책/활성), DAG Manager(그래프/큐)
-  - 배포/팬아웃: EventPool(내부), 외부에는 Gateway가 단일 접점
+  - 배포/팬아웃: ControlBus(내부), 외부에는 Gateway가 단일 접점
 - EventStreamDescriptor(불투명)
-  - `stream_url`(wss): 게이트웨이 도메인 하의 URL. 내부 구현상 EventPool로 프록시/리다이렉트될 수 있으나 클라이언트는 불문에 부친다.
+  - `stream_url`(wss): 게이트웨이 도메인 하의 URL. 내부 구현상 ControlBus로 프록시/리다이렉트될 수 있으나 클라이언트는 불문에 부친다.
   - `token`(JWT): 구독 범위(world_id/strategy_id/topics)와 만료를 포함. SDK는 그대로 사용.
   - `topics`: 서버가 정규화한 구독 주제(예: `activation`, `queues`, `policy`).
   - `expires_at`: 재구독 시점 안내.
@@ -397,7 +397,7 @@ SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이�
 
 ## 15. 컴포넌트 관계(모듈/인터페이스 명세)
 
-본 절은 sdk, gateway, eventpool(은닉), worldservice, dagmanager 간의 책임·경계·인터페이스를 모듈 관점에서 명시한다.
+본 절은 sdk, gateway, controlbus(은닉), worldservice, dagmanager 간의 책임·경계·인터페이스를 모듈 관점에서 명시한다.
 
 ### 15.1 소유권(SSOT)과 책임
 
@@ -407,7 +407,7 @@ SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이�
   - 그래프/노드/토픽/태그 쿼리, Diff, 버전/롤백, 큐 메타데이터
 - Gateway(프록시/캐시)
   - SDK 외부 단일 접점; 전략 제출/상태/큐 조회 프록시, 월드 API 프록시, 이벤트 스트림 발급, 캐시/서킷/관측
-- EventPool(배포/팬아웃)
+- ControlBus(배포/팬아웃)
   - 제어 이벤트의 내부 퍼브/섭 허브(비공개). SSOT 아님. WS/DM의 업데이트를 다수 Gateway 인스턴스로 팬아웃
 - SDK(클라이언트/런타임)
   - 전략 직렬화/제출, 태그 해석, OrderGateNode로 주문 게이트, 이벤트 스트림 구독/적용
@@ -422,11 +422,11 @@ SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이�
   - 인증: 서비스 간 토큰(mTLS/JWT), world‑scope RBAC 위임
 - Gateway → DAG Manager (gRPC/HTTP)
   - `get_queues_by_tag`, Diff/콜백, 센티넬 트래픽 업데이트 수신
-- WorldService → EventPool (Publish)
+- WorldService → ControlBus (Publish)
   - `ActivationUpdated`, `PolicyUpdated`, `WorldUpdated`
-- DAG Manager → EventPool (Publish)
+- DAG Manager → ControlBus (Publish)
   - `QueueUpdated`
-- Gateway → EventPool (Subscribe)
+- Gateway → ControlBus (Subscribe)
   - WS/DM 이벤트를 수신 → SDK로 WS 재전송. 실패 시 HTTP 폴백
 
 ### 15.3 이벤트 타입(요약)
@@ -449,12 +449,12 @@ SDK는 오직 Gateway와만 통신한다. EventPool은 내부 제어 버스이�
 - sdk/
   - Runner: `auto_async(world_id)`, `OrderGateNode`, TagQueryManager(WS/폴백)
 - gateway/
-  - api: `/worlds/*` 프록시, `/events/subscribe`, EventPool 구독자, 캐시/서킷
+  - api: `/worlds/*` 프록시, `/events/subscribe`, ControlBus 구독자, 캐시/서킷
 - worldservice/
   - api: CRUD/Policy/Decide/Evaluate/Apply, 감사/알림, RBAC
 - dagmanager/
   - api: get_queues_by_tag, Diff, 센티넬/토픽 관리
-- eventpool/
+- controlbus/
   - control.* 토픽/채널 구성, 파티션 키, 보관/압축 정책, 관측
 
 ### 15.6 상호작용 개요(다이어그램)
@@ -470,16 +470,16 @@ graph LR
   subgraph Core
     WS[WorldService (SSOT Worlds)]
     DM[DAG Manager (SSOT Graph)]
-    EP[(EventPool — internal)]
+    CB[(ControlBus — internal)]
   end
 
   SDK -- HTTP submit/decide/activation --> GW
   GW -- proxy --> WS
   GW -- proxy --> DM
-  WS -- publish --> EP
-  DM -- publish --> EP
-  GW -- subscribe --> EP
+  WS -- publish --> CB
+  DM -- publish --> CB
+  GW -- subscribe --> CB
   GW -- WS (opaque) --> SDK
 ```
 
-상기 구조에서 EventPool은 외부에 노출되지 않으며, SDK는 Gateway로부터 불투명 스트림을 전달받아 구독한다(§14).
+상기 구조에서 ControlBus는 외부에 노출되지 않으며, SDK는 Gateway로부터 불투명 스트림을 전달받아 구독한다(§14).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ nav:
       - DAG Manager: architecture/dag-manager.md
       - Gateway: architecture/gateway.md
       - World Service: architecture/worldservice.md
-      - EventPool: architecture/eventpool.md
+      - ControlBus: architecture/controlbus.md
       - Lean Brokerage Model: architecture/lean_brokerage_model.md
   - Guides:
       - Overview: guides/README.md


### PR DESCRIPTION
## Summary
- rename EventPool docs and navigation to ControlBus
- update architecture, gateway, world, and glossary references
- reflect ControlBus in /events/subscribe docs

## Testing
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b189b9298083299f66167ce57567a0