### PR TITLE
ci: harden pytest warnings handling (Fixes #593)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHONWARNINGS: error
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
- Add PYTHONWARNINGS=error for CI\n- Already running pytest with -W error\n\nFixes #593