### PR TITLE
feat: add WorldService proxy endpoints

### DIFF
--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -13,3 +13,7 @@ class GatewayConfig:
     database_backend: str = "sqlite"
     database_dsn: str = "./qmtl.db"
     insert_sentinel: bool = True
+    worldservice_url: str = "http://localhost:8421"
+    worldservice_timeout: float = 0.3
+    worldservice_retries: int = 2
+    worldservice_enabled: bool = True

--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -40,6 +40,21 @@ dagclient_breaker_open_total = Gauge(
     registry=global_registry,
 )
 
+# WorldService proxy metrics
+worldservice_cache_hits_total = Counter(
+    "worldservice_cache_hits_total",
+    "Total cache hits for WorldService proxy",
+    ["endpoint"],
+    registry=global_registry,
+)
+
+worldservice_latency_ms = Gauge(
+    "worldservice_latency_ms",
+    "WorldService request latency in milliseconds",
+    ["endpoint"],
+    registry=global_registry,
+)
+
 
 # Track the percentage of traffic routed to each sentinel version
 if "gateway_sentinel_traffic_ratio" in global_registry._names_to_collectors:
@@ -107,4 +122,6 @@ def reset_metrics() -> None:
     degrade_level.clear()
     dagclient_breaker_open_total.set(0)
     dagclient_breaker_open_total._val = 0  # type: ignore[attr-defined]
+    worldservice_cache_hits_total._metrics.clear()
+    worldservice_latency_ms.clear()
 

