### PR TITLE
fix(gateway): load event token secret from env

### DIFF
--- a/tests/gateway/test_event_descriptor.py
+++ b/tests/gateway/test_event_descriptor.py
@@ -56,3 +56,10 @@ async def test_event_descriptor_scope_and_expiry(fake_redis):
     assert header["kid"] == cfg.kid
     now = int(time.time())
     assert 50 <= claims["exp"] - now <= 60
+
+
+@pytest.mark.asyncio
+async def test_event_descriptor_secret_from_env(fake_redis, monkeypatch):
+    monkeypatch.setenv("QMTL_EVENT_SECRET", "envsecret")
+    app = create_app(redis_client=fake_redis, database=FakeDB())
+    assert app.state.event_config.secret == "envsecret"


### PR DESCRIPTION
## Summary
- read `QMTL_EVENT_SECRET` for event token signing and fall back to generated secret
- test that gateway pulls descriptor secret from environment

## Testing
- `uv run -m pytest tests/gateway/test_event_descriptor.py -W error`
- `uv run -m pytest tests/gateway/test_api.py::test_ingest_and_status -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b20e0256fc8329bf5027587ca0d1a2