### PR TITLE
feat: add transactional commit log writer

### DIFF
--- a/qmtl/gateway/commit_log.py
+++ b/qmtl/gateway/commit_log.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Iterable
+
+try:
+    from aiokafka import AIOKafkaProducer
+except Exception:  # pragma: no cover - aiokafka optional
+    AIOKafkaProducer = Any  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class CommitLogWriter:
+    """Write commit-log records to a compacted Kafka topic.
+
+    The writer uses a Kafka producer configured for idempotent transactional
+    publishing.  Each call to :meth:`publish_bucket` writes all records for a
+    bucket within a single transaction which is either committed or aborted.
+    """
+
+    def __init__(self, producer: AIOKafkaProducer, topic: str) -> None:  # type: ignore[misc]
+        self._producer = producer
+        self._topic = topic
+
+    async def publish_bucket(
+        self,
+        bucket_ts: int,
+        records: Iterable[tuple[str, str, Any]],
+    ) -> None:
+        """Publish ``records`` for ``bucket_ts`` in a single transaction.
+
+        Each record is a tuple ``(node_id, input_window_hash, payload)``.  The
+        value sent to Kafka contains ``(node_id, bucket_ts, input_window_hash,
+        payload)`` serialised as JSON.  The message key combines the
+        ``node_id``, ``bucket_ts`` and ``input_window_hash`` so that the topic
+        can be compacted.
+        """
+
+        await self._producer.begin_transaction()
+        try:
+            for node_id, input_window_hash, payload in records:
+                value = json.dumps(
+                    (node_id, bucket_ts, input_window_hash, payload)
+                ).encode()
+                key = f"{node_id}:{bucket_ts}:{input_window_hash}".encode()
+                await self._producer.send_and_wait(
+                    self._topic,
+                    key=key,
+                    value=value,
+                )
+            await self._producer.commit_transaction()
+        except Exception:  # pragma: no cover - defensive log
+            try:
+                await self._producer.abort_transaction()
+            except Exception:  # pragma: no cover - double failure
+                logger.exception("Commit-log abort failed")
+            raise
+
+
+async def create_commit_log_writer(
+    bootstrap_servers: str, topic: str, transactional_id: str
+) -> CommitLogWriter:
+    """Create a :class:`CommitLogWriter` with idempotent producer settings."""
+
+    producer = AIOKafkaProducer(
+        bootstrap_servers=bootstrap_servers,
+        acks="all",
+        enable_idempotence=True,
+        transactional_id=transactional_id,
+    )
+    await producer.start()
+    return CommitLogWriter(producer, topic)
+
+
+__all__ = ["CommitLogWriter", "create_commit_log_writer"]

--- a/tests/gateway/test_commit_log_writer.py
+++ b/tests/gateway/test_commit_log_writer.py
@@ -1,0 +1,56 @@
+import json
+import pytest
+
+from qmtl.gateway.commit_log import CommitLogWriter
+
+
+class FakeProducer:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, bytes, bytes]] = []
+        self.begin_called = 0
+        self.commit_called = 0
+        self.abort_called = 0
+
+    async def begin_transaction(self) -> None:
+        self.begin_called += 1
+
+    async def send_and_wait(self, topic: str, key: bytes, value: bytes) -> None:
+        self.messages.append((topic, key, value))
+
+    async def commit_transaction(self) -> None:
+        self.commit_called += 1
+
+    async def abort_transaction(self) -> None:
+        self.abort_called += 1
+
+
+@pytest.mark.asyncio
+async def test_publish_bucket_commits() -> None:
+    producer = FakeProducer()
+    writer = CommitLogWriter(producer, "commit-log")
+
+    await writer.publish_bucket(100, [("n1", "h1", {"a": 1})])
+
+    assert producer.begin_called == 1
+    assert producer.commit_called == 1
+    assert producer.abort_called == 0
+    assert producer.messages[0][0] == "commit-log"
+    assert producer.messages[0][1] == b"n1:100:h1"
+    assert json.loads(producer.messages[0][2].decode()) == ["n1", 100, "h1", {"a": 1}]
+
+
+@pytest.mark.asyncio
+async def test_publish_bucket_aborts_on_error() -> None:
+    class ErrProducer(FakeProducer):
+        async def send_and_wait(self, topic: str, key: bytes, value: bytes) -> None:  # pragma: no cover - deterministic
+            raise RuntimeError("boom")
+
+    producer = ErrProducer()
+    writer = CommitLogWriter(producer, "commit-log")
+
+    with pytest.raises(RuntimeError):
+        await writer.publish_bucket(200, [("n1", "h1", "x")])
+
+    assert producer.begin_called == 1
+    assert producer.commit_called == 0
+    assert producer.abort_called == 1


### PR DESCRIPTION
## Summary
- implement commit-log writer using an idempotent, transactional Kafka producer
- publish `(node_id, bucket_ts, input_window_hash, payload)` tuples and commit per bucket
- add tests for commit and abort paths

## Testing
- `uv pip install --system -e .[dev]`
- `uv run --extra dev -m pytest -W error` *(fails: ExceptionGroup multiple unraisable exception warnings in tests/gateway/test_callbacks.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f1fb16a4832985e267a91a90999f