### PR TITLE
Brokerage P3: OrderGate utility + Docs + Example stub

### DIFF
--- a/docs/reference/api/brokerage.md
+++ b/docs/reference/api/brokerage.md
@@ -1,0 +1,38 @@
+---
+title: "Brokerage API"
+tags: [api]
+author: "QMTL Team"
+last_modified: 2025-08-31
+---
+
+{{ nav_links() }}
+
+# Brokerage API
+
+- qmtl.brokerage interfaces: BuyingPowerModel, FillModel, SlippageModel, FeeModel
+- Fill models: MarketFillModel, LimitFillModel, StopMarketFillModel, StopLimitFillModel
+- Slippage models: NullSlippageModel, ConstantSlippageModel, SpreadBasedSlippageModel, VolumeShareSlippageModel
+- Fee models: PerShareFeeModel, PercentFeeModel, CompositeFeeModel
+- Providers: SymbolPropertiesProvider (tick/lot/min), ExchangeHoursProvider (regular/pre/post), ShortableProvider
+- Profiles: BrokerageProfile, SecurityInitializer, ibkr_equities_like_profile()
+
+Usage skeleton:
+
+```python
+from qmtl.brokerage import (
+    BrokerageModel, CashBuyingPowerModel,
+    MarketFillModel, PerShareFeeModel,
+    NullSlippageModel, SymbolPropertiesProvider,
+)
+
+model = BrokerageModel(
+    CashBuyingPowerModel(),
+    PerShareFeeModel(),
+    NullSlippageModel(),
+    MarketFillModel(),
+    symbols=SymbolPropertiesProvider(),
+)
+```
+
+{{ nav_links() }}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - World Service: architecture/worldservice.md
       - ControlBus: architecture/controlbus.md
       - Lean Brokerage Model: architecture/lean_brokerage_model.md
+      - Brokerage API: reference/api/brokerage.md
       - Implementation TODOs: architecture/implementation_todos.md
   - Guides:
       - Overview: guides/README.md
@@ -35,6 +36,7 @@ nav:
       - Enhanced Validation: reference/enhanced_validation.md
       - Backtest Validation: reference/backtest_validation.md
       - Lean-like Features: reference/lean_like_features.md
+      - Brokerage API: reference/api/brokerage.md
       - Inventory: reference/_inventory.md
       - Changelog: reference/CHANGELOG.md
   - World:

--- a/qmtl/examples/brokerage_demo/README.md
+++ b/qmtl/examples/brokerage_demo/README.md
@@ -1,0 +1,10 @@
+# Brokerage Demo
+
+Minimal example demonstrating the brokerage model usage and validation chain.
+
+Run tests:
+
+```
+uv run -m pytest -q tests
+```
+

--- a/qmtl/sdk/order_gate.py
+++ b/qmtl/sdk/order_gate.py
@@ -1,0 +1,28 @@
+"""Order gating utilities bridging WorldService activation and brokerage checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class Activation:
+    """Represents activation status per symbol or route."""
+
+    enabled: bool
+    reason: str | None = None
+
+
+def gate_order(activation_map: Mapping[str, Activation], symbol: str) -> tuple[bool, str | None]:
+    """Check if orders for `symbol` are allowed per activation map.
+
+    Returns (allowed, reason).
+    """
+    act = activation_map.get(symbol)
+    if act is None:
+        return False, "activation unknown"
+    if not act.enabled:
+        return False, act.reason or "activation disabled"
+    return True, None
+


### PR DESCRIPTION
Summary
- Adds `qmtl.sdk.order_gate` with a simple activation gate helper
- Documents Brokerage API under docs/reference/api/brokerage.md and updates mkdocs navigation
- Adds a minimal brokerage demo README under examples

Refs #495, #496, #497
Refs #385

Notes
- This PR wires the documentation and helper utilities; deeper gateway/SDK integration remains incremental.
BODY && gh pr merge --squash --auto --delete-branch
