### PR TITLE
Deprecate legacy queue watch endpoint

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -249,6 +249,13 @@ Token (JWT) claims (delegated WS or future use):
 - `world_id`, `strategy_id`, `topics`: subscription scope
 - `jti`, `iat`, `exp`, `kid`: idempotency and keying
 
+### Legacy Queue Watch & HTTP Fallback
+
+`GET /queues/watch` remains for backward compatibility but is marked as deprecated.
+Responses include a `Deprecation` header pointing callers to `POST /events/subscribe`.
+SDKs should use the event stream when available and periodically reconcile via
+`GET /queues/by_tag` if the stream drops or diverges.
+
 ### Degrade & Fail‑Safe Policy (Summary)
 
 - WorldService unavailable:

--- a/docs/architecture/implementation_todos.md
+++ b/docs/architecture/implementation_todos.md
@@ -59,8 +59,9 @@ Related specs:
 
 ## Low Priority (P2)
 
-- Deprecation path for "/queues/watch":
-  - Mark as legacy once "/events/subscribe" is available. Keep until SDK migrates to the opaque event stream.
+- Legacy "/queues/watch":
+  - Endpoint retained for compatibility; emits ``Deprecation`` header pointing to ``/events/subscribe``.
+  - SDKs should reconcile via ``/queues/by_tag`` over HTTP if the event stream is unavailable.
 
 - World initial snapshot semantics:
   - Add optional HTTP endpoints for "state_hash" probe to avoid full snapshot when unchanged.

--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -483,6 +483,8 @@ def create_app(
     async def queues_watch(
         tags: str, interval: int, match: str = "any", match_mode: str | None = None
     ):
+        """Legacy queue watch; prefer ``POST /events/subscribe``."""
+        logger.warning("/queues/watch is deprecated; use /events/subscribe instead")
         tag_list = [t for t in tags.split(",") if t]
         mode_str = match_mode or match
         try:
@@ -502,7 +504,11 @@ def create_app(
             async for queues in watch_hub_local.subscribe(tag_list, interval, mode):
                 yield json.dumps({"queues": queues}) + "\n"
 
-        return StreamingResponse(streamer(), media_type="text/plain")
+        headers = {
+            "Deprecation": "true",
+            "Link": "</events/subscribe>; rel=\"successor-version\"",
+        }
+        return StreamingResponse(streamer(), media_type="text/plain", headers=headers)
 
     @app.post("/events/subscribe", response_model=EventSubscribeResponse)
     async def events_subscribe(payload: EventSubscribeRequest) -> EventSubscribeResponse:


### PR DESCRIPTION
## Summary
- warn clients that GET /queues/watch is deprecated and point them to POST /events/subscribe
- document HTTP reconciliation fallback for queues when the event stream is unavailable

## Testing
- `uv run -m pytest -W error` *(fails: ModuleNotFoundError: No module named 'qmtl.indicators.gap_amplification_alpha')*
- `uv run mkdocs build`

Closes #430

------
https://chatgpt.com/codex/tasks/task_e_68b21ad181588329886e6295c14a694c