### PR TITLE
Gateway: respect zero envelope TTL in WorldService fallback (P1)

### DIFF
--- a/docs/architecture/implementation_todos.md
+++ b/docs/architecture/implementation_todos.md
@@ -1,3 +1,107 @@
-# Implementation TODOs
+# Architecture–Code Sync TODOs (Aug 2025)
 
-- Gateway now recomputes deterministic NodeID from `node_type`, `code_hash`, `config_hash`, and `schema_hash`, rejecting mismatched IDs before diff.
+This document lists concrete implementation tasks required to align the current codebase with the updated architecture documents.
+
+Related specs:
+- Architecture Overview: architecture.md
+- Gateway: gateway.md
+- DAG Manager: dag-manager.md
+- WorldService: worldservice.md
+- ControlBus: controlbus.md
+
+---
+
+## High Priority (P0)
+
+- Worlds Proxy API in Gateway:
+  - Implement GET "/worlds/{id}/decide" and "/worlds/{id}/activation" with TTL/etag caching and safe fallbacks when stale. Enforce live guard (header "X-Allow-Live: true" or CLI "--allow-live").
+  - Implement POST "/worlds/{id}/evaluate" (read-only) and POST "/worlds/{id}/apply" (2-phase apply with "run_id", idempotent). Forward caller identity (JWT subject/claims) to WorldService.
+  - Config: add "worldservice_url", timeouts/retry budgets separate from DAG Manager. Metrics: cache hit ratio, proxy latency p95.
+  - Spec refs: architecture/gateway.md §S6; architecture/worldservice.md §2–§6; reference/api_world.md; reference/schemas.md.
+
+- Event Stream Descriptor endpoint:
+  - Implement POST "/events/subscribe" -> returns "{ stream_url, token, topics, expires_at, fallback_url }". Generate short-lived JWT (claims: "aud=controlbus", "sub", "world_id", "strategy_id", "topics", "jti", "iat", "exp", "kid").
+  - Provide WS entrypoint (e.g., "wss://…/ws/evt") that relays ControlBus events to clients; first message per topic MUST be a full snapshot or include "state_hash".
+  - Spec refs: architecture/gateway.md §S6, architecture/controlbus.md §7, reference/api_world.md.
+
+- ControlBus subscription in Gateway:
+  - Subscribe to "control.activation" (ActivationUpdated), "control.policy" (PolicyUpdated), "control.queues" (QueueUpdated). Deduplicate via "etag"/"run_id". Partition ordering per key.
+  - Bridge to WebSocketHub broadcast. Maintain per-topic last "etag" and export lag/skew metrics.
+  - Config: "controlbus" section (brokers/DSN, topics, consumer group). Backoff and at-least-once semantics.
+  - Spec refs: architecture/controlbus.md §0–§3; architecture/dag-manager.md §3-B.
+
+- Deterministic NodeID verification in Gateway:
+  - Compute NodeID = SHA-256("node_type, code_hash, config_hash, schema_hash") with SHA-3 fallback on collision; verify against SDK-supplied IDs before Diff. Return HTTP 400 on mismatch.
+  - Replace the current CRC32-of-node-ids check or keep it as a lightweight early guard in addition to NodeID recompute.
+  - Spec refs: architecture/architecture.md §3; architecture/gateway.md §S4; architecture/dag-manager.md §1.3.
+
+---
+
+## Medium Priority (P1)
+
+- WebSocket integration cleanup:
+  - Expose a stable WS path under FastAPI (e.g., "/ws" and "/ws/evt") instead of running an ad-hoc server. Ensure compatibility with "qmtl.sdk.ws_client.WebSocketClient" default "/ws" path.
+  - Add broadcasts for ActivationUpdated and PolicyUpdated in "WebSocketHub".
+  - Provide "fallback_url" and reconnection guidance (HTTP reconcile to "/worlds/{id}/activation" and "/queues/by_tag").
+
+- Metrics & observability additions:
+  - "sentinel_skew_seconds" (after weight updates) and ControlBus consumer lag per topic.
+  - World proxy metrics: "world_decide_latency_ms_p95", "world_activation_cache_hit_ratio", proxy error rates.
+  - Gateway event relay metrics: fanout rate, dropped subscribers, partition skew.
+
+- Circuit budgets & degradation policies (WorldService):
+  - Add independent timeouts/retries for WorldService proxy calls (defaults: WS 300 ms 2x; DM 500 ms 1x). Integrate with existing "AsyncCircuitBreaker". Surface states in "/status".
+
+- Backward-compat callbacks:
+  - Keep "/callbacks/dag-event" handling but migrate payloads to the versioned ControlBus envelopes ("ActivationUpdated", "PolicyUpdated", "QueueUpdated").
+
+---
+
+## Low Priority (P2)
+
+- Deprecation path for "/queues/watch":
+  - Mark as legacy once "/events/subscribe" is available. Keep until SDK migrates to the opaque event stream.
+
+- World initial snapshot semantics:
+  - Add optional HTTP endpoints for "state_hash" probe to avoid full snapshot when unchanged.
+
+- Security hardening:
+  - JWT key rotation and JWKS for delegated WS; world-scope RBAC claims pass-through; audit correlation IDs for all proxied calls and relayed events.
+
+---
+
+## Affected Code (initial mapping)
+
+- Gateway additions/changes:
+  - "qmtl/gateway/api.py": add "/worlds/*", "/events/subscribe", integrate WS endpoints; identity propagation and live guard.
+  - "qmtl/gateway/ws.py": extend to ActivationUpdated/PolicyUpdated; integrate with FastAPI lifecycle.
+  - "qmtl/gateway/config.py": add "worldservice_url", "controlbus" settings, timeouts/retries.
+  - "qmtl/gateway/dagmanager_client.py": keep; ensure NodeID recompute occurs before Diff (new helper module if needed).
+  - New: "qmtl/gateway/controlbus_consumer.py" (subscribe, dedupe, metrics) — config-driven; optional in dev.
+  - New: "qmtl/common/nodeid.py" (deterministic NodeID computation, SHA-3 fallback).
+
+- DAG Manager (alignment):
+  - Ensure QueueUpdated events are also published to ControlBus in addition to HTTP callback (already documented as preferred path).
+
+- SDK (follow-up, separate PR):
+  - Migrate "TagQueryManager" to use "/events/subscribe" descriptor when available; keep "/queues/by_tag" + "/queues/watch" as fallback.
+
+---
+
+## Test Plan (summary)
+
+- Contract tests for Decision/Activation envelopes using JSON Schemas in "docs/reference/schemas/".
+- Gateway proxy tests: caching TTL semantics, live-guard behaviour, identity propagation headers.
+- ControlBus bridge tests: at-least-once delivery, per-key ordering, dedupe via "etag"/"run_id".
+- WebSocket throughput: >= 500 msg/s sustained; initial snapshot or "state_hash" presence.
+- NodeID recompute: mismatch -> 400; match -> call Diff.
+
+---
+
+## Already Compliant (no action)
+
+- Strategy ingest & FSM with Redis + DB mirror; idempotent queue locking ("SETNX lock:{id}" with TTL).
+- VersionSentinel insertion with "insert_sentinel" config and "--no-sentinel" flag.
+- Tag query resolution via "/queues/by_tag" with "match_mode" (and "match" alias) and streaming updates bridged to SDK.
+- Degradation manager and local fallback queue for DAG outages; "/status" health caching.
+- Sentinel traffic ratio metric "gateway_sentinel_traffic_ratio{sentinel_id=...}".

