### PR TITLE
feat(gateway): relay ControlBus updates via WebSocket

### DIFF
--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 
@@ -13,3 +13,7 @@ class GatewayConfig:
     database_backend: str = "sqlite"
     database_dsn: str = "./qmtl.db"
     insert_sentinel: bool = True
+    controlbus_brokers: list[str] = field(default_factory=list)
+    controlbus_dsn: Optional[str] = None
+    controlbus_topics: list[str] = field(default_factory=list)
+    controlbus_group: str = "gateway"

--- a/qmtl/gateway/controlbus_consumer.py
+++ b/qmtl/gateway/controlbus_consumer.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from prometheus_client import Gauge
+
+from qmtl.sdk.node import MatchMode
+
+from .ws import WebSocketHub
+
+logger = logging.getLogger(__name__)
+
+
+# Metrics for monitoring consumer delay and clock skew
+_controlbus_lag_ms = Gauge(
+    "controlbus_lag_ms",
+    "Delay between event creation and processing in milliseconds",
+    ["topic"],
+)
+_controlbus_skew_ms = Gauge(
+    "controlbus_skew_ms",
+    "Clock skew between event timestamp and consumer processing time in milliseconds",
+    ["topic"],
+)
+
+
+@dataclass
+class ControlBusMessage:
+    """Represents a message delivered from the ControlBus."""
+
+    topic: str
+    key: str
+    etag: str
+    run_id: str
+    data: dict[str, Any]
+    timestamp_ms: Optional[float] = None
+
+
+class ControlBusConsumer:
+    """Consume ControlBus events and relay them to WebSocket clients."""
+
+    def __init__(
+        self,
+        brokers: list[str] | None,
+        topics: list[str],
+        group: str,
+        *,
+        ws_hub: WebSocketHub | None = None,
+    ) -> None:
+        self.brokers = brokers or []
+        self.topics = topics
+        self.group = group
+        self.ws_hub = ws_hub
+        self._queue: asyncio.Queue[ControlBusMessage | None] = asyncio.Queue()
+        self._task: asyncio.Task | None = None
+        self._last_seen: dict[tuple[str, str], tuple[str, str]] = {}
+
+    async def start(self) -> None:
+        """Start the background consumer task."""
+        if self._task is None:
+            self._task = asyncio.create_task(self._worker())
+
+    async def stop(self) -> None:
+        """Stop the background consumer task."""
+        await self._queue.put(None)
+        if self._task is not None:
+            await self._task
+            self._task = None
+
+    async def publish(self, message: ControlBusMessage) -> None:
+        """Submit a ControlBus message for processing."""
+        await self._queue.put(message)
+
+    async def _worker(self) -> None:
+        while True:
+            msg = await self._queue.get()
+            if msg is None:
+                break
+            try:
+                await self._handle_message(msg)
+            finally:
+                self._queue.task_done()
+
+    async def _handle_message(self, msg: ControlBusMessage) -> None:
+        key = (msg.topic, msg.key)
+        marker = (msg.etag, msg.run_id)
+        if self._last_seen.get(key) == marker:
+            return
+        self._last_seen[key] = marker
+
+        now_ms = time.time() * 1000
+        if msg.timestamp_ms is not None:
+            lag = max(0.0, now_ms - msg.timestamp_ms)
+            _controlbus_lag_ms.labels(topic=msg.topic).set(lag)
+            _controlbus_skew_ms.labels(topic=msg.topic).set(msg.timestamp_ms - now_ms)
+
+        if not self.ws_hub:
+            return
+
+        if msg.topic == "activation":
+            await self.ws_hub.send_activation_updated(msg.data)
+        elif msg.topic == "policy":
+            await self.ws_hub.send_policy_updated(msg.data)
+        elif msg.topic == "queue":
+            tags = msg.data.get("tags", [])
+            interval = msg.data.get("interval", 0)
+            queues = msg.data.get("queues", [])
+            match_mode = msg.data.get("match_mode", MatchMode.ANY.value)
+            try:
+                mode = MatchMode(match_mode)
+            except ValueError:
+                mode = MatchMode.ANY
+            await self.ws_hub.send_queue_update(tags, interval, queues, mode)
+        else:
+            logger.warning("Unhandled ControlBus topic %s", msg.topic)
+
+
+__all__ = ["ControlBusConsumer", "ControlBusMessage"]

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -133,6 +133,24 @@ class WebSocketHub:
         )
         await self.broadcast(event)
 
