### PR TITLE
Schema Registry + ControlBus CloudEvents scaffold

### DIFF
--- a/docs/reference/schemas.md
+++ b/docs/reference/schemas.md
@@ -15,5 +15,21 @@ last_modified: 2025-08-29
 - QueueUpdated (event): reference/schemas/event_queue_updated.schema.json
 - PolicyUpdated (event): reference/schemas/event_policy_updated.schema.json
 
-{{ nav_links() }}
+## Registry Integration (optional)
 
+When `QMTL_SCHEMA_REGISTRY_URL` is set, components can resolve `schema_id`s via
+an external Schema Registry. A lightweight in-memory client is available at
+`qmtl/schema/registry.py` with a simple backward-compatibility check
+(`is_backward_compatible`). Production deployments can swap in Confluent or
+Redpanda clients.
+
+## ControlBus CloudEvents — Protobuf Migration Path
+
+ControlBus supports JSON today. A migration path to CloudEvents-over-Protobuf is
+available via the placeholder codec in `qmtl/gateway/controlbus_codec.py` which
+attaches `content_type=application/cloudevents+proto` and keeps a JSON payload
+for compatibility. Consumers route based on the header and decode accordingly.
+Rollout can proceed using dual publishing until all consumers understand the
+new header.
+
+{{ nav_links() }}


### PR DESCRIPTION
Introduce a minimal Schema Registry client and a CloudEvents codec with a Proto placeholder path. Update docs and wire consumer decoding via header.\n\nFixes #564\nFixes #566\nFixes #567\nFixes #568\nRefs #548\nRefs #565