### PR TITLE
Brokerage P1: Orders/TIF, Fill Models, Symbol/Hours Providers, Slippage/Fees

### DIFF
--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -2,27 +2,45 @@
 
 # Source: docs/architecture/lean_brokerage_model.md
 
-from .order import Order, Fill, Account
+from .order import Order, Fill, Account, OrderType, TimeInForce
 from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
 from .simple import (
     CashBuyingPowerModel,
-    PerShareFeeModel,
-    VolumeShareSlippageModel,
     ImmediateFillModel,
 )
+from .fees import PerShareFeeModel, PercentFeeModel, CompositeFeeModel
+from .slippage import NullSlippageModel, ConstantSlippageModel, SpreadBasedSlippageModel, VolumeShareSlippageModel
+from .fill_models import BaseFillModel, MarketFillModel, LimitFillModel, StopMarketFillModel, StopLimitFillModel
+from .symbols import SymbolPropertiesProvider, SymbolProperties
+from .exchange_hours import ExchangeHoursProvider
 from .brokerage_model import BrokerageModel
 
 __all__ = [
     "Order",
     "Fill",
     "Account",
+    "OrderType",
+    "TimeInForce",
     "BuyingPowerModel",
     "FeeModel",
     "SlippageModel",
     "FillModel",
     "CashBuyingPowerModel",
-    "PerShareFeeModel",
-    "VolumeShareSlippageModel",
     "ImmediateFillModel",
+    "PerShareFeeModel",
+    "PercentFeeModel",
+    "CompositeFeeModel",
+    "NullSlippageModel",
+    "ConstantSlippageModel",
+    "SpreadBasedSlippageModel",
+    "VolumeShareSlippageModel",
+    "BaseFillModel",
+    "MarketFillModel",
+    "LimitFillModel",
+    "StopMarketFillModel",
+    "StopLimitFillModel",
+    "SymbolProperties",
+    "SymbolPropertiesProvider",
+    "ExchangeHoursProvider",
     "BrokerageModel",
 ]

--- a/qmtl/brokerage/exchange_hours.py
+++ b/qmtl/brokerage/exchange_hours.py
@@ -1,0 +1,32 @@
+"""Exchange hours provider backed by SDK timing controls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from qmtl.sdk.timing_controls import MarketHours, MarketSession
+
+
+@dataclass
+class ExchangeHoursProvider:
+    """Simple provider to answer market session queries."""
+
+    market_hours: MarketHours = MarketHours()
+    allow_pre_post_market: bool = False
+    require_regular_hours: bool = False
+
+    def session(self, ts: datetime) -> MarketSession:
+        return self.market_hours.get_session(ts)
+
+    def is_open(self, ts: datetime) -> bool:
+        session = self.session(ts)
+        if session == MarketSession.CLOSED:
+            return False
+        if self.require_regular_hours and session != MarketSession.REGULAR:
+            return False
+        if not self.allow_pre_post_market and session in {MarketSession.PRE_MARKET, MarketSession.POST_MARKET}:
+            return False
+        return True
+

--- a/qmtl/brokerage/fees.py
+++ b/qmtl/brokerage/fees.py
@@ -1,0 +1,48 @@
+"""Fee model implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .interfaces import FeeModel
+from .order import Order
+
+
+@dataclass
+class PercentFeeModel(FeeModel):
+    """Percentage-of-notional fees with a minimum."""
+
+    rate: float = 0.001  # 0.1%
+    minimum: float = 0.0
+
+    def calculate(self, order: Order, fill_price: float) -> float:
+        notional = abs(order.quantity) * fill_price
+        return max(notional * self.rate, self.minimum)
+
+
+@dataclass
+class PerShareFeeModel(FeeModel):
+    """Per-share fees with optional minimum/maximum caps."""
+
+    fee_per_share: float = 0.01
+    minimum: float = 0.0
+    maximum: float | None = None
+
+    def calculate(self, order: Order, fill_price: float) -> float:
+        fee = abs(order.quantity) * self.fee_per_share
+        if fee < self.minimum:
+            fee = self.minimum
+        if self.maximum is not None and fee > self.maximum:
+            fee = self.maximum
+        return fee
+
+
+@dataclass
+class CompositeFeeModel(FeeModel):
+    """Combine multiple fee models by summing their outputs."""
+
+    components: tuple[FeeModel, ...]
+
+    def calculate(self, order: Order, fill_price: float) -> float:
+        return sum(c.calculate(order, fill_price) for c in self.components)
+

