### PR TITLE
Brokerage P4: Margin Interest Model

### DIFF
--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -16,6 +16,7 @@ from .exchange_hours import ExchangeHoursProvider
 from .shortable import ShortableProvider, StaticShortableProvider
 from .settlement import SettlementModel
 from .profile import BrokerageProfile, SecurityInitializer, ibkr_equities_like_profile
+from .interest import MarginInterestModel
 from .brokerage_model import BrokerageModel
 
 __all__ = [
@@ -48,6 +49,7 @@ __all__ = [
     "ShortableProvider",
     "StaticShortableProvider",
     "SettlementModel",
+    "MarginInterestModel",
     "BrokerageProfile",
     "SecurityInitializer",
     "ibkr_equities_like_profile",

--- a/qmtl/brokerage/interest.py
+++ b/qmtl/brokerage/interest.py
@@ -1,0 +1,23 @@
+"""Margin interest model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class MarginInterestModel:
+    """Simple daily interest calculator for borrow/cash balances.
+
+    Positive balances accrue at `cash_rate`; negative balances incur `borrow_rate`.
+    Rates are annual; calculation assumes 365-day convention.
+    """
+
+    cash_rate: float = 0.0
+    borrow_rate: float = 0.05
+
+    def daily_interest(self, balance: float, now: datetime) -> float:
+        rate = self.cash_rate if balance >= 0 else -self.borrow_rate
+        return balance * (rate / 365.0)
+

--- a/tests/test_brokerage_interest.py
+++ b/tests/test_brokerage_interest.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from qmtl.brokerage import MarginInterestModel
+
+
+def test_margin_interest_daily_accrual():
+    m = MarginInterestModel(cash_rate=0.01, borrow_rate=0.10)
+    now = datetime.utcnow()
+    # Positive cash accrues
+    assert m.daily_interest(1000.0, now) == 1000.0 * (0.01 / 365.0)
+    # Negative balance incurs cost
+    assert m.daily_interest(-2000.0, now) == -2000.0 * (0.10 / 365.0)
+


### PR DESCRIPTION
Summary
- Adds a simple `MarginInterestModel` to compute daily interest for cash/borrow balances
- Includes a unit test for daily accrual logic

Refs #492
Refs #385
BODY && gh pr merge --squash --auto --delete-branch
