### PR TITLE
Docs: CI (Python 3.11 + uv, -W error)

### DIFF
--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -1,0 +1,10 @@
+# CI Environment
+
+Continuous Integration runs on Python 3.11 via uv-managed virtualenvs. Tests run with warnings treated as errors to catch resource leaks early.
+
+- Python: 3.11 (managed by `uv python install 3.11` + `uv venv`)
+- Dependency install: `uv pip install -e .[dev]`
+- Protobuf generation: `uv run python -m grpc_tools.protoc ...`
+- Tests: `PYTHONPATH=qmtl/proto uv run pytest -W error -q tests`
+
+See `.github/workflows/ci.yml` for the authoritative configuration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Risk Management: operations/risk_management.md
       - Timing Controls: operations/timing_controls.md
       - Release: operations/release.md
+      - CI: operations/ci.md
   - Reference:
       - Overview: reference/README.md
       - FAQ: reference/faq.md


### PR DESCRIPTION
Document CI environment and strict warnings to close CI tracking issues.\n\nFixes #585\nFixes #589