--- a/qmtl/brokerage/fill_models.py
+++ b/qmtl/brokerage/fill_models.py
@@ -1,0 +1,127 @@
+"""Fill model implementations for different order types and TIF policies."""
+
+# Source: docs/architecture/lean_brokerage_model.md
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .interfaces import FillModel
+from .order import Order, Fill, OrderType, TimeInForce
+
+
+@dataclass
+class BaseFillModel(FillModel):
+    """Base fill model with optional liquidity cap for IOC partials.
+
+    Parameters
+    ----------
+    liquidity_cap : Optional[int]
+        If set, represents the max shares that can be filled immediately.
+        This enables simple IOC partial behavior without a full order book.
+    """
+
+    liquidity_cap: Optional[int] = None
+
+    def _apply_tif(self, order: Order, desired_qty: int) -> int:
+        """Apply simple TIF semantics to the computed desired quantity.
+
+        - FOK: require full fill, otherwise 0
+        - IOC: fill up to `liquidity_cap` (if set) or desired quantity
+        - DAY/GTC: take desired quantity
+        """
+
+        if desired_qty <= 0:
+            return 0
+
+        if order.tif == TimeInForce.FOK:
+            return desired_qty if (self.liquidity_cap is None or desired_qty <= self.liquidity_cap) else 0
+
+        if order.tif == TimeInForce.IOC:
+            if self.liquidity_cap is None:
+                return desired_qty
+            return min(desired_qty, self.liquidity_cap)
+
+        # DAY/GTC
+        return desired_qty
+
+
+class MarketFillModel(BaseFillModel):
+    """Market orders fill immediately at the given market price."""
+
+    def fill(self, order: Order, market_price: float) -> Fill:
+        qty = self._apply_tif(order, abs(order.quantity))
+        qty = qty if order.quantity >= 0 else -qty
+        return Fill(symbol=order.symbol, quantity=qty, price=market_price)
+
+
+class LimitFillModel(BaseFillModel):
+    """Limit orders fill when price crosses the limit."""
+
+    def fill(self, order: Order, market_price: float) -> Fill:
+        if order.limit_price is None:
+            # No limit specified, cannot fill
+            return Fill(symbol=order.symbol, quantity=0, price=market_price)
+
+        can_fill = False
+        if order.quantity > 0:
+            # Buy: market must be <= limit
+            can_fill = market_price <= order.limit_price
+        else:
+            # Sell: market must be >= limit
+            can_fill = market_price >= order.limit_price
+
+        if not can_fill:
+            return Fill(symbol=order.symbol, quantity=0, price=market_price)
+
+        qty = self._apply_tif(order, abs(order.quantity))
+        qty = qty if order.quantity >= 0 else -qty
+        # Fill at min/max of market and limit to be conservative
+        price = min(market_price, order.limit_price) if order.quantity > 0 else max(market_price, order.limit_price)
+        return Fill(symbol=order.symbol, quantity=qty, price=price)
+
+
+class StopMarketFillModel(BaseFillModel):
+    """Stop orders trigger at the stop price and then execute at market."""
+
+    def fill(self, order: Order, market_price: float) -> Fill:
+        if order.stop_price is None:
+            return Fill(symbol=order.symbol, quantity=0, price=market_price)
+
+        triggered = False
+        if order.quantity > 0:
+            # Buy stop triggers when price >= stop
+            triggered = market_price >= order.stop_price
+        else:
+            # Sell stop triggers when price <= stop
+            triggered = market_price <= order.stop_price
+
+        if not triggered:
+            return Fill(symbol=order.symbol, quantity=0, price=market_price)
+
+        qty = self._apply_tif(order, abs(order.quantity))
+        qty = qty if order.quantity >= 0 else -qty
+        return Fill(symbol=order.symbol, quantity=qty, price=market_price)
+
+
+class StopLimitFillModel(BaseFillModel):
+    """Stop-limit triggers at stop, then uses limit for execution."""
+
+    def fill(self, order: Order, market_price: float) -> Fill:
+        if order.stop_price is None or order.limit_price is None:
+            return Fill(symbol=order.symbol, quantity=0, price=market_price)
+
+        triggered = False
+        if order.quantity > 0:
+            triggered = market_price >= order.stop_price
+        else:
+            triggered = market_price <= order.stop_price
+
+        if not triggered:
+            return Fill(symbol=order.symbol, quantity=0, price=market_price)
+
+        # After trigger, behave like limit
+        lfm = LimitFillModel(liquidity_cap=self.liquidity_cap)
+        return lfm.fill(order, market_price)
+

