### PR TITLE
refactor: modularize node validation and hashing

### DIFF
--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -25,6 +25,7 @@ from qmtl.sdk.data_io import (
     QuestDBLoader,
     QuestDBRecorder,
 )
+from .event_recorder_service import EventRecorderService
 from .backfill_engine import BackfillEngine
 from .util import parse_interval, parse_period, validate_tag, validate_name
 from .exceptions import (
@@ -59,6 +60,7 @@ __all__ = [
     "EventRecorder",
     "QuestDBLoader",
     "QuestDBRecorder",
+    "EventRecorderService",
     "BackfillEngine",
     "metrics",
     "TradeExecutionService",

--- a/qmtl/sdk/event_recorder_service.py
+++ b/qmtl/sdk/event_recorder_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Service wrapper for event recording."""
+
+import asyncio
+from typing import Any
+
+from .data_io import EventRecorder
+
+
+class EventRecorderService:
+    """Delegate asynchronous persistence to an :class:`EventRecorder`.
+
+    Parameters
+    ----------
+    recorder:
+        Concrete :class:`EventRecorder` implementation. When ``None``, calls to
+        :meth:`record` become no-ops.
+    """
+
+    def __init__(self, recorder: EventRecorder | None = None) -> None:
+        self.recorder = recorder
+
+    def record(self, node_id: str, interval: int, timestamp: int, payload: Any) -> None:
+        """Persist ``payload`` if a recorder was configured."""
+        if self.recorder is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(self.recorder.persist(node_id, interval, timestamp, payload))
+        else:  # pragma: no cover - scheduling in running loop
+            loop.create_task(self.recorder.persist(node_id, interval, timestamp, payload))
+
+
+__all__ = ["EventRecorderService"]

--- a/qmtl/sdk/hash_utils.py
+++ b/qmtl/sdk/hash_utils.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Reusable hashing helpers for nodes."""
+
+import hashlib
+import inspect
+import json
+from typing import Any
+
+
+def _sha256(data: bytes) -> str:
+    try:
+        h = hashlib.sha256()
+        h.update(data)
+        return h.hexdigest()
+    except Exception:
+        h = hashlib.sha3_256()
+        h.update(data)
+        return h.hexdigest()
+
+
+def _sha3(data: bytes) -> str:
+    h = hashlib.sha3_256()
+    h.update(data)
+    return h.hexdigest()
+
+
+def code_hash(compute_fn: Any) -> str:
+    """Return a stable hash for ``compute_fn``."""
+    if compute_fn is None:
+        return _sha256(b"null")
+    try:
+        source = inspect.getsource(compute_fn).encode()
+    except (OSError, TypeError):
+        source = getattr(compute_fn, "__code__", None)
+        if source is not None:
+            source = source.co_code
+        else:
+            source = repr(compute_fn).encode()
+    return _sha256(source)
+
+
+def config_hash(config: dict) -> str:
+    data = json.dumps(config, sort_keys=True).encode()
+    return _sha256(data)
+
+
+def schema_hash(schema: dict) -> str:
+    data = json.dumps(schema, sort_keys=True).encode()
+    return _sha256(data)
+
+__all__ = [
+    "_sha256",
+    "_sha3",
+    "code_hash",
+    "config_hash",
+    "schema_hash",
+]

--- a/qmtl/sdk/node_validation.py
+++ b/qmtl/sdk/node_validation.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Validation helpers for :mod:`qmtl.sdk.node`."""
+
+from collections.abc import Iterable, Mapping
+
+from .exceptions import InvalidParameterError
+from .util import validate_tag, validate_name
+
+
+def normalize_inputs(inp: "Node | Iterable[Node] | None") -> list["Node"]:
+    """Normalize ``inp`` into a list of nodes.
+
+    Raises
+    ------
+    TypeError
+        If ``inp`` is neither ``None``, a ``Node`` instance nor an iterable of
+        ``Node`` objects.
+    """
+    if inp is None:
+        return []
+    from .node import Node as NodeType  # local import to avoid circular
+    if isinstance(inp, NodeType):
+        return [inp]
+    if isinstance(inp, Mapping):
+        raise TypeError("mapping inputs no longer supported")
+    if isinstance(inp, Iterable):
+        return list(inp)
+    raise TypeError("invalid input type")
+
+
+def validate_tags(tags: list[str] | None) -> list[str]:
+    """Return a validated copy of ``tags``.
+
+    Duplicate tags raise :class:`InvalidParameterError`.
+    """
+    validated: list[str] = []
+    if tags is None:
+        return validated
+    if not isinstance(tags, list):
+        raise InvalidParameterError("tags must be a list")
+    seen: set[str] = set()
+    for tag in tags:
+        validated_tag = validate_tag(tag)
+        if validated_tag in seen:
+            raise InvalidParameterError(f"duplicate tag: {validated_tag!r}")
+        seen.add(validated_tag)
+        validated.append(validated_tag)
+    return validated
+
+
+def validate_name_value(name: str | None) -> str | None:
+    """Validate ``name`` and return the normalized value."""
+    return validate_name(name)
+
+
+def validate_config_schema(config, schema) -> None:
+    """Validate optional ``config`` and ``schema`` dictionaries."""
+    if config is not None and not isinstance(config, dict):
+        raise InvalidParameterError("config must be a dictionary")
+    if schema is not None and not isinstance(schema, dict):
+        raise InvalidParameterError("schema must be a dictionary")

--- a/tests/test_event_recorder_service.py
+++ b/tests/test_event_recorder_service.py
@@ -1,0 +1,20 @@
+import asyncio
+from qmtl.sdk import SourceNode
+from qmtl.sdk.event_recorder_service import EventRecorderService
+from qmtl.sdk.data_io import EventRecorder
+
+
+class DummyRecorder(EventRecorder):
+    def __init__(self):
+        self.records = []
+
+    async def persist(self, node_id: str, interval: int, timestamp: int, payload):
+        self.records.append((node_id, interval, timestamp, payload))
+
+
+def test_event_recorder_service_invocation():
+    recorder = DummyRecorder()
+    service = EventRecorderService(recorder)
+    node = SourceNode(interval="1s", period=1, event_recorder_service=service)
+    node.feed("up", 1, 0, {"v": 1})
+    assert recorder.records == [(node.node_id, 1, 0, {"v": 1})]


### PR DESCRIPTION
## Summary
- extract node input/name/tag validation to dedicated module
- move hashing helpers into reusable `hash_utils`
- introduce `EventRecorderService` and delegate from `Node.feed`
- export new utilities and add coverage for event recording

## Testing
- `uv run -m pytest -W error` *(fails: tests/gateway/test_event_descriptor.py::test_event_descriptor_scope_and_expiry, tests/gateway/test_world_proxy.py::test_status_reports_worldservice_breaker, tests/integrity/test_checksum.py::test_checksum_rejects_tampered_ids, tests/strategy/test_conflict.py::test_duplicate_strategy_returns_409, tests/tagquery/test_runner_live_updates.py::test_live_auto_subscribes, tests/gateway/test_tag_query.py::test_queues_by_tag_route)*

------
https://chatgpt.com/codex/tasks/task_e_68b486c83e9c8329ab302bee08960fc9