### PR TITLE
Refactor runner to use gateway client and tag service

### DIFF
--- a/qmtl/sdk/gateway_client.py
+++ b/qmtl/sdk/gateway_client.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Optional
+
+import httpx
+from opentelemetry.propagate import inject
+
+from qmtl.common import AsyncCircuitBreaker, crc32_of_list
+
+
+class GatewayClient:
+    """HTTP client for communicating with the Gateway service."""
+
+    def __init__(self, circuit_breaker: AsyncCircuitBreaker | None = None) -> None:
+        self._circuit_breaker = circuit_breaker or AsyncCircuitBreaker(max_failures=3)
+
+    def set_circuit_breaker(self, cb: AsyncCircuitBreaker | None) -> None:
+        """Replace the current circuit breaker."""
+        self._circuit_breaker = cb or AsyncCircuitBreaker(max_failures=3)
+
+    async def post_strategy(
+        self,
+        *,
+        gateway_url: str,
+        dag: dict,
+        meta: Optional[dict],
+        run_type: str,
+    ) -> dict:
+        """Submit a strategy DAG to the gateway."""
+        url = gateway_url.rstrip("/") + "/strategies"
+        payload = {
+            "dag_json": base64.b64encode(json.dumps(dag).encode()).decode(),
+            "meta": meta,
+            "run_type": run_type,
+            "node_ids_crc32": crc32_of_list(n["node_id"] for n in dag.get("nodes", [])),
+        }
+        headers: dict[str, str] = {}
+        inject(headers)
+        try:
+            client = httpx.AsyncClient(headers=headers)
+        except TypeError:
+            client = httpx.AsyncClient()
+        try:
+            client.headers.update(headers)  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        async with client:
+            post_fn = client.post
+            if self._circuit_breaker is not None:
+                post_fn = self._circuit_breaker(post_fn)
+            try:
+                resp = await post_fn(url, json=payload)
+            except Exception as exc:  # pragma: no cover - network errors
+                return {"error": str(exc)}
+        if resp.status_code == 202:
+            if self._circuit_breaker is not None:
+                self._circuit_breaker.reset()
+            return resp.json().get("queue_map", {})
+        if resp.status_code == 409:
+            return {"error": "duplicate strategy"}
+        if resp.status_code == 422:
+            return {"error": "invalid strategy payload"}
+        return {"error": f"gateway error {resp.status_code}"}

--- a/qmtl/sdk/history_loader.py
+++ b/qmtl/sdk/history_loader.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import asyncio
+
+from .node import StreamInput
+
+
+class HistoryLoader:
+    """Utility to load historical data for strategies."""
+
+    @staticmethod
+    async def load(strategy, start: int | None = None, end: int | None = None) -> None:
+        if start is None or end is None:
+            return
+        tasks = [
+            asyncio.create_task(n.load_history(start, end))
+            for n in strategy.nodes
+            if isinstance(n, StreamInput)
+        ]
+        if tasks:
+            await asyncio.gather(*tasks)

--- a/qmtl/sdk/tag_manager_service.py
+++ b/qmtl/sdk/tag_manager_service.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .tagquery_manager import TagQueryManager
+from .node import TagQueryNode
+
+logger = logging.getLogger(__name__)
+
+
+class TagManagerService:
+    """Manage tag queries and queue mappings for a strategy."""
+
+    def __init__(self, gateway_url: str | None) -> None:
+        self.gateway_url = gateway_url
+
+    def init(self, strategy) -> TagQueryManager:
+        """Initialize and attach a :class:`TagQueryManager` to ``strategy``."""
+        manager = TagQueryManager(self.gateway_url)
+        for n in strategy.nodes:
+            if isinstance(n, TagQueryNode):
+                manager.register(n)
+        setattr(strategy, "tag_query_manager", manager)
+        return manager
+
+    def apply_queue_map(self, strategy, queue_map: dict[str, str | list[str]]) -> None:
+        """Apply queue mappings to strategy nodes."""
+        for node in strategy.nodes:
+            mapping = queue_map.get(node.node_id)
+            old_execute = node.execute
+            if isinstance(node, TagQueryNode):
+                if isinstance(mapping, list):
+                    node.upstreams = list(mapping)
+                    node.execute = bool(mapping)
+                else:
+                    node.upstreams = []
+                    node.execute = False
+            else:
+                if mapping:
+                    node.execute = False
+                    node.kafka_topic = mapping  # type: ignore[assignment]
+                else:
+                    node.execute = True
+                    node.kafka_topic = None
+            if node.execute != old_execute:
+                logger.debug(
+                    "execute changed for %s: %s -> %s (mapping=%s)",
+                    node.node_id,
+                    old_execute,
+                    node.execute,
+                    mapping,
+                )

