### PR TITLE
feat(gateway): add allow-live CLI flag

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -212,6 +212,7 @@ Available flags:
 
 - ``--config`` – optional path to configuration file.
 - ``--no-sentinel`` – disable automatic ``VersionSentinel`` insertion.
+- ``--allow-live`` – disable the live trading guard requiring ``X-Allow-Live: true``.
 
 ---
 
@@ -264,7 +265,9 @@ SDKs should use the event stream when available and periodically reconcile via
   - ``/activation`` → inactive
 - Event stream unavailable:
   - Reconnect with provided ``fallback_url``; SDK may periodically reconcile via HTTP
-- Live guard: even if DecisionEnvelope says ``live``, Gateway requires explicit caller consent (e.g., CLI `--allow-live` or header `X-Allow-Live: true`).
+- Live guard: Gateway rejects live trading unless consent is given.
+  - When enabled, callers must include header ``X-Allow-Live: true``.
+  - Starting Gateway with ``--allow-live`` disables the guard for testing.
 - Identity propagation: Gateway forwards caller identity (JWT subject/claims) to WorldService; WorldService logs it in audit records.
 
 See also: World API Reference (reference/api_world.md) and Schemas (reference/schemas.md).

--- a/qmtl/gateway/cli.py
+++ b/qmtl/gateway/cli.py
@@ -25,6 +25,13 @@ async def _main(argv: list[str] | None = None) -> None:
         help="Disable automatic VersionSentinel insertion",
         default=None,
     )
+    parser.add_argument(
+        "--allow-live",
+        dest="enforce_live_guard",
+        action="store_false",
+        help="Disable live trading guard requiring X-Allow-Live header",
+        default=None,
+    )
     args = parser.parse_args(argv)
 
     cfg_path = args.config or find_config_file()
@@ -40,6 +47,11 @@ async def _main(argv: list[str] | None = None) -> None:
         config.insert_sentinel
         if args.insert_sentinel is None
         else args.insert_sentinel
+    )
+    enforce_live_guard = (
+        config.enforce_live_guard
+        if args.enforce_live_guard is None
+        else args.enforce_live_guard
     )
     consumer = None
     if config.controlbus_topics:
@@ -59,7 +71,7 @@ async def _main(argv: list[str] | None = None) -> None:
         worldservice_timeout=config.worldservice_timeout,
         worldservice_retries=config.worldservice_retries,
         enable_worldservice_proxy=config.enable_worldservice_proxy,
-        enforce_live_guard=config.enforce_live_guard,
+        enforce_live_guard=enforce_live_guard,
     )
     db = app.state.database
     if hasattr(db, "connect"):

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -89,11 +89,12 @@ def create_api_router(
     router = APIRouter()
 
     @router.get("/status")
-    async def status_endpoint() -> dict[str, str]:
+    async def status_endpoint() -> dict[str, Any]:
         health_data = await gateway_health(
             redis_conn, database_obj, dagmanager, world_client
         )
         health_data["degrade_level"] = degradation.level.name
+        health_data["enforce_live_guard"] = enforce_live_guard
         return health_data
 
     @router.get("/health")

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -98,6 +98,29 @@ async def test_live_guard(fake_redis):
 
 
 @pytest.mark.asyncio
+async def test_live_guard_disabled(fake_redis):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/apply"):
+            return httpx.Response(200, json={"ok": True})
+        raise AssertionError("unexpected path")
+
+    transport = httpx.MockTransport(handler)
+    client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
+    app = create_app(
+        redis_client=fake_redis,
+        database=FakeDB(),
+        world_client=client,
+        enforce_live_guard=False,
+    )
+    asgi = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
+        r = await api_client.post("/worlds/abc/apply", json={})
+    await asgi.aclose()
+    await client._client.aclose()
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_decide_ttl_envelope_fallback(fake_redis):
     calls = {"n": 0}
 

--- a/tests/test_gateway_config.py
+++ b/tests/test_gateway_config.py
@@ -14,6 +14,7 @@ def test_load_config_gateway_yaml(tmp_path: Path) -> None:
         "database_backend": "postgres",
         "database_dsn": "postgresql://db/test",
         "insert_sentinel": False,
+        "enforce_live_guard": False,
     }
     config_file = tmp_path / "gw.yaml"
     config_file.write_text(yaml.safe_dump({"gateway": data}))
@@ -22,6 +23,7 @@ def test_load_config_gateway_yaml(tmp_path: Path) -> None:
     assert config.gateway.database_backend == "postgres"
     assert config.gateway.database_dsn == data["database_dsn"]
     assert config.gateway.insert_sentinel is False
+    assert config.gateway.enforce_live_guard is False
 
 
 def test_load_config_gateway_json(tmp_path: Path) -> None:
@@ -30,6 +32,7 @@ def test_load_config_gateway_json(tmp_path: Path) -> None:
         "database_backend": "memory",
         "database_dsn": "sqlite:///:memory:",
         "insert_sentinel": True,
+        "enforce_live_guard": True,
     }
     config_file = tmp_path / "gw.json"
     config_file.write_text(json.dumps({"gateway": data}))
@@ -38,6 +41,7 @@ def test_load_config_gateway_json(tmp_path: Path) -> None:
     assert config.gateway.database_backend == "memory"
     assert config.gateway.database_dsn == data["database_dsn"]
     assert config.gateway.insert_sentinel is True
+    assert config.gateway.enforce_live_guard is True
 
 
 def test_load_config_missing_file() -> None:
@@ -75,3 +79,4 @@ def test_gateway_config_defaults() -> None:
     assert cfg.insert_sentinel is True
     assert cfg.worldservice_timeout == 0.3
     assert cfg.worldservice_retries == 2
+    assert cfg.enforce_live_guard is True


### PR DESCRIPTION
## Summary
- add `--allow-live` flag to Gateway CLI to disable live trading guard
- surface `enforce_live_guard` in `/status` responses
- document live guard override and add tests for CLI and proxy behavior

## Testing
- `uv run -m pytest -W error` *(fails: tests/gateway/test_degradation.py::test_static_returns_204, tests/gateway/test_event_descriptor.py::test_event_descriptor_scope_and_expiry, tests/gateway/test_tag_query.py::test_dag_client_queries_grpc, tests/gateway/test_world_proxy.py::test_status_reports_worldservice_breaker, tests/tagquery/test_runner_live_updates.py::test_live_auto_subscribes)*
- `uv run -m pytest tests/test_gateway_cli.py tests/test_health.py::test_gateway_health tests/test_health.py::test_gateway_health_live_guard_disabled tests/test_gateway_config.py tests/gateway/test_world_proxy.py::test_live_guard tests/gateway/test_world_proxy.py::test_live_guard_disabled -W error`
- `uv run -m mkdocs build`

Closes #473

------
https://chatgpt.com/codex/tasks/task_e_68b4a3b8ff388329a058f2ae6ca5b6c4