--- a/qmtl/gateway/world_client.py
+++ b/qmtl/gateway/world_client.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+"""WorldService HTTP proxy client with in-memory caching."""
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any, Optional, Dict
+
+import httpx
+
+from . import metrics as gw_metrics
+
+
+@dataclass
+class _DecisionCacheEntry:
+    data: Dict[str, Any]
+    expires_at: float
+    etag: Optional[str]
+
+
+@dataclass
+class _ActivationCacheEntry:
+    data: Dict[str, Any]
+    etag: Optional[str]
+
+
+class WorldClient:
+    """Async HTTP client for WorldService with basic caching."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 0.3,
+        retries: int = 2,
+        http_client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.retries = retries
+        self._client = http_client or httpx.AsyncClient(base_url=self.base_url, timeout=timeout)
+        self._decision_cache: Dict[str, _DecisionCacheEntry] = {}
+        self._activation_cache: Dict[str, _ActivationCacheEntry] = {}
+
+    async def _request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        last_exc: Exception | None = None
+        for attempt in range(self.retries + 1):
+            try:
+                return await self._client.request(method, url, **kwargs)
+            except Exception as exc:  # pragma: no cover - network failure
+                last_exc = exc
+                if attempt < self.retries:
+                    await asyncio.sleep(0.05)
+        assert last_exc is not None
+        raise last_exc
+
+    async def get_decision(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        entry = self._decision_cache.get(world_id)
+        now = time.time()
+        if entry and entry.expires_at > now:
+            gw_metrics.worldservice_cache_hits_total.labels(endpoint="decide").inc()
+            return entry.data
+
+        start = time.perf_counter()
+        resp = await self._request("GET", f"/worlds/{world_id}/decide", headers=headers)
+        duration_ms = (time.perf_counter() - start) * 1000
+        gw_metrics.worldservice_latency_ms.labels(endpoint="decide").set(duration_ms)
+        resp.raise_for_status()
+        data = resp.json()
+        ttl = float(data.get("ttl", 300))
+        self._decision_cache[world_id] = _DecisionCacheEntry(
+            data=data, expires_at=now + ttl, etag=resp.headers.get("ETag")
+        )
+        return data
+
+    async def get_activation(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        entry = self._activation_cache.get(world_id)
+        req_headers = dict(headers or {})
+        if entry and entry.etag:
+            req_headers["If-None-Match"] = entry.etag
+
+        start = time.perf_counter()
+        resp = await self._request("GET", f"/worlds/{world_id}/activation", headers=req_headers)
+        duration_ms = (time.perf_counter() - start) * 1000
+        gw_metrics.worldservice_latency_ms.labels(endpoint="activation").set(duration_ms)
+
+        if resp.status_code == 304 and entry:
+            gw_metrics.worldservice_cache_hits_total.labels(endpoint="activation").inc()
+            return entry.data
+
+        resp.raise_for_status()
+        data = resp.json()
+        etag = resp.headers.get("ETag") or data.get("state_hash")
+        self._activation_cache[world_id] = _ActivationCacheEntry(data=data, etag=etag)
+        return data
+
+    async def post_evaluate(
+        self, world_id: str, payload: Dict[str, Any], headers: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        start = time.perf_counter()
+        resp = await self._request(
+            "POST", f"/worlds/{world_id}/evaluate", headers=headers, json=payload
+        )
+        duration_ms = (time.perf_counter() - start) * 1000
+        gw_metrics.worldservice_latency_ms.labels(endpoint="evaluate").set(duration_ms)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def post_apply(
+        self, world_id: str, payload: Dict[str, Any], headers: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        start = time.perf_counter()
+        resp = await self._request(
+            "POST", f"/worlds/{world_id}/apply", headers=headers, json=payload
+        )
+        duration_ms = (time.perf_counter() - start) * 1000
+        gw_metrics.worldservice_latency_ms.labels(endpoint="apply").set(duration_ms)
+        resp.raise_for_status()
+        return resp.json()
+

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -1,0 +1,102 @@
+import pytest
+import httpx
+from fastapi import FastAPI, Response, Request
+
+from qmtl.gateway.api import create_app, Database
+from qmtl.gateway.world_client import WorldClient
+from qmtl.gateway import metrics
+
+
+class FakeDB(Database):
+    async def insert_strategy(self, strategy_id: str, meta):
+        pass
+
+    async def set_status(self, strategy_id: str, status: str):
+        pass
+
+    async def get_status(self, strategy_id: str):
+        return "queued"
+
+    async def append_event(self, strategy_id: str, event: str):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_decide_ttl_cache(fake_redis):
+    metrics.reset_metrics()
+    ws_app = FastAPI()
+    calls = {"decide": 0}
+
+    @ws_app.get("/worlds/{world_id}/decide")
+    async def decide(world_id: str):
+        calls["decide"] += 1
+        return {"decision": "hold", "ttl": 60}
+
+    ws_client = WorldClient(
+        "http://ws",
+        http_client=httpx.AsyncClient(transport=httpx.ASGITransport(app=ws_app), base_url="http://ws"),
+    )
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=ws_client)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://gw") as client:
+        r1 = await client.get("/worlds/foo/decide")
+        assert r1.status_code == 200
+        r2 = await client.get("/worlds/foo/decide")
+        assert r2.status_code == 200
+    assert calls["decide"] == 1
+    assert metrics.worldservice_cache_hits_total.labels(endpoint="decide")._value.get() == 1
+
+
+@pytest.mark.asyncio
+async def test_activation_etag_cache(fake_redis):
+    metrics.reset_metrics()
+    ws_app = FastAPI()
+    calls = {"activation": 0}
+
+    @ws_app.get("/worlds/{world_id}/activation")
+    async def activation(world_id: str, request: Request, response: Response):
+        calls["activation"] += 1
+        etag = '"v1"'
+        if request.headers.get("if-none-match") == etag:
+            response.status_code = 304
+            return Response(status_code=304)
+        response.headers["ETag"] = etag
+        return {"active": True}
+
+    ws_client = WorldClient(
+        "http://ws",
+        http_client=httpx.AsyncClient(transport=httpx.ASGITransport(app=ws_app), base_url="http://ws"),
+    )
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=ws_client)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://gw") as client:
+        r1 = await client.get("/worlds/foo/activation")
+        assert r1.status_code == 200 and r1.json()["active"] is True
+        r2 = await client.get("/worlds/foo/activation")
+        assert r2.status_code == 200 and r2.json()["active"] is True
+    assert calls["activation"] == 2
+    assert metrics.worldservice_cache_hits_total.labels(endpoint="activation")._value.get() == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_live_guard(fake_redis):
+    ws_app = FastAPI()
+    calls = {"apply": 0}
+
+    @ws_app.post("/worlds/{world_id}/apply")
+    async def apply(world_id: str):
+        calls["apply"] += 1
+        return {"status": "ok"}
+
+    ws_client = WorldClient(
+        "http://ws",
+        http_client=httpx.AsyncClient(transport=httpx.ASGITransport(app=ws_app), base_url="http://ws"),
+    )
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=ws_client)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://gw") as client:
+        r1 = await client.post("/worlds/foo/apply", json={})
+        assert r1.status_code == 403
+        r2 = await client.post("/worlds/foo/apply", json={}, headers={"X-Allow-Live": "true"})
+        assert r2.status_code == 200
+    assert calls["apply"] == 1


### PR DESCRIPTION
## Summary
- add worldservice configuration fields and metrics
- proxy `/worlds/*` endpoints with TTL/etag cache and live guard
- cover world proxy caching and guard behavior with tests

## Testing
- `uv run -m pytest -W error tests/gateway/test_world_proxy.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1913cb1fc8329946b43733e52dd81