### PR TITLE
Add commit log ownership tests

### DIFF
--- a/tests/gateway/test_commit_log_consumer.py
+++ b/tests/gateway/test_commit_log_consumer.py
@@ -1,3 +1,6 @@
+import asyncio
+import pytest
+
 from qmtl.gateway.commit_log_consumer import CommitLogDeduplicator
 from qmtl.gateway import metrics
 
@@ -19,3 +22,42 @@ def test_commit_log_deduplicator_filters_duplicates():
     more = list(dedup.filter([( "n1", 100, "h1", {"a": 4})]))
     assert more == []
     assert metrics.commit_duplicate_total._value.get() == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_workers_single_commit() -> None:
+    metrics.reset_metrics()
+    log: list[tuple[str, int, str, dict[str, int]]] = []
+
+    async def worker(record: tuple[str, int, str, dict[str, int]], delay: float) -> None:
+        await asyncio.sleep(delay)
+        log.append(record)
+
+    r1 = ("n1", 100, "h1", {"a": 1})
+    r2 = ("n1", 100, "h1", {"a": 2})
+    await asyncio.gather(worker(r1, 0), worker(r2, 0.01))
+
+    dedup = CommitLogDeduplicator()
+    out = list(dedup.filter(log))
+    assert out == [r1]
+    assert metrics.commit_duplicate_total._value.get() == 1
+
+
+@pytest.mark.asyncio
+async def test_owner_reassign_emits_one_additional_commit() -> None:
+    metrics.reset_metrics()
+    dedup = CommitLogDeduplicator()
+
+    first = ("n1", 100, "h1", {"a": 1})
+    out1 = list(dedup.filter([first]))
+    assert out1 == [first]
+
+    # Reassigned worker processes the same bucket again
+    second_batch = [
+        ("n1", 100, "h1", {"a": 1}),  # duplicate of first
+        ("n1", 100, "h2", {"a": 2}),  # new commit
+    ]
+    out2 = list(dedup.filter(second_batch))
+
+    assert out2 == [("n1", 100, "h2", {"a": 2})]
+    assert metrics.commit_duplicate_total._value.get() == 1


### PR DESCRIPTION
## Summary
- add test ensuring concurrent workers log only one commit
- add test for mid-bucket owner termination yielding one additional commit

## Testing
- `uv run -m pytest -W error tests/gateway/test_commit_log_consumer.py::test_concurrent_workers_single_commit tests/gateway/test_commit_log_consumer.py::test_owner_reassign_emits_one_additional_commit`

------
https://chatgpt.com/codex/tasks/task_e_68b602c540e48329a41c82c7f3634a09