### PR TITLE
Fix WebSocket hub topic routing for activation and policy events

### DIFF
--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -217,12 +217,12 @@ class WebSocketHub:
     async def send_activation_updated(self, payload: dict) -> None:
         """Broadcast activation updates."""
         event = format_event("qmtl.gateway", "activation_updated", payload)
-        await self.broadcast(event, topic="policy")
+        await self.broadcast(event, topic="activation")
 
     async def send_policy_updated(self, payload: dict) -> None:
         """Broadcast policy updates."""
         event = format_event("qmtl.gateway", "policy_updated", payload)
-        await self.broadcast(event)
+        await self.broadcast(event, topic="policy")
 
 
 __all__ = ["WebSocketHub"]


### PR DESCRIPTION
## Summary
- broadcast activation updates on the `activation` topic
- scope policy updates to the `policy` topic
- test hub topic routing by subscription

Fixes #468

## Testing
- `uv run -m pytest -W error tests/gateway/test_ws.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4a39763388329a728ddc8a3d2b4bf