### PR TITLE
P0: Event-time semantics + runtime policy hooks + CLI health

### DIFF
--- a/qmtl/sdk/metrics.py
+++ b/qmtl/sdk/metrics.py
@@ -398,3 +398,57 @@ def reset_metrics() -> None:
     pretrade_rejections_total._vals = {}  # type: ignore[attr-defined]
     pretrade_rejection_ratio.set(0.0)
     pretrade_rejection_ratio._val = 0.0  # type: ignore[attr-defined]
+    # Snapshot metrics reset
+    try:
+        snapshot_write_duration_ms.clear()  # type: ignore[attr-defined]
+        snapshot_bytes_total._value.set(0)  # type: ignore[attr-defined]
+        snapshot_hydration_success_total._value.set(0)  # type: ignore[attr-defined]
+        snapshot_hydration_fallback_total._value.set(0)  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+# ---------------------------------------------------------------------------
+# Snapshot metrics
+if "snapshot_write_duration_ms" in global_registry._names_to_collectors:
+    snapshot_write_duration_ms = global_registry._names_to_collectors[
+        "snapshot_write_duration_ms"
+    ]
+else:
+    snapshot_write_duration_ms = Histogram(
+        "snapshot_write_duration_ms",
+        "Duration of snapshot writes in milliseconds",
+        registry=global_registry,
+    )
+
+if "snapshot_bytes_total" in global_registry._names_to_collectors:
+    snapshot_bytes_total = global_registry._names_to_collectors[
+        "snapshot_bytes_total"
+    ]
+else:
+    snapshot_bytes_total = Counter(
+        "snapshot_bytes_total",
+        "Total bytes written to snapshots",
+        registry=global_registry,
+    )
+
+if "snapshot_hydration_success_total" in global_registry._names_to_collectors:
+    snapshot_hydration_success_total = global_registry._names_to_collectors[
+        "snapshot_hydration_success_total"
+    ]
+else:
+    snapshot_hydration_success_total = Counter(
+        "snapshot_hydration_success_total",
+        "Total number of successful snapshot hydrations",
+        registry=global_registry,
+    )
+
+if "snapshot_hydration_fallback_total" in global_registry._names_to_collectors:
+    snapshot_hydration_fallback_total = global_registry._names_to_collectors[
+        "snapshot_hydration_fallback_total"
+    ]
+else:
+    snapshot_hydration_fallback_total = Counter(
+        "snapshot_hydration_fallback_total",
+        "Total number of hydration fallbacks due to snapshot mismatch",
+        registry=global_registry,
+    )

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -111,11 +111,16 @@ class NodeCache:
         buf = self._ensure_buffer(u, interval)
         timestamp_bucket = timestamp - (timestamp % interval)
         prev = self._last_ts.get((u, interval))
-        if prev is not None and prev + interval != timestamp_bucket:
-            self._missing[(u, interval)] = True
-        else:
+        if prev is None:
             self._missing[(u, interval)] = False
-        self._last_ts[(u, interval)] = timestamp_bucket
+            self._last_ts[(u, interval)] = timestamp_bucket
+        else:
+            if timestamp_bucket < prev:
+                # Late arrival: do not regress last_ts nor set missing
+                self._missing[(u, interval)] = False
+            else:
+                self._missing[(u, interval)] = prev + interval != timestamp_bucket
+                self._last_ts[(u, interval)] = timestamp_bucket
         off = self._offset.get((u, interval), 0)
         buf.data[off, 0] = timestamp_bucket
         buf.data[off, 1] = payload
@@ -197,6 +202,19 @@ class NodeCache:
             ordered.append((u, i, items))
         blob = json.dumps(ordered, sort_keys=True, default=repr).encode()
         return hash_utils._sha256(blob)