--- a/qmtl/examples/qmtl.yml
+++ b/qmtl/examples/qmtl.yml
@@ -8,6 +8,16 @@ gateway:
   database_dsn: ./qmtl.db
   # Insert a VersionSentinel node for each DAG; set to false to disable
   insert_sentinel: true
+  # ControlBus (optional): list brokers and topics to subscribe for control events
+  # controlbus_brokers: ["localhost:9092"]
+  # controlbus_topics: ["activation", "policy", "queue"]
+  # controlbus_group: gateway
+  # WorldService proxy (optional): enable proxying /worlds/* via Gateway
+  # worldservice_url: http://localhost:8080
+  # worldservice_timeout: 0.3
+  # worldservice_retries: 2
+  # enable_worldservice_proxy: true
+  # enforce_live_guard: true
   # To use Postgres in a production cluster uncomment below
   # database_backend: postgres
   # database_dsn: postgresql://user:pass@db/qmtl

--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -15,6 +15,7 @@ from fastapi.responses import StreamingResponse
 import time
 from pydantic import BaseModel, Field
 import redis.asyncio as redis
+import grpc
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -11,6 +11,7 @@ from .redis_client import InMemoryRedis
 from .api import create_app
 from .config import GatewayConfig
 from ..config import load_config, find_config_file
