### PR TITLE
feat: add gateway proxy and relay metrics

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -48,3 +48,10 @@ prometheus:
             severity: warning
           annotations:
             summary: Queue count growth is abnormal
+        - alert: SentinelSkewHigh
+          expr: sentinel_skew_seconds > 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Sentinel traffic skew persists beyond 5s

--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -316,6 +316,7 @@ def create_app(
                 await self.ws_hub.send_sentinel_weight(sid, weight)
             self._sentinel_weights[sid] = weight
             from . import metrics as gw_metrics
+            gw_metrics.record_sentinel_weight_update(sid)
             gw_metrics.set_sentinel_traffic_ratio(sid, weight)
 
         async def _handle_activation_updated(self, payload: dict) -> None:

--- a/qmtl/gateway/world_client.py
+++ b/qmtl/gateway/world_client.py
@@ -69,8 +69,7 @@ class WorldServiceClient:
     async def get_decide(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
         entry = self._decision_cache.get(world_id)
         if entry and entry.valid():
-            gw_metrics.worlds_cache_hits_total.inc()
-            gw_metrics.worlds_cache_hits_total._val = gw_metrics.worlds_cache_hits_total._value.get()  # type: ignore[attr-defined]
+            gw_metrics.record_worlds_cache_hit()
             return entry.value
         resp = await self._request("GET", f"{self._base}/worlds/{world_id}/decide", headers=headers)
         resp.raise_for_status()
@@ -126,8 +125,7 @@ class WorldServiceClient:
             req_headers["If-None-Match"] = etag
         resp = await self._request("GET", f"{self._base}/worlds/{world_id}/activation", headers=req_headers)
         if resp.status_code == 304 and cached is not None:
-            gw_metrics.worlds_cache_hits_total.inc()
-            gw_metrics.worlds_cache_hits_total._val = gw_metrics.worlds_cache_hits_total._value.get()  # type: ignore[attr-defined]
+            gw_metrics.record_worlds_cache_hit()
             return cached
         resp.raise_for_status()
         data = resp.json()

--- a/tests/gateway/test_metrics.py
+++ b/tests/gateway/test_metrics.py
@@ -32,6 +32,7 @@ def test_metrics_endpoint(app):
     metrics.reset_metrics()
     metrics.lost_requests_total.inc()
     metrics.observe_gateway_latency(42)
+    metrics.record_sentinel_weight_update("v1")
     metrics.set_sentinel_traffic_ratio("v1", 0.5)
     with TestClient(app) as client:
         resp = client.get("/metrics")
@@ -39,6 +40,7 @@ def test_metrics_endpoint(app):
         assert "lost_requests_total" in resp.text
         assert "gateway_e2e_latency_p95" in resp.text
         assert "gateway_sentinel_traffic_ratio" in resp.text
+        assert "sentinel_skew_seconds" in resp.text
         resp.close()
 
 

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -3,6 +3,7 @@ import httpx
 
 from qmtl.gateway.api import create_app, Database
 from qmtl.gateway.world_client import WorldServiceClient
+from qmtl.gateway import metrics
 
 
 class FakeDB(Database):
@@ -21,6 +22,7 @@ class FakeDB(Database):
 
 @pytest.mark.asyncio
 async def test_decide_ttl_cache(fake_redis):
+    metrics.reset_metrics()
     call_count = {"n": 0}
 
     async def handler(request: httpx.Request) -> httpx.Response:
@@ -41,6 +43,7 @@ async def test_decide_ttl_cache(fake_redis):
     assert r1.json() == {"v": 1}
     assert r2.json() == {"v": 1}
     assert call_count["n"] == 1
+    assert metrics.worlds_cache_hit_ratio._value.get() == pytest.approx(0.5)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add p95 and cache-hit metrics for WorldService proxy
- track event relay throughput, drops, and clock skew
- expose sentinel skew metric and alert rule

## Testing
- `uv run -m pytest -W error` *(fails: ModuleNotFoundError: No module named 'qmtl.indicators.gap_amplification_alpha')*

Fixes #428

------
https://chatgpt.com/codex/tasks/task_e_68b21ac000688329abcb963cd1f35ce5