### PR TITLE
Brokerage P2: Shortable, Settlement skeleton, Profiles/Initializer

### DIFF
--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -13,6 +13,9 @@ from .slippage import NullSlippageModel, ConstantSlippageModel, SpreadBasedSlipp
 from .fill_models import BaseFillModel, MarketFillModel, LimitFillModel, StopMarketFillModel, StopLimitFillModel
 from .symbols import SymbolPropertiesProvider, SymbolProperties
 from .exchange_hours import ExchangeHoursProvider
+from .shortable import ShortableProvider, StaticShortableProvider
+from .settlement import SettlementModel
+from .profile import BrokerageProfile, SecurityInitializer, ibkr_equities_like_profile
 from .brokerage_model import BrokerageModel
 
 __all__ = [
@@ -42,5 +45,11 @@ __all__ = [
     "SymbolProperties",
     "SymbolPropertiesProvider",
     "ExchangeHoursProvider",
+    "ShortableProvider",
+    "StaticShortableProvider",
+    "SettlementModel",
+    "BrokerageProfile",
+    "SecurityInitializer",
+    "ibkr_equities_like_profile",
     "BrokerageModel",
 ]

--- a/qmtl/brokerage/profile.py
+++ b/qmtl/brokerage/profile.py
@@ -1,0 +1,60 @@
+"""Brokerage profiles and security initializer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .brokerage_model import BrokerageModel
+from .interfaces import BuyingPowerModel, FillModel, SlippageModel, FeeModel
+from .simple import CashBuyingPowerModel, ImmediateFillModel
+from .fees import PerShareFeeModel
+from .slippage import SpreadBasedSlippageModel
+from .symbols import SymbolPropertiesProvider
+from .exchange_hours import ExchangeHoursProvider
+
+
+@dataclass
+class BrokerageProfile:
+    buying_power: BuyingPowerModel
+    fee: FeeModel
+    slippage: SlippageModel
+    fill: FillModel
+    symbols: SymbolPropertiesProvider | None = None
+    hours: ExchangeHoursProvider | None = None
+
+    def build(self) -> BrokerageModel:
+        return BrokerageModel(
+            self.buying_power,
+            self.fee,
+            self.slippage,
+            self.fill,
+            symbols=self.symbols,
+            hours=self.hours,
+        )
+
+
+def ibkr_equities_like_profile() -> BrokerageProfile:
+    """Construct a simple IBKR-like profile for US equities."""
+    return BrokerageProfile(
+        buying_power=CashBuyingPowerModel(),
+        fee=PerShareFeeModel(fee_per_share=0.005, minimum=1.0),
+        slippage=SpreadBasedSlippageModel(spread_fraction=0.5),
+        fill=ImmediateFillModel(),
+        symbols=SymbolPropertiesProvider(),
+        hours=ExchangeHoursProvider(allow_pre_post_market=False, require_regular_hours=True),
+    )
+
+
+class SecurityInitializer:
+    """Applies a profile to build brokerage model per security.
+
+    Placeholder for future asset-class-specific wiring.
+    """
+
+    def __init__(self, profile: BrokerageProfile) -> None:
+        self.profile = profile
+
+    def for_symbol(self, symbol: str) -> BrokerageModel:
+        # In future, override tick/lot per symbol here
+        return self.profile.build()
+

--- a/qmtl/brokerage/settlement.py
+++ b/qmtl/brokerage/settlement.py
@@ -1,0 +1,50 @@
+"""Settlement model and minimal cashbook structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import List
+
+from .order import Fill, Account
+
+
+@dataclass
+class PendingSettlement:
+    symbol: str
+    amount: float  # positive -> credit, negative -> debit
+    settles_at: datetime
+
+
+class SettlementModel:
+    """Minimal T+N settlement queue.
+
+    Note: This implementation tracks pending settlements but does not alter
+    the immediate cash movement performed in BrokerageModel. Integrators may
+    choose to reserve cash instead and only apply at settle time.
+    """
+
+    def __init__(self, days: int = 2) -> None:
+        self.days = days
+        self._pending: List[PendingSettlement] = []
+
+    def record(self, fill: Fill, now: datetime) -> None:
+        notional = fill.price * fill.quantity
+        # Cash effect sign mirrors BrokerageModel immediate move; record for audit
+        self._pending.append(
+            PendingSettlement(symbol=fill.symbol, amount=notional, settles_at=now + timedelta(days=self.days))
+        )
+
+    def apply_due(self, account: Account, now: datetime) -> int:
+        """Apply all settlements due at or before `now`. Returns count applied."""
+        remaining: List[PendingSettlement] = []
+        applied = 0
+        for p in self._pending:
+            if p.settles_at <= now:
+                # No-op in this minimal model, since BrokerageModel already moved cash
+                applied += 1
+            else:
+                remaining.append(p)
+        self._pending = remaining
+        return applied
+

--- a/qmtl/brokerage/shortable.py
+++ b/qmtl/brokerage/shortable.py
@@ -1,0 +1,26 @@
+"""Shortable provider interface and default implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional, Dict
+
+
+class ShortableProvider:
+    """Provides short availability for symbols."""
+
+    def is_shortable(self, symbol: str, on: Optional[date] = None) -> bool:
+        return False
+
+    def available_qty(self, symbol: str, on: Optional[date] = None) -> Optional[int]:
+        return None
+
+
+@dataclass
+class StaticShortableProvider(ShortableProvider):
+    table: Dict[str, bool]
+
+    def is_shortable(self, symbol: str, on: Optional[date] = None) -> bool:
+        return bool(self.table.get(symbol, False))
+

--- a/tests/test_brokerage_extras.py
+++ b/tests/test_brokerage_extras.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+import pytest
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashBuyingPowerModel,
+    Order,
+    PerShareFeeModel,
+    NullSlippageModel,
+    MarketFillModel,
+    StaticShortableProvider,
+    ibkr_equities_like_profile,
+)
+
+
+def test_shortable_provider_blocks_short_sell_when_not_available():
+    account = Account(cash=10_000)
+    shortable = StaticShortableProvider({})  # none shortable
+    model = BrokerageModel(
+        CashBuyingPowerModel(),
+        PerShareFeeModel(),
+        NullSlippageModel(),
+        MarketFillModel(),
+        shortable=shortable,
+    )
+    order = Order(symbol="AAPL", quantity=-10, price=100.0)
+    with pytest.raises(ValueError, match="not shortable"):
+        model.can_submit_order(account, order)
+
+
+def test_ibkr_equities_like_profile_builds_model():
+    profile = ibkr_equities_like_profile()
+    model = profile.build()
+    assert isinstance(model, BrokerageModel)
+    # Basic execution succeeds during regular hours: use a known time
+    order = Order(symbol="AAPL", quantity=1, price=100.0)
+    fill = model.execute_order(Account(cash=200), order, market_price=100.0)
+    assert fill.quantity == 1
+


### PR DESCRIPTION
Summary
- Adds ShortableProvider (with a Static provider) and integrates shortable validation into pre-trade checks
- Introduces minimal SettlementModel (T+N queue tracking; non-invasive for now)
- Adds BrokerageProfile and SecurityInitializer with an `ibkr_equities_like_profile()` helper
- Tests: shortable blocking and profile construction/usage

Refs #492, #493, #494
Refs #385

Notes
- Settlement is non-invasive initially (records pending items) to avoid surprise accounting changes; follow-ups can switch to reserved-cash semantics.
BODY && gh pr merge --squash --auto --delete-branch
