### PR TITLE
refactor: extract validation, hashing, and event services

### DIFF
--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -38,6 +38,7 @@ from .exceptions import (
 )
 from . import metrics
 from .trade_execution_service import TradeExecutionService
+from .event_service import EventRecorderService
 
 __all__ = [
     "Node",
@@ -62,6 +63,7 @@ __all__ = [
     "BackfillEngine",
     "metrics",
     "TradeExecutionService",
+    "EventRecorderService",
     "parse_interval",
     "parse_period",
     "validate_tag",

--- a/qmtl/sdk/event_service.py
+++ b/qmtl/sdk/event_service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+__all__ = ["EventRecorderService"]
+
+
+class EventRecorderService:
+    """Thin wrapper that persists events via the provided recorder."""
+
+    def __init__(self, recorder: Any) -> None:
+        self.recorder = recorder
+
+    def record(self, node_id: str, interval: int, timestamp: int, payload: Any) -> None:
+        if self.recorder is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(
+                self.recorder.persist(node_id, interval, timestamp, payload)
+            )
+        else:  # pragma: no cover - create_task executed in loop
+            loop.create_task(
+                self.recorder.persist(node_id, interval, timestamp, payload)
+            )
+
+    def bind_stream(self, stream: Any) -> None:
+        if self.recorder and hasattr(self.recorder, "bind_stream"):
+            self.recorder.bind_stream(stream)

--- a/qmtl/sdk/hash_utils.py
+++ b/qmtl/sdk/hash_utils.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from typing import Any
+
+__all__ = ["_sha256", "_sha3", "code_hash", "config_hash", "schema_hash"]
+
+
+def _sha256(data: bytes) -> str:
+    """Return the SHA-256 hex digest of ``data`` with SHA3 fallback."""
+    try:
+        h = hashlib.sha256()
+        h.update(data)
+        return h.hexdigest()
+    except Exception:  # pragma: no cover - unlikely fallback
+        h = hashlib.sha3_256()
+        h.update(data)
+        return h.hexdigest()
+
+
+def _sha3(data: bytes) -> str:
+    """Return the SHA3-256 hex digest of ``data``."""
+    h = hashlib.sha3_256()
+    h.update(data)
+    return h.hexdigest()
+
+
+def code_hash(compute_fn: Any) -> str:
+    """Hash the source of ``compute_fn`` for reproducible node ids."""
+    if compute_fn is None:
+        return _sha256(b"null")
+    try:
+        source = inspect.getsource(compute_fn).encode()
+    except (OSError, TypeError):
+        source = getattr(compute_fn, "__code__", None)
+        if source is not None:
+            source = source.co_code
+        else:
+            source = repr(compute_fn).encode()
+    return _sha256(source)
+
+
+def config_hash(config: dict) -> str:
+    """Return a stable hash for ``config`` dictionaries."""
+    data = json.dumps(config, sort_keys=True).encode()
+    return _sha256(data)
+
+
+def schema_hash(schema: dict) -> str:
+    """Return a stable hash for ``schema`` dictionaries."""
+    data = json.dumps(schema, sort_keys=True).encode()
+    return _sha256(data)

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import hashlib
 import inspect
 import json
 import os
-from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from typing import Any, TYPE_CHECKING
 import logging
 from enum import Enum
@@ -15,14 +13,15 @@ from opentelemetry import trace
 import numpy as np
 import xarray as xr
 import httpx
-import asyncio
 
 from .cache_view import CacheView
 from .backfill_state import BackfillState
-from .util import parse_interval, parse_period, validate_tag, validate_name
 from .exceptions import NodeValidationError, InvalidParameterError
 from . import arrow_cache
 from . import metrics as sdk_metrics
+from . import node_validation as default_validator
+from . import hash_utils as default_hash_utils
+from .event_service import EventRecorderService
 
 if TYPE_CHECKING:  # pragma: no cover - type checking import
     from qmtl.io import HistoryProvider, EventRecorder
@@ -377,21 +376,10 @@ class Node:
     """
 
     # ------------------------------------------------------------------
-    @staticmethod
-    def _normalize_inputs(inp: Node | Iterable[Node] | None) -> list[Node]:
-        if inp is None:
-            return []
-        if isinstance(inp, Node):
-            return [inp]
-        if isinstance(inp, Mapping):
-            raise TypeError("mapping inputs no longer supported")
-        if isinstance(inp, Iterable):
-            return list(inp)
-        raise TypeError("invalid input type")
 
     def __init__(
         self,
-        input: Node | Iterable[Node] | None = None,
+        input: "Node" | Iterable["Node"] | None = None,
         compute_fn=None,
         name: str | None = None,
         interval: int | str | None = None,
@@ -399,60 +387,32 @@ class Node:
         tags: list[str] | None = None,
         config: dict | None = None,
         schema: dict | None = None,
+        *,
+        validator=default_validator,
+        hash_utils=default_hash_utils,
+        event_service: EventRecorderService | None = None,
     ) -> None:
-        # Validate and parse parameters
-        interval_val = parse_interval(interval) if interval is not None else None
-        period_val = parse_period(period) if period is not None else None
-        
-        # Validate name
-        validated_name = validate_name(name)
-        
-        # Validate tags
-        validated_tags = []
-        if tags is not None:
-            if not isinstance(tags, list):
-                raise InvalidParameterError("tags must be a list")
-            seen_tags = set()
-            for tag in tags:
-                validated_tag = validate_tag(tag)
-                if validated_tag in seen_tags:
-                    raise InvalidParameterError(f"duplicate tag: {validated_tag!r}")
-                seen_tags.add(validated_tag)
-                validated_tags.append(validated_tag)
-        
-        # Validate config and schema
-        if config is not None and not isinstance(config, dict):
-            raise InvalidParameterError("config must be a dictionary")
-        if schema is not None and not isinstance(schema, dict):
-            raise InvalidParameterError("schema must be a dictionary")
-        
-        # Validate compatibility between interval and period
-        if interval_val is not None and period_val is not None:
-            if period_val < 1:
-                raise InvalidParameterError("period must be at least 1 when interval is specified")
+        self.validator = validator
+        self.hash_utils = hash_utils
+        self.event_service = event_service
 
-        if compute_fn is not None:
-            sig = inspect.signature(compute_fn)
-            positional = [
-                p
-                for p in sig.parameters.values()
-                if p.kind
-                in (
-                    inspect.Parameter.POSITIONAL_ONLY,
-                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                )
-            ]
-            has_var_positional = any(
-                p.kind == inspect.Parameter.VAR_POSITIONAL
-                for p in sig.parameters.values()
-            )
-            if len(positional) != 1 or has_var_positional:
-                raise TypeError(
-                    "compute_fn must accept exactly one positional argument (지원되지 않는 함수 시그니처). compute_fn(view) 형태로 작성했는지 확인하세요"
-                )
+        validator.validate_compute_fn(compute_fn)
+        (
+            validated_name,
+            validated_tags,
+            interval_val,
+            period_val,
+        ) = validator.validate_node_params(
+            name,
+            tags,
+            interval,
+            period,
+            config,
+            schema,
+        )
 
         self.input = input
-        self.inputs = self._normalize_inputs(input)
+        self.inputs = validator.normalize_inputs(input)
         self.compute_fn = compute_fn
         self.name = validated_name
         self.interval = interval_val
@@ -475,57 +435,27 @@ class Node:
 
     def add_tag(self, tag: str) -> "Node":
         """Append ``tag`` to :attr:`tags` if missing and return ``self``."""
-        validated_tag = validate_tag(tag)
+        validated_tag = self.validator.validate_tag(tag)
         if validated_tag not in self.tags:
             self.tags.append(validated_tag)
         return self
 
     # --- hashing helpers -------------------------------------------------
-    @staticmethod
-    def _sha256(data: bytes) -> str:
-        try:
-            h = hashlib.sha256()
-            h.update(data)
-            return h.hexdigest()
-        except Exception:
-            # Fallback if sha256 unavailable
-            h = hashlib.sha3_256()
-            h.update(data)
-            return h.hexdigest()
-
-    @staticmethod
-    def _sha3(data: bytes) -> str:
-        h = hashlib.sha3_256()
-        h.update(data)
-        return h.hexdigest()
-
     @property
     def node_type(self) -> str:
         return self.__class__.__name__
 
     @property
     def code_hash(self) -> str:
-        if self.compute_fn is None:
-            return self._sha256(b"null")
-        try:
-            source = inspect.getsource(self.compute_fn).encode()
-        except (OSError, TypeError):
-            source = getattr(self.compute_fn, "__code__", None)
-            if source is not None:
-                source = source.co_code
-            else:
-                source = repr(self.compute_fn).encode()
-        return self._sha256(source)
+        return self.hash_utils.code_hash(self.compute_fn)
 
     @property
     def config_hash(self) -> str:
-        data = json.dumps(self.config, sort_keys=True).encode()
-        return self._sha256(data)
+        return self.hash_utils.config_hash(self.config)
 
     @property
     def schema_hash(self) -> str:
-        data = json.dumps(self.schema, sort_keys=True).encode()
-        return self._sha256(data)
+        return self.hash_utils.schema_hash(self.schema)
 
     @property
     def node_id(self) -> str:
@@ -578,16 +508,8 @@ class Node:
                 self.node_id, self.cache.resident_bytes
             )
 
-        recorder = getattr(self, "event_recorder", None)
-        if recorder is not None:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                asyncio.run(recorder.persist(self.node_id, interval, timestamp, payload))
-            else:
-                loop.create_task(
-                    recorder.persist(self.node_id, interval, timestamp, payload)
-                )
+        if self.event_service is not None:
+            self.event_service.record(self.node_id, interval, timestamp, payload)
 
         if self.pre_warmup and self.cache.ready():
             self.pre_warmup = False
@@ -638,9 +560,10 @@ class ProcessingNode(Node):
 class StreamInput(SourceNode):
     """Represents an upstream data stream placeholder.
 
-    ``history_provider`` and ``event_recorder`` must be supplied when the
-    instance is created. These dependencies are immutable for the lifetime of
-    the node and attempts to reassign them will raise ``AttributeError``.
+    ``history_provider`` and ``event_service`` must be supplied when the
+    instance is created. For backward compatibility an ``event_recorder`` may
+    be provided and will be wrapped by :class:`EventRecorderService`. These
+    dependencies are immutable for the lifetime of the node.
     """
 
     def __init__(
@@ -651,7 +574,12 @@ class StreamInput(SourceNode):
         *,
         history_provider: "HistoryProvider" | None = None,
         event_recorder: "EventRecorder" | None = None,
+        event_service: EventRecorderService | None = None,
+        validator=default_validator,
+        hash_utils=default_hash_utils,
     ) -> None:
+        if event_service is None and event_recorder is not None:
+            event_service = EventRecorderService(event_recorder)
         super().__init__(
             input=None,
             compute_fn=None,
@@ -659,13 +587,15 @@ class StreamInput(SourceNode):
             interval=interval,
             period=period,
             tags=tags or [],
+            validator=validator,
+            hash_utils=hash_utils,
+            event_service=event_service,
         )
         self._history_provider = history_provider
         if history_provider and hasattr(history_provider, "bind_stream"):
             history_provider.bind_stream(self)
-        self._event_recorder = event_recorder
-        if event_recorder and hasattr(event_recorder, "bind_stream"):
-            event_recorder.bind_stream(self)
+        if event_service and hasattr(event_service, "bind_stream"):
+            event_service.bind_stream(self)
 
     @property
     def history_provider(self) -> "HistoryProvider" | None:
@@ -678,8 +608,10 @@ class StreamInput(SourceNode):
 
     @property
     def event_recorder(self) -> "EventRecorder" | None:
-        """Return the configured event recorder."""
-        return self._event_recorder
+        """Return the configured event recorder, if any."""
+        if self.event_service is None:
+            return None
+        return getattr(self.event_service, "recorder", None)
 
     @event_recorder.setter
     def event_recorder(self, value: "EventRecorder" | None) -> None:
@@ -731,7 +663,7 @@ class TagQueryNode(SourceNode):
         validated_query_tags = []
         seen_tags = set()
         for tag in query_tags:
-            validated_tag = validate_tag(tag)
+            validated_tag = default_validator.validate_tag(tag)
             if validated_tag in seen_tags:
                 raise InvalidParameterError(f"duplicate query tag: {validated_tag!r}")
             seen_tags.add(validated_tag)

--- a/qmtl/sdk/node_validation.py
+++ b/qmtl/sdk/node_validation.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from .util import parse_interval, parse_period, validate_tag, validate_name
+from .exceptions import InvalidParameterError
+
+__all__ = [
+    "normalize_inputs",
+    "validate_node_params",
+    "validate_compute_fn",
+    "validate_tag",
+    "validate_name",
+]
+
+
+def normalize_inputs(inp: Any) -> list:
+    """Normalize ``inp`` into a list of upstream nodes."""
+    from .node import Node  # local import to avoid circular dependency
+
+    if inp is None:
+        return []
+    if isinstance(inp, Node):
+        return [inp]
+    if isinstance(inp, Mapping):
+        raise TypeError("mapping inputs no longer supported")
+    if isinstance(inp, Iterable):
+        return list(inp)
+    raise TypeError("invalid input type")
+
+
+def validate_node_params(
+    name: str | None,
+    tags: list[str] | None,
+    interval: int | str | None,
+    period: int | None,
+    config: dict | None,
+    schema: dict | None,
+) -> tuple[str | None, list[str], int | None, int | None]:
+    """Validate common ``Node`` constructor arguments."""
+    interval_val = parse_interval(interval) if interval is not None else None
+    period_val = parse_period(period) if period is not None else None
+
+    validated_name = validate_name(name)
+
+    validated_tags: list[str] = []
+    if tags is not None:
+        if not isinstance(tags, list):
+            raise InvalidParameterError("tags must be a list")
+        seen_tags = set()
+        for tag in tags:
+            validated_tag = validate_tag(tag)
+            if validated_tag in seen_tags:
+                raise InvalidParameterError(f"duplicate tag: {validated_tag!r}")
+            seen_tags.add(validated_tag)
+            validated_tags.append(validated_tag)
+
+    if config is not None and not isinstance(config, dict):
+        raise InvalidParameterError("config must be a dictionary")
+    if schema is not None and not isinstance(schema, dict):
+        raise InvalidParameterError("schema must be a dictionary")
+
+    if interval_val is not None and period_val is not None and period_val < 1:
+        raise InvalidParameterError(
+            "period must be at least 1 when interval is specified"
+        )
+
+    return validated_name, validated_tags, interval_val, period_val
+
+
+def validate_compute_fn(compute_fn) -> None:
+    """Ensure ``compute_fn`` has a valid callable signature."""
+    if compute_fn is None:
+        return
+    sig = inspect.signature(compute_fn)
+    positional = [
+        p
+        for p in sig.parameters.values()
+        if p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    has_var_positional = any(
+        p.kind == inspect.Parameter.VAR_POSITIONAL for p in sig.parameters.values()
+    )
+    if len(positional) != 1 or has_var_positional:
+        raise TypeError(
+            "compute_fn must accept exactly one positional argument (지원되지 않는 함수 시그니처). compute_fn(view) 형태로 작성했는지 확인하세요"
+        )


### PR DESCRIPTION
## Summary
- centralize node input/name/tag validation in new `node_validation` module
- expose reusable hashing utilities and event recorder service
- inject validation, hashing, and event services into nodes for easier testing

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error` *(fails: tests/gateway/test_deprecation.py::test_queues_watch_has_deprecation_headers, tests/gateway/test_event_descriptor.py::test_event_descriptor_scope_and_expiry, tests/gateway/test_tag_query.py::test_dag_client_queries_grpc, tests/gateway/test_world_proxy.py::test_status_reports_worldservice_breaker, tests/tagquery/test_runner_live_updates.py::test_live_auto_subscribes)*

------
https://chatgpt.com/codex/tasks/task_e_68b48f6dcb788329bbfa83d32c2e224d