### PR TITLE
TagQuery: normalize queues/tags/match_mode via shared utils

### DIFF
--- a/qmtl/common/tagquery.py
+++ b/qmtl/common/tagquery.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Common helpers for TagQuery normalization shared by SDK and Gateway."""
+
+from typing import Any, Iterable
+
+from qmtl.sdk.node import MatchMode
+
+__all__ = [
+    "split_tags",
+    "normalize_match_mode",
+    "normalize_queues",
+]
+
+
+def split_tags(tags: str | Iterable[str] | None) -> list[str]:
+    if tags is None:
+        return []
+    if isinstance(tags, str):
+        return [t for t in tags.split(",") if t]
+    return [str(t) for t in tags]
+
+
+def normalize_match_mode(match: str | None, match_mode: str | None) -> MatchMode:
+    mode_str = (match_mode or match or "any").lower()
+    try:
+        return MatchMode(mode_str)
+    except ValueError:
+        return MatchMode.ANY
+
+
+def normalize_queues(raw: Iterable[Any]) -> list[str]:
+    queues: list[str] = []
+    for q in raw:
+        if isinstance(q, dict):
+            if q.get("global"):
+                continue
+            val = q.get("queue") or q.get("topic")
+            if val:
+                queues.append(str(val))
+        else:
+            queues.append(str(q))
+    return queues
+

--- a/qmtl/gateway/event_handlers.py
+++ b/qmtl/gateway/event_handlers.py
@@ -78,16 +78,14 @@ def create_event_router(
                         or "any"
                     )
                     if tags_param and interval_param:
+                        from qmtl.common.tagquery import split_tags, normalize_match_mode
                         try:
                             interval_int = int(interval_param)
                         except (TypeError, ValueError):
                             interval_int = None
-                        tags_list = [t for t in tags_param.split(",") if t]
+                        tags_list = split_tags(tags_param)
                         if interval_int is not None and tags_list:
-                            try:
-                                mode = MatchMode(match_param)
-                            except ValueError:
-                                mode = MatchMode.ANY
+                            mode = normalize_match_mode(match_param, None)
                             try:
                                 queues = await dagmanager.get_queues_by_tag(
                                     tags_list, interval_int, mode.value


### PR DESCRIPTION
Summary: Add qmtl/common/tagquery.py and refactor both SDK and Gateway paths to remove duplicate normalization logic for queues, tags, and match_mode. Ensures consistent behavior across REST/WS.\n\nFixes #619