### PR TITLE
Phase 2 fixes: WS send_text + descriptor payload ids

### DIFF
--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -69,13 +69,13 @@ class WebSocketHub:
                 clients = list(self._clients)
             if clients:
                 results = await asyncio.gather(
-                    *(ws.send(msg) for ws in clients), return_exceptions=True
+                    *(ws.send_text(msg) for ws in clients), return_exceptions=True
                 )
                 for client_ws, res in zip(clients, results):
                     if isinstance(res, Exception):
                         logger.warning(
                             "Failed to send message to client %s: %s",
-                            client_ws.remote_address,
+                            getattr(client_ws, "client", None) or "unknown",
                             res,
                         )
             self._queue.task_done()

--- a/tests/gateway/test_ws.py
+++ b/tests/gateway/test_ws.py
@@ -11,9 +11,9 @@ from qmtl.gateway.ws import WebSocketHub
 class DummyWS:
     def __init__(self):
         self.messages: list[str] = []
-        self.remote_address = ("test", 0)
+        self.client = ("test", 0)
 
-    async def send(self, msg: str) -> None:
+    async def send_text(self, msg: str) -> None:
         self.messages.append(msg)
 
 
@@ -59,9 +59,9 @@ async def test_hub_logs_send_errors(caplog):
     await hub.start()
 
     class BadWS:
-        remote_address = ("dummy", 1234)
+        client = ("dummy", 1234)
 
-        async def send(self, msg):
+        async def send_text(self, msg):
             raise RuntimeError("boom")
 
     async with hub._lock:


### PR DESCRIPTION
- WebSocketHub now uses FastAPI WebSocket.send_text and logs client info safely\n- TagQueryManager accepts world_id/strategy_id and includes them in /events/subscribe\n- Tests updated to align with new WS interface and to assert descriptor payload includes ids\n\nThis completes the Phase 2 review items identified earlier.