### PR TITLE
feat: consume event descriptor in TagQueryManager

### DIFF
--- a/tests/test_tagquery_manager.py
+++ b/tests/test_tagquery_manager.py
@@ -205,3 +205,57 @@ async def test_start_falls_back_to_watch(monkeypatch):
     assert node.upstreams == ["q4"]
     await manager.stop()
 
+
+@pytest.mark.asyncio
+async def test_watch_reconnects(monkeypatch):
+    node = TagQueryNode(["t1"], interval="60s", period=1)
+    manager = TagQueryManager("http://gw")
+    manager.register(node)
+
+    calls = {"count": 0}
+
+    class Stream:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def aiter_lines(self):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                yield json.dumps({"queues": ["q1"]})
+            else:
+                yield json.dumps({"queues": ["q2"]})
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json=None):
+            return httpx.Response(404)
+
+        async def get(self, url, params=None):
+            resp = httpx.Response(200, json={"queues": []})
+            resp.request = httpx.Request("GET", url, params=params)
+            return resp
+
+        def stream(self, method, url, params=None):
+            return Stream()
+
+    orig_sleep = asyncio.sleep
+
+    async def fast_sleep(_):
+        await orig_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: DummyClient())
+
+    await manager.start()
+    await orig_sleep(0.1)
+    assert node.upstreams == ["q2"]
+    await manager.stop()
+


### PR DESCRIPTION
## Summary
- reconnect `/queues/watch` fallback streams with exponential backoff
- clean up watch tasks on shutdown
- add regression test for reconnection

## Testing
- `uv run -m pytest tests/test_tagquery_manager.py tests/test_ws_client.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b20e4263fc8329aaed45b515d26391