--- a/tests/sdk/test_history_loader.py
+++ b/tests/sdk/test_history_loader.py
@@ -1,0 +1,24 @@
+import pytest
+
+from qmtl.sdk import Strategy, StreamInput
+from qmtl.sdk.history_loader import HistoryLoader
+
+
+class _Strat(Strategy):
+    def setup(self):
+        self.src = StreamInput(interval="60s", period=2)
+        self.add_nodes([self.src])
+
+
+@pytest.mark.asyncio
+async def test_history_loader_calls_nodes(monkeypatch):
+    strat = _Strat()
+    strat.setup()
+    called = []
+
+    async def fake_load_history(self, start, end):
+        called.append((start, end))
+
+    monkeypatch.setattr(StreamInput, "load_history", fake_load_history)
+    await HistoryLoader.load(strat, 1, 2)
+    assert called == [(1, 2)]

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -97,8 +97,9 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
         async def get(self, url, params=None):
             return await self._client.get(url, params=params)
 
-    monkeypatch.setattr("qmtl.sdk.runner.httpx.AsyncClient", DummyClient)
+    monkeypatch.setattr("qmtl.sdk.gateway_client.httpx.AsyncClient", DummyClient)
     monkeypatch.setattr("qmtl.sdk.tagquery_manager.httpx.AsyncClient", DummyClient)
+    monkeypatch.setattr(Runner, "_kafka_available", True)
 
     strat = await Runner.live_async(TQStrategy, gateway_url="http://gw")
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -163,13 +163,16 @@ def test_gateway_queue_mapping(monkeypatch):
 
 
 def test_dry_run_exits_when_all_nodes_mapped(monkeypatch, caplog):
-    async def fake_post_gateway_async(*, gateway_url, dag, meta, run_type, circuit_breaker):
+    async def fake_post_gateway_async(*, gateway_url, dag, meta, run_type):
         return {n["node_id"]: "topic" for n in dag["nodes"]}
 
     def fake_run_pipeline(strategy):
         raise RuntimeError("should not run")
 
-    monkeypatch.setattr(Runner, "_post_gateway_async", staticmethod(fake_post_gateway_async))
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.Runner._gateway_client.post_strategy",
+        fake_post_gateway_async,
+    )
     monkeypatch.setattr(Runner, "run_pipeline", fake_run_pipeline)
 
     with caplog.at_level(logging.INFO):
@@ -183,7 +186,7 @@ def test_dry_run_exits_when_all_nodes_mapped(monkeypatch, caplog):
 def test_live_exits_when_all_nodes_mapped(monkeypatch, caplog):
     from qmtl.sdk.tagquery_manager import TagQueryManager
 
-    async def fake_post_gateway_async(*, gateway_url, dag, meta, run_type, circuit_breaker):
+    async def fake_post_gateway_async(*, gateway_url, dag, meta, run_type):
         return {n["node_id"]: "topic" for n in dag["nodes"]}
 
     def fake_run_pipeline(strategy):
