### PR TITLE
refactor: drop topic parameter from order publisher

### DIFF
--- a/docs/guides/sdk_tutorial.md
+++ b/docs/guides/sdk_tutorial.md
@@ -230,8 +230,9 @@ metrics = alpha_performance_node(
 ## Order Results and External Executors
 
 `TradeOrderPublisherNode` turns trade signals into standardized order
-payloads. The `Runner` examines node results and delivers these orders to
-external systems through a series of hooks:
+payloads. Publication targets are configured through `Runner` hooks; the
+node itself carries no topic information. The `Runner` examines node results
+and delivers orders to external systems via:
 
 1. `Runner.set_trade_execution_service(service)` forwards the order to a
    custom object exposing ``post_order``.
@@ -252,7 +253,7 @@ from qmtl.transforms import (
 
 history = alpha_history_node(alpha, window=30)
 signal = TradeSignalGeneratorNode(history, long_threshold=0.5, short_threshold=-0.5)
-orders = TradeOrderPublisherNode(signal, topic="orders")
+orders = TradeOrderPublisherNode(signal)
 
 from qmtl.sdk import Runner, TradeExecutionService
 

--- a/qmtl/examples/strategies/order_pipeline_strategy.py
+++ b/qmtl/examples/strategies/order_pipeline_strategy.py
@@ -26,7 +26,7 @@ class OrderPipelineStrategy(Strategy):
         signal = TradeSignalGeneratorNode(
             history, long_threshold=0.0, short_threshold=0.0
         )
-        orders = TradeOrderPublisherNode(signal, topic="orders")
+        orders = TradeOrderPublisherNode(signal)
         self.add_nodes([price, alpha, history, signal, orders])
 
 

--- a/qmtl/transforms/publisher.py
+++ b/qmtl/transforms/publisher.py
@@ -2,29 +2,30 @@
 
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Any
 
 from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
 
 
-def publisher_node(signal: Any, *, topic: str) -> Tuple[str, Any]:
-    """Return the given ``signal`` and ``topic`` pair.
+def publisher_node(signal: Any) -> Any:
+    """Return ``signal`` unchanged.
+
+    The Runner's hooks determine the publication destination; this function
+    simply forwards the payload without embedding any topic information.
 
     Parameters
     ----------
     signal:
         Message payload to publish.
-    topic:
-        Kafka topic name for the ``signal``.
 
     Returns
     -------
-    tuple[str, Any]
-        A ``(topic, signal)`` tuple that leaves ``signal`` untouched.
+    Any
+        The ``signal`` payload.
     """
 
-    return topic, signal
+    return signal
 
 
 class TradeOrderPublisherNode(Node):
@@ -34,13 +35,9 @@ class TradeOrderPublisherNode(Node):
         self,
         signal: Node,
         *,
-        topic: str,
         name: str | None = None,
     ) -> None:
         self.signal = signal
-        # ``topic`` is kept for API compatibility though the Runner's hooks
-        # ultimately decide the publication destination.
-        self.topic = topic
         super().__init__(
             input=signal,
             compute_fn=self._compute,

--- a/tests/transforms/test_trade_order_publisher.py
+++ b/tests/transforms/test_trade_order_publisher.py
@@ -22,7 +22,7 @@ def test_trade_order_publisher_builds_order_and_publishes():
     runner.set_trade_order_kafka_topic("orders")
 
     signal_node = Node(name="signal", interval="1s", period=1)
-    pub_node = TradeOrderPublisherNode(signal_node, topic="orders")
+    pub_node = TradeOrderPublisherNode(signal_node)
     view = CacheView({signal_node.node_id: {1: [(0, {"action": "BUY", "size": 2, "stop_loss": 3, "take_profit": 4})]}})
     order = pub_node.compute_fn(view)
     runner._postprocess_result(pub_node, order)
@@ -40,7 +40,7 @@ def test_trade_order_publisher_builds_order_and_publishes():
 
 def test_trade_order_publisher_filters_actions():
     signal_node = Node(name="signal", interval="1s", period=1)
-    pub_node = TradeOrderPublisherNode(signal_node, topic="orders")
+    pub_node = TradeOrderPublisherNode(signal_node)
     view = CacheView({signal_node.node_id: {1: [(0, {"action": "HOLD"})]}})
     assert pub_node.compute_fn(view) is None
     view = CacheView({signal_node.node_id: {1: [(0, {"action": "WAIT"})]}})


### PR DESCRIPTION
## Summary
- remove topic argument from publisher helper and TradeOrderPublisherNode
- adapt tests, example strategy, and docs to rely on Runner hooks for publishing

## Testing
- `uv run -m pytest -W error`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b7e699831c83298fc9f1bb3446dfa0