### PR TITLE
docs: document ownership and commit log

### DIFF
--- a/docs/architecture/dag-manager.md
+++ b/docs/architecture/dag-manager.md
@@ -34,6 +34,13 @@ last_modified: 2025-08-21
 
 ---
 
+## 0-A. Ownership & Commit-Log Design
+
+- **Ownership** — DAG Manager는 ComputeNode와 Queue 메타데이터의 단일 소스로서 토픽 생성·버전 롤아웃·GC를 전담한다. Gateway는 제출 파이프라인을 조정하지만 그래프 상태를 소유하지 않으며, WorldService는 월드·결정 상태를 유지한다.
+- **Commit Log** — 모든 큐는 Redpanda/Kafka의 append-only 토픽으로 구현되며, DAG Manager는 `QueueUpdated` 등 제어 이벤트를 ControlBus 토픽에 발행한다. 토픽 생성·삭제 이력도 관리 로그에 기록되어 장애 시점 복원과 감사(audit)을 지원한다.
+
+---
+
 ## 1. 데이터 모델 (Neo4j Property Graph)
 
 ### 1.1 노드·관계 스키마

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -216,6 +216,13 @@ Available flags:
 
 ---
 
+## S4 · Ownership & Commit‑Log Design
+
+- **Ownership** — Gateway는 제출 요청 큐(FIFO)와 전략별 FSM만을 관리하며, 그래프나 큐, 월드 상태의 단일 소스는 아니다. Diff 이후 생성되는 토픽과 그 생명주기는 DAG Manager가 소유하고, 월드 정책과 활성 상태는 WorldService가 책임진다.
+- **Commit Log** — 모든 전략 제출은 처리 전에 `gateway.ingest` 토픽(Redpanda/Kafka)에 append된다. Gateway는 오프셋을 Redis에 저장해 재시도 시점을 복원하며, DAG Manager와 WorldService가 발행하는 ControlBus 이벤트를 구독해 SDK로 중계한다. 이러한 로그 기반 경계는 장애 시 재생(replay)과 감사를 가능하게 한다.
+
+---
+
 ## S6 · Worlds Proxy & Event Stream (New)
 
 Gateway remains the single public boundary for SDKs. It proxies WorldService endpoints and provides an opaque event stream descriptor to SDKs; it does not compute world policy itself.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ nav:
   - Maintenance Schedule: MAINTENANCE_SCHEDULE.md
   - Architecture:
       - Overview: architecture/README.md
-      - Architecture: architecture/architecture.md
+      - Architecture & Ownership: architecture/architecture.md
       - Glossary: architecture/glossary.md
       - DAG Manager: architecture/dag-manager.md
       - Gateway: architecture/gateway.md


### PR DESCRIPTION
## Summary
- describe service ownership boundaries and commit-log strategy in core architecture docs
- clarify gateway's transient ownership and ingest logging
- note DAG Manager's authority over graph and queue metadata

## Testing
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b603d5428c8329af2bc42ec4b2e4bf