### PR TITLE
docs: clarify activation updates consumption

### DIFF
--- a/qmtl/sdk/activation_manager.py
+++ b/qmtl/sdk/activation_manager.py
@@ -1,4 +1,7 @@
-"""Manage activation state (long/short) via Gateway events."""
+"""Consume activation updates via the Gateway's `/events/subscribe` descriptor, bridging the internal ControlBus.
+
+If the descriptor or resulting stream is unavailable, all sides remain allowed without error.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- clarify activation stream source and fallback behavior for ActivationManager

## Testing
- `uv run -m pytest -W error` *(fails: MarketHours.__init__() missing 4 required positional arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68b53e7667fc832986d062785090944b