### PR TITLE
Gateway/SDK: Standardized pre-trade rejection reasons + metrics + /status exposure

### DIFF
--- a/qmtl/common/pretrade.py
+++ b/qmtl/common/pretrade.py
@@ -1,0 +1,39 @@
+"""Standardized pre-trade rejection reasons and helpers.
+
+# Source: docs/architecture/gateway.md
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RejectionReason(str, Enum):
+    ACTIVATION_DISABLED = "activation_disabled"
+    ACTIVATION_UNKNOWN = "activation_unknown"
+    SYMBOL_VALIDATION_FAILED = "symbol_validation_failed"
+    MARKET_CLOSED = "market_closed"
+    NOT_SHORTABLE = "not_shortable"
+    INSUFFICIENT_BUYING_POWER = "insufficient_buying_power"
+    INVALID_ORDER = "invalid_order"
+    UNKNOWN = "unknown"
+
+
+def categorize_exception(exc: Exception) -> RejectionReason:
+    """Best-effort mapping from validation exceptions to a reason code."""
+    msg = str(exc).lower()
+    if "market is closed" in msg or "hours" in msg:
+        return RejectionReason.MARKET_CLOSED
+    if "shortable" in msg:
+        return RejectionReason.NOT_SHORTABLE
+    if "tick" in msg or "lot" in msg or "symbol" in msg or "price" in msg:
+        return RejectionReason.SYMBOL_VALIDATION_FAILED
+    if "buying power" in msg or "sufficient" in msg:
+        return RejectionReason.INSUFFICIENT_BUYING_POWER
+    if "order" in msg:
+        return RejectionReason.INVALID_ORDER
+    return RejectionReason.UNKNOWN
+
+
+__all__ = ["RejectionReason", "categorize_exception"]
+

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -95,6 +95,11 @@ def create_api_router(
         )
         health_data["degrade_level"] = degradation.level.name
         health_data["enforce_live_guard"] = enforce_live_guard
+        # Include basic pre-trade rejection metrics for quick visibility
+        try:
+            health_data["pretrade"] = gw_metrics.get_pretrade_stats()
+        except Exception:
+            pass
         return health_data
 
     @router.get("/health")

--- a/qmtl/sdk/pretrade.py
+++ b/qmtl/sdk/pretrade.py
@@ -1,0 +1,75 @@
+"""SDK pre-trade validation wrapper with standardized reasons + metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+from qmtl.common.pretrade import RejectionReason, categorize_exception
+from qmtl.brokerage import BrokerageModel, Order, OrderType, TimeInForce, Account
+from . import metrics as sdk_metrics
+from .order_gate import Activation, gate_order
+
+
+@dataclass(frozen=True)
+class PreTradeCheckResult:
+    allowed: bool
+    reason: Optional[RejectionReason] = None
+
+
+def check_pretrade(
+    *,
+    activation_map: Mapping[str, Activation],
+    brokerage: BrokerageModel,
+    account: Account,
+    symbol: str,
+    quantity: int,
+    price: float,
+    order_type: OrderType = OrderType.MARKET,
+    tif: TimeInForce = TimeInForce.DAY,
+    limit_price: float | None = None,
+    stop_price: float | None = None,
+) -> PreTradeCheckResult:
+    """Run activation + brokerage checks and record metrics.
+
+    Returns a structured result with standardized reason codes when rejected.
+    """
+    sdk_metrics.record_pretrade_attempt()
+
+    # Activation gating
+    allowed, reason = gate_order(activation_map, symbol)
+    if not allowed:
+        code = (
+            RejectionReason.ACTIVATION_DISABLED
+            if (reason and "disabled" in reason)
+            else RejectionReason.ACTIVATION_UNKNOWN
+        )
+        sdk_metrics.record_pretrade_rejection(code.value)
+        return PreTradeCheckResult(False, code)
+
+    # Brokerage checks
+    order = Order(
+        symbol=symbol,
+        quantity=quantity,
+        price=price,
+        type=order_type,
+        tif=tif,
+        limit_price=limit_price,
+        stop_price=stop_price,
+    )
+    try:
+        ok = brokerage.can_submit_order(account, order)
+    except Exception as exc:  # Hours/shortable/symbol checks raise
+        code = categorize_exception(exc)
+        sdk_metrics.record_pretrade_rejection(code.value)
+        return PreTradeCheckResult(False, code)
+    if not ok:
+        code = RejectionReason.INSUFFICIENT_BUYING_POWER
+        sdk_metrics.record_pretrade_rejection(code.value)
+        return PreTradeCheckResult(False, code)
+
+    return PreTradeCheckResult(True, None)
+
+
+__all__ = ["check_pretrade", "PreTradeCheckResult"]
+

