### PR TITLE
chore: remove legacy back-compat shims (slippage alias, data_io re-exports)

### DIFF
--- a/qmtl/brokerage/slippage.py
+++ b/qmtl/brokerage/slippage.py
@@ -57,9 +57,6 @@ class VolumeShareSlippageModel(SlippageModel):
     fallback_pct: float = 0.0005
 
     def __init__(self, k: float = 0.1, bar_volume: Optional[float] = None, fallback_pct: float = 0.0005, **kwargs) -> None:
-        # Backward-compat: support `slippage_rate` alias for fallback_pct
-        if "slippage_rate" in kwargs and "fallback_pct" not in kwargs:
-            fallback_pct = float(kwargs["slippage_rate"])
         self.k = k
         self.bar_volume = bar_volume
         self.fallback_pct = fallback_pct

--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -22,9 +22,8 @@ from qmtl.sdk.data_io import (
     DataFetcher,
     HistoryProvider,
     EventRecorder,
-    QuestDBLoader,
-    QuestDBRecorder,
 )
+from qmtl.io import QuestDBLoader, QuestDBRecorder
 from .backfill_engine import BackfillEngine
 from .util import parse_interval, parse_period, validate_tag, validate_name
 from .exceptions import (

--- a/qmtl/sdk/data_io.py
+++ b/qmtl/sdk/data_io.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-"""Interfaces for I/O operations and legacy re-exports."""
+"""Interfaces for I/O operations.
+
+This module defines the abstract I/O interfaces used by the SDK.
+Concrete implementations live under ``qmtl.io``.
+"""
 
 from typing import Protocol, Any, TYPE_CHECKING
 from abc import ABC, abstractmethod
@@ -75,14 +79,8 @@ class EventRecorder(ABC):
 
 
 # re-export concrete implementations for backward compatibility
-from qmtl.io.historyprovider import QuestDBLoader
-from qmtl.io.eventrecorder import QuestDBRecorder
-
 __all__ = [
     "DataFetcher",
     "HistoryProvider",
     "EventRecorder",
-    "QuestDBLoader",
-    "QuestDBRecorder",
 ]
-

--- a/tests/test_brokerage_model.py
+++ b/tests/test_brokerage_model.py
@@ -33,7 +33,7 @@ def test_execute_order_applies_slippage_and_fee():
     brokerage = BrokerageModel(
         CashBuyingPowerModel(),
         PerShareFeeModel(fee_per_share=0.5),
-        VolumeShareSlippageModel(slippage_rate=0.01),
+        VolumeShareSlippageModel(fallback_pct=0.01),
         ImmediateFillModel(),
     )
     fill = brokerage.execute_order(account, order, market_price=100)


### PR DESCRIPTION
Summary: Remove remaining backward-compat shims in SDK and brokerage components.

Changes
- Drop `slippage_rate` alias from `VolumeShareSlippageModel` (use `fallback_pct`).
- Remove QuestDB re-exports from `qmtl.sdk.data_io`; continue re-export from `qmtl.sdk` via `qmtl.io` to keep top-level import path stable.
- Update unit test to use `fallback_pct`.

Rationale
- Aligns with architecture cleanup efforts and reduces legacy API surface.
- Keeps `qmtl.sdk` imports stable while avoiding double-export patterns inside `sdk.data_io`.

Notes
- Repo requires Python 3.11+ (per `pyproject.toml`). Please run tests via `uv run -m pytest -W error`.

Refs #624
Refs #625
Refs #626
Refs #627
Also Refs docs/architecture/improvement_250901.md
