### PR TITLE
feat: add JWKS rotation and correlation IDs

### DIFF
--- a/qmtl/common/cloudevents.py
+++ b/qmtl/common/cloudevents.py
@@ -5,8 +5,13 @@ from typing import Any
 from uuid import uuid4
 
 
-def format_event(source: str, event_type: str, data: dict[str, Any]) -> dict[str, Any]:
-    """Return a CloudEvents-formatted dictionary."""
+def format_event(
+    source: str, event_type: str, data: dict[str, Any], *, correlation_id: str | None = None
+) -> dict[str, Any]:
+    """Return a CloudEvents-formatted dictionary with ``correlation_id``."""
+
+    if correlation_id is None:
+        correlation_id = str(uuid4())
     return {
         "specversion": "1.0",
         "id": str(uuid4()),
@@ -15,6 +20,7 @@ def format_event(source: str, event_type: str, data: dict[str, Any]) -> dict[str
         "time": datetime.now(tz=timezone.utc).isoformat(),
         "datacontenttype": "application/json",
         "data": data,
+        "correlation_id": correlation_id,
     }
 
 __all__ = ["format_event"]

--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -22,7 +22,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from contextlib import asynccontextmanager
-from fastapi.responses import StreamingResponse
+from fastapi.responses import StreamingResponse, JSONResponse
 import time
 from pydantic import BaseModel, Field
 import redis.asyncio as redis
@@ -43,7 +43,7 @@ from .controlbus_consumer import ControlBusConsumer
 from .gateway_health import get_health as gateway_health
 from .database import Database, PostgresDatabase, MemoryDatabase, SQLiteDatabase
 from .world_client import WorldServiceClient, Budget
-from .event_descriptor import EventDescriptorConfig, sign_event_token
+from .event_descriptor import EventDescriptorConfig, sign_event_token, jwks
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -201,8 +201,8 @@ def create_app(
             secret = secrets.token_hex(32)
             logger.warning("QMTL_EVENT_SECRET is not set; using a generated secret")
         event_cfg = EventDescriptorConfig(
-            secret=secret,
-            kid="default",
+            keys={"default": secret},
+            active_kid="default",
             ttl=300,
             stream_url="wss://gateway/ws/evt",
             fallback_url="wss://gateway/ws/fallback",
@@ -535,6 +535,11 @@ def create_app(
             fallback_url=cfg.fallback_url,
         )
 
+    @app.get("/events/jwks")
+    async def events_jwks() -> dict[str, Any]:
+        cfg: EventDescriptorConfig = app.state.event_config
+        return jwks(cfg)
+
     @app.get("/worlds/{world_id}/decide")
     async def get_world_decide(world_id: str, request: Request) -> Any:
         client: WorldServiceClient | None = app.state.world_client
@@ -544,7 +549,13 @@ def create_app(
         auth = request.headers.get("authorization")
         if auth:
             headers["Authorization"] = auth
-        return await client.get_decide(world_id, headers=headers)
+        roles = request.headers.get("x-world-roles")
+        if roles:
+            headers["X-World-Roles"] = roles
+        cid = uuid.uuid4().hex
+        headers["X-Correlation-ID"] = cid
+        data = await client.get_decide(world_id, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
 
     @app.get("/worlds/{world_id}/activation")
     async def get_world_activation(world_id: str, request: Request) -> Any:
@@ -555,7 +566,13 @@ def create_app(
         auth = request.headers.get("authorization")
         if auth:
             headers["Authorization"] = auth
-        return await client.get_activation(world_id, headers=headers)
+        roles = request.headers.get("x-world-roles")
+        if roles:
+            headers["X-World-Roles"] = roles
+        cid = uuid.uuid4().hex
+        headers["X-Correlation-ID"] = cid
+        data = await client.get_activation(world_id, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
 
     @app.get("/worlds/{world_id}/{topic}/state_hash")
     async def get_world_state_hash(world_id: str, topic: str, request: Request) -> Any:
@@ -566,7 +583,13 @@ def create_app(
         auth = request.headers.get("authorization")
         if auth:
             headers["Authorization"] = auth
-        return await client.get_state_hash(world_id, topic, headers=headers)
+        roles = request.headers.get("x-world-roles")
+        if roles:
+            headers["X-World-Roles"] = roles
+        cid = uuid.uuid4().hex
+        headers["X-Correlation-ID"] = cid
+        data = await client.get_state_hash(world_id, topic, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
 
     @app.post("/worlds/{world_id}/evaluate")
     async def post_world_evaluate(world_id: str, payload: dict, request: Request) -> Any:
@@ -577,7 +600,13 @@ def create_app(
         auth = request.headers.get("authorization")
         if auth:
             headers["Authorization"] = auth
-        return await client.post_evaluate(world_id, payload, headers=headers)
+        roles = request.headers.get("x-world-roles")
+        if roles:
+            headers["X-World-Roles"] = roles
+        cid = uuid.uuid4().hex
+        headers["X-Correlation-ID"] = cid
+        data = await client.post_evaluate(world_id, payload, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
 
     @app.post("/worlds/{world_id}/apply")
     async def post_world_apply(world_id: str, payload: dict, request: Request) -> Any:
@@ -590,7 +619,13 @@ def create_app(
         auth = request.headers.get("authorization")
         if auth:
             headers["Authorization"] = auth
-        return await client.post_apply(world_id, payload, headers=headers)
+        roles = request.headers.get("x-world-roles")
+        if roles:
+            headers["X-World-Roles"] = roles
+        cid = uuid.uuid4().hex
+        headers["X-Correlation-ID"] = cid
+        data = await client.post_apply(world_id, payload, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
 
     @app.get("/metrics")
     async def metrics_endpoint() -> Response:

--- a/qmtl/gateway/event_descriptor.py
+++ b/qmtl/gateway/event_descriptor.py
@@ -1,21 +1,23 @@
+"""Utility helpers for event stream JWT descriptors.
+
+This module provides minimal JWT creation and validation using symmetric
+HMAC keys. Keys are identified by ``kid`` allowing rotation. A helper is
+also provided to expose the configured keys as a JWKS document so that
+external services can validate tokens without sharing secrets.
+
+The implementation intentionally avoids external dependencies to keep the
+Gateway lightweight.
+"""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
 import time
 import base64
 import hmac
 import hashlib
+from dataclasses import dataclass
 from typing import Any
-
-
-@dataclass
-class EventDescriptorConfig:
-    secret: str
-    kid: str
-    ttl: int = 300
-    stream_url: str = "wss://gateway/ws/evt"
-    fallback_url: str = "wss://gateway/ws/fallback"
 
 
 def _b64url_encode(data: bytes) -> str:
@@ -27,8 +29,27 @@ def _b64url_decode(data: str) -> bytes:
     return base64.urlsafe_b64decode(data + pad)
 
 
+@dataclass
+class EventDescriptorConfig:
+    """Configuration for signing event stream tokens.
+
+    ``keys`` maps ``kid`` values to HMAC secrets. ``active_kid`` denotes the key
+    used for new tokens. Keeping previous keys in the map allows validating
+    tokens issued before a rotation.
+    """
+
+    keys: dict[str, str]
+    active_kid: str
+    ttl: int = 300
+    stream_url: str = "wss://gateway/ws/evt"
+    fallback_url: str = "wss://gateway/ws/fallback"
+
+
 def sign_event_token(claims: dict[str, Any], cfg: EventDescriptorConfig) -> str:
-    header = {"alg": "HS256", "typ": "JWT", "kid": cfg.kid}
+    """Return a signed JWT containing ``claims``."""
+
+    secret = cfg.keys[cfg.active_kid]
+    header = {"alg": "HS256", "typ": "JWT", "kid": cfg.active_kid}
     header_b64 = _b64url_encode(
         json.dumps(header, separators=(",", ":"), sort_keys=True).encode()
     )
@@ -36,7 +57,7 @@ def sign_event_token(claims: dict[str, Any], cfg: EventDescriptorConfig) -> str:
         json.dumps(claims, separators=(",", ":"), sort_keys=True).encode()
     )
     signing_input = f"{header_b64}.{payload_b64}".encode()
-    signature = hmac.new(cfg.secret.encode(), signing_input, hashlib.sha256).digest()
+    signature = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
     sig_b64 = _b64url_encode(signature)
     return f"{header_b64}.{payload_b64}.{sig_b64}"
 
@@ -44,9 +65,20 @@ def sign_event_token(claims: dict[str, Any], cfg: EventDescriptorConfig) -> str:
 def validate_event_token(
     token: str, cfg: EventDescriptorConfig, audience: str = "controlbus"
 ) -> dict[str, Any]:
+    """Validate ``token`` and return its claims.
+
+    Raises ``ValueError`` if the token is invalid, expired or has the wrong
+    audience.
+    """
+
     header_b64, payload_b64, sig_b64 = token.split(".")
+    header = json.loads(_b64url_decode(header_b64))
+    kid = header.get("kid")
+    secret = cfg.keys.get(kid)
+    if secret is None:
+        raise ValueError("unknown kid")
     signing_input = f"{header_b64}.{payload_b64}".encode()
-    expected_sig = hmac.new(cfg.secret.encode(), signing_input, hashlib.sha256).digest()
+    expected_sig = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
     if not hmac.compare_digest(_b64url_decode(sig_b64), expected_sig):
         raise ValueError("invalid signature")
     payload = json.loads(_b64url_decode(payload_b64))
@@ -59,5 +91,34 @@ def validate_event_token(
 
 
 def get_token_header(token: str) -> dict[str, Any]:
+    """Return the decoded header for ``token``."""
+
     header_b64 = token.split(".")[0]
     return json.loads(_b64url_decode(header_b64))
+
+
+def jwks(cfg: EventDescriptorConfig) -> dict[str, Any]:
+    """Return a JWKS document for the configured keys."""
+
+    keys = []
+    for kid, secret in cfg.keys.items():
+        keys.append(
+            {
+                "kty": "oct",
+                "use": "sig",
+                "alg": "HS256",
+                "kid": kid,
+                "k": _b64url_encode(secret.encode()),
+            }
+        )
+    return {"keys": keys}
+
+
+__all__ = [
+    "EventDescriptorConfig",
+    "sign_event_token",
+    "validate_event_token",
+    "get_token_header",
+    "jwks",
+]
+

--- a/qmtl/gateway/world_client.py
+++ b/qmtl/gateway/world_client.py
@@ -4,6 +4,7 @@ import asyncio
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
+import uuid
 
 import httpx
 
@@ -52,6 +53,8 @@ class WorldServiceClient:
         self._activation_cache: Dict[str, tuple[str, Any]] = {}
 
     async def _request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        headers = kwargs.setdefault("headers", {})
+        headers.setdefault("X-Correlation-ID", uuid.uuid4().hex)
         backoff = 0.1
         for attempt in range(self._budget.retries + 1):
             try:

--- a/tests/gateway/test_event_descriptor.py
+++ b/tests/gateway/test_event_descriptor.py
@@ -1,5 +1,5 @@
-import time
 import httpx
+import time
 import pytest
 
 from qmtl.gateway.api import create_app, Database
@@ -7,6 +7,8 @@ from qmtl.gateway.event_descriptor import (
     EventDescriptorConfig,
     validate_event_token,
     get_token_header,
+    sign_event_token,
+    jwks,
 )
 
 
@@ -27,8 +29,8 @@ class FakeDB(Database):
 @pytest.mark.asyncio
 async def test_event_descriptor_scope_and_expiry(fake_redis):
     cfg = EventDescriptorConfig(
-        secret="s3cr3t",
-        kid="kid1",
+        keys={"kid1": "s3cr3t"},
+        active_kid="kid1",
         ttl=60,
         stream_url="wss://gateway/ws/evt",
         fallback_url="wss://gateway/ws/fallback",
@@ -53,7 +55,7 @@ async def test_event_descriptor_scope_and_expiry(fake_redis):
     assert claims["strategy_id"] == "s1"
     assert claims["topics"] == ["activation"]
     header = get_token_header(token)
-    assert header["kid"] == cfg.kid
+    assert header["kid"] == cfg.active_kid
     now = int(time.time())
     assert 50 <= claims["exp"] - now <= 60
 
@@ -62,4 +64,24 @@ async def test_event_descriptor_scope_and_expiry(fake_redis):
 async def test_event_descriptor_secret_from_env(fake_redis, monkeypatch):
     monkeypatch.setenv("QMTL_EVENT_SECRET", "envsecret")
     app = create_app(redis_client=fake_redis, database=FakeDB())
-    assert app.state.event_config.secret == "envsecret"
+    cfg: EventDescriptorConfig = app.state.event_config
+    assert cfg.keys[cfg.active_kid] == "envsecret"
+
+
+@pytest.mark.asyncio
+async def test_event_descriptor_rotation_and_jwks():
+    cfg = EventDescriptorConfig(
+        keys={"old": "s1", "new": "s2"},
+        active_kid="old",
+        ttl=60,
+        stream_url="wss://gateway/ws/evt",
+        fallback_url="wss://gateway/ws/fallback",
+    )
+    claims = {"aud": "controlbus", "sub": "s1"}
+    tok_old = sign_event_token(claims, cfg)
+    cfg.active_kid = "new"
+    tok_new = sign_event_token(claims, cfg)
+    assert validate_event_token(tok_old, cfg)["sub"] == "s1"
+    assert validate_event_token(tok_new, cfg)["sub"] == "s1"
+    keyset = jwks(cfg)
+    assert {k["kid"] for k in keyset["keys"]} == {"old", "new"}


### PR DESCRIPTION
## Summary
- support key rotation with JWKS export for gateway event tokens
- forward RBAC headers and correlation IDs to WorldService
- attach correlation IDs to CloudEvents

## Testing
- `uv run -m pytest -W error` *(fails: ModuleNotFoundError: No module named 'qmtl.indicators.gap_amplification_alpha')*
- `uv run -m pytest tests/gateway/test_event_descriptor.py -W error`

Closes #432

------
https://chatgpt.com/codex/tasks/task_e_68b21df1070c8329b49ce69dd5b0d8d6