### PR TITLE
feat(gateway): add event stream descriptor endpoint

### DIFF
--- a/qmtl/gateway/event_descriptor.py
+++ b/qmtl/gateway/event_descriptor.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import time
+import base64
+import hmac
+import hashlib
+from typing import Any
+
+
+@dataclass
+class EventDescriptorConfig:
+    secret: str
+    kid: str
+    ttl: int = 300
+    stream_url: str = "wss://gateway/ws/evt"
+    fallback_url: str = "wss://gateway/ws/fallback"
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _b64url_decode(data: str) -> bytes:
+    pad = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + pad)
+
+
+def sign_event_token(claims: dict[str, Any], cfg: EventDescriptorConfig) -> str:
+    header = {"alg": "HS256", "typ": "JWT", "kid": cfg.kid}
+    header_b64 = _b64url_encode(
+        json.dumps(header, separators=(",", ":"), sort_keys=True).encode()
+    )
+    payload_b64 = _b64url_encode(
+        json.dumps(claims, separators=(",", ":"), sort_keys=True).encode()
+    )
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    signature = hmac.new(cfg.secret.encode(), signing_input, hashlib.sha256).digest()
+    sig_b64 = _b64url_encode(signature)
+    return f"{header_b64}.{payload_b64}.{sig_b64}"
+
+
+def validate_event_token(
+    token: str, cfg: EventDescriptorConfig, audience: str = "controlbus"
+) -> dict[str, Any]:
+    header_b64, payload_b64, sig_b64 = token.split(".")
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    expected_sig = hmac.new(cfg.secret.encode(), signing_input, hashlib.sha256).digest()
+    if not hmac.compare_digest(_b64url_decode(sig_b64), expected_sig):
+        raise ValueError("invalid signature")
+    payload = json.loads(_b64url_decode(payload_b64))
+    if payload.get("aud") != audience:
+        raise ValueError("invalid audience")
+    exp = payload.get("exp")
+    if exp is not None and int(exp) < int(time.time()):
+        raise ValueError("token expired")
+    return payload
+
+
+def get_token_header(token: str) -> dict[str, Any]:
+    header_b64 = token.split(".")[0]
+    return json.loads(_b64url_decode(header_b64))

--- a/tests/gateway/test_event_descriptor.py
+++ b/tests/gateway/test_event_descriptor.py
@@ -1,0 +1,58 @@
+import time
+import httpx
+import pytest
+
+from qmtl.gateway.api import create_app, Database
+from qmtl.gateway.event_descriptor import (
+    EventDescriptorConfig,
+    validate_event_token,
+    get_token_header,
+)
+
+
+class FakeDB(Database):
+    async def insert_strategy(self, strategy_id: str, meta: dict | None) -> None:
+        return None
+
+    async def set_status(self, strategy_id: str, status: str) -> None:
+        return None
+
+    async def get_status(self, strategy_id: str) -> str | None:
+        return None
+
+    async def append_event(self, strategy_id: str, event: str) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_event_descriptor_scope_and_expiry(fake_redis):
+    cfg = EventDescriptorConfig(
+        secret="s3cr3t",
+        kid="kid1",
+        ttl=60,
+        stream_url="wss://gateway/ws/evt",
+        fallback_url="wss://gateway/ws/fallback",
+    )
+    app = create_app(redis_client=fake_redis, database=FakeDB(), event_config=cfg)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        payload = {
+            "world_id": "w1",
+            "strategy_id": "s1",
+            "topics": ["activation"],
+        }
+        resp = await client.post("/events/subscribe", json=payload)
+    await transport.aclose()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["stream_url"] == cfg.stream_url
+    assert data["topics"] == ["activation"]
+    token = data["token"]
+    claims = validate_event_token(token, cfg)
+    assert claims["world_id"] == "w1"
+    assert claims["strategy_id"] == "s1"
+    assert claims["topics"] == ["activation"]
+    header = get_token_header(token)
+    assert header["kid"] == cfg.kid
+    now = int(time.time())
+    assert 50 <= claims["exp"] - now <= 60


### PR DESCRIPTION
## Summary
- implement POST `/events/subscribe` returning opaque descriptor with signed JWT
- add `EventDescriptorConfig` and helpers for JWT signing and validation
- cover token scope and expiration with tests

## Testing
- `uv run -m pytest tests/gateway/test_event_descriptor.py -W error`
- `uv run -m pytest tests/gateway/test_api.py::test_ingest_and_status -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b20bb9cc208329a866fa623487b4a5