### PR TITLE
feat: serve stale WorldService cache on errors

### DIFF
--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -67,6 +67,12 @@ worlds_cache_hits_total = Counter(
     registry=global_registry,
 )
 
+worlds_cache_stale_total = Counter(
+    "worlds_cache_stale_total",
+    "Total number of stale responses served by WorldService proxy",
+    registry=global_registry,
+)
+
 worlds_cache_hit_ratio = Gauge(
     "worlds_cache_hit_ratio",
     "Cache hit ratio for WorldService proxy requests",
@@ -194,6 +200,12 @@ def record_worlds_cache_hit() -> None:
     _update_worlds_cache_ratio()
 
 
+def record_worlds_stale_served() -> None:
+    """Record that a stale cached response was served."""
+    worlds_cache_stale_total.inc()
+    worlds_cache_stale_total._val = worlds_cache_stale_total._value.get()  # type: ignore[attr-defined]
+
+
 def _update_worlds_cache_ratio() -> None:
     total = worlds_cache_hits_total._value.get() + worlds_proxy_requests_total._value.get()
     ratio = worlds_cache_hits_total._value.get() / total if total else 0
@@ -254,6 +266,8 @@ def reset_metrics() -> None:
     worlds_proxy_requests_total._val = 0  # type: ignore[attr-defined]
     worlds_cache_hits_total._value.set(0)  # type: ignore[attr-defined]
     worlds_cache_hits_total._val = 0  # type: ignore[attr-defined]
+    worlds_cache_stale_total._value.set(0)  # type: ignore[attr-defined]
+    worlds_cache_stale_total._val = 0  # type: ignore[attr-defined]
     worlds_cache_hit_ratio.set(0)
     worlds_cache_hit_ratio._val = 0  # type: ignore[attr-defined]
     _worlds_samples.clear()

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -277,8 +277,11 @@ def create_api_router(
             headers["X-World-Roles"] = roles
         cid = uuid.uuid4().hex
         headers["X-Correlation-ID"] = cid
-        data = await client.get_decide(world_id, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        data, stale = await client.get_decide(world_id, headers=headers)
+        resp_headers = {"X-Correlation-ID": cid}
+        if stale:
+            resp_headers.update({"Warning": "110 - Response is stale", "X-Stale": "true"})
+        return JSONResponse(data, headers=resp_headers)
 
     @router.get("/worlds/{world_id}/activation")
     async def get_world_activation(world_id: str, request: Request) -> Any:
@@ -294,8 +297,11 @@ def create_api_router(
             headers["X-World-Roles"] = roles
         cid = uuid.uuid4().hex
         headers["X-Correlation-ID"] = cid
-        data = await client.get_activation(world_id, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        data, stale = await client.get_activation(world_id, headers=headers)
+        resp_headers = {"X-Correlation-ID": cid}
+        if stale:
+            resp_headers.update({"Warning": "110 - Response is stale", "X-Stale": "true"})
+        return JSONResponse(data, headers=resp_headers)
 
     @router.get("/worlds/{world_id}/{topic}/state_hash")
     async def get_world_state_hash(world_id: str, topic: str, request: Request) -> Any:

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -207,3 +207,96 @@ async def test_status_reports_worldservice_breaker(fake_redis):
     await asgi.aclose()
     await client._client.aclose()
     assert s.json()["worldservice"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_decide_stale_on_upstream_failure(fake_redis):
+    metrics.reset_metrics()
+    calls = {"n": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/decide"):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(200, json={"v": 1}, headers={"Cache-Control": "max-age=60"})
+            return httpx.Response(500)
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        r1 = await api_client.get("/worlds/abc/decide")
+        client._decision_cache["abc"].expires_at = 0  # expire cache
+        r2 = await api_client.get("/worlds/abc/decide")
+    await asgi.aclose()
+    await client._client.aclose()
+    assert r1.json() == {"v": 1}
+    assert r2.json() == {"v": 1}
+    assert r2.headers["X-Stale"] == "true"
+    assert metrics.worlds_cache_stale_total._value.get() == 1
+
+
+@pytest.mark.asyncio
+async def test_decide_failure_no_cache(fake_redis):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/decide"):
+            return httpx.Response(500)
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await api_client.get("/worlds/abc/decide")
+    await asgi.aclose()
+    await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_activation_stale_on_upstream_failure(fake_redis):
+    metrics.reset_metrics()
+    calls = {"n": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/activation"):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(200, json={"a": 1}, headers={"ETag": "abc"})
+            return httpx.Response(500)
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        r1 = await api_client.get("/worlds/abc/activation")
+        r2 = await api_client.get("/worlds/abc/activation")
+    await asgi.aclose()
+    await client._client.aclose()
+    assert r1.json() == {"a": 1}
+    assert r2.json() == {"a": 1}
+    assert r2.headers["X-Stale"] == "true"
+    assert metrics.worlds_cache_stale_total._value.get() == 1
+
+
+@pytest.mark.asyncio
+async def test_activation_failure_no_cache(fake_redis):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/activation"):
+            return httpx.Response(500)
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await api_client.get("/worlds/abc/activation")
+    await asgi.aclose()
+    await client._client.aclose()


### PR DESCRIPTION
## Summary
- support stale-while-revalidate for WorldService decide and activation requests
- add metric for stale cache responses and propagate `Warning`/`X-Stale` headers
- test stale fallback and error behavior

## Testing
- `uv run -m pytest -W error` *(fails: tests/tagquery/test_runner_live_updates.py F)*
- `uv run -m pytest -W error tests/gateway/test_world_proxy.py::test_decide_stale_on_upstream_failure tests/gateway/test_world_proxy.py::test_decide_failure_no_cache tests/gateway/test_world_proxy.py::test_activation_stale_on_upstream_failure tests/gateway/test_world_proxy.py::test_activation_failure_no_cache`

Fixes #471

------
https://chatgpt.com/codex/tasks/task_e_68b4a3ac997883299b79cd563dd6203f