### PR TITLE
feat: add Kafka-backed control bus consumer

### DIFF
--- a/qmtl/gateway/controlbus_consumer.py
+++ b/qmtl/gateway/controlbus_consumer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
 import logging
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -42,15 +44,28 @@ class ControlBusConsumer:
         self.ws_hub = ws_hub
         self._queue: asyncio.Queue[ControlBusMessage | None] = asyncio.Queue()
         self._task: asyncio.Task | None = None
+        self._broker_task: asyncio.Task | None = None
+        self._consumer: Any | None = None
         self._last_seen: dict[tuple[str, str], tuple[str, str]] = {}
 
     async def start(self) -> None:
         """Start the background consumer task."""
         if self._task is None:
             self._task = asyncio.create_task(self._worker())
+        if self.brokers and self.topics and self._broker_task is None:
+            self._broker_task = asyncio.create_task(self._broker_loop())
 
     async def stop(self) -> None:
         """Stop the background consumer task."""
+        if self._broker_task is not None:
+            self._broker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._broker_task
+            self._broker_task = None
+        if self._consumer is not None:
+            with contextlib.suppress(Exception):
+                await self._consumer.stop()
+            self._consumer = None
         await self._queue.put(None)
         if self._task is not None:
             await self._task
@@ -69,6 +84,67 @@ class ControlBusConsumer:
                 await self._handle_message(msg)
             finally:
                 self._queue.task_done()
+
+    async def _broker_loop(self) -> None:
+        try:
+            from aiokafka import AIOKafkaConsumer
+        except Exception:  # pragma: no cover - dependency optional
+            logger.error("aiokafka is required for broker consumption")
+            return
+
+        backoff = 1.0
+        while True:
+            try:
+                self._consumer = AIOKafkaConsumer(
+                    *self.topics,
+                    bootstrap_servers=self.brokers,
+                    group_id=self.group,
+                    enable_auto_commit=False,
+                )
+                await self._consumer.start()
+                backoff = 1.0
+                while True:
+                    msg = await self._consumer.getone()
+                    try:
+                        cb_msg = self._parse_kafka_message(msg)
+                        await self._handle_message(cb_msg)
+                        await self._consumer.commit()
+                    except Exception as exc:  # pragma: no cover - robustness
+                        logger.exception("Error handling ControlBus message: %s", exc)
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:  # pragma: no cover - connection issues
+                logger.warning("ControlBus consumer error: %s", exc)
+                with contextlib.suppress(Exception):
+                    if self._consumer:
+                        await self._consumer.stop()
+                self._consumer = None
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 60)
+            finally:
+                if self._consumer is not None:
+                    with contextlib.suppress(Exception):
+                        await self._consumer.stop()
+                    self._consumer = None
+
+    def _parse_kafka_message(self, message: Any) -> ControlBusMessage:
+        key = message.key.decode() if message.key else ""
+        headers = {k: (v.decode() if isinstance(v, bytes) else v) for k, v in (message.headers or [])}
+        etag = headers.get("etag", "")
+        run_id = headers.get("run_id", "")
+        try:
+            data = json.loads(message.value.decode()) if isinstance(message.value, (bytes, bytearray)) else json.loads(message.value)
+        except Exception:  # pragma: no cover - malformed message
+            data = {}
+        timestamp_ms = getattr(message, "timestamp", None)
+        return ControlBusMessage(
+            topic=message.topic,
+            key=key,
+            etag=etag,
+            run_id=run_id,
+            data=data,
+            timestamp_ms=timestamp_ms,
+        )
 
     async def _handle_message(self, msg: ControlBusMessage) -> None:
         key = (msg.topic, msg.key)


### PR DESCRIPTION
## Summary
- connect ControlBusConsumer to Kafka brokers when configured
- support per-key ordering with backoff and manual offset commits

## Testing
- `uv run -m pytest -q`

Fixes #470

------
https://chatgpt.com/codex/tasks/task_e_68b4a84029b883298bfa381f954379d8