### PR TITLE
Refine snapshot optional dependency imports

### DIFF
--- a/qmtl/sdk/snapshot.py
+++ b/qmtl/sdk/snapshot.py
@@ -14,21 +14,31 @@ Environment variables:
 
 import base64
 import json
+import logging
 import os
 import time
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
+logger = logging.getLogger(__name__)
+
 try:  # optional
     import pyarrow as pa  # type: ignore
     import pyarrow.parquet as pq  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    pa = None  # type: ignore
+    pq = None  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
+    logger.exception("unexpected error importing pyarrow")
     pa = None  # type: ignore
     pq = None  # type: ignore
 
 try:  # optional
     import fsspec  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    fsspec = None  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
+    logger.exception("unexpected error importing fsspec")
     fsspec = None  # type: ignore
 
 from . import metrics as sdk_metrics

--- a/tests/sdk/test_snapshot_imports.py
+++ b/tests/sdk/test_snapshot_imports.py
@@ -1,0 +1,73 @@
+import importlib
+import sys
+import builtins
+import logging
+
+import pytest
+
+
+def _remove_modules(prefix: str):
+    removed = {}
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(prefix + "."):
+            removed[name] = sys.modules.pop(name)
+    return removed
+
+
+def _restore_modules(mods):
+    sys.modules.update(mods)
+
+
+def test_pyarrow_missing(monkeypatch):
+    removed = _remove_modules("pyarrow")
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("pyarrow"):
+            raise ImportError("mocked missing pyarrow")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("qmtl.sdk.snapshot", None)
+    snap = importlib.import_module("qmtl.sdk.snapshot")
+    assert snap.pa is None
+    assert snap.pq is None
+    sys.modules.pop("qmtl.sdk.snapshot", None)
+    _restore_modules(removed)
+
+
+def test_fsspec_missing(monkeypatch):
+    removed = _remove_modules("fsspec")
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "fsspec":
+            raise ImportError("mocked missing fsspec")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("qmtl.sdk.snapshot", None)
+    snap = importlib.import_module("qmtl.sdk.snapshot")
+    assert snap.fsspec is None
+    sys.modules.pop("qmtl.sdk.snapshot", None)
+    _restore_modules(removed)
+
+
+def test_pyarrow_other_exception_logged(monkeypatch, caplog):
+    removed = _remove_modules("pyarrow")
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("pyarrow"):
+            raise RuntimeError("boom")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("qmtl.sdk.snapshot", None)
+    with caplog.at_level(logging.ERROR):
+        snap = importlib.import_module("qmtl.sdk.snapshot")
+    assert snap.pa is None
+    assert snap.pq is None
+    assert any("pyarrow" in rec.message for rec in caplog.records)
+    sys.modules.pop("qmtl.sdk.snapshot", None)
+    _restore_modules(removed)


### PR DESCRIPTION
## Summary
- log unexpected errors when importing pyarrow or fsspec
- ensure snapshot tests cover missing optional dependencies

## Testing
- `uv run -m pytest -W error tests/sdk/test_snapshot_imports.py`
- `uv run -m pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b7e69cb68c83298ec5d9a44219a890