--- a/sdk/metrics.py
+++ b/sdk/metrics.py
@@ -172,6 +172,61 @@ else:
 alpha_sharpe._val = 0  # type: ignore[attr-defined]
 alpha_max_drawdown._val = 0  # type: ignore[attr-defined]
 
+# ---------------------------------------------------------------------------
+# Pre-trade rejection metrics (SDK-side)
+if "pretrade_attempts_total" in global_registry._names_to_collectors:
+    pretrade_attempts_total = global_registry._names_to_collectors["pretrade_attempts_total"]
+else:
+    pretrade_attempts_total = Counter(
+        "pretrade_attempts_total",
+        "Total number of pre-trade validation attempts",
+        registry=global_registry,
+    )
+
+if "pretrade_rejections_total" in global_registry._names_to_collectors:
+    pretrade_rejections_total = global_registry._names_to_collectors["pretrade_rejections_total"]
+else:
+    pretrade_rejections_total = Counter(
+        "pretrade_rejections_total",
+        "Total number of pre-trade rejections grouped by reason",
+        ["reason"],
+        registry=global_registry,
+    )
+
+if "pretrade_rejection_ratio" in global_registry._names_to_collectors:
+    pretrade_rejection_ratio = global_registry._names_to_collectors["pretrade_rejection_ratio"]
+else:
+    pretrade_rejection_ratio = Gauge(
+        "pretrade_rejection_ratio",
+        "Ratio of rejected to attempted pre-trade validations",
+        registry=global_registry,
+    )
+
+# Expose values for tests
+pretrade_attempts_total._val = 0  # type: ignore[attr-defined]
+pretrade_rejections_total._vals = {}  # type: ignore[attr-defined]
+pretrade_rejection_ratio._val = 0.0  # type: ignore[attr-defined]
+
+
+def _update_pretrade_ratio() -> None:
+    total = pretrade_attempts_total._value.get()
+    rejected = sum(pretrade_rejections_total._vals.values())  # type: ignore[attr-defined]
+    ratio = (rejected / total) if total else 0.0
+    pretrade_rejection_ratio.set(ratio)
+    pretrade_rejection_ratio._val = ratio  # type: ignore[attr-defined]
+
+
+def record_pretrade_attempt() -> None:
+    pretrade_attempts_total.inc()
+    pretrade_attempts_total._val = pretrade_attempts_total._value.get()  # type: ignore[attr-defined]
+    _update_pretrade_ratio()
+
+
+def record_pretrade_rejection(reason: str) -> None:
+    pretrade_rejections_total.labels(reason=reason).inc()
+    pretrade_rejections_total._vals[reason] = pretrade_rejections_total._vals.get(reason, 0) + 1  # type: ignore[attr-defined]
+    _update_pretrade_ratio()
+
 
 def observe_cache_read(upstream_id: str, interval: int) -> None:
     """Increment read metrics for a given upstream/interval pair."""
@@ -291,3 +346,9 @@ def reset_metrics() -> None:
     alpha_sharpe._val = 0  # type: ignore[attr-defined]
     alpha_max_drawdown.set(0)
     alpha_max_drawdown._val = 0  # type: ignore[attr-defined]
