### PR TITLE
Brokerage: Settlement deferred cash + BP integration

### DIFF
--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -7,6 +7,7 @@ from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
 from .simple import (
     CashBuyingPowerModel,
     ImmediateFillModel,
+    CashWithSettlementBuyingPowerModel,
 )
 from .fees import PerShareFeeModel, PercentFeeModel, CompositeFeeModel, IBKRFeeModel
 from .slippage import NullSlippageModel, ConstantSlippageModel, SpreadBasedSlippageModel, VolumeShareSlippageModel
@@ -30,6 +31,7 @@ __all__ = [
     "SlippageModel",
     "FillModel",
     "CashBuyingPowerModel",
+    "CashWithSettlementBuyingPowerModel",
     "ImmediateFillModel",
     "PerShareFeeModel",
     "PercentFeeModel",

--- a/qmtl/brokerage/simple.py
+++ b/qmtl/brokerage/simple.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
 from .order import Account, Order, Fill
+from .settlement import SettlementModel
 
 
 class CashBuyingPowerModel(BuyingPowerModel):
@@ -14,6 +15,17 @@ class CashBuyingPowerModel(BuyingPowerModel):
     def has_sufficient_buying_power(self, account: Account, order: Order) -> bool:
         required = order.price * order.quantity
         return account.cash >= required
+
+
+class CashWithSettlementBuyingPowerModel(BuyingPowerModel):
+    """Buying power that accounts for reserved cash in SettlementModel."""
+
+    def __init__(self, settlement: SettlementModel) -> None:
+        self.settlement = settlement
+
+    def has_sufficient_buying_power(self, account: Account, order: Order) -> bool:
+        required = order.price * order.quantity
+        return self.settlement.available_cash(account) >= required
 
 
 class PerShareFeeModel(FeeModel):

--- a/tests/test_brokerage_settlement_defer.py
+++ b/tests/test_brokerage_settlement_defer.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timedelta
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashWithSettlementBuyingPowerModel,
+    MarketFillModel,
+    PerShareFeeModel,
+    NullSlippageModel,
+    SettlementModel,
+    Order,
+)
+
+
+def test_deferred_settlement_reserves_cash_and_applies_later():
+    settlement = SettlementModel(days=1, defer_cash=True)
+    bp = CashWithSettlementBuyingPowerModel(settlement)
+    model = BrokerageModel(
+        bp,
+        PerShareFeeModel(fee_per_share=0.0),
+        NullSlippageModel(),
+        MarketFillModel(),
+        settlement=settlement,
+    )
+    acct = Account(cash=1000.0)
+
+    order = Order(symbol="AAPL", quantity=5, price=100.0)
+    # Buying power respects reserved cash (initially none)
+    assert model.can_submit_order(acct, order)
+    fill = model.execute_order(acct, order, market_price=100.0, ts=datetime.utcnow())
+    assert fill.quantity == 5
+    # Cash not moved immediately
+    assert acct.cash == 1000.0
+    # But reserved increased
+    assert settlement.reserved >= 500.0
+    # Next day, apply settlement reduces cash
+    next_day = datetime.utcnow() + timedelta(days=1)
+    applied = settlement.apply_due(acct, now=next_day)
+    assert applied >= 1
+    assert acct.cash == 500.0
+


### PR DESCRIPTION
Adds deferred-cash option to SettlementModel, a buying-power model that accounts for reservations, and integrates settlement into BrokerageModel (record-only by default, or no immediate cash move when `defer_cash=True`). Includes tests.

Refs #490, Refs #385
BODY && gh pr merge --squash --auto --delete-branch
