### PR TITLE
refactor: remove compat_mode from backtest engine

### DIFF
--- a/qmtl/sdk/brokerage_backtest.py
+++ b/qmtl/sdk/brokerage_backtest.py
@@ -6,8 +6,8 @@ This engine provides an adapter that can simulate executions using the
 pluggable QMTL ``BrokerageModel`` while producing the same shape as the
 existing SDK ``ExecutionModel`` (i.e., returning ``ExecutionFill``).
 
-In ``compat_mode=True``, the pricing logic mirrors the simplified
-``ExecutionModel`` so results are identical given the same inputs.
+The pricing logic mirrors the simplified ``ExecutionModel`` so results
+are identical given the same inputs.
 """
 
 from __future__ import annotations
@@ -64,7 +64,6 @@ class BrokerageBacktestEngine:
     ) -> None:
         self._brokerage = brokerage
         self._account = account or Account(cash=10_000_000.0)
-        self._latency_ms = latency_ms
         self._compat = compat_params or ExecCompatParams(latency_ms=latency_ms)
 
     def _base_price(self, order_type: OrderType, side: OrderSide, requested: float, md: MarketData) -> float:
@@ -82,14 +81,12 @@ class BrokerageBacktestEngine:
         requested_price: float,
         market_data: MarketData,
         timestamp: int,
-        *,
-        compat_mode: bool = True,
     ) -> ExecutionFill:
         """Simulate execution via brokerage components.
 
-        When ``compat_mode=True``, this reproduces the SDK ExecutionModel
-        pricing (base + slippage formula) and uses ``PercentFeeModel`` with
-        the same rate/minimum for fees to ensure output parity.
+        This reproduces the SDK ExecutionModel pricing (base + slippage
+        formula) and uses ``PercentFeeModel`` with the same rate/minimum
+        for fees to ensure output parity.
         """
 
         # Build brokerage order (quantity sign indicates side)

--- a/tests/test_brokerage_backtest_parity.py
+++ b/tests/test_brokerage_backtest_parity.py
@@ -50,6 +50,7 @@ def test_parity_market_orders():
         market_data=md,
         timestamp=1_700_000_000,
     )
+    # simulate_execution no longer accepts a compat_mode flag; parity behaviour is default
     f2 = engine.simulate_execution(
         order_id="o1",
         symbol="AAPL",
@@ -76,6 +77,7 @@ def test_parity_market_orders():
         market_data=md,
         timestamp=1_700_000_000,
     )
+    # default parity path without compat_mode flag
     f2s = engine.simulate_execution(
         order_id="o2",
         symbol="AAPL",
@@ -123,6 +125,7 @@ def test_parity_limit_orders():
         market_data=md,
         timestamp=1_700_000_100,
     )
+    # ensure limit order path also uses default parity behaviour
     f2 = engine.simulate_execution(
         order_id="o3",
         symbol="MSFT",


### PR DESCRIPTION
## Summary
- drop unused `compat_mode` parameter from `BrokerageBacktestEngine.simulate_execution`
- clarify docstrings and comments to reflect always-on parity behavior
- note compat-mode removal in parity tests

## Testing
- `uv run -m pytest -W error tests/test_brokerage_backtest_parity.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7e698502c8329b80c7d94d569cce4