### PR TITLE
feat: consume event descriptor in TagQueryManager

### DIFF
--- a/qmtl/sdk/tagquery_manager.py
+++ b/qmtl/sdk/tagquery_manager.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import json
+import contextlib
 import httpx
 from typing import Dict, List, Tuple, Optional, TYPE_CHECKING
 
@@ -21,22 +24,21 @@ class TagQueryManager:
         ws_client: WebSocketClient | None = None,
     ) -> None:
         self.gateway_url = gateway_url
-        if ws_client is not None:
-            ws_client.on_message = self.handle_message
-            self.client = ws_client
-        elif gateway_url:
-            self.client = WebSocketClient(
-                gateway_url.rstrip("/") + "/ws",
-                on_message=self.handle_message,
-            )
-        else:
-            self.client = None
+        self.client = ws_client
+        if self.client is not None:
+            self.client.on_message = self.handle_message
         self._nodes: Dict[Tuple[Tuple[str, ...], int, MatchMode], List[TagQueryNode]] = {}
+        self._watch_tasks: Dict[
+            Tuple[Tuple[str, ...], int, MatchMode], asyncio.Task
+        ] = {}
+        self._use_watch = False
 
     # ------------------------------------------------------------------
     def register(self, node: TagQueryNode) -> None:
         key = (tuple(sorted(node.query_tags)), node.interval, node.match_mode)
         self._nodes.setdefault(key, []).append(node)
+        if self._use_watch and key not in self._watch_tasks:
+            self._watch_tasks[key] = asyncio.create_task(self._watch(*key))
 
     def unregister(self, node: TagQueryNode) -> None:
         key = (tuple(sorted(node.query_tags)), node.interval, node.match_mode)
@@ -99,7 +101,74 @@ class TagQueryManager:
     async def start(self) -> None:
         if self.client:
             await self.client.start()
+            return
+        if not self.gateway_url:
+            return
+
+        subscribe_url = self.gateway_url.rstrip("/") + "/events/subscribe"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    subscribe_url, json={"topics": ["queues"]}
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    stream_url = data.get("stream_url")
+                    token = data.get("token")
+                    if stream_url:
+                        self.client = WebSocketClient(
+                            stream_url, on_message=self.handle_message, token=token
+                        )
+                        await self.client.start()
+                        return
+        except Exception:
+            pass
+
+        # fallback to /queues/watch + HTTP reconcile
+        self._use_watch = True
+        await self.resolve_tags()
+        for key in list(self._nodes.keys()):
+            if key not in self._watch_tasks:
+                self._watch_tasks[key] = asyncio.create_task(self._watch(*key))
 
     async def stop(self) -> None:
         if self.client:
             await self.client.stop()
+        for task in self._watch_tasks.values():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        self._watch_tasks.clear()
+
+    async def _watch(
+        self, tags: Tuple[str, ...], interval: int, match_mode: MatchMode
+    ) -> None:
+        if not self.gateway_url:
+            return
+        params = {
+            "tags": ",".join(tags),
+            "interval": interval,
+            "match_mode": match_mode.value,
+        }
+        url = self.gateway_url.rstrip("/") + "/queues/watch"
+        try:
+            async with httpx.AsyncClient() as client:
+                async with client.stream("GET", url, params=params) as resp:
+                    async for line in resp.aiter_lines():
+                        if not line:
+                            continue
+                        try:
+                            data = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        payload = {
+                            "tags": list(tags),
+                            "interval": interval,
+                            "queues": data.get("queues", []),
+                            "match_mode": match_mode.value,
+                        }
+                        await self.handle_message(
+                            {"event": "queue_update", "data": payload}
+                        )
+        except Exception:
+            return


### PR DESCRIPTION
## Summary
- use `/events/subscribe` descriptor when starting TagQueryManager
- support Authorization tokens in `WebSocketClient`
- add tests for descriptor path and fallback

## Testing
- `uv run -m pytest tests/test_tagquery_manager.py tests/test_ws_client.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b20bc2c2908329b4da52768c2b2ff0