### PR TITLE
SDK: Activation gate integration for trade orders

### DIFF
--- a/qmtl/sdk/activation_manager.py
+++ b/qmtl/sdk/activation_manager.py
@@ -1,0 +1,89 @@
+"""Manage activation state (long/short) via Gateway events."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Optional, Dict
+
+import httpx
+
+from .ws_client import WebSocketClient
+
+
+@dataclass
+class ActivationState:
+    long_active: bool = True
+    short_active: bool = True
+    etag: Optional[str] = None
+
+
+class ActivationManager:
+    """Subscribe to activation updates and expose allow/deny checks."""
+
+    def __init__(self, gateway_url: str | None = None, *, ws_client: WebSocketClient | None = None,
+                 world_id: str | None = None, strategy_id: str | None = None) -> None:
+        self.gateway_url = gateway_url
+        self.client = ws_client
+        if self.client is not None:
+            self.client.on_message = self._on_message
+        self.world_id = world_id
+        self.strategy_id = strategy_id
+        self.state = ActivationState()
+        self._started = False
+
+    def allow_side(self, side: str) -> bool:
+        s = side.lower()
+        if s in {"buy", "long"}:
+            return self.state.long_active
+        if s in {"sell", "short"}:
+            return self.state.short_active
+        return False
+
+    async def _on_message(self, data: dict) -> None:
+        event = data.get("event") or data.get("type")
+        payload = data.get("data", data)
+        if event == "activation_updated" or payload.get("type") == "ActivationUpdated":
+            side = (payload.get("side") or "").lower()
+            active = bool(payload.get("active", False))
+            self.state.etag = payload.get("etag") or self.state.etag
+            if side == "long":
+                self.state.long_active = active
+            elif side == "short":
+                self.state.short_active = active
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        if self.client:
+            await self.client.start()
+            self._started = True
+            return
+        if not self.gateway_url:
+            return
+        subscribe_url = self.gateway_url.rstrip("/") + "/events/subscribe"
+        try:
+            async with httpx.AsyncClient() as client:
+                payload = {
+                    "topics": ["activation"],
+                    "world_id": self.world_id or "",
+                    "strategy_id": self.strategy_id or "",
+                }
+                resp = await client.post(subscribe_url, json=payload)
+                if resp.status_code == 200:
+                    data = resp.json()
+                    stream_url = data.get("stream_url")
+                    token = data.get("token")
+                    if stream_url:
+                        self.client = WebSocketClient(stream_url, on_message=self._on_message, token=token)
+                        await self.client.start()
+                        self._started = True
+        except Exception:
+            # Silent fallback; allow all sides by default
+            return
+
+    async def stop(self) -> None:
+        if self.client:
+            await self.client.stop()
+        self._started = False
+

--- a/tests/test_order_gate_integration.py
+++ b/tests/test_order_gate_integration.py
@@ -1,0 +1,45 @@
+import importlib
+
+import qmtl.sdk.runner as runner_module
+from qmtl.sdk.runner import Runner
+
+
+class DummyActivationManager:
+    def __init__(self, allow_long: bool = True, allow_short: bool = True) -> None:
+        self.allow_long = allow_long
+        self.allow_short = allow_short
+
+    def allow_side(self, side: str) -> bool:
+        s = side.lower()
+        if s in {"buy", "long"}:
+            return self.allow_long
+        if s in {"sell", "short"}:
+            return self.allow_short
+        return False
+
+
+class FakeKafkaProducer:
+    def __init__(self) -> None:
+        self.messages = []
+
+    def send(self, topic, payload):
+        self.messages.append((topic, payload))
+
+
+def test_runner_gates_orders_by_activation():
+    # Reload runner module to reset class-level state
+    importlib.reload(runner_module)
+    producer = FakeKafkaProducer()
+    Runner.set_kafka_producer(producer)
+    Runner.set_trade_order_kafka_topic("orders")
+
+    # Disallow BUY/long; allow SELL/short
+    Runner.set_activation_manager(DummyActivationManager(allow_long=False, allow_short=True))
+
+    # BUY order should be dropped
+    Runner._handle_trade_order({"side": "BUY", "quantity": 1, "timestamp": 0})
+    # SELL order should be sent
+    Runner._handle_trade_order({"side": "SELL", "quantity": 1, "timestamp": 0})
+
+    assert producer.messages == [("orders", {"side": "SELL", "quantity": 1, "timestamp": 0})]
+


### PR DESCRIPTION
- Adds `qmtl/sdk/activation_manager.py` to subscribe to activation updates via Gateway events
- Integrates gate check in `Runner._handle_trade_order` (side-based gating)
- Starts ActivationManager in `Runner.live_async` when gateway_url provided
- Adds unit test verifying BUY is gated off while SELL passes

Refs #495, Refs #385
BODY && gh pr merge --squash --auto --delete-branch
