### PR TITLE
Use ownership manager for strategy worker

### DIFF
--- a/tests/reliability/test_worker_alerts.py
+++ b/tests/reliability/test_worker_alerts.py
@@ -7,6 +7,18 @@ from qmtl.gateway.fsm import StrategyFSM
 from qmtl.gateway.database import Database
 
 
+class DummyManager:
+    def __init__(self) -> None:
+        self.acquire_calls: list[int] = []
+
+    async def acquire(self, key: int) -> bool:
+        self.acquire_calls.append(key)
+        return True
+
+    async def release(self, key: int) -> None:
+        pass
+
+
 class FakeDB(Database):
     def __init__(self) -> None:
         self.states: dict[str, str] = {}
@@ -60,6 +72,7 @@ async def test_worker_alerts_after_repeated_failures(fake_redis):
         ws_hub=None,
         alert_manager=alerts,
         grpc_fail_threshold=2,
+        manager=DummyManager(),
     )
 
     # enqueue three strategies that will all fail


### PR DESCRIPTION
## Summary
- remove Redis-based strategy lock
- manage strategy ownership via OwnershipManager
- mock ownership in tests to ensure single worker processing

## Testing
- `uv run -m pytest -W error tests/gateway/test_worker.py tests/reliability/test_worker_alerts.py tests/test_health.py::test_worker_healthy`

------
https://chatgpt.com/codex/tasks/task_e_68b6f185954c8329913b10b4ced50fb5