### PR TITLE
docs: clarify core components and WS event flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 # qmtl
 
-QMTL orchestrates trading strategies as directed acyclic graphs (DAGs). The gateway forwards DAGs to the DAG Manager to deduplicate and schedule computations, while the SDK enables building reusable nodes for local or distributed execution. See [architecture.md](docs/architecture/architecture.md) for full details.
+QMTL orchestrates trading strategies as directed acyclic graphs (DAGs). Its architecture is built around three components:
+
+1. **Gateway** – accepts strategy submissions from SDKs and forwards DAGs to the DAG Manager for deduplication and scheduling.
+2. **WorldService** – the single source of truth for policy and activation state.
+3. **ControlBus** – an internal event bus bridged to clients through a tokenized WebSocket.
+
+SDKs submit strategies through the Gateway, but activation and queue updates along with strategy file controls are delivered from the ControlBus via `/events/subscribe` over that WebSocket. See [architecture.md](docs/architecture/architecture.md) for full details.
 
 Use the DAG Manager CLI to preview DAG structures:
 


### PR DESCRIPTION
## Summary
- outline Gateway, WorldService and ControlBus in README introduction
- document that `/events/subscribe` WebSocket delivers activation and queue updates

## Testing
- `uv run -m pytest` *(fails: MarketHours.__init__ missing 4 required positional arguments)*
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b4b632433483299e65a3ac725d4555