+    async def send_activation_updated(self, activation: dict) -> None:
+        """Broadcast activation updates."""
+        event = format_event(
+            "qmtl.gateway",
+            "activation_updated",
+            activation,
+        )
+        await self.broadcast(event)
+
+    async def send_policy_updated(self, policy: dict) -> None:
+        """Broadcast policy updates."""
+        event = format_event(
+            "qmtl.gateway",
+            "policy_updated",
+            policy,
+        )
+        await self.broadcast(event)
+
     async def send_sentinel_weight(self, sentinel_id: str, weight: float) -> None:
         """Broadcast sentinel weight updates."""
         event = format_event(

--- a/tests/gateway/test_controlbus_consumer.py
+++ b/tests/gateway/test_controlbus_consumer.py
@@ -1,0 +1,77 @@
+import asyncio
+import pytest
+
+from qmtl.gateway.controlbus_consumer import ControlBusConsumer, ControlBusMessage
+from qmtl.gateway.api import create_app, Database
+
+
+class FakeHub:
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    async def send_activation_updated(self, data: dict) -> None:
+        self.events.append(("activation_updated", data))
+
+    async def send_policy_updated(self, data: dict) -> None:
+        self.events.append(("policy_updated", data))
+
+
+class DummyDB(Database):
+    async def insert_strategy(self, strategy_id: str, meta: dict | None) -> None:  # pragma: no cover - not used
+        raise NotImplementedError
+
+    async def set_status(self, strategy_id: str, status: str) -> None:  # pragma: no cover - not used
+        raise NotImplementedError
+
+    async def get_status(self, strategy_id: str) -> str | None:  # pragma: no cover - not used
+        return None
+
+    async def append_event(self, strategy_id: str, event: str) -> None:  # pragma: no cover - not used
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_consumer_relays_and_deduplicates():
+    hub = FakeHub()
+    consumer = ControlBusConsumer(brokers=[], topics=["activation", "policy"], group="g", ws_hub=hub)
+    await consumer.start()
+    msg1 = ControlBusMessage(topic="activation", key="a", etag="e1", run_id="r1", data={"id": 1})
+    dup = ControlBusMessage(topic="activation", key="a", etag="e1", run_id="r1", data={"id": 1})
+    msg2 = ControlBusMessage(topic="policy", key="a", etag="e2", run_id="r2", data={"id": 2})
+    await consumer.publish(msg1)
+    await consumer.publish(dup)
+    await consumer.publish(msg2)
+    await asyncio.sleep(0.1)
+    await consumer.stop()
+    assert hub.events == [
+        ("activation_updated", {"id": 1}),
+        ("policy_updated", {"id": 2}),
+    ]
+
+
+class StartStopConsumer(ControlBusConsumer):
+    def __init__(self):
+        super().__init__(brokers=[], topics=[], group="g")
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:  # type: ignore[override]
+        self.started = True
+
+    async def stop(self) -> None:  # type: ignore[override]
+        self.stopped = True
+
+
+@pytest.mark.asyncio
+async def test_app_starts_and_stops_consumer(fake_redis):
+    hub = FakeHub()
+    consumer = StartStopConsumer()
+    app = create_app(
+        redis_client=fake_redis,
+        database=DummyDB(),
+        ws_hub=hub,
+        controlbus_consumer=consumer,
+    )
+    async with app.router.lifespan_context(app):
+        assert consumer.started
+    assert consumer.stopped


### PR DESCRIPTION
## Summary
- add ControlBusConsumer to dedupe and forward Activation/Policy/Queue events
- extend GatewayConfig and WebSocketHub with ControlBus support
- wire consumer startup/shutdown in API lifespan and add tests

## Testing
- `uv run -m pytest tests/gateway/test_ws.py::test_hub_sends_activation_and_policy tests/gateway/test_controlbus_consumer.py -W error`

Fixes #423 

------
https://chatgpt.com/codex/tasks/task_e_68b1916406b08329844d5a1cc745687e