### PR TITLE
docs: describe WebSocketClient event stream

### DIFF
--- a/qmtl/sdk/ws_client.py
+++ b/qmtl/sdk/ws_client.py
@@ -15,7 +15,12 @@ if TYPE_CHECKING:  # pragma: no cover - only for typing
 
 
 class WebSocketClient:
-    """Subscribe to Gateway state updates via WebSocket."""
+    """Connect to the opaque event stream returned by ``/events/subscribe``.
+
+    The stream bridges Gateway to ControlBus and forwards event messages.
+    A JWT token is passed during connection when provided. The client also
+    stores auxiliary data such as ``queue_topics`` and ``sentinel_weights``.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- clarify WebSocketClient docstring to describe `/events/subscribe` stream, ControlBus bridging, JWT usage, and stored auxiliary data

## Testing
- `uv run -m pytest -W error` *(fails: MarketHours.__init__() missing required positional arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68b53e7bf5a0832998e0142d480f4bc0