--- a/qmtl/brokerage/order.py
+++ b/qmtl/brokerage/order.py
@@ -5,21 +5,49 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class OrderType(str, Enum):
+    """Supported order types."""
+
+    MARKET = "market"
+    LIMIT = "limit"
+    STOP = "stop"
+    STOP_LIMIT = "stop_limit"
+
+
+class TimeInForce(str, Enum):
+    """Time-in-Force policies."""
+
+    DAY = "day"
+    GTC = "gtc"
+    IOC = "ioc"
+    FOK = "fok"
 
 
 @dataclass
 class Order:
-    """Simple order representation.
+    """Order representation.
 
     Attributes:
         symbol: Trading pair or ticker.
         quantity: Number of units to buy (>0) or sell (<0).
-        price: Expected execution price used for buying power checks.
+        price: Expected price reference used for buying power checks.
+        type: Order type.
+        tif: Time-in-Force policy.
+        limit_price: Limit price for limit/stop-limit orders.
+        stop_price: Stop trigger for stop/stop-limit orders.
     """
 
     symbol: str
     quantity: int
     price: float
+    type: OrderType = OrderType.MARKET
+    tif: TimeInForce = TimeInForce.DAY
+    limit_price: Optional[float] = None
+    stop_price: Optional[float] = None
 
 
 @dataclass
@@ -34,6 +62,6 @@ class Fill:
 
 @dataclass
 class Account:
-    """Account holding cash for trading."""
+    """Account holding cash for trading (simplified)."""
 
     cash: float

--- a/qmtl/brokerage/simple.py
+++ b/qmtl/brokerage/simple.py
@@ -17,7 +17,7 @@ class CashBuyingPowerModel(BuyingPowerModel):
 
 
 class PerShareFeeModel(FeeModel):
-    """Charge a fixed fee per share."""
+    """Deprecated: use qmtl.brokerage.fees.PerShareFeeModel instead."""
 
     def __init__(self, fee_per_share: float = 0.01) -> None:
         self.fee_per_share = fee_per_share
@@ -27,7 +27,7 @@ class PerShareFeeModel(FeeModel):
 
 
 class VolumeShareSlippageModel(SlippageModel):
-    """Apply slippage proportional to price."""
+    """Deprecated: use qmtl.brokerage.slippage.VolumeShareSlippageModel."""
 
     def __init__(self, slippage_rate: float = 0.0005) -> None:
         self.slippage_rate = slippage_rate

--- a/qmtl/brokerage/slippage.py
+++ b/qmtl/brokerage/slippage.py
@@ -1,0 +1,73 @@
+"""Slippage model implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .interfaces import SlippageModel
+from .order import Order
+
+
+class NullSlippageModel(SlippageModel):
+    """No slippage applied."""
+
+    def apply(self, order: Order, market_price: float) -> float:
+        return market_price
+
+
+@dataclass
+class ConstantSlippageModel(SlippageModel):
+    """Apply fixed percentage slippage to market price."""
+
+    pct: float = 0.0005
+
+    def apply(self, order: Order, market_price: float) -> float:
+        direction = 1 if order.quantity > 0 else -1
+        return market_price + direction * market_price * self.pct
+
+
+@dataclass
+class SpreadBasedSlippageModel(SlippageModel):
+    """Apply slippage equal to a fraction of a provided spread.
+
+    Note: In absence of live bid/ask, users may precompute a proxy spread
+    and pass it as `spread_hint` to `apply_price` helper.
+    """
+
+    spread_fraction: float = 0.5
+    spread_hint: Optional[float] = None
+
+    def apply(self, order: Order, market_price: float) -> float:
+        spread = self.spread_hint or 0.0
+        slip = (spread * self.spread_fraction)
+        return market_price + (slip if order.quantity > 0 else -slip)
+
+
+@dataclass
+class VolumeShareSlippageModel(SlippageModel):
+    """Volume-share slippage approximation.
+
+    Uses simple quadratic form: impact = k * (q / vol)^2 * price
+    if `bar_volume` is provided; otherwise falls back to constant pct.
+    """
+
+    k: float = 0.1
+    bar_volume: Optional[float] = None
+    fallback_pct: float = 0.0005
+
+    def __init__(self, k: float = 0.1, bar_volume: Optional[float] = None, fallback_pct: float = 0.0005, **kwargs) -> None:
+        # Backward-compat: support `slippage_rate` alias for fallback_pct
+        if "slippage_rate" in kwargs and "fallback_pct" not in kwargs:
+            fallback_pct = float(kwargs["slippage_rate"])
+        self.k = k
+        self.bar_volume = bar_volume
+        self.fallback_pct = fallback_pct
+
+    def apply(self, order: Order, market_price: float) -> float:
+        if self.bar_volume and self.bar_volume > 0:
+            ratio = abs(order.quantity) / float(self.bar_volume)
+            impact = self.k * (ratio ** 2) * market_price
+        else:
+            impact = market_price * self.fallback_pct
+        return market_price + (impact if order.quantity > 0 else -impact)

