### PR TITLE
Add DB advisory lock helpers and ownership manager

### DIFF
--- a/qmtl/gateway/database.py
+++ b/qmtl/gateway/database.py
@@ -14,6 +14,31 @@ logger = logging.getLogger(__name__)
 _INITIAL_STATUS = "queued"
 
 
+async def pg_try_advisory_lock(conn: asyncpg.Connection, key: int) -> bool:
+    """Attempt to acquire a PostgreSQL advisory lock.
+
+    Parameters
+    ----------
+    conn:
+        An open :class:`asyncpg.Connection`.
+    key:
+        The lock identifier.
+
+    Returns
+    -------
+    bool
+        ``True`` if the lock was acquired, ``False`` otherwise.
+    """
+
+    return await conn.fetchval("SELECT pg_try_advisory_lock($1)", key)
+
+
+async def pg_advisory_unlock(conn: asyncpg.Connection, key: int) -> bool:
+    """Release a previously acquired PostgreSQL advisory lock."""
+
+    return await conn.fetchval("SELECT pg_advisory_unlock($1)", key)
+
+
 class Database:
     async def insert_strategy(self, strategy_id: str, meta: Optional[dict]) -> None:
         raise NotImplementedError
@@ -261,4 +286,6 @@ __all__ = [
     "PostgresDatabase",
     "SQLiteDatabase",
     "MemoryDatabase",
+    "pg_try_advisory_lock",
+    "pg_advisory_unlock",
 ]

--- a/qmtl/gateway/ownership.py
+++ b/qmtl/gateway/ownership.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional, Protocol
+
+from .database import PostgresDatabase, pg_try_advisory_lock, pg_advisory_unlock
+
+logger = logging.getLogger(__name__)
+
+
+class KafkaOwnership(Protocol):
+    async def acquire(self, key: int) -> bool:
+        """Try to obtain Kafka-based ownership for ``key``."""
+
+    async def release(self, key: int) -> None:
+        """Release Kafka-based ownership for ``key``."""
+
+
+class OwnershipManager:
+    """Coordinate ownership using Kafka with DB advisory lock fallback."""
+
+    def __init__(self, db: PostgresDatabase, kafka_owner: Optional[KafkaOwnership] = None) -> None:
+        self._db = db
+        self._kafka = kafka_owner
+
+    async def acquire(self, key: int) -> bool:
+        """Attempt to acquire ownership for ``key``."""
+
+        if self._kafka is not None:
+            try:
+                if await self._kafka.acquire(key):
+                    return True
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("Kafka ownership acquisition failed")
+
+        assert self._db._pool is not None, "database not connected"
+        async with self._db._pool.acquire() as conn:
+            return await pg_try_advisory_lock(conn, key)
+
+    async def release(self, key: int) -> None:
+        """Release ownership for ``key``."""
+
+        if self._kafka is not None:
+            try:
+                await self._kafka.release(key)
+                return
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("Kafka ownership release failed")
+
+        assert self._db._pool is not None, "database not connected"
+        async with self._db._pool.acquire() as conn:
+            await pg_advisory_unlock(conn, key)
+
+
+__all__ = ["OwnershipManager", "KafkaOwnership"]

--- a/tests/gateway/test_database_locks.py
+++ b/tests/gateway/test_database_locks.py
@@ -1,0 +1,26 @@
+import pytest
+
+from qmtl.gateway.database import pg_try_advisory_lock, pg_advisory_unlock
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+
+    async def fetchval(self, query: str, key: int) -> bool:
+        self.calls.append((query, key))
+        return True
+
+
+@pytest.mark.asyncio
+async def test_pg_try_advisory_lock_executes_correct_query() -> None:
+    conn = FakeConn()
+    assert await pg_try_advisory_lock(conn, 1)
+    assert conn.calls == [("SELECT pg_try_advisory_lock($1)", 1)]
+
+
+@pytest.mark.asyncio
+async def test_pg_advisory_unlock_executes_correct_query() -> None:
+    conn = FakeConn()
+    assert await pg_advisory_unlock(conn, 2)
+    assert conn.calls == [("SELECT pg_advisory_unlock($1)", 2)]

--- a/tests/gateway/test_ownership_manager.py
+++ b/tests/gateway/test_ownership_manager.py
@@ -1,0 +1,80 @@
+import pytest
+
+from qmtl.gateway.database import PostgresDatabase
+from qmtl.gateway.ownership import OwnershipManager
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+
+    async def fetchval(self, query: str, key: int) -> bool:
+        self.calls.append((query, key))
+        return True
+
+
+class FakePool:
+    def __init__(self, conn: FakeConn) -> None:
+        self.conn = conn
+
+    def acquire(self):
+        conn = self.conn
+
+        class _Ctx:
+            async def __aenter__(self):
+                return conn
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+        return _Ctx()
+
+
+class FakeKafkaOwner:
+    def __init__(self, result: bool) -> None:
+        self.result = result
+        self.acquire_calls: list[int] = []
+        self.release_calls: list[int] = []
+
+    async def acquire(self, key: int) -> bool:
+        self.acquire_calls.append(key)
+        return self.result
+
+    async def release(self, key: int) -> None:
+        self.release_calls.append(key)
+
+
+@pytest.mark.asyncio
+async def test_kafka_preferred_over_db() -> None:
+    conn = FakeConn()
+    db = PostgresDatabase("dsn")
+    db._pool = FakePool(conn)  # type: ignore[assignment]
+    kafka = FakeKafkaOwner(result=True)
+    manager = OwnershipManager(db, kafka)
+
+    assert await manager.acquire(10)
+    assert kafka.acquire_calls == [10]
+    assert conn.calls == []
+
+
+@pytest.mark.asyncio
+async def test_fallback_to_db_when_kafka_unavailable() -> None:
+    conn = FakeConn()
+    db = PostgresDatabase("dsn")
+    db._pool = FakePool(conn)  # type: ignore[assignment]
+    kafka = FakeKafkaOwner(result=False)
+    manager = OwnershipManager(db, kafka)
+
+    assert await manager.acquire(20)
+    assert conn.calls == [("SELECT pg_try_advisory_lock($1)", 20)]
+
+
+@pytest.mark.asyncio
+async def test_release_uses_db_when_no_kafka_owner() -> None:
+    conn = FakeConn()
+    db = PostgresDatabase("dsn")
+    db._pool = FakePool(conn)  # type: ignore[assignment]
+    manager = OwnershipManager(db)
+
+    await manager.release(30)
+    assert conn.calls == [("SELECT pg_advisory_unlock($1)", 30)]


### PR DESCRIPTION
## Summary
- add Postgres advisory lock helpers for reuse
- implement OwnershipManager that prefers Kafka ownership and falls back to DB locks
- cover lock helpers and ownership manager with tests

## Testing
- `uv run -m pytest -W error tests/gateway/test_database_locks.py tests/gateway/test_ownership_manager.py`
- `uv run -m pytest -W error` *(fails: ExceptionGroup: multiple unraisable exception warnings in tests/gateway/test_degradation.py::test_static_returns_204)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e139c9148329a74811ac4a6284c6