### PR TITLE
feat: include interval in commit log keys

### DIFF
--- a/tests/gateway/test_commit_log_writer.py
+++ b/tests/gateway/test_commit_log_writer.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 
+from qmtl.dagmanager.kafka_admin import partition_key
 from qmtl.gateway.commit_log import CommitLogWriter
 from qmtl.sdk.node import NodeCache
 
@@ -35,13 +36,14 @@ async def test_publish_bucket_commits() -> None:
     cache.append("u1", 60, 120, {"v": 2})
     h = cache.input_window_hash()
 
-    await writer.publish_bucket(120, [("n1", h, {"a": 1})])
+    await writer.publish_bucket(120, 60, [("n1", h, {"a": 1})])
 
     assert producer.begin_called == 1
     assert producer.commit_called == 1
     assert producer.abort_called == 0
     assert producer.messages[0][0] == "commit-log"
-    assert producer.messages[0][1] == f"n1:120:{h}".encode()
+    expected_key = f"{partition_key('n1', 60, 120)}:{h}".encode()
+    assert producer.messages[0][1] == expected_key
     assert json.loads(producer.messages[0][2].decode()) == ["n1", 120, h, {"a": 1}]
 
 
@@ -55,7 +57,7 @@ async def test_publish_bucket_aborts_on_error() -> None:
     writer = CommitLogWriter(producer, "commit-log")
 
     with pytest.raises(RuntimeError):
-        await writer.publish_bucket(200, [("n1", "h1", "x")])
+        await writer.publish_bucket(200, 60, [("n1", "h1", "x")])
 
     assert producer.begin_called == 1
     assert producer.commit_called == 0


### PR DESCRIPTION
## Summary
- include interval parameter in `CommitLogWriter.publish_bucket`
- build commit-log message key with `partition_key` and `input_window_hash`
- update commit log writer tests for interval-aware keys

## Testing
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b6f1a499308329b272612bf582bfa4