### PR TITLE
feat: serve stale world cache on backend errors

### DIFF
--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -297,8 +297,12 @@ def create_api_router(
         if client is None:
             raise HTTPException(status_code=503, detail="world service disabled")
         headers, cid = _build_world_headers(request)
-        data = await client.get_decide(world_id, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        data, stale = await client.get_decide(world_id, headers=headers)
+        resp_headers = {"X-Correlation-ID": cid}
+        if stale:
+            resp_headers["Warning"] = "110 - Response is stale"
+            resp_headers["X-Stale"] = "true"
+        return JSONResponse(data, headers=resp_headers)
 
     @router.get("/worlds/{world_id}/activation")
     async def get_world_activation(world_id: str, request: Request) -> Any:
@@ -306,8 +310,12 @@ def create_api_router(
         if client is None:
             raise HTTPException(status_code=503, detail="world service disabled")
         headers, cid = _build_world_headers(request)
-        data = await client.get_activation(world_id, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        data, stale = await client.get_activation(world_id, headers=headers)
+        resp_headers = {"X-Correlation-ID": cid}
+        if stale:
+            resp_headers["Warning"] = "110 - Response is stale"
+            resp_headers["X-Stale"] = "true"
+        return JSONResponse(data, headers=resp_headers)
 
     @router.get("/worlds/{world_id}/{topic}/state_hash")
     async def get_world_state_hash(world_id: str, topic: str, request: Request) -> Any:

--- a/qmtl/gateway/world_client.py
+++ b/qmtl/gateway/world_client.py
@@ -97,12 +97,25 @@ class WorldServiceClient:
     def breaker(self) -> AsyncCircuitBreaker:
         return self._breaker
 
-    async def get_decide(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
+    async def get_decide(
+        self, world_id: str, headers: Optional[Dict[str, str]] = None
+    ) -> tuple[Any, bool]:
         entry = self._decision_cache.get(world_id)
         if entry and entry.valid():
             gw_metrics.record_worlds_cache_hit()
-            return entry.value
-        resp = await self._request("GET", f"{self._base}/worlds/{world_id}/decide", headers=headers)
+            return entry.value, False
+        try:
+            resp = await self._request(
+                "GET", f"{self._base}/worlds/{world_id}/decide", headers=headers
+            )
+        except Exception:
+            if entry is not None:
+                gw_metrics.record_worlds_stale_response()
+                return entry.value, True
+            raise
+        if resp.status_code >= 500 and entry is not None:
+            gw_metrics.record_worlds_stale_response()
+            return entry.value, True
         resp.raise_for_status()
         data = resp.json()
         cache_control = resp.headers.get("Cache-Control", "")
@@ -116,14 +129,14 @@ class WorldServiceClient:
         # Header max-age takes precedence if positive
         if ttl > 0:
             self._decision_cache[world_id] = TTLCacheEntry(data, ttl)
-            return data
+            return data, False
 
         # Fallback to envelope ttl semantics when header is missing or <= 0
         tval = data.get("ttl") if isinstance(data, dict) else None
         if tval is None:
             # Spec default when envelope omits ttl
             self._decision_cache[world_id] = TTLCacheEntry(data, 300)
-            return data
+            return data, False
 
         # Envelope provided ttl; honor zero as "do not cache"
         env_ttl: int | None = None
@@ -141,29 +154,42 @@ class WorldServiceClient:
 
         if env_ttl is None:
             # Invalid ttl provided → be conservative and do not cache
-            return data
+            return data, False
         if env_ttl <= 0:
             # Explicit no-cache
-            return data
+            return data, False
 
         self._decision_cache[world_id] = TTLCacheEntry(data, env_ttl)
-        return data
+        return data, False
 
-    async def get_activation(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
+    async def get_activation(
+        self, world_id: str, headers: Optional[Dict[str, str]] = None
+    ) -> tuple[Any, bool]:
         etag, cached = self._activation_cache.get(world_id, (None, None))
         req_headers = dict(headers or {})
         if etag:
             req_headers["If-None-Match"] = etag
-        resp = await self._request("GET", f"{self._base}/worlds/{world_id}/activation", headers=req_headers)
+        try:
+            resp = await self._request(
+                "GET", f"{self._base}/worlds/{world_id}/activation", headers=req_headers
+            )
+        except Exception:
+            if cached is not None:
+                gw_metrics.record_worlds_stale_response()
+                return cached, True
+            raise
         if resp.status_code == 304 and cached is not None:
             gw_metrics.record_worlds_cache_hit()
-            return cached
+            return cached, False
+        if resp.status_code >= 500 and cached is not None:
+            gw_metrics.record_worlds_stale_response()
+            return cached, True
         resp.raise_for_status()
         data = resp.json()
         new_etag = resp.headers.get("ETag")
         if new_etag:
             self._activation_cache[world_id] = (new_etag, data)
-        return data
+        return data, False
 
     async def get_state_hash(
         self,


### PR DESCRIPTION
## Summary
- add stale-while-revalidate fallback for WorldService proxy
- expose metric for stale responses served
- test stale behavior and failure modes

## Testing
- `uv run -m pytest tests/gateway/test_world_proxy.py -W error`
- `uv run -m pytest -W error` *(fails: address already in use, ConnectError, unraisable coroutine warnings)*

Fixes #471

------
https://chatgpt.com/codex/tasks/task_e_68b4a66f07ac8329ae95bd9c90e7dcb0