@@ -192,7 +195,10 @@ def test_live_exits_when_all_nodes_mapped(monkeypatch, caplog):
     async def fake_start(self):
         raise RuntimeError("should not start")
 
-    monkeypatch.setattr(Runner, "_post_gateway_async", staticmethod(fake_post_gateway_async))
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.Runner._gateway_client.post_strategy",
+        fake_post_gateway_async,
+    )
     monkeypatch.setattr(Runner, "run_pipeline", fake_run_pipeline)
     monkeypatch.setattr(TagQueryManager, "start", fake_start)
 

--- a/tests/test_runner_postprocess.py
+++ b/tests/test_runner_postprocess.py
@@ -3,6 +3,7 @@ from typing import Any
 from qmtl.sdk.runner import Runner
 from qmtl.sdk.node import Node
 from qmtl.sdk.strategy import Strategy
+from qmtl.sdk.tag_manager_service import TagManagerService
 
 
 class AlphaPerformanceNode(Node):
@@ -52,8 +53,15 @@ def test_backtest_hooks(monkeypatch):
         async def resolve_tags(self, offline=False):
             pass
 
-    monkeypatch.setattr("qmtl.sdk.runner.Runner._post_gateway_async", staticmethod(fake_gateway))
-    monkeypatch.setattr(Runner, "_init_tag_manager", lambda s, u: DummyManager())
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.Runner._gateway_client.post_strategy",
+        fake_gateway,
+    )
+    monkeypatch.setattr(
+        TagManagerService,
+        "init",
+        lambda self, strategy: DummyManager(),
+    )
     monkeypatch.setattr("qmtl.sdk.runner.Runner._handle_alpha_performance", staticmethod(fake_alpha))
     monkeypatch.setattr("qmtl.sdk.runner.Runner._handle_trade_order", staticmethod(fake_order))
 
@@ -122,9 +130,16 @@ def test_live_hooks(monkeypatch):
         async def resolve_tags(self, offline=False):
             pass
 
-    monkeypatch.setattr("qmtl.sdk.runner.Runner._post_gateway_async", staticmethod(fake_gateway))
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.Runner._gateway_client.post_strategy",
+        fake_gateway,
+    )
     monkeypatch.setattr("qmtl.sdk.runner.Runner.run_pipeline", staticmethod(lambda s: None))
-    monkeypatch.setattr(Runner, "_init_tag_manager", lambda s, u: DummyManager())
+    monkeypatch.setattr(
+        TagManagerService,
+        "init",
+        lambda self, strategy: DummyManager(),
+    )
     monkeypatch.setattr("qmtl.sdk.runner.Runner._handle_alpha_performance", staticmethod(fake_alpha))
     monkeypatch.setattr("qmtl.sdk.runner.Runner._handle_trade_order", staticmethod(fake_order))
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -9,7 +9,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
 
-from qmtl.sdk.runner import Runner
+from qmtl.sdk.gateway_client import GatewayClient
 from qmtl.sdk.node import Node
 
 
@@ -42,8 +42,9 @@ async def test_post_gateway_propagates_trace(monkeypatch):
 
     monkeypatch.setattr(httpx, "AsyncClient", lambda **_: DummyClient())
     tracer = trace.get_tracer(__name__)
+    client = GatewayClient()
     with tracer.start_as_current_span("parent"):
-        await Runner._post_gateway_async(
+        await client.post_strategy(
             gateway_url="http://gw", dag={}, meta=None, run_type="test"
         )
     assert "traceparent" in captured


### PR DESCRIPTION
## Summary
- move gateway HTTP calls into a reusable GatewayClient
- extract TagManagerService for tag manager init and queue mapping
- isolate history loading in HistoryLoader and slim down Runner

## Testing
- `uv run -m pytest tests/sdk/test_gateway_client.py tests/sdk/test_tag_manager_service.py tests/sdk/test_history_loader.py tests/test_queue_map_logging.py tests/test_tracing.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b486c8767c8329bd5e95940de1ecb7