### PR TITLE
Add WorldService proxy with caching and live guard

### DIFF
--- a/qmtl/gateway/config.py
+++ b/qmtl/gateway/config.py
@@ -17,3 +17,8 @@ class GatewayConfig:
     controlbus_dsn: Optional[str] = None
     controlbus_topics: list[str] = field(default_factory=list)
     controlbus_group: str = "gateway"
+    worldservice_url: Optional[str] = None
+    worldservice_timeout: float = 5.0
+    worldservice_retries: int = 0
+    enable_worldservice_proxy: bool = True
+    enforce_live_guard: bool = True

--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -40,6 +40,19 @@ dagclient_breaker_open_total = Gauge(
     registry=global_registry,
 )
 
+# Metrics for WorldService proxy
+worlds_proxy_latency_ms = Gauge(
+    "worlds_proxy_latency_ms",
+    "Latency of requests proxied to WorldService in milliseconds",
+    registry=global_registry,
+)
+
+worlds_cache_hits_total = Counter(
+    "worlds_cache_hits_total",
+    "Total number of cache hits when proxying WorldService requests",
+    registry=global_registry,
+)
+
 
 # Track the percentage of traffic routed to each sentinel version
 if "gateway_sentinel_traffic_ratio" in global_registry._names_to_collectors:
@@ -79,6 +92,12 @@ def observe_gateway_latency(duration_ms: float) -> None:
     gateway_e2e_latency_p95._val = gateway_e2e_latency_p95._value.get()  # type: ignore[attr-defined]
 
 
+def observe_worlds_proxy_latency(duration_ms: float) -> None:
+    """Record latency for WorldService proxy requests."""
+    worlds_proxy_latency_ms.set(duration_ms)
+    worlds_proxy_latency_ms._val = worlds_proxy_latency_ms._value.get()  # type: ignore[attr-defined]
+
+
 def start_metrics_server(port: int = 8000) -> None:
     """Start an HTTP server to expose metrics."""
     start_http_server(port, registry=global_registry)
@@ -107,4 +126,8 @@ def reset_metrics() -> None:
     degrade_level.clear()
     dagclient_breaker_open_total.set(0)
     dagclient_breaker_open_total._val = 0  # type: ignore[attr-defined]
+    worlds_proxy_latency_ms.set(0)
+    worlds_proxy_latency_ms._val = 0  # type: ignore[attr-defined]
+    worlds_cache_hits_total._value.set(0)  # type: ignore[attr-defined]
+    worlds_cache_hits_total._val = 0  # type: ignore[attr-defined]
 

--- a/qmtl/gateway/world_client.py
+++ b/qmtl/gateway/world_client.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import httpx
+
+from . import metrics as gw_metrics
+
+
+@dataclass
+class Budget:
+    """Request budget configuration."""
+
+    timeout: float = 5.0
+    retries: int = 0
+
+
+class TTLCacheEntry:
+    """Internal structure for TTL cached items."""
+
+    __slots__ = ("value", "expires_at")
+
+    def __init__(self, value: Any, ttl: float) -> None:
+        self.value = value
+        self.expires_at = time.time() + ttl
+
+    def valid(self) -> bool:
+        return time.time() < self.expires_at
+
+
+class WorldServiceClient:
+    """HTTP client proxying requests to WorldService.
+
+    Implements simple TTL cache for decision envelopes and
+    ETag-based caching for activations.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        budget: Budget | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._budget = budget or Budget()
+        self._client = client or httpx.AsyncClient()
+        self._decision_cache: Dict[str, TTLCacheEntry] = {}
+        self._activation_cache: Dict[str, tuple[str, Any]] = {}
+
+    async def _request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        backoff = 0.1
+        for attempt in range(self._budget.retries + 1):
+            try:
+                start = time.perf_counter()
+                resp = await self._client.request(method, url, timeout=self._budget.timeout, **kwargs)
+                gw_metrics.observe_worlds_proxy_latency((time.perf_counter() - start) * 1000)
+                return resp
+            except Exception:
+                if attempt == self._budget.retries:
+                    raise
+                await asyncio.sleep(backoff)
+                backoff *= 2
+        raise RuntimeError("unreachable")
+
+    async def get_decide(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
+        entry = self._decision_cache.get(world_id)
+        if entry and entry.valid():
+            gw_metrics.worlds_cache_hits_total.inc()
+            gw_metrics.worlds_cache_hits_total._val = gw_metrics.worlds_cache_hits_total._value.get()  # type: ignore[attr-defined]
+            return entry.value
+        resp = await self._request("GET", f"{self._base}/worlds/{world_id}/decide", headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        cache_control = resp.headers.get("Cache-Control", "")
+        ttl = 0
+        if "max-age=" in cache_control:
+            try:
+                ttl = int(cache_control.split("max-age=")[1].split(",")[0])
+            except Exception:
+                ttl = 0
+        if ttl > 0:
+            self._decision_cache[world_id] = TTLCacheEntry(data, ttl)
+        return data
+
+    async def get_activation(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
+        etag, cached = self._activation_cache.get(world_id, (None, None))
+        req_headers = dict(headers or {})
+        if etag:
+            req_headers["If-None-Match"] = etag
+        resp = await self._request("GET", f"{self._base}/worlds/{world_id}/activation", headers=req_headers)
+        if resp.status_code == 304 and cached is not None:
+            gw_metrics.worlds_cache_hits_total.inc()
+            gw_metrics.worlds_cache_hits_total._val = gw_metrics.worlds_cache_hits_total._value.get()  # type: ignore[attr-defined]
+            return cached
+        resp.raise_for_status()
+        data = resp.json()
+        new_etag = resp.headers.get("ETag")
+        if new_etag:
+            self._activation_cache[world_id] = (new_etag, data)
+        return data
+
+    async def post_evaluate(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request(
+            "POST",
+            f"{self._base}/worlds/{world_id}/evaluate",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def post_apply(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request(
+            "POST",
+            f"{self._base}/worlds/{world_id}/apply",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+__all__ = ["Budget", "WorldServiceClient"]

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -1,0 +1,93 @@
+import pytest
+import httpx
+
+from qmtl.gateway.api import create_app, Database
+from qmtl.gateway.world_client import WorldServiceClient
+
+
+class FakeDB(Database):
+    async def insert_strategy(self, strategy_id: str, meta: dict | None) -> None:
+        return None
+
+    async def set_status(self, strategy_id: str, status: str) -> None:
+        return None
+
+    async def get_status(self, strategy_id: str) -> str | None:
+        return None
+
+    async def append_event(self, strategy_id: str, event: str) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_decide_ttl_cache(fake_redis):
+    call_count = {"n": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/decide"):
+            call_count["n"] += 1
+            return httpx.Response(200, json={"v": call_count["n"]}, headers={"Cache-Control": "max-age=60"})
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        r1 = await api_client.get("/worlds/abc/decide")
+        r2 = await api_client.get("/worlds/abc/decide")
+    await asgi.aclose()
+    await client._client.aclose()
+    assert r1.json() == {"v": 1}
+    assert r2.json() == {"v": 1}
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_activation_etag_cache(fake_redis):
+    call_count = {"n": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/activation"):
+            if request.headers.get("If-None-Match") == "abc":
+                return httpx.Response(304, headers={"ETag": "abc"})
+            call_count["n"] += 1
+            return httpx.Response(200, json={"a": call_count["n"]}, headers={"ETag": "abc"})
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        r1 = await api_client.get("/worlds/abc/activation")
+        r2 = await api_client.get("/worlds/abc/activation")
+    await asgi.aclose()
+    await client._client.aclose()
+    assert r1.json() == {"a": 1}
+    assert r2.json() == {"a": 1}
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_live_guard(fake_redis):
+    call_count = {"n": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/apply"):
+            call_count["n"] += 1
+            return httpx.Response(200, json={"ok": True})
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        r1 = await api_client.post("/worlds/abc/apply", json={})
+        r2 = await api_client.post("/worlds/abc/apply", json={}, headers={"X-Allow-Live": "true"})
+    await asgi.aclose()
+    await client._client.aclose()
+    assert r1.status_code == 403
+    assert r2.status_code == 200
+    assert call_count["n"] == 1


### PR DESCRIPTION
## Summary
- add WorldService client and proxy endpoints with TTL and ETag caching
- extend gateway configuration and metrics for world proxy
- guard live apply requests and add tests

## Testing
- `uv run -m pytest tests/gateway/test_world_proxy.py -W error`

Fixes #422 

------
https://chatgpt.com/codex/tasks/task_e_68b1fd511a2483299f005c6aed2dbdcf