### PR TITLE
Add Kafka commit log consumer with deduplication

### DIFF
--- a/tests/gateway/test_commit_log_consumer.py
+++ b/tests/gateway/test_commit_log_consumer.py
@@ -1,7 +1,10 @@
 import asyncio
+import json
+from collections import deque
+
 import pytest
 
-from qmtl.gateway.commit_log_consumer import CommitLogDeduplicator
+from qmtl.gateway.commit_log_consumer import CommitLogConsumer, CommitLogDeduplicator
 from qmtl.gateway import metrics
 
 
@@ -41,6 +44,63 @@ async def test_concurrent_workers_single_commit() -> None:
     out = list(dedup.filter(log))
     assert out == [r1]
     assert metrics.commit_duplicate_total._value.get() == 1
+
+
+class _FakeMessage:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+
+class _FakeConsumer:
+    def __init__(self, batches: list[list[_FakeMessage]]) -> None:
+        self._batches: deque[list[_FakeMessage]] = deque(batches)
+        self.commit_calls = 0
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def getmany(self, timeout_ms: int | None = None):  # noqa: D401 - test shim
+        if self._batches:
+            return {None: self._batches.popleft()}
+        return {}
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_commit_log_consumer_dedup_and_metrics() -> None:
+    metrics.reset_metrics()
+
+    r1 = ("n1", 100, "h1", {"a": 1})
+    r2 = ("n1", 100, "h2", {"a": 2})
+    r3 = ("n1", 100, "h3", {"a": 3})
+
+    def _enc(record: tuple[str, int, str, dict[str, int]]) -> _FakeMessage:
+        return _FakeMessage(json.dumps(record).encode())
+
+    batches = [
+        [_enc(r1), _enc(r1), _enc(r2)],  # duplicate r1
+        [_enc(r1), _enc(r3)],  # r1 duplicate again
+    ]
+
+    fake_consumer = _FakeConsumer(batches)
+    cl_consumer = CommitLogConsumer(fake_consumer, topic="commit", group_id="g1")
+
+    received: list[list[tuple[str, int, str, dict[str, int]]]] = []
+
+    async def handler(records: list[tuple[str, int, str, dict[str, int]]]) -> None:
+        received.append(records)
+
+    await cl_consumer.consume(handler)
+    await cl_consumer.consume(handler)
+
+    assert received == [[r1, r2], [r3]]
+    assert metrics.commit_duplicate_total._value.get() == 2
+    assert fake_consumer.commit_calls == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `CommitLogConsumer` wrapping `AIOKafkaConsumer` with duplicate filtering and configurable offsets
- test consumer deduplication to ensure duplicate metrics only increment for repeated records

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b6f1905e948329aa0f5218651e1933