### PR TITLE
Data plane: schema-aware producer + registry

### DIFF
--- a/qmtl/gateway/commit_log_consumer.py
+++ b/qmtl/gateway/commit_log_consumer.py
@@ -80,7 +80,14 @@ class CommitLogConsumer:
         records: list[tuple[str, int, str, Any]] = []
         for messages in result.values():
             for msg in messages:
-                node_id, bucket_ts, input_hash, payload = json.loads(msg.value)
+                try:
+                    node_id, bucket_ts, input_hash, payload = json.loads(msg.value)
+                except json.JSONDecodeError:
+                    gw_metrics.commit_invalid_total.inc()
+                    gw_metrics.commit_invalid_total._val = (
+                        gw_metrics.commit_invalid_total._value.get()
+                    )  # type: ignore[attr-defined]
+                    continue
                 records.append((node_id, bucket_ts, input_hash, payload))
         return records
 

--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -36,6 +36,12 @@ commit_duplicate_total = Counter(
     registry=global_registry,
 )
 
+commit_invalid_total = Counter(
+    "commit_invalid_total",
+    "Total number of invalid commit-log records detected",
+    registry=global_registry,
+)
+
 owner_reassign_total = Counter(
     "owner_reassign_total",
     "Total number of lease owner changes mid-bucket",
@@ -357,6 +363,8 @@ def reset_metrics() -> None:
     lost_requests_total._val = 0  # type: ignore[attr-defined]
     commit_duplicate_total._value.set(0)  # type: ignore[attr-defined]
     commit_duplicate_total._val = 0  # type: ignore[attr-defined]
+    commit_invalid_total._value.set(0)  # type: ignore[attr-defined]
+    commit_invalid_total._val = 0  # type: ignore[attr-defined]
     owner_reassign_total._value.set(0)  # type: ignore[attr-defined]
     owner_reassign_total._val = 0  # type: ignore[attr-defined]
     gateway_sentinel_traffic_ratio.clear()

--- a/qmtl/kafka/schema_producer.py
+++ b/qmtl/kafka/schema_producer.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Schema-aware producer wrapper.
+
+Wraps a minimal :class:`Producer` and injects a `schema_id` envelope for data
+plane messages using a Schema Registry client. The envelope format is a dict:
+
+    {"schema_id": <int>, "payload": <Any>}
+
+This keeps JSON compatibility while allowing consumers to resolve and validate
+payloads via a registry.
+"""
+
+from typing import Any
+
+from . import Producer
+from qmtl.schema.registry import SchemaRegistryClient
+
+
+class SchemaAwareProducer:
+    def __init__(self, inner: Producer, registry: SchemaRegistryClient | None = None) -> None:
+        self._inner = inner
+        self._registry = registry or SchemaRegistryClient()
+
+    def register_schema(self, subject: str, schema_str: str) -> int:
+        sch = self._registry.register(subject, schema_str)
+        return sch.id
+
+    def produce(self, topic: str, value: Any, *, subject: str | None = None, schema: str | None = None) -> None:
+        subj = subject or topic
+        sch = self._registry.latest(subj)
+        if sch is None:
+            if schema is None:
+                raise ValueError("schema required for first publish to subject")
+            sch = self._registry.register(subj, schema)
+        envelope = {"schema_id": sch.id, "payload": value}
+        self._inner.produce(topic, envelope)
+
+    def flush(self) -> None:
+        self._inner.flush()
+
+
+__all__ = ["SchemaAwareProducer"]
+

--- a/qmtl/schema/__init__.py
+++ b/qmtl/schema/__init__.py
@@ -1,0 +1,4 @@
+from .registry import SchemaRegistryClient, Schema
+
+__all__ = ["SchemaRegistryClient", "Schema"]
+

--- a/qmtl/schema/registry.py
+++ b/qmtl/schema/registry.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+import json
+import os
+
+
+@dataclass
+class Schema:
+    subject: str
+    id: int
+    schema: str
+    version: int
+
+
+class SchemaRegistryClient:
+    def __init__(self) -> None:
+        self._url = os.getenv("QMTL_SCHEMA_REGISTRY_URL")
+        self._by_subject: Dict[str, list[Schema]] = {}
+        self._next_id = 1
+
+    def register(self, subject: str, schema_str: str) -> Schema:
+        versions = self._by_subject.setdefault(subject, [])
+        sch = Schema(subject=subject, id=self._next_id, schema=schema_str, version=len(versions) + 1)
+        self._next_id += 1
+        versions.append(sch)
+        return sch
+
+    def latest(self, subject: str) -> Optional[Schema]:
+        versions = self._by_subject.get(subject)
+        return versions[-1] if versions else None
+
+    def get(self, subject: str, version: int) -> Optional[Schema]:
+        versions = self._by_subject.get(subject)
+        if not versions or version <= 0 or version > len(versions):
+            return None
+        return versions[version - 1]
+
+    @staticmethod
+    def is_backward_compatible(old_schema: str, new_schema: str) -> bool:
+        try:
+            old = json.loads(old_schema)
+            new = json.loads(new_schema)
+            if not isinstance(old, dict) or not isinstance(new, dict):
+                return True
+            return set(old.keys()).issubset(set(new.keys()))
+        except Exception:
+            return True
+
+
+__all__ = ["SchemaRegistryClient", "Schema"]

--- a/tests/kafka/test_schema_producer.py
+++ b/tests/kafka/test_schema_producer.py
@@ -1,0 +1,25 @@
+from qmtl.kafka.schema_producer import SchemaAwareProducer
+
+
+class DummyProducer:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, dict]] = []
+
+    def produce(self, topic: str, value):
+        self.records.append((topic, value))
+
+    def flush(self):
+        return None
+
+
+def test_schema_producer_envelope_and_register():
+    inner = DummyProducer()
+    sap = SchemaAwareProducer(inner)
+    sap.produce("ticks", {"p": 1}, schema="{\"p\": 0}")
+    assert inner.records and inner.records[-1][0] == "ticks"
+    out = inner.records[-1][1]
+    assert "schema_id" in out and out["payload"] == {"p": 1}
+    # Subsequent publish does not require schema
+    sap.produce("ticks", {"p": 2})
+    assert inner.records[-1][1]["schema_id"] == out["schema_id"]
+

--- a/tests/schema/test_registry.py
+++ b/tests/schema/test_registry.py
@@ -1,0 +1,11 @@
+from qmtl.schema import SchemaRegistryClient
+
+
+def test_register_latest_and_compatibility():
+    reg = SchemaRegistryClient()
+    s1 = reg.register("prices", "{\"a\": 1}")
+    assert s1.id > 0 and s1.version == 1
+    assert reg.latest("prices").id == s1.id
+    assert SchemaRegistryClient.is_backward_compatible("{\"a\": 1}", "{\"a\": 1, \"b\": 2}")
+    assert not SchemaRegistryClient.is_backward_compatible("{\"a\": 1, \"b\": 2}", "{\"a\": 1}")
+


### PR DESCRIPTION
Introduce SchemaRegistryClient and a schema-aware producer wrapper that injects schema_id envelopes for data plane messages.\n\nFixes #565