### PR TITLE
Propagate dryrun failures via CLI exit codes

### DIFF
--- a/qmtl/__main__.py
+++ b/qmtl/__main__.py
@@ -1,4 +1,5 @@
 from .cli import main
+import sys
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/qmtl/cli/sdk.py
+++ b/qmtl/cli/sdk.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from typing import List
 
 
@@ -10,5 +11,5 @@ def run(argv: List[str] | None = None) -> None:
     from qmtl.sdk.cli import main as sdk_main
 
     logging.basicConfig(level=logging.INFO)
-    sdk_main(argv)
+    sys.exit(sdk_main(argv))
 


### PR DESCRIPTION
## Summary
- handle `Runner.dryrun_async` errors and return non-zero status
- propagate SDK CLI exit codes through top-level entry points

## Testing
- `uv run -m pytest -W error` *(fails: tests/gateway/test_deprecation.py::test_queues_watch_has_deprecation_headers, tests/gateway/test_event_descriptor.py::test_event_descriptor_scope_and_expiry, tests/gateway/test_tag_query.py::test_dag_client_queries_grpc, tests/gateway/test_world_proxy.py::test_status_reports_worldservice_breaker, tests/tagquery/test_runner_live_updates.py::test_live_auto_subscribes)*

------
https://chatgpt.com/codex/tasks/task_e_68b4966b80c083298b07eb9143c3525a