### PR TITLE
docs: clarify event token kid location

### DIFF
--- a/docs/architecture/controlbus.md
+++ b/docs/architecture/controlbus.md
@@ -123,7 +123,7 @@ Runbooks
 - Initial snapshot: first message per topic SHOULD be a full snapshot or include a `state_hash` so clients can confirm convergence without a full GET.
 - Clients MAY probe `/worlds/{id}/{topic}/state_hash` via Gateway to check for divergence before fetching a snapshot.
 - Delegated WS (feature‑flagged): Gateway may return an alternate `alt_stream_url` that points to a dedicated event streamer tier sitting in front of ControlBus.
-  - Tokens are short‑lived JWTs with claims: `aud=controlbus`, `sub=<user|svc>`, `world_id`, `strategy_id`, `topics`, `jti`, `iat`, `exp`, `kid`.
+  - Tokens are short‑lived JWTs with claims: `aud=controlbus`, `sub=<user|svc>`, `world_id`, `strategy_id`, `topics`, `jti`, `iat`, `exp`. Key ID (`kid`) is conveyed in the JWT header.
   - Streamer verifies JWKS/claims and bridges to ControlBus; default deployment keeps this disabled.
 
 {{ nav_links() }}

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -248,7 +248,7 @@ Token (JWT) claims (delegated WS or future use):
 - `aud`: `controlbus`
 - `sub`: user/service identity
 - `world_id`, `strategy_id`, `topics`: subscription scope
-- `jti`, `iat`, `exp`, `kid`: idempotency and keying
+- `jti`, `iat`, `exp`: idempotency and keying. Key ID (`kid`) is conveyed in the JWT header.
 
 ### Legacy Queue Watch & HTTP Fallback
 

--- a/docs/architecture/implementation_todos.md
+++ b/docs/architecture/implementation_todos.md
@@ -20,7 +20,7 @@ Related specs:
   - Spec refs: architecture/gateway.md §S6; architecture/worldservice.md §2–§6; reference/api_world.md; reference/schemas.md.
 
 - Event Stream Descriptor endpoint:
-  - Implement POST "/events/subscribe" -> returns "{ stream_url, token, topics, expires_at, fallback_url }". Generate short-lived JWT (claims: "aud=controlbus", "sub", "world_id", "strategy_id", "topics", "jti", "iat", "exp", "kid").
+  - Implement POST "/events/subscribe" -> returns "{ stream_url, token, topics, expires_at, fallback_url }". Generate short-lived JWT (claims: "aud=controlbus", "sub", "world_id", "strategy_id", "topics", "jti", "iat", "exp". Key ID ("kid") is conveyed in the JWT header).
   - Provide WS entrypoint (e.g., "wss://…/ws/evt") that relays ControlBus events to clients; first message per topic MUST be a full snapshot or include "state_hash".
   - Spec refs: architecture/gateway.md §S6, architecture/controlbus.md §7, reference/api_world.md.
 

--- a/docs/reference/api_world.md
+++ b/docs/reference/api_world.md
@@ -109,7 +109,7 @@ Response
 ```json
 { "stream_url": "wss://gateway/ws/evt?ticket=...", "token": "<jwt>", "topics": ["activation"], "expires_at": "...", "fallback_url": "wss://gateway/ws/fallback" }
 ```
-Initial message MUST be a full snapshot or include a `state_hash` per topic. Tokens are short‑lived JWTs with claims: `aud`, `sub`, `world_id`, `strategy_id`, `topics`, `jti`, `iat`, `exp`, `kid`.
+Initial message MUST be a full snapshot or include a `state_hash` per topic. Tokens are short‑lived JWTs with claims: `aud`, `sub`, `world_id`, `strategy_id`, `topics`, `jti`, `iat`, `exp`. Key ID (`kid`) is conveyed in the JWT header.
 
 ### GET /events/jwks
 Returns a JWKS document describing the current and previous signing keys for event stream tokens.

--- a/qmtl/gateway/event_descriptor.py
+++ b/qmtl/gateway/event_descriptor.py
@@ -1,8 +1,9 @@
 """Utility helpers for event stream JWT descriptors.
 
 This module provides minimal JWT creation and validation using symmetric
-HMAC keys. Keys are identified by ``kid`` allowing rotation. A helper is
-also provided to expose the configured keys as a JWKS document so that
+HMAC keys. Keys are identified by ``kid`` allowing rotation. The ``kid``
+is embedded in the JWT header, not the payload claims. A helper is also
+provided to expose the configured keys as a JWKS document so that
 external services can validate tokens without sharing secrets.
 
 The implementation intentionally avoids external dependencies to keep the
@@ -46,7 +47,11 @@ class EventDescriptorConfig:
 
 
 def sign_event_token(claims: dict[str, Any], cfg: EventDescriptorConfig) -> str:
-    """Return a signed JWT containing ``claims``."""
+    """Return a signed JWT containing ``claims``.
+
+    The key ID used for signing is written to the JWT header; ``claims``
+    MUST NOT include a ``kid`` entry.
+    """
 
     secret = cfg.keys[cfg.active_kid]
     header = {"alg": "HS256", "typ": "JWT", "kid": cfg.active_kid}

--- a/qmtl/gateway/event_handlers.py
+++ b/qmtl/gateway/event_handlers.py
@@ -81,6 +81,8 @@ def create_event_router(
             "iat": int(now.timestamp()),
             "exp": int(exp.timestamp()),
         }
+        # ``kid`` is not part of the payload claims; ``sign_event_token`` writes
+        # the key identifier to the JWT header.
         token = sign_event_token(claims, event_config)
         return EventSubscribeResponse(
             stream_url=event_config.stream_url,

--- a/tests/gateway/test_event_descriptor.py
+++ b/tests/gateway/test_event_descriptor.py
@@ -54,6 +54,7 @@ async def test_event_descriptor_scope_and_expiry(fake_redis):
     assert claims["world_id"] == "w1"
     assert claims["strategy_id"] == "s1"
     assert claims["topics"] == ["activation"]
+    assert "kid" not in claims
     header = get_token_header(token)
     assert header["kid"] == cfg.active_kid
     now = int(time.time())


### PR DESCRIPTION
## Summary
- document that event token `kid` lives in JWT header
- note header-only `kid` in event token helpers
- assert event token claims omit `kid`

## Testing
- `uv run mkdocs build`
- `uv run -m pytest -W error` *(fails: test_deprecation, test_event_descriptor_scope_and_expiry, test_tag_query_dag_client_queries_grpc, test_status_reports_worldservice_breaker, test_runner_live_updates)*
- `uv run -m pytest -W error tests/gateway/test_event_descriptor.py::test_event_descriptor_scope_and_expiry`
- `uv run -m pytest -W error tests/gateway/test_event_handlers_module.py::test_event_subscription_endpoints`

Closes #472

------
https://chatgpt.com/codex/tasks/task_e_68b4a3b21f688329a41edea65b864ac2