### PR TITLE
Preserve trade execution service across module reload

### DIFF
--- a/tests/test_runner_trade_execution_service.py
+++ b/tests/test_runner_trade_execution_service.py
@@ -25,3 +25,17 @@ def test_runner_trade_execution_service_invoked():
         service.post_order.assert_called_once_with({"side": "BUY"})
     finally:
         runner_mod.Runner.set_trade_execution_service(None)
+
+
+def test_runner_trade_execution_service_survives_reload():
+    service = MagicMock()
+    runner_module.Runner.set_trade_execution_service(service)
+    try:
+        runner_module.Runner._handle_trade_order({"side": "BUY"})
+        service.post_order.assert_called_once_with({"side": "BUY"})
+        service.post_order.reset_mock()
+        importlib.reload(runner_module)
+        runner_module.Runner._handle_trade_order({"side": "SELL"})
+        service.post_order.assert_called_once_with({"side": "SELL"})
+    finally:
+        runner_module.Runner.set_trade_execution_service(None)


### PR DESCRIPTION
## Summary
- keep a module-level trade execution service sentinel across module reloads
- sync `Runner.set_trade_execution_service` with the global service reference
- verify trade execution service usage persists after reloading the runner module

## Testing
- `uv run -m pytest tests/test_runner_trade_execution_service.py::test_runner_trade_execution_service_invoked tests/test_runner_trade_execution_service.py::test_runner_trade_execution_service_survives_reload tests/test_trade_execution_service.py::test_runner_delegates_to_service -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49bfbf6508329882c1b3e57a04160