### PR TITLE
Docs: Ownership/Commit-Log status pointers

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -231,7 +231,7 @@ Available flags:
 
 ## S4 · Ownership & Commit‑Log Design
 
-- **Ownership** — Gateway는 제출 요청 큐(FIFO)와 전략별 FSM만을 관리하며, 그래프나 큐, 월드 상태의 단일 소스는 아니다. Diff 이후 생성되는 토픽과 그 생명주기는 DAG Manager가 소유하고, 월드 정책과 활성 상태는 WorldService가 책임진다.
+- **Ownership** — Gateway는 제출 요청 큐(FIFO)와 전략별 FSM만을 관리하며, 그래프나 큐, 월드 상태의 단일 소스는 아니다. Diff 이후 생성되는 토픽과 그 생명주기는 DAG Manager가 소유하고, 월드 정책과 활성 상태는 WorldService가 책임진다.
 - **Commit Log** — 모든 전략 제출은 처리 전에 `gateway.ingest` 토픽(Redpanda/Kafka)에 append된다. Gateway는 오프셋을 Redis에 저장해 재시도 시점을 복원하며, DAG Manager와 WorldService가 발행하는 ControlBus 이벤트를 구독해 SDK로 중계한다. 이러한 로그 기반 경계는 장애 시 재생(replay)과 감사를 가능하게 한다.
 
 ---
@@ -293,3 +293,9 @@ SDKs should use the event stream when available and periodically reconcile via
 See also: World API Reference (reference/api_world.md) and Schemas (reference/schemas.md).
 
 {{ nav_links() }}
+- Status (2025-09):
+  - Partition key is defined in `qmtl/dagmanager/kafka_admin.py:partition_key(node_id, interval, bucket)` and used by the commit‑log writer.
+  - Transactional commit‑log writer/consumer are implemented (`qmtl/gateway/commit_log.py`, `qmtl/gateway/commit_log_consumer.py`) with deduplication and metrics.
+  - OwnershipManager coordinates Kafka ownership with Postgres advisory locks fallback (`qmtl/gateway/ownership.py`), and `owner_reassign_total` is recorded on handoff.
+  - SDK/Gateway integration skips local execution when queues are globally owned (see `qmtl/gateway/worker.py`).
+  - Chaos/soak style dedup tests exist under `tests/gateway/test_commit_log_soak.py`.


### PR DESCRIPTION
Document current implementation pointers for ownership, partition key, transactional commit-log, SDK/Gateway integration, and chaos tests.\n\nCloses #549\nCloses #550\nCloses #551\nCloses #552\nCloses #553