+
+    # ------------------------------------------------------------------
+    def watermark(self, *, allowed_lateness: int = 0) -> int | None:
+        """Return event-time watermark for the cache.
+
+        Watermark is defined as ``min(last_ts) - allowed_lateness`` across all
+        observed ``(upstream_id, interval)`` pairs. Returns ``None`` if the
+        cache has not seen any data yet.
+        """
+        last = [ts for ts in self._last_ts.values() if ts is not None]
+        if not last:
+            return None
+        return int(min(last)) - int(allowed_lateness)
 
     def as_xarray(self) -> xr.DataArray:
         """Return a read-only ``xarray`` view of the internal tensor.
@@ -406,6 +424,9 @@ class Node:
         config: dict | None = None,
         schema: dict | None = None,
         *,
+        allowed_lateness: int = 0,
+        on_late: str = "recompute",
+        runtime_compat: str = "loose",
         validator=default_validator,
         hash_utils=default_hash_utils,
         event_service: EventRecorderService | None = None,
@@ -451,6 +472,14 @@ class Node:
         else:
             self.cache = NodeCache(period_val or 0)
         self.pre_warmup = True
+        # Event-time controls
+        self.allowed_lateness: int = int(allowed_lateness)
+        self.on_late: str = on_late
+        self._last_watermark: int | None = None
+        # Late event sink for optional side output policy
+        self._late_events: list[tuple[str, int, Any]] = []
+        # Runtime reuse policy surface
+        self.runtime_compat: str = runtime_compat  # "strict" | "loose"
 
     def __repr__(self) -> str:  # pragma: no cover - simple repr
         return (
@@ -545,7 +574,38 @@ class Node:
             if on_missing == "skip":
                 return False
 
-        return not self.pre_warmup and self.compute_fn is not None
+        # Event-time gating & late-data handling
+        try:
+            self._last_watermark = self.cache.watermark(allowed_lateness=self.allowed_lateness)  # type: ignore[attr-defined]
+        except Exception:
+            self._last_watermark = None
+
+        if self.pre_warmup or self.compute_fn is None:
+            return False
+
+        if self._last_watermark is None:
+            return False
+
+        bucket_ts = timestamp - (timestamp % (interval or 1))
+        wm = int(self._last_watermark)
+
+        if bucket_ts < wm:
+            policy = (self.on_late or "recompute").lower()
+            if policy == "ignore":
+                return False
+            if policy == "side_output":
+                self._late_events.append((upstream_id, bucket_ts, payload))
+                return False
+            return True
+
+        if bucket_ts >= wm:
+            return True
+
+        return False
+
+    def watermark(self) -> int | None:
+        """Return the last computed watermark for this node."""
+        return self._last_watermark
 
     def to_dict(self) -> dict:
         return {
@@ -601,6 +661,7 @@ class StreamInput(SourceNode):
         event_service: EventRecorderService | None = None,
         validator=default_validator,
         hash_utils=default_hash_utils,
+        **node_kwargs,
     ) -> None:
         if event_service is None and event_recorder is not None:
             event_service = EventRecorderService(event_recorder)
@@ -614,6 +675,7 @@ class StreamInput(SourceNode):
             validator=validator,
             hash_utils=hash_utils,
             event_service=event_service,
+            **node_kwargs,
         )
         self._history_provider = history_provider
         if history_provider and hasattr(history_provider, "bind_stream"):
@@ -747,4 +809,3 @@ class TagQueryNode(SourceNode):
                     "warmup_reset": warmup_reset,
                 },
             )
-

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -200,7 +200,12 @@ class Runner:
         for n in strategy.nodes:
             if isinstance(n, StreamInput) and n.interval is not None and n.period:
                 try:
-                    if snap.hydrate(n):
+                    strict = False
+                    try:
+                        strict = getattr(n, "runtime_compat", "loose") == "strict"
+                    except Exception:
+                        strict = False
+                    if snap.hydrate(n, strict_runtime=strict):
                         count += 1
                 except Exception:
                     logger.exception("snapshot hydration failed for %s", n.node_id)

--- a/tests/gateway/test_commit_log_headers.py
+++ b/tests/gateway/test_commit_log_headers.py
@@ -1,0 +1,32 @@
+import json
+import pytest
+
+from qmtl.gateway.commit_log import CommitLogWriter
+
+
+class ProducerWithHeaders:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, bytes, bytes, list[tuple[str, bytes]] | None]] = []
+        self.started = False
+        self.committed = 0
+
+    async def begin_transaction(self) -> None:
+        return None
+
+    async def send_and_wait(self, topic, *, key=None, value=None, headers=None):
+        self.records.append((topic, key, value, headers))
+
+    async def commit_transaction(self) -> None:
+        self.committed += 1
+
+
+@pytest.mark.asyncio
+async def test_commit_log_writer_attaches_runtime_fingerprint_header():
+    p = ProducerWithHeaders()
+    w = CommitLogWriter(p, "t")
+    await w.publish_bucket(100, 60, [("n1", "h1", {"x": 1})])
+    assert p.committed == 1
+    assert p.records and isinstance(p.records[-1][3], list)
+    headers = dict((k, v) for k, v in p.records[-1][3] or [])
+    assert b"rfp" in headers or "rfp" in headers
+

--- a/tests/gateway/test_ownership_handoff_metric.py
+++ b/tests/gateway/test_ownership_handoff_metric.py
@@ -1,0 +1,55 @@
+import pytest
+
+from qmtl.gateway.database import PostgresDatabase
+from qmtl.gateway.ownership import OwnershipManager
+from qmtl.gateway import metrics as gw_metrics
+
+
+class _Conn:
+    async def fetchval(self, query: str, key: int) -> bool:
+        return True
+
+
+class _Pool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        conn = self._conn
+
+        class _Ctx:
+            async def __aenter__(self):
+                return conn
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+        return _Ctx()
+
+
+class _KafkaOwner:
+    def __init__(self):
+        self.calls: list[int] = []
+
+    async def acquire(self, key: int) -> bool:
+        self.calls.append(key)
+        return True
+
+    async def release(self, key: int) -> None:  # pragma: no cover - not used
+        return None
+
+
+@pytest.mark.asyncio
+async def test_ownership_handoff_metric_increments_on_owner_change():
+    gw_metrics.reset_metrics()
+    db = PostgresDatabase("dsn")
+    db._pool = _Pool(_Conn())  # type: ignore[assignment]
+    kafka = _KafkaOwner()
+    mgr = OwnershipManager(db, kafka)
+
+    # First owner acquires key
+    assert await mgr.acquire(123, owner="w1")
+    # Different owner acquires same key -> increment handoff metric
+    assert await mgr.acquire(123, owner="w2")
+    assert gw_metrics.owner_reassign_total._value.get() >= 1
+

--- a/tests/sdk/test_runtime_fingerprint_policy.py
+++ b/tests/sdk/test_runtime_fingerprint_policy.py
@@ -1,0 +1,30 @@
+import types
+import pytest
+
+from qmtl.sdk.runner import Runner
+from qmtl.sdk.node import StreamInput
+from qmtl.sdk.strategy import Strategy
+from qmtl.sdk import snapshot as snap
+
+
+class _S(Strategy):
+    def setup(self) -> None:
+        self.n = StreamInput(tags=["t"], interval=60, period=2, runtime_compat="strict")
+        self.add_nodes([self.n])
+
+
+def test_runner_hydrate_uses_strict_for_node_runtime_policy(monkeypatch):
+    calls: list[bool] = []
+
+    def fake_hydrate(node, *, strict_runtime=None):
+        calls.append(bool(strict_runtime))
+        return False
+
+    monkeypatch.setattr(snap, "hydrate", fake_hydrate)
+    strategy = _S()
+    strategy.setup()
+    # Directly call the internal helper to avoid network/history work
+    count = Runner._hydrate_snapshots(strategy)
+    assert count == 0
+    # Ensure we passed strict=True based on node.runtime_compat
+    assert calls and calls[-1] is True

--- a/tests/sdk/test_watermark.py
+++ b/tests/sdk/test_watermark.py
@@ -1,0 +1,48 @@
+import pytest
+
+from qmtl.sdk.node import Node, ProcessingNode
+
+
+def _mk_node(on_late: str = "recompute", allowed_lateness: int = 0) -> ProcessingNode:
+    def compute(view):
+        # Return latest of upstream for assertion purposes
+        items = view["N1"][60].latest()
+        return items
+
+    # Single upstream processing node; cache period=2 for quick warmup
+    n = ProcessingNode(
+        input=Node(input=None, compute_fn=None, name="src", interval=60, period=2, tags=[]),
+        compute_fn=compute,
+        name="proc",
+        interval=60,
+        period=2,
+        tags=[],
+        allowed_lateness=allowed_lateness,
+        on_late=on_late,
+    )
+    return n
+
+
+def test_watermark_and_gating_recompute():
+    n = _mk_node(on_late="recompute", allowed_lateness=0)
+    # warmup fill
+    assert n.feed("N1", 60, 60, {"a": 1}) is False
+    assert n.feed("N1", 60, 120, {"a": 2}) is True
+    assert n.watermark() == 120  # min(last_ts) - 0
+    # late event arrives
+    assert n.feed("N1", 60, 60, {"a": 3}) is True  # recompute on late
+
+
+def test_watermark_late_ignore_and_side_output():
+    n_ignore = _mk_node(on_late="ignore", allowed_lateness=0)
+    n_ignore.feed("N1", 60, 60, 1)
+    n_ignore.feed("N1", 60, 120, 2)
+    assert n_ignore.watermark() == 120
+    assert n_ignore.feed("N1", 60, 60, 3) is False
+
+    n_side = _mk_node(on_late="side_output", allowed_lateness=0)
+    n_side.feed("N1", 60, 60, 1)
+    n_side.feed("N1", 60, 120, 2)
+    assert n_side.feed("N1", 60, 60, 3) is False
+    assert getattr(n_side, "_late_events", None) and n_side._late_events[-1][1] == 60
+


### PR DESCRIPTION
This PR implements and wires P0/P1 tasks derived from docs/architecture/improvement_250901.md.\n\nSummary\n- SDK: Add NodeCache/ArrowCache watermark() and late-data handling surfaces. Node gains allowed_lateness, on_late policies, and watermark gating in feed().\n- Runner: Honors node.runtime_compat by passing strict_runtime to snapshot hydration.\n- Gateway: CommitLogWriter attaches runtime fingerprint in Kafka headers to gate reuse.\n- CLI: qmtl-commitlog-consumer gains optional --health-port for /healthz.\n- Tests: Add watermark/late-data tests, runtime policy hydration test, CommitLog headers + dedup soak test, and ownership handoff metric test.\n\nFixes #545\nFixes #554\nFixes #555\nFixes #556\nFixes #546\nFixes #558\nFixes #559\nFixes #582\nFixes #583\nFixes #584\nAlso Closes #586\nAlso Closes #587\nAlso Closes #588