### PR TITLE
Propagate correlation IDs through world proxies

### DIFF
--- a/qmtl/common/cloudevents.py
+++ b/qmtl/common/cloudevents.py
@@ -5,8 +5,19 @@ from typing import Any
 from uuid import uuid4
 
 
-def format_event(source: str, event_type: str, data: dict[str, Any]) -> dict[str, Any]:
-    """Return a CloudEvents-formatted dictionary."""
+def format_event(
+    source: str,
+    event_type: str,
+    data: dict[str, Any],
+    *,
+    correlation_id: str | None = None,
+) -> dict[str, Any]:
+    """Return a CloudEvents-formatted dictionary.
+
+    ``correlation_id`` allows callers to associate related events across
+    services. When omitted a new random identifier is generated.
+    """
+
     return {
         "specversion": "1.0",
         "id": str(uuid4()),
@@ -15,6 +26,7 @@ def format_event(source: str, event_type: str, data: dict[str, Any]) -> dict[str
         "time": datetime.now(tz=timezone.utc).isoformat(),
         "datacontenttype": "application/json",
         "data": data,
+        "correlation_id": correlation_id or str(uuid4()),
     }
 
 __all__ = ["format_event"]

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -84,21 +84,29 @@ class WebSocketHub:
         """Queue ``data`` for broadcast to all connected clients."""
         await self._queue.put(json.dumps(data))
 
-    async def send_progress(self, strategy_id: str, status: str) -> None:
+    async def send_progress(
+        self, strategy_id: str, status: str, *, correlation_id: str | None = None
+    ) -> None:
         event = format_event(
             "qmtl.gateway",
             "progress",
             {"strategy_id": strategy_id, "status": status},
+            correlation_id=correlation_id,
         )
         await self.broadcast(event)
 
     async def send_queue_map(
-        self, strategy_id: str, queue_map: dict[str, list[str] | str]
+        self,
+        strategy_id: str,
+        queue_map: dict[str, list[str] | str],
+        *,
+        correlation_id: str | None = None,
     ) -> None:
         event = format_event(
             "qmtl.gateway",
             "queue_map",
             {"strategy_id": strategy_id, "queue_map": queue_map},
+            correlation_id=correlation_id,
         )
         await self.broadcast(event)
 
@@ -108,6 +116,8 @@ class WebSocketHub:
         interval: int,
         queues: list[str],
         match_mode: MatchMode = MatchMode.ANY,
+        *,
+        correlation_id: str | None = None,
     ) -> None:
         """Broadcast queue update events.
 
@@ -122,26 +132,44 @@ class WebSocketHub:
                 "queues": queues,
                 "match_mode": match_mode.value,
             },
+            correlation_id=correlation_id,
         )
         await self.broadcast(event)
 
-    async def send_sentinel_weight(self, sentinel_id: str, weight: float) -> None:
+    async def send_sentinel_weight(
+        self, sentinel_id: str, weight: float, *, correlation_id: str | None = None
+    ) -> None:
         """Broadcast sentinel weight updates."""
         event = format_event(
             "qmtl.gateway",
             "sentinel_weight",
             {"sentinel_id": sentinel_id, "weight": weight},
+            correlation_id=correlation_id,
         )
         await self.broadcast(event)
 
-    async def send_activation_updated(self, payload: dict) -> None:
+    async def send_activation_updated(
+        self, payload: dict, *, correlation_id: str | None = None
+    ) -> None:
         """Broadcast activation updates."""
-        event = format_event("qmtl.gateway", "activation_updated", payload)
+        event = format_event(
+            "qmtl.gateway",
+            "activation_updated",
+            payload,
+            correlation_id=correlation_id or payload.get("correlation_id"),
+        )
         await self.broadcast(event)
 
-    async def send_policy_updated(self, payload: dict) -> None:
+    async def send_policy_updated(
+        self, payload: dict, *, correlation_id: str | None = None
+    ) -> None:
         """Broadcast policy updates."""
-        event = format_event("qmtl.gateway", "policy_updated", payload)
+        event = format_event(
+            "qmtl.gateway",
+            "policy_updated",
+            payload,
+            correlation_id=correlation_id or payload.get("correlation_id"),
+        )
         await self.broadcast(event)
 
 

--- a/qmtl/indicators/__init__.py
+++ b/qmtl/indicators/__init__.py
@@ -17,7 +17,6 @@ from .kalman_trend import kalman_trend
 from .rough_bergomi import rough_bergomi
 from .stoch_rsi import stoch_rsi
 from .volatility import volatility_node, volatility
-from .gap_amplification_alpha import gap_amplification_node
 from .helpers import alpha_indicator_with_history
 
 __all__ = [
@@ -39,6 +38,5 @@ __all__ = [
     "stoch_rsi",
     "volatility_node",
     "volatility",
-    "gap_amplification_node",
     "alpha_indicator_with_history",
 ]

--- a/tests/gateway/test_ws.py
+++ b/tests/gateway/test_ws.py
@@ -29,9 +29,10 @@ async def test_hub_broadcasts_progress_and_queue_map():
     await asyncio.sleep(0.1)
     await hub.stop()
     assert len(ws.messages) == 2
-    types = {json.loads(m)["type"] for m in ws.messages}
-    assert "progress" in types
-    assert "queue_map" in types
+    for msg in ws.messages:
+        payload = json.loads(msg)
+        assert payload["type"] in {"progress", "queue_map"}
+        assert "correlation_id" in payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- propagate correlation IDs across gateway events and world service requests
- add optional world-scope RBAC validation for proxied world calls
- test correlation ID handling in websocket hub and world proxy
- drop missing gap_amplification alpha import

## Testing
- `uv run -m pytest tests/gateway/test_world_proxy.py::test_decide_ttl_cache -W error`
- `uv run -m pytest tests/gateway/test_ws.py::test_hub_broadcasts_progress_and_queue_map -W error`
- `uv run -m pytest -W error` *(fails: gateway error 400, sentinel WS port cast issues, etc.)*

Refs #432

------
https://chatgpt.com/codex/tasks/task_e_68b21adba25c8329a7295677d1bef5a2