--- a/qmtl/brokerage/symbols.py
+++ b/qmtl/brokerage/symbols.py
@@ -1,0 +1,49 @@
+"""Symbol properties provider and order validation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Dict
+
+
+@dataclass(frozen=True)
+class SymbolProperties:
+    symbol: str
+    tick_size: float = 0.01
+    lot_size: int = 1
+    min_qty: int = 1
+    contract_multiplier: float = 1.0
+    currency: str = "USD"
+    price_precision: int = 2
+
+
+class SymbolPropertiesProvider:
+    """Provides symbol properties. Default implementation for US equities."""
+
+    def __init__(self, table: Optional[Dict[str, SymbolProperties]] = None) -> None:
+        self._table = table or {}
+
+    def get(self, symbol: str) -> SymbolProperties:
+        return self._table.get(symbol) or SymbolProperties(symbol)
+
+    @staticmethod
+    def round_price(price: float, tick_size: float) -> float:
+        if tick_size <= 0:
+            return price
+        ticks = round(price / tick_size)
+        return ticks * tick_size
+
+    def validate_order(self, symbol: str, price: Optional[float], quantity: int) -> None:
+        sp = self.get(symbol)
+        if abs(quantity) < sp.min_qty:
+            raise ValueError(f"Quantity {quantity} below min {sp.min_qty} for {symbol}")
+        if abs(quantity) % sp.lot_size != 0:
+            raise ValueError(f"Quantity {quantity} not multiple of lot size {sp.lot_size} for {symbol}")
+        if price is not None:
+            rounded = self.round_price(price, sp.tick_size)
+            # Accept if already exactly on tick
+            if abs(rounded - price) > 1e-9:
+                raise ValueError(
+                    f"Price {price} not aligned to tick {sp.tick_size} for {symbol} (expected {rounded})"
+                )
+

--- a/tests/test_brokerage_orders_tif.py
+++ b/tests/test_brokerage_orders_tif.py
@@ -1,0 +1,102 @@
+import pytest
+
+from datetime import datetime, time
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashBuyingPowerModel,
+    Order,
+    OrderType,
+    TimeInForce,
+    MarketFillModel,
+    LimitFillModel,
+    PerShareFeeModel,
+    NullSlippageModel,
+    SymbolPropertiesProvider,
+    ExchangeHoursProvider,
+)
+
+
+def make_brokerage(symbols=None, hours=None, fill=None):
+    return BrokerageModel(
+        CashBuyingPowerModel(),
+        PerShareFeeModel(fee_per_share=0.0),
+        NullSlippageModel(),
+        fill or MarketFillModel(),
+        symbols=symbols,
+        hours=hours,
+    )
+
+
+def test_market_order_fok_and_ioc_fill_full_when_liquidity_unlimited():
+    account = Account(cash=1_000_000)
+    order_ioc = Order(symbol="AAPL", quantity=100, price=100.0, type=OrderType.MARKET, tif=TimeInForce.IOC)
+    order_fok = Order(symbol="AAPL", quantity=100, price=100.0, type=OrderType.MARKET, tif=TimeInForce.FOK)
+    brk = make_brokerage(fill=MarketFillModel())
+
+    fill_ioc = brk.execute_order(account, order_ioc, market_price=100.0)
+    assert fill_ioc.quantity == 100
+    fill_fok = brk.execute_order(account, order_fok, market_price=100.0)
+    assert fill_fok.quantity == 100
+
+
+def test_limit_order_not_crossed_does_not_fill():
+    account = Account(cash=1_000_000)
+    # Buy limit below market should not fill
+    order = Order(
+        symbol="AAPL",
+        quantity=100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.DAY,
+        limit_price=99.0,
+    )
+    brk = make_brokerage(fill=LimitFillModel())
+    fill = brk.execute_order(account, order, market_price=100.0)
+    assert fill.quantity == 0
+
+
+def test_limit_order_crosses_and_fok_requires_full_fill():
+    account = Account(cash=1_000_000)
+    # Buy limit above market -> can cross
+    order = Order(
+        symbol="AAPL",
+        quantity=100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.FOK,
+        limit_price=101.0,
+    )
+    brk = make_brokerage(fill=LimitFillModel())
+    fill = brk.execute_order(account, order, market_price=100.0)
+    assert fill.quantity == 100
+    # Expect conservative buy price = min(market, limit)
+    assert fill.price == 100.0
+
+
+def test_symbol_properties_validation_enforces_tick_and_lot():
+    symbols = SymbolPropertiesProvider()
+    brk = make_brokerage(symbols=symbols, fill=MarketFillModel())
+    account = Account(cash=1_000_000)
+    # Invalid tick: 100.003 not aligned to 0.01
+    bad_order = Order(symbol="AAPL", quantity=1, price=100.003, type=OrderType.MARKET)
+    with pytest.raises(ValueError, match="not aligned to tick"):
+        brk.can_submit_order(account, bad_order)
+    # Invalid lot: quantity 0
+    bad_qty = Order(symbol="AAPL", quantity=0, price=100.0, type=OrderType.MARKET)
+    with pytest.raises(ValueError, match="below min"):
+        brk.can_submit_order(account, bad_qty)
+
+
+def test_exchange_hours_provider_blocks_when_closed():
+    # Pre/post not allowed and require regular hours
+    hours = ExchangeHoursProvider(allow_pre_post_market=False, require_regular_hours=True)
+    brk = make_brokerage(hours=hours)
+    account = Account(cash=1_000_000)
+    order = Order(symbol="AAPL", quantity=1, price=100.0)
+    # 3:00 AM US/Eastern equivalent naive: treat as closed (MarketHours defaults assume US equities)
+    ts = datetime.combine(datetime.utcnow().date(), time(3, 0))
+    with pytest.raises(ValueError, match="Market is closed"):
+        brk.can_submit_order(account, order, ts=ts)
+


### PR DESCRIPTION
Summary
- Introduces order types (Market/Limit/Stop/StopLimit) and Time-in-Force (DAY/GTC/IOC/FOK)
- Adds fill models for each order type with basic IOC/FOK semantics
- Provides SymbolPropertiesProvider (tick/lot/min_qty) and ExchangeHoursProvider (regular/pre/post rules)
- Adds slippage (Null/Constant/Spread/VolumeShare) and fee (Percent/PerShare/Composite) models
- Updates BrokerageModel to run pre-trade validations and use filled quantity for cash movement
- Adds tests for order crossing & TIF behavior, tick/lot validation, and exchange-hours gating

Refs #485, #486, #487, #488, #489
Refs #385

Notes
- VolumeShareSlippageModel keeps backward-compat alias `slippage_rate` for current tests.
- Settlement, Cashbook, Profiles, Pre-Trade Gate wiring into SDK/Gateway come in subsequent PRs.
