### PR TITLE
feat: add state hash probe endpoint

### DIFF
--- a/docs/architecture/controlbus.md
+++ b/docs/architecture/controlbus.md
@@ -121,6 +121,7 @@ Runbooks
 ## 7. Initial Snapshot & Delegated WS (Optional)
 
 - Initial snapshot: first message per topic SHOULD be a full snapshot or include a `state_hash` so clients can confirm convergence without a full GET.
+- Clients MAY probe `/worlds/{id}/{topic}/state_hash` via Gateway to check for divergence before fetching a snapshot.
 - Delegated WS (feature‑flagged): Gateway may return an alternate `alt_stream_url` that points to a dedicated event streamer tier sitting in front of ControlBus.
   - Tokens are short‑lived JWTs with claims: `aud=controlbus`, `sub=<user|svc>`, `world_id`, `strategy_id`, `topics`, `jti`, `iat`, `exp`, `kid`.
   - Streamer verifies JWKS/claims and bridges to ControlBus; default deployment keeps this disabled.

--- a/docs/reference/api_world.md
+++ b/docs/reference/api_world.md
@@ -61,6 +61,16 @@ Response (ActivationEnvelope)
 ```
 Schema: reference/schemas/activation_envelope.schema.json
 
+### GET /worlds/{id}/{topic}/state_hash
+Returns a `state_hash` for the given topic so clients can check for divergence before requesting a full snapshot.
+
+Example: `/worlds/{id}/activation/state_hash`
+
+Response
+```json
+{ "state_hash": "sha256:..." }
+```
+
 ### POST /worlds/{id}/evaluate
 Evaluates current policy and returns a plan. Read‑only; does not change activation.
 

--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -550,6 +550,17 @@ def create_app(
             headers["Authorization"] = auth
         return await client.get_activation(world_id, headers=headers)
 
+    @app.get("/worlds/{world_id}/{topic}/state_hash")
+    async def get_world_state_hash(world_id: str, topic: str, request: Request) -> Any:
+        client: WorldServiceClient | None = app.state.world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers: dict[str, str] = {}
+        auth = request.headers.get("authorization")
+        if auth:
+            headers["Authorization"] = auth
+        return await client.get_state_hash(world_id, topic, headers=headers)
+
     @app.post("/worlds/{world_id}/evaluate")
     async def post_world_evaluate(world_id: str, payload: dict, request: Request) -> Any:
         client: WorldServiceClient | None = app.state.world_client

--- a/qmtl/gateway/world_client.py
+++ b/qmtl/gateway/world_client.py
@@ -136,6 +136,22 @@ class WorldServiceClient:
             self._activation_cache[world_id] = (new_etag, data)
         return data
 
+    async def get_state_hash(
+        self,
+        world_id: str,
+        topic: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        """Fetch state hash for a topic without retrieving full snapshot."""
+
+        resp = await self._request(
+            "GET",
+            f"{self._base}/worlds/{world_id}/{topic}/state_hash",
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
     async def post_evaluate(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
         resp = await self._request(
             "POST",

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -142,3 +142,40 @@ async def test_decide_ttl_zero_no_cache(fake_redis):
     assert r2.json() == {"v": 2, "ttl": "0s"}
     # No cache should have been used
     assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_state_hash_probe_divergence(fake_redis):
+    hashes = ["h1", "h1", "h2"]
+    calls = {"hash": 0, "snap": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/activation/state_hash"):
+            idx = calls["hash"]
+            calls["hash"] += 1
+            return httpx.Response(200, json={"state_hash": hashes[idx]})
+        if request.url.path.endswith("/activation"):
+            calls["snap"] += 1
+            return httpx.Response(200, json={"a": calls["snap"]})
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        # initial full snapshot
+        await api_client.get("/worlds/abc/activation")
+        # unchanged hash
+        h1 = await api_client.get("/worlds/abc/activation/state_hash")
+        assert h1.json() == {"state_hash": "h1"}
+        h2 = await api_client.get("/worlds/abc/activation/state_hash")
+        assert h2.json() == {"state_hash": "h1"}
+        assert calls["snap"] == 1
+        # divergence
+        h3 = await api_client.get("/worlds/abc/activation/state_hash")
+        assert h3.json() == {"state_hash": "h2"}
+        await api_client.get("/worlds/abc/activation")
+    await asgi.aclose()
+    await client._client.aclose()
+    assert calls["snap"] == 2


### PR DESCRIPTION
## Summary
- add `/worlds/{id}/{topic}/state_hash` proxy endpoint
- document state hash probes and update control bus guidance
- test state hash divergence detection

## Testing
- `uv run -m pytest -W error` *(fails: No module named 'qmtl.indicators.gap_amplification_alpha')*
- `uv run -m pytest tests/gateway/test_world_proxy.py -W error`
- `uv run mkdocs build`

Closes #431

------
https://chatgpt.com/codex/tasks/task_e_68b21ad552f883298af33f594cc0ba75