+    pretrade_attempts_total._value.set(0)  # type: ignore[attr-defined]
+    pretrade_attempts_total._val = 0  # type: ignore[attr-defined]
+    pretrade_rejections_total.clear()
+    pretrade_rejections_total._vals = {}  # type: ignore[attr-defined]
+    pretrade_rejection_ratio.set(0)
+    pretrade_rejection_ratio._val = 0.0  # type: ignore[attr-defined]

--- a/tests/test_pretrade_metrics.py
+++ b/tests/test_pretrade_metrics.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+
+from qmtl.sdk import metrics as sdk_metrics
+from qmtl.sdk.pretrade import check_pretrade, Activation
+from qmtl.common.pretrade import RejectionReason
+from qmtl.brokerage import BrokerageModel
+from qmtl.brokerage.simple import CashBuyingPowerModel
+from qmtl.brokerage.fees import PercentFeeModel
+from qmtl.brokerage.slippage import NullSlippageModel
+from qmtl.brokerage.fill_models import MarketFillModel
+from qmtl.brokerage.order import Account
+from qmtl.gateway.metrics import (
+    record_pretrade_attempt as gw_record_attempt,
+    record_pretrade_rejection as gw_record_rej,
+    get_pretrade_stats,
+)
+from qmtl.gateway.degradation import DegradationManager
+from qmtl.gateway.routes import create_api_router
+
+
+def test_sdk_pretrade_metrics_activation_reject():
+    sdk_metrics.reset_metrics()
+
+    activation = {"AAPL": Activation(enabled=False, reason="disabled by policy")}
+    brokerage = BrokerageModel(
+        buying_power_model=CashBuyingPowerModel(),
+        fee_model=PercentFeeModel(),
+        slippage_model=NullSlippageModel(),
+        fill_model=MarketFillModel(),
+    )
+    account = Account(cash=100_000.0)
+
+    res = check_pretrade(
+        activation_map=activation,
+        brokerage=brokerage,
+        account=account,
+        symbol="AAPL",
+        quantity=10,
+        price=100.0,
+    )
+    assert not res.allowed
+    assert res.reason == RejectionReason.ACTIVATION_DISABLED
+    # Attempt and rejection counters should update
+    assert sdk_metrics.pretrade_attempts_total._val == 1  # type: ignore[attr-defined]
+    assert sdk_metrics.pretrade_rejections_total._vals.get(RejectionReason.ACTIVATION_DISABLED.value, 0) == 1  # type: ignore[attr-defined]
+
+
+def test_gateway_status_includes_pretrade_metrics():
+    # Simulate two attempts, one rejection at gateway
+    gw_record_attempt()
+    gw_record_attempt()
+    gw_record_rej("activation_disabled")
+
+    stats = get_pretrade_stats()
+    assert stats["attempts"] >= 2
+    assert stats["rejections"].get("activation_disabled", 0) >= 1
+    assert 0 <= stats["ratio"] <= 1
+
+    # Build API router and call status endpoint
+    router = create_api_router(
+        manager=None,
+        redis_conn=None,
+        database_obj=None,
+        dagmanager=None,
+        watch_hub=None,
+        ws_hub=None,
+        degradation=DegradationManager(None, None, None),
+        world_client=None,
+        enforce_live_guard=False,
+    )
+
+    # Extract the status endpoint and execute
+    status_func = next(r.endpoint for r in router.routes if getattr(r, "path", None) == "/status")
+    result = asyncio.get_event_loop().run_until_complete(status_func())
+    assert "pretrade" in result
+    assert "degrade_level" in result
+


### PR DESCRIPTION
Summary: Adds canonical rejection reason codes, SDK/Gateway counters with ratio, and surfaces a pretrade block on Gateway /status. Provides SDK wrapper to unify activation + brokerage pre-trade checks with metrics.

Fixes #520

Notes:
- Designed to be forward-compatible with additional reasons and richer dimensions.
- Gateway aggregates metrics only; no change to order handling.

How to test:
- uv pip install -e .[dev]
- uv run -m pytest -W error -k pretrade_metrics