### PR TITLE
Normalize string intervals during node initialization

### DIFF
--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -22,6 +22,7 @@ from . import metrics as sdk_metrics
 from . import node_validation as default_validator
 from . import hash_utils as default_hash_utils
 from .event_service import EventRecorderService
+from .util import parse_interval
 
 if TYPE_CHECKING:  # pragma: no cover - type checking import
     from qmtl.io import HistoryProvider, EventRecorder
@@ -396,6 +397,9 @@ class Node:
         self.hash_utils = hash_utils
         self.event_service = event_service
 
+        if isinstance(interval, str):
+            interval = parse_interval(interval)
+
         validator.validate_compute_fn(compute_fn)
         (
             validated_name,
@@ -410,6 +414,9 @@ class Node:
             config,
             schema,
         )
+
+        if isinstance(interval_val, str):
+            interval_val = parse_interval(interval_val)
 
         self.input = input
         self.inputs = validator.normalize_inputs(input)

--- a/tests/test_string_interval.py
+++ b/tests/test_string_interval.py
@@ -1,4 +1,4 @@
-from qmtl.sdk import StreamInput, ProcessingNode, Runner
+from qmtl.sdk import Node, ProcessingNode, Runner, StreamInput
 
 
 def _compute(view):
@@ -18,3 +18,19 @@ def test_node_with_string_interval_behaves_like_int():
     assert src_str.interval == src_int.interval == 60
     assert node_str.interval == node_int.interval == 60
     assert node_str.cache.get_slice("q", 60, count=1) == node_int.cache.get_slice("q", 60, count=1)
+
+
+def test_streaminput_interval_string_normalization():
+    src = StreamInput(interval="1m", period=2)
+    assert src.interval == 60
+
+
+def test_processingnode_interval_string_normalization():
+    src = StreamInput(interval=60, period=2)
+    node = ProcessingNode(input=src, compute_fn=_compute, name="n", interval="1m", period=2)
+    assert node.interval == 60
+
+
+def test_node_interval_string_normalization():
+    node = Node(input=None, compute_fn=_compute, name="n", interval="1m", period=2)
+    assert node.interval == 60


### PR DESCRIPTION
## Summary
- Normalize string `interval` values in `Node.__init__` using `parse_interval`
- Add tests ensuring `Node`, `StreamInput`, and `ProcessingNode` convert `'1m'` to `60`

## Testing
- `uv run -m pytest -W error tests/test_string_interval.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49a92ba288329bbf65a5cd114b6cb