### PR TITLE
feat: auto owner handoff metric (Fixes #590)

### DIFF
--- a/qmtl/gateway/worker.py
+++ b/qmtl/gateway/worker.py
@@ -68,7 +68,7 @@ class StrategyWorker:
     async def _process(self, strategy_id: str) -> bool:
         key_str = partition_key(strategy_id, None, None)
         key = zlib.crc32(key_str.encode())
-        acquired = await self.manager.acquire(key)
+        acquired = await self.manager.acquire(key, owner=self.worker_id)
         if not acquired:
             return False
         try:

--- a/tests/gateway/test_worker.py
+++ b/tests/gateway/test_worker.py
@@ -20,7 +20,7 @@ class DummyManager:
         self.acquire_calls: list[int] = []
         self.release_calls: list[int] = []
 
-    async def acquire(self, key: int) -> bool:
+    async def acquire(self, key: int, owner: str | None = None) -> bool:
         self.acquire_calls.append(key)
         if key in self.locked:
             return False
@@ -215,5 +215,4 @@ async def test_process_logs_unhandled_error(fake_redis, caplog):
     assert result is False
     assert "Unhandled error processing strategy sid" in caplog.text
     assert db.records["sid"] == "failed"
-
 

--- a/tests/gateway/test_worker_ownership_metrics.py
+++ b/tests/gateway/test_worker_ownership_metrics.py
@@ -146,7 +146,7 @@ async def test_worker_takeover_increments_reassign_metric_once() -> None:
     key = 456
 
     async def owning_worker() -> None:
-        acquired = await manager.acquire(key)
+        acquired = await manager.acquire(key, owner="w1")
         assert acquired
         try:
             await asyncio.sleep(0.1)
@@ -159,10 +159,8 @@ async def test_worker_takeover_increments_reassign_metric_once() -> None:
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    metrics.owner_reassign_total.inc()
-
     async def takeover_worker() -> None:
-        acquired = await manager.acquire(key)
+        acquired = await manager.acquire(key, owner="w2")
         assert acquired
         try:
             await writer.publish_bucket(200, 60, [("n1", "h2", {"b": 2})])

--- a/tests/reliability/test_worker_alerts.py
+++ b/tests/reliability/test_worker_alerts.py
@@ -11,7 +11,7 @@ class DummyManager:
     def __init__(self) -> None:
         self.acquire_calls: list[int] = []
 
-    async def acquire(self, key: int) -> bool:
+    async def acquire(self, key: int, owner: str | None = None) -> bool:
         self.acquire_calls.append(key)
         return True
 


### PR DESCRIPTION
Summary
- OwnershipManager best-effort owner tracking; increments owner_reassign_total on handoff
- StrategyWorker passes worker_id to OwnershipManager.acquire
- Update tests to assert automatic increment and accept owner arg

Testing
- uv run --python 3.11 -m pytest -W error: 638 passed, 1 skipped

Fixes #590