+from .controlbus_consumer import ControlBusConsumer
 
 
 async def _main(argv: list[str] | None = None) -> None:
@@ -40,11 +41,25 @@ async def _main(argv: list[str] | None = None) -> None:
         if args.insert_sentinel is None
         else args.insert_sentinel
     )
+    consumer = None
+    if config.controlbus_topics:
+        consumer = ControlBusConsumer(
+            brokers=config.controlbus_brokers,
+            topics=config.controlbus_topics,
+            group=config.controlbus_group,
+        )
+
     app = create_app(
         redis_client=redis_client,
         database_backend=config.database_backend,
         database_dsn=config.database_dsn,
         insert_sentinel=insert_sentinel,
+        controlbus_consumer=consumer,
+        worldservice_url=config.worldservice_url,
+        worldservice_timeout=config.worldservice_timeout,
+        worldservice_retries=config.worldservice_retries,
+        enable_worldservice_proxy=config.enable_worldservice_proxy,
+        enforce_live_guard=config.enforce_live_guard,
     )
     db = app.state.database
     if hasattr(db, "connect"):
@@ -72,4 +87,3 @@ def main(argv: list[str] | None = None) -> None:
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     main()
-

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -133,24 +133,6 @@ class WebSocketHub:
         )
         await self.broadcast(event)
 
-    async def send_activation_updated(self, activation: dict) -> None:
-        """Broadcast activation updates."""
-        event = format_event(
-            "qmtl.gateway",
-            "activation_updated",
-            activation,
-        )
-        await self.broadcast(event)
-
-    async def send_policy_updated(self, policy: dict) -> None:
-        """Broadcast policy updates."""
-        event = format_event(
-            "qmtl.gateway",
-            "policy_updated",
-            policy,
-        )
-        await self.broadcast(event)
-
     async def send_sentinel_weight(self, sentinel_id: str, weight: float) -> None:
         """Broadcast sentinel weight updates."""
         event = format_event(
@@ -161,19 +143,13 @@ class WebSocketHub:
         await self.broadcast(event)
 
     async def send_activation_updated(self, payload: dict) -> None:
-        event = format_event(
-            "qmtl.gateway",
-            "activation_updated",
-            payload,
-        )
+        """Broadcast activation updates."""
+        event = format_event("qmtl.gateway", "activation_updated", payload)
         await self.broadcast(event)
 
     async def send_policy_updated(self, payload: dict) -> None:
-        event = format_event(
-            "qmtl.gateway",
-            "policy_updated",
-            payload,
-        )
+        """Broadcast policy updates."""
+        event = format_event("qmtl.gateway", "policy_updated", payload)
         await self.broadcast(event)
 
 

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -116,3 +116,29 @@ async def test_decide_ttl_envelope_fallback(fake_redis):
     assert r1.json() == {"v": 1, "ttl": "300s"}
     assert r2.json() == {"v": 1, "ttl": "300s"}
     assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_decide_ttl_zero_no_cache(fake_redis):
+    calls = {"n": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/decide"):
+            calls["n"] += 1
+            # No Cache-Control; envelope explicitly disables caching
+            return httpx.Response(200, json={"v": calls["n"], "ttl": "0s"})
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        r1 = await api_client.get("/worlds/abc/decide")
+        r2 = await api_client.get("/worlds/abc/decide")
+    await asgi.aclose()
+    await client._client.aclose()
+    assert r1.json() == {"v": 1, "ttl": "0s"}
+    assert r2.json() == {"v": 2, "ttl": "0s"}
+    # No cache should have been used
+    assert calls["n"] == 2


### PR DESCRIPTION
When Cache-Control is absent, fallback was doing `env_ttl or 300`, causing `ttl: 0` / `"0s"` to be treated as falsy and cached for 300s.\n\nThis PR:\n- Honors zero envelope TTL as "do not cache"\n- Uses the 300s default only when the envelope omits `ttl`\n- Keeps header `Cache-Control: max-age` precedence\n- Adds tests for envelope ttl fallback and zero-ttl no-cache\n\nScope: qmtl/gateway/world_client.py; tests/gateway/test_world_proxy.py\n