### PR TITLE
feat: support versioned controlbus envelopes

### DIFF
--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -344,7 +344,7 @@ def create_app(
                 if event_type == "ActivationUpdated"
                 else gateway._handle_policy_updated
             )
-            await handler(event)
+            await handler(data)
             return {"ok": True}
 
         return {"ok": True}


### PR DESCRIPTION
## Summary
- route ActivationUpdated and PolicyUpdated controlbus events using their inner `data` payloads
- exercise versioned Activation/Policy controlbus events through data envelopes in tests

## Testing
- `uv run -m pytest tests/gateway/test_callbacks.py -W error`

------
https://chatgpt.com/codex/tasks/task_e_68b194b9468c8329be52fc34a515d210