### PR TITLE
Brokerage: IBKR-like tiered fee model

### DIFF
--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -8,7 +8,7 @@ from .simple import (
     CashBuyingPowerModel,
     ImmediateFillModel,
 )
-from .fees import PerShareFeeModel, PercentFeeModel, CompositeFeeModel
+from .fees import PerShareFeeModel, PercentFeeModel, CompositeFeeModel, IBKRFeeModel
 from .slippage import NullSlippageModel, ConstantSlippageModel, SpreadBasedSlippageModel, VolumeShareSlippageModel
 from .fill_models import BaseFillModel, MarketFillModel, LimitFillModel, StopMarketFillModel, StopLimitFillModel
 from .symbols import SymbolPropertiesProvider, SymbolProperties
@@ -34,6 +34,7 @@ __all__ = [
     "PerShareFeeModel",
     "PercentFeeModel",
     "CompositeFeeModel",
+    "IBKRFeeModel",
     "NullSlippageModel",
     "ConstantSlippageModel",
     "SpreadBasedSlippageModel",

--- a/qmtl/brokerage/fees.py
+++ b/qmtl/brokerage/fees.py
@@ -46,3 +46,52 @@ class CompositeFeeModel(FeeModel):
     def calculate(self, order: Order, fill_price: float) -> float:
         return sum(c.calculate(order, fill_price) for c in self.components)
 
+
+@dataclass
+class IBKRFeeModel(FeeModel):
+    """Simplified Interactive Brokers-like per-share tiered fee model.
+
+    Parameters
+    ----------
+    tiers : list[tuple[int, float]]
+        Sorted ascending by share threshold; (threshold, fee_per_share).
+        The highest tier applies beyond the last threshold.
+    minimum : float
+        Minimum fee per order.
+    exchange_fees : float
+        Flat per-order exchange/regulatory surcharge (very simplified).
+
+    Notes
+    -----
+    This is a simplified approximation for backtests; real schedules vary by venue and product.
+    """
+
+    tiers: list[tuple[int, float]] = None
+    minimum: float = 1.0
+    exchange_fees: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.tiers is None:
+            # Default: 0–300k: $0.0035, >300k: $0.0020
+            self.tiers = [(300_000, 0.0035)]
+            # Implicit last tier: 0.0020
+
+    def calculate(self, order: Order, fill_price: float) -> float:
+        shares = abs(order.quantity)
+        remaining = shares
+        total = 0.0
+        last_rate = 0.0020
+        prev_thresh = 0
+        for thresh, rate in self.tiers:
+            band = max(0, min(remaining, thresh - prev_thresh))
+            if band > 0:
+                total += band * rate
+                remaining -= band
+                prev_thresh = thresh
+        if remaining > 0:
+            total += remaining * last_rate
+        # Apply minimum and exchange surcharges
+        if total < self.minimum:
+            total = self.minimum
+        total += self.exchange_fees
+        return total

--- a/tests/test_brokerage_ibkr_fee.py
+++ b/tests/test_brokerage_ibkr_fee.py
@@ -1,0 +1,12 @@
+from qmtl.brokerage import IBKRFeeModel
+
+
+def test_ibkr_fee_applies_tiers_and_minimum():
+    fee = IBKRFeeModel(tiers=[(300000, 0.0035)], minimum=1.0, exchange_fees=0.0)
+    # Small order -> minimum
+    assert fee.calculate(order=type('O', (), {'quantity': 10})(), fill_price=100.0) == 1.0
+    # Medium order inside first tier
+    assert fee.calculate(order=type('O', (), {'quantity': 1000})(), fill_price=100.0) == 1000 * 0.0035
+    # Beyond first tier uses last_rate 0.0020
+    assert fee.calculate(order=type('O', (), {'quantity': 300500})(), fill_price=100.0) == 300000 * 0.0035 + 500 * 0.0020
+


### PR DESCRIPTION
Adds a simplified Interactive Brokers-like per-share tiered fee model with per-order minimum and optional exchange surcharges. Includes unit tests and package export.

Refs #489, Refs #385
BODY && gh pr merge --squash --auto --delete-branch
