### PR TITLE
Mark global queues and skip local execution

### DIFF
--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -38,7 +38,7 @@ class _MemRepo(NodeRepository):
 
     def get_queues_by_tag(
         self, tags: Iterable[str], interval: int, match_mode: str = "any"
-    ) -> list[str]:
+    ) -> list[dict[str, object]]:
         return []
 
     def get_node_by_queue(self, queue: str) -> NodeRecord | None:

--- a/qmtl/gateway/models.py
+++ b/qmtl/gateway/models.py
@@ -15,7 +15,7 @@ class StrategySubmit(BaseModel):
 
 class StrategyAck(BaseModel):
     strategy_id: str
-    queue_map: dict[str, list[str] | str] = Field(default_factory=dict)
+    queue_map: dict[str, object] = Field(default_factory=dict)
 
 
 class StatusResponse(BaseModel):

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -221,7 +221,7 @@ class WebSocketHub:
         self,
         tags: list[str],
         interval: int,
-        queues: list[str],
+        queues: list[dict[str, object]],
         match_mode: MatchMode = MatchMode.ANY,
     ) -> None:
         """Broadcast queue update events.

--- a/qmtl/proto/dagmanager.proto
+++ b/qmtl/proto/dagmanager.proto
@@ -40,8 +40,13 @@ message TagQueryRequest {
   string match_mode = 3;
 }
 
+message QueueDescriptor {
+  string queue = 1;
+  bool global = 2;
+}
+
 message TagQueryReply {
-  repeated string queues = 1;
+  repeated QueueDescriptor queues = 1;
 }
 
 service TagQuery {

--- a/qmtl/proto/dagmanager_pb2.py
+++ b/qmtl/proto/dagmanager_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10\x64\x61gmanager.proto\x12\x0fqmtl.dagmanager\"4\n\x0b\x44iffRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\xaf\x01\n\x11\x42ufferInstruction\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x11\n\tnode_type\x18\x02 \x01(\t\x12\x11\n\tcode_hash\x18\x03 \x01(\t\x12\x13\n\x0bschema_hash\x18\x04 \x01(\t\x12\x10\n\x08interval\x18\x05 \x01(\x03\x12\x0e\n\x06period\x18\x06 \x01(\x05\x12\x0c\n\x04tags\x18\x07 \x03(\t\x12\x0b\n\x03lag\x18\x08 \x01(\x05\x12\x11\n\tschema_id\x18\t \x01(\t\"\xc8\x01\n\tDiffChunk\x12;\n\tqueue_map\x18\x01 \x03(\x0b\x32(.qmtl.dagmanager.DiffChunk.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x12\x38\n\x0c\x62uffer_nodes\x18\x03 \x03(\x0b\x32\".qmtl.dagmanager.BufferInstruction\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"1\n\x08\x43hunkAck\x12\x13\n\x0bsentinel_id\x18\x01 \x01(\t\x12\x10\n\x08\x63hunk_id\x18\x02 \x01(\r\"E\n\x0fTagQueryRequest\x12\x0c\n\x04tags\x18\x01 \x03(\t\x12\x10\n\x08interval\x18\x02 \x01(\x03\x12\x12\n\nmatch_mode\x18\x03 \x01(\t\"\x1f\n\rTagQueryReply\x12\x0e\n\x06queues\x18\x01 \x03(\t\"%\n\x0e\x43leanupRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\"\x11\n\x0f\x43leanupResponse\"#\n\x11QueueStatsRequest\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\"q\n\nQueueStats\x12\x35\n\x05sizes\x18\x01 \x03(\x0b\x32&.qmtl.dagmanager.QueueStats.SizesEntry\x1a,\n\nSizesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"8\n\x0fRedoDiffRequest\x12\x13\n\x0bsentinel_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\x90\x01\n\nDiffResult\x12<\n\tqueue_map\x18\x01 \x03(\x0b\x32).qmtl.dagmanager.DiffResult.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x0f\n\rStatusRequest\"+\n\x0bStatusReply\x12\r\n\x05neo4j\x18\x01 \x01(\t\x12\r\n\x05state\x18\x02 \x01(\t2\x93\x01\n\x0b\x44iffService\x12\x42\n\x04\x44iff\x12\x1c.qmtl.dagmanager.DiffRequest\x1a\x1a.qmtl.dagmanager.DiffChunk0\x01\x12@\n\x08\x41\x63kChunk\x12\x19.qmtl.dagmanager.ChunkAck\x1a\x19.qmtl.dagmanager.ChunkAck2Y\n\x08TagQuery\x12M\n\tGetQueues\x12 .qmtl.dagmanager.TagQueryRequest\x1a\x1e.qmtl.dagmanager.TagQueryReply2\xf9\x01\n\x0c\x41\x64minService\x12L\n\x07\x43leanup\x12\x1f.qmtl.dagmanager.CleanupRequest\x1a .qmtl.dagmanager.CleanupResponse\x12P\n\rGetQueueStats\x12\".qmtl.dagmanager.QueueStatsRequest\x1a\x1b.qmtl.dagmanager.QueueStats\x12I\n\x08RedoDiff\x12 .qmtl.dagmanager.RedoDiffRequest\x1a\x1b.qmtl.dagmanager.DiffResult2U\n\x0bHealthCheck\x12\x46\n\x06Status\x12\x1e.qmtl.dagmanager.StatusRequest\x1a\x1c.qmtl.dagmanager.StatusReplyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10\x64\x61gmanager.proto\x12\x0fqmtl.dagmanager\"4\n\x0b\x44iffRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\xaf\x01\n\x11\x42ufferInstruction\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x11\n\tnode_type\x18\x02 \x01(\t\x12\x11\n\tcode_hash\x18\x03 \x01(\t\x12\x13\n\x0bschema_hash\x18\x04 \x01(\t\x12\x10\n\x08interval\x18\x05 \x01(\x03\x12\x0e\n\x06period\x18\x06 \x01(\x05\x12\x0c\n\x04tags\x18\x07 \x03(\t\x12\x0b\n\x03lag\x18\x08 \x01(\x05\x12\x11\n\tschema_id\x18\t \x01(\t\"\xc8\x01\n\tDiffChunk\x12;\n\tqueue_map\x18\x01 \x03(\x0b\x32(.qmtl.dagmanager.DiffChunk.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x12\x38\n\x0c\x62uffer_nodes\x18\x03 \x03(\x0b\x32\".qmtl.dagmanager.BufferInstruction\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"1\n\x08\x43hunkAck\x12\x13\n\x0bsentinel_id\x18\x01 \x01(\t\x12\x10\n\x08\x63hunk_id\x18\x02 \x01(\r\"E\n\x0fTagQueryRequest\x12\x0c\n\x04tags\x18\x01 \x03(\t\x12\x10\n\x08interval\x18\x02 \x01(\x03\x12\x12\n\nmatch_mode\x18\x03 \x01(\t\"0\n\x0fQueueDescriptor\x12\r\n\x05queue\x18\x01 \x01(\t\x12\x0e\n\x06global\x18\x02 \x01(\x08\"A\n\rTagQueryReply\x12\x30\n\x06queues\x18\x01 \x03(\x0b\x32 .qmtl.dagmanager.QueueDescriptor\"%\n\x0e\x43leanupRequest\x12\x13\n\x0bstrategy_id\x18\x01 \x01(\t\"\x11\n\x0f\x43leanupResponse\"#\n\x11QueueStatsRequest\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\"q\n\nQueueStats\x12\x35\n\x05sizes\x18\x01 \x03(\x0b\x32&.qmtl.dagmanager.QueueStats.SizesEntry\x1a,\n\nSizesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"8\n\x0fRedoDiffRequest\x12\x13\n\x0bsentinel_id\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61g_json\x18\x02 \x01(\t\"\x90\x01\n\nDiffResult\x12<\n\tqueue_map\x18\x01 \x03(\x0b\x32).qmtl.dagmanager.DiffResult.QueueMapEntry\x12\x13\n\x0bsentinel_id\x18\x02 \x01(\t\x1a/\n\rQueueMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x0f\n\rStatusRequest\"+\n\x0bStatusReply\x12\r\n\x05neo4j\x18\x01 \x01(\t\x12\r\n\x05state\x18\x02 \x01(\t2\x93\x01\n\x0b\x44iffService\x12\x42\n\x04\x44iff\x12\x1c.qmtl.dagmanager.DiffRequest\x1a\x1a.qmtl.dagmanager.DiffChunk0\x01\x12@\n\x08\x41\x63kChunk\x12\x19.qmtl.dagmanager.ChunkAck\x1a\x19.qmtl.dagmanager.ChunkAck2Y\n\x08TagQuery\x12M\n\tGetQueues\x12 .qmtl.dagmanager.TagQueryRequest\x1a\x1e.qmtl.dagmanager.TagQueryReply2\xf9\x01\n\x0c\x41\x64minService\x12L\n\x07\x43leanup\x12\x1f.qmtl.dagmanager.CleanupRequest\x1a .qmtl.dagmanager.CleanupResponse\x12P\n\rGetQueueStats\x12\".qmtl.dagmanager.QueueStatsRequest\x1a\x1b.qmtl.dagmanager.QueueStats\x12I\n\x08RedoDiff\x12 .qmtl.dagmanager.RedoDiffRequest\x1a\x1b.qmtl.dagmanager.DiffResult2U\n\x0bHealthCheck\x12\x46\n\x06Status\x12\x1e.qmtl.dagmanager.StatusRequest\x1a\x1c.qmtl.dagmanager.StatusReplyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -49,34 +49,36 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_CHUNKACK']._serialized_end=521
   _globals['_TAGQUERYREQUEST']._serialized_start=523
   _globals['_TAGQUERYREQUEST']._serialized_end=592
-  _globals['_TAGQUERYREPLY']._serialized_start=594
-  _globals['_TAGQUERYREPLY']._serialized_end=625
-  _globals['_CLEANUPREQUEST']._serialized_start=627
-  _globals['_CLEANUPREQUEST']._serialized_end=664
-  _globals['_CLEANUPRESPONSE']._serialized_start=666
-  _globals['_CLEANUPRESPONSE']._serialized_end=683
-  _globals['_QUEUESTATSREQUEST']._serialized_start=685
-  _globals['_QUEUESTATSREQUEST']._serialized_end=720
-  _globals['_QUEUESTATS']._serialized_start=722
-  _globals['_QUEUESTATS']._serialized_end=835
-  _globals['_QUEUESTATS_SIZESENTRY']._serialized_start=791
-  _globals['_QUEUESTATS_SIZESENTRY']._serialized_end=835
-  _globals['_REDODIFFREQUEST']._serialized_start=837
-  _globals['_REDODIFFREQUEST']._serialized_end=893
-  _globals['_DIFFRESULT']._serialized_start=896
-  _globals['_DIFFRESULT']._serialized_end=1040
+  _globals['_QUEUEDESCRIPTOR']._serialized_start=594
+  _globals['_QUEUEDESCRIPTOR']._serialized_end=642
+  _globals['_TAGQUERYREPLY']._serialized_start=644
+  _globals['_TAGQUERYREPLY']._serialized_end=709
+  _globals['_CLEANUPREQUEST']._serialized_start=711
+  _globals['_CLEANUPREQUEST']._serialized_end=748
+  _globals['_CLEANUPRESPONSE']._serialized_start=750
+  _globals['_CLEANUPRESPONSE']._serialized_end=767
+  _globals['_QUEUESTATSREQUEST']._serialized_start=769
+  _globals['_QUEUESTATSREQUEST']._serialized_end=804
+  _globals['_QUEUESTATS']._serialized_start=806
+  _globals['_QUEUESTATS']._serialized_end=919
+  _globals['_QUEUESTATS_SIZESENTRY']._serialized_start=875
+  _globals['_QUEUESTATS_SIZESENTRY']._serialized_end=919
+  _globals['_REDODIFFREQUEST']._serialized_start=921
+  _globals['_REDODIFFREQUEST']._serialized_end=977
+  _globals['_DIFFRESULT']._serialized_start=980
+  _globals['_DIFFRESULT']._serialized_end=1124
   _globals['_DIFFRESULT_QUEUEMAPENTRY']._serialized_start=423
   _globals['_DIFFRESULT_QUEUEMAPENTRY']._serialized_end=470
-  _globals['_STATUSREQUEST']._serialized_start=1042
-  _globals['_STATUSREQUEST']._serialized_end=1057
-  _globals['_STATUSREPLY']._serialized_start=1059
-  _globals['_STATUSREPLY']._serialized_end=1102
-  _globals['_DIFFSERVICE']._serialized_start=1105
-  _globals['_DIFFSERVICE']._serialized_end=1252
-  _globals['_TAGQUERY']._serialized_start=1254
-  _globals['_TAGQUERY']._serialized_end=1343
-  _globals['_ADMINSERVICE']._serialized_start=1346
-  _globals['_ADMINSERVICE']._serialized_end=1595
-  _globals['_HEALTHCHECK']._serialized_start=1597
-  _globals['_HEALTHCHECK']._serialized_end=1682
+  _globals['_STATUSREQUEST']._serialized_start=1126
+  _globals['_STATUSREQUEST']._serialized_end=1141
+  _globals['_STATUSREPLY']._serialized_start=1143
+  _globals['_STATUSREPLY']._serialized_end=1186
+  _globals['_DIFFSERVICE']._serialized_start=1189
+  _globals['_DIFFSERVICE']._serialized_end=1336
+  _globals['_TAGQUERY']._serialized_start=1338
+  _globals['_TAGQUERY']._serialized_end=1427
+  _globals['_ADMINSERVICE']._serialized_start=1430
+  _globals['_ADMINSERVICE']._serialized_end=1679
+  _globals['_HEALTHCHECK']._serialized_start=1681
+  _globals['_HEALTHCHECK']._serialized_end=1766
 # @@protoc_insertion_point(module_scope)

--- a/tests/buffer/test_buffer_scheduler.py
+++ b/tests/buffer/test_buffer_scheduler.py
@@ -48,7 +48,17 @@ class FakeDiff(DiffService):
 async def test_scheduler_reprocesses_old_nodes():
     repo = FakeRepo()
     repo.records["A"] = NodeRecord(
-        "A", "N", "c", "s", "id1", None, None, [], None, topic_name("asset", "N", "c", "v1")
+        "A",
+        "N",
+        "c",
+        "s",
+        "id1",
+        None,
+        None,
+        [],
+        None,
+        False,
+        topic_name("asset", "N", "c", "v1"),
     )
     repo.mark_buffering("A", timestamp_ms=0)
     diff = FakeDiff()

--- a/tests/gateway/test_controlbus_consumer.py
+++ b/tests/gateway/test_controlbus_consumer.py
@@ -73,7 +73,12 @@ async def test_consumer_relays_and_deduplicates():
         key="t",
         etag="e3",
         run_id="r3",
-        data={"tags": ["x"], "interval": 60, "queues": ["q"], "match_mode": "any"},
+        data={
+            "tags": ["x"],
+            "interval": 60,
+            "queues": [{"queue": "q", "global": False}],
+            "match_mode": "any",
+        },
         timestamp_ms=ts,
     )
     await consumer.publish(msg1)
@@ -85,10 +90,15 @@ async def test_consumer_relays_and_deduplicates():
     assert hub.events == [
         ("activation_updated", {"id": 1}),
         ("policy_updated", {"id": 2}),
-        (
-            "queue_update",
-            {"tags": ["x"], "interval": 60, "queues": ["q"], "match_mode": MatchMode.ANY},
-        ),
+            (
+                "queue_update",
+                {
+                    "tags": ["x"],
+                    "interval": 60,
+                    "queues": [{"queue": "q", "global": False}],
+                    "match_mode": MatchMode.ANY,
+                },
+            ),
     ]
     assert metrics.event_relay_events_total.labels(topic="activation")._value.get() == 1
     assert metrics.event_relay_events_total.labels(topic="policy")._value.get() == 1

--- a/tests/gateway/test_queue_update_ws_execution.py
+++ b/tests/gateway/test_queue_update_ws_execution.py
@@ -48,7 +48,12 @@ async def test_node_unpauses_on_queue_update():
     event = format_event(
         "qmtl.dagmanager",
         "queue_update",
-        {"tags": ["t1"], "interval": 60, "queues": ["q1"], "match_mode": "any"},
+        {
+            "tags": ["t1"],
+            "interval": 60,
+            "queues": [{"queue": "q1", "global": False}],
+            "match_mode": "any",
+        },
     )
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
         resp = await c.post("/callbacks/dag-event", json=event)

--- a/tests/sdk/test_tag_manager_service.py
+++ b/tests/sdk/test_tag_manager_service.py
@@ -43,3 +43,17 @@ def test_apply_queue_map_updates_nodes(caplog):
         if r.name == "qmtl.sdk.tag_manager_service"
     ]
     assert any(strat.proc.node_id in m for m in msgs)
+
+
+def test_apply_queue_map_filters_global():
+    strat = _Strat()
+    strat.setup()
+    service = TagManagerService(None)
+    mapping = {
+        partition_key(strat.tq.node_id, strat.tq.interval, 0): [
+            {"queue": "q1", "global": True},
+            {"queue": "q2", "global": False},
+        ]
+    }
+    service.apply_queue_map(strat, mapping)
+    assert strat.tq.upstreams == ["q2"]

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -108,7 +108,12 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
     event = format_event(
         "qmtl.dagmanager",
         "queue_update",
-        {"tags": ["t1"], "interval": 60, "queues": ["q1"], "match_mode": "any"},
+        {
+            "tags": ["t1"],
+            "interval": 60,
+            "queues": [{"queue": "q1", "global": False}],
+            "match_mode": "any",
+        },
     )
     async with httpx.AsyncClient(transport=transport, base_url="http://gw") as c:
         resp = await c.post("/callbacks/dag-event", json=event)
@@ -116,7 +121,15 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
 
     # Directly apply queue update to ensure subscription processed
     await strat.tag_query_manager.handle_message(
-        {"type": "queue_update", "data": {"tags": ["t1"], "interval": 60, "queues": ["q1"], "match_mode": "any"}}
+        {
+            "type": "queue_update",
+            "data": {
+                "tags": ["t1"],
+                "interval": 60,
+                "queues": [{"queue": "q1", "global": False}],
+                "match_mode": "any",
+            },
+        }
     )
     await asyncio.sleep(0.1)
     node = strat.tq

--- a/tests/tagquery/test_update_warmup.py
+++ b/tests/tagquery/test_update_warmup.py
@@ -12,10 +12,17 @@ async def test_update_warmup_and_removal():
     manager.register(node)
 
     # Initial queue registration
-    await manager.handle_message({
-        "event": "queue_update",
-        "data": {"tags": ["t"], "interval": 60, "queues": ["q1"], "match_mode": "any"},
-    })
+    await manager.handle_message(
+        {
+            "event": "queue_update",
+            "data": {
+                "tags": ["t"],
+                "interval": 60,
+                "queues": [{"queue": "q1", "global": False}],
+                "match_mode": "any",
+            },
+        }
+    )
     assert node.upstreams == ["q1"]
     assert node.pre_warmup
 
@@ -27,10 +34,20 @@ async def test_update_warmup_and_removal():
     assert len(calls) == 1
 
     # Add new queue and ensure warmup resets
-    await manager.handle_message({
-        "event": "queue_update",
-        "data": {"tags": ["t"], "interval": 60, "queues": ["q1", "q2"], "match_mode": "any"},
-    })
+    await manager.handle_message(
+        {
+            "event": "queue_update",
+            "data": {
+                "tags": ["t"],
+                "interval": 60,
+                "queues": [
+                    {"queue": "q1", "global": False},
+                    {"queue": "q2", "global": False},
+                ],
+                "match_mode": "any",
+            },
+        }
+    )
     assert set(node.upstreams) == {"q1", "q2"}
     assert node.pre_warmup
 
@@ -41,9 +58,16 @@ async def test_update_warmup_and_removal():
     assert len(calls) == 2
 
     # Remove queue and validate cache drop
-    await manager.handle_message({
-        "event": "queue_update",
-        "data": {"tags": ["t"], "interval": 60, "queues": ["q2"], "match_mode": "any"},
-    })
+    await manager.handle_message(
+        {
+            "event": "queue_update",
+            "data": {
+                "tags": ["t"],
+                "interval": 60,
+                "queues": [{"queue": "q2", "global": False}],
+                "match_mode": "any",
+            },
+        }
+    )
     assert node.upstreams == ["q2"]
     assert node.cache.get_slice("q1", 60, count=1) == []

--- a/tests/test_completion_monitor.py
+++ b/tests/test_completion_monitor.py
@@ -18,6 +18,7 @@ class DummyRepo(NodeRepository):
             period=1,
             tags=["t1"],
             bucket=None,
+            is_global=False,
             topic="q1",
         )
 

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -123,6 +123,7 @@ def test_hash_compare_and_queue_upsert():
         None,
         [],
         None,
+        False,
         topic_name("asset", "N", "c1", "v1"),
     )
     queue = FakeQueue()
@@ -155,6 +156,7 @@ def test_schema_change_buffering_flag():
         None,
         [],
         None,
+        False,
         topic_name("asset", "N", "c1", "v1"),
     )
     queue = FakeQueue()
@@ -301,6 +303,7 @@ def test_integration_with_memory_repo(tmp_path):
             None,
             [],
             None,
+            False,
             topic_name("asset", "N", "c1", "v1"),
         )
     )

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -373,7 +373,7 @@ async def test_grpc_tag_query():
         req = dagmanager_pb2.TagQueryRequest(tags=["t"], interval=60)
         resp = await stub.GetQueues(req)
     await server.stop(None)
-    assert list(resp.queues) == ["q1", "q2"]
+    assert [q.queue for q in resp.queues] == ["q1", "q2"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -17,7 +17,7 @@ async def test_ws_client_updates_state():
             "event": "queue_update",
             "tags": ["t"],
             "interval": 60,
-            "queues": ["q1"],
+            "queues": [{"queue": "q1", "global": False}],
             "match_mode": "any",
         },
     ]


### PR DESCRIPTION
## Summary
- include global flag in TagQuery responses and queue mapping
- filter global queues in TagQueryManager and TagManagerService
- adapt gRPC/HTTP endpoints and tests for global-aware queue descriptors

## Testing
- `uv run -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5fc0be0148329b8e9cc199f839a43