### PR TITLE
Clarify TagQueryManager queue subscription

### DIFF
--- a/qmtl/sdk/tagquery_manager.py
+++ b/qmtl/sdk/tagquery_manager.py
@@ -15,7 +15,12 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 
 class TagQueryManager:
-    """Manage :class:`TagQueryNode` instances and deliver updates."""
+    """Manage :class:`TagQueryNode` instances and deliver updates.
+
+    Queue updates are received via the ControlBus-backed WebSocket from
+    ``/events/subscribe``. The ``/queues/watch`` stream is retained only as a
+    legacy fallback.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- document that queue updates now use ControlBus-backed `/events/subscribe`
- note legacy fallback to `/queues/watch`

## Testing
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error` *(fails: MarketHours.__init__ missing required args)*

------
https://chatgpt.com/codex/tasks/task_e_68b53e7957088329973deb75ad2053c4