### PR TITLE
Examples: Brokerage demo + IOC partial fill test

### DIFF
--- a/qmtl/examples/brokerage_demo/run_demo.py
+++ b/qmtl/examples/brokerage_demo/run_demo.py
@@ -1,0 +1,49 @@
+"""Minimal demo showing BrokerageModel end-to-end usage.
+
+Run with: uv run python qmtl/examples/brokerage_demo/run_demo.py
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    MarketFillModel,
+    PercentFeeModel,
+    ConstantSlippageModel,
+    SymbolPropertiesProvider,
+    ExchangeHoursProvider,
+    Order,
+    OrderType,
+    TimeInForce,
+)
+
+
+def main() -> None:
+    model = BrokerageModel(
+        buying_power_model=lambda: None,  # type: ignore[assignment]
+        fee_model=PercentFeeModel(rate=0.001, minimum=1.0),
+        slippage_model=ConstantSlippageModel(0.0005),
+        fill_model=MarketFillModel(),
+        symbols=SymbolPropertiesProvider(),
+        hours=ExchangeHoursProvider.with_us_sample_holidays(require_regular_hours=True),
+    )
+    # Provide a trivial buying power model inline
+    class _BP:
+        def has_sufficient_buying_power(self, account: Account, order: Order) -> bool:
+            return account.cash >= order.price * abs(order.quantity)
+
+    model.buying_power_model = _BP()  # type: ignore[attr-defined]
+
+    acct = Account(cash=10_000.0)
+    ts = datetime.utcnow()
+    order = Order(symbol="AAPL", quantity=10, price=100.0, type=OrderType.MARKET, tif=TimeInForce.DAY)
+    fill = model.execute_order(acct, order, market_price=100.0, ts=ts)
+    print({"fill": fill, "cash": acct.cash})
+
+
+if __name__ == "__main__":
+    main()
+

--- a/qmtl/examples/tests/test_brokerage_demo.py
+++ b/qmtl/examples/tests/test_brokerage_demo.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    MarketFillModel,
+    PercentFeeModel,
+    ConstantSlippageModel,
+    SymbolPropertiesProvider,
+    ExchangeHoursProvider,
+    Order,
+    OrderType,
+    TimeInForce,
+)
+
+
+def test_demo_executes_market_order():
+    # Construct a simple brokerage model akin to the demo
+    model = BrokerageModel(
+        buying_power_model=lambda: None,  # type: ignore[assignment]
+        fee_model=PercentFeeModel(rate=0.001, minimum=1.0),
+        slippage_model=ConstantSlippageModel(0.0),
+        fill_model=MarketFillModel(),
+        symbols=SymbolPropertiesProvider(),
+        hours=ExchangeHoursProvider(),
+    )
+
+    class _BP:
+        def has_sufficient_buying_power(self, account: Account, order: Order) -> bool:
+            return account.cash >= order.price * abs(order.quantity)
+
+    model.buying_power_model = _BP()  # type: ignore[attr-defined]
+
+    acct = Account(cash=1_000.0)
+    order = Order(symbol="AAPL", quantity=5, price=100.0, type=OrderType.MARKET, tif=TimeInForce.DAY)
+    fill = model.execute_order(acct, order, market_price=100.0, ts=datetime.utcnow())
+    assert fill.quantity == 5
+    # Fee minimum applies: $1
+    assert fill.fee >= 1.0
+    assert acct.cash <= 1_000.0 - (fill.price * 5)
+

--- a/tests/test_brokerage_orders_tif.py
+++ b/tests/test_brokerage_orders_tif.py
@@ -75,6 +75,15 @@ def test_limit_order_crosses_and_fok_requires_full_fill():
     assert fill.price == 100.0
 
 
+def test_ioc_partial_fill_with_liquidity_cap():
+    account = Account(cash=1_000_000)
+    order = Order(symbol="AAPL", quantity=100, price=100.0, type=OrderType.MARKET, tif=TimeInForce.IOC)
+    # Cap immediate liquidity to 30 shares
+    brk = make_brokerage(fill=MarketFillModel(liquidity_cap=30))
+    fill = brk.execute_order(account, order, market_price=100.0)
+    assert fill.quantity == 30
+
+
 def test_symbol_properties_validation_enforces_tick_and_lot():
     symbols = SymbolPropertiesProvider()
     brk = make_brokerage(symbols=symbols, fill=MarketFillModel())
@@ -99,4 +108,3 @@ def test_exchange_hours_provider_blocks_when_closed():
     ts = datetime.combine(datetime.utcnow().date(), time(3, 0))
     with pytest.raises(ValueError, match="Market is closed"):
         brk.can_submit_order(account, order, ts=ts)
-


### PR DESCRIPTION
Adds a minimal runnable brokerage demo and tests an IOC partial fill scenario using `liquidity_cap` on MarketFillModel.

- `qmtl/examples/brokerage_demo/run_demo.py`
- `qmtl/examples/tests/test_brokerage_demo.py`
- Extends `tests/test_brokerage_orders_tif.py` with IOC partial test

Refs #496, Refs #485, Refs #385
BODY && gh pr merge --squash --auto --delete-branch
