### PR TITLE
Schema registry tests + docs (Fixes #620)

### DIFF
--- a/docs/reference/schema_registry.md
+++ b/docs/reference/schema_registry.md
@@ -1,0 +1,67 @@
+# Schema Registry
+
+QMTL ships with a lightweight, in-memory schema registry client and an optional
+remote HTTP client. Use `SchemaRegistryClient.from_env()` to automatically pick
+the right implementation based on the `QMTL_SCHEMA_REGISTRY_URL` environment
+variable.
+
+## In-Memory Client
+
+The default `SchemaRegistryClient` stores schemas in-process and assigns
+incrementing ids and versions per subject.
+
+Example:
+
+```python
+from qmtl.schema import SchemaRegistryClient
+
+reg = SchemaRegistryClient()
+sch1 = reg.register("prices", '{"a": 1}')
+assert reg.latest("prices").id == sch1.id
+sch2 = reg.register("prices", '{"a": 1, "b": 2}')
+assert sch2.version == 2
+```
+
+`get_by_id(id: int)` looks up schemas by global id when available.
+
+## Remote Client
+
+Set `QMTL_SCHEMA_REGISTRY_URL` to enable a minimal HTTP client:
+
+```bash
+export QMTL_SCHEMA_REGISTRY_URL="http://registry:8081"
+```
+
+```python
+from qmtl.schema import SchemaRegistryClient
+
+reg = SchemaRegistryClient.from_env()  # returns RemoteSchemaRegistryClient
+reg.register("prices", '{"a": 1}')
+latest = reg.latest("prices")
+by_id = reg.get_by_id(latest.id)
+```
+
+The expected JSON API is similar to common registry endpoints:
+
+- `POST /subjects/{subject}/versions` → `{ "id": <int> }`
+- `GET /subjects/{subject}/versions/latest` → `{ "id": <int>, "schema": <str>, "version": <int> }`
+- `GET /schemas/ids/{id}` → `{ "schema": <str> }`
+
+Network errors raise `RuntimeError`. Future versions may introduce a dedicated
+exception type.
+
+## Compatibility Checks
+
+`SchemaRegistryClient.is_backward_compatible(old, new)` performs a
+shallow-to-recursive check:
+
+- All keys in `old` must exist in `new` (recurse into nested dicts)
+- For lists, only structure presence is checked
+- For scalars, type must not change; numeric (int/float) changes are allowed
+
+## Kafka Integration
+
+`qmtl.kafka.schema_producer.SchemaAwareProducer` uses `SchemaRegistryClient.from_env()`
+when a registry is not explicitly provided. This makes it easy to switch between
+in-memory and remote registries via environment configuration.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
   - Reference:
       - Overview: reference/README.md
       - FAQ: reference/faq.md
+      - Schema Registry: reference/schema_registry.md
       - Schemas: reference/schemas.md
       - Templates: reference/templates.md
       - World API: reference/api_world.md

--- a/tests/schema/test_registry_remote.py
+++ b/tests/schema/test_registry_remote.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import io
+import json
+import types
+
+import pytest
+
+from qmtl.schema import SchemaRegistryClient
+
+
+class _Resp:
+    def __init__(self, payload: dict) -> None:
+        self._buf = io.BytesIO(json.dumps(payload).encode("utf-8"))
+
+    def read(self) -> bytes:
+        return self._buf.getvalue()
+
+    def __enter__(self):  # pragma: no cover - exercised indirectly
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # pragma: no cover - passthrough
+        return False
+
+
+@pytest.mark.asyncio
+async def test_remote_registry_register_latest_get_by_id_and_from_env(monkeypatch):
+    # Minimal in-memory remote service state
+    state: dict[str, list[tuple[int, str]]] = {}
+    next_id = {"val": 100}
+
+    def fake_urlopen(req, timeout=5):  # type: ignore[no-untyped-def]
+        url: str = getattr(req, "full_url", req)  # Request or str
+        method: str = getattr(req, "method", "GET")
+        body = getattr(req, "data", None)
+        path = url.split("://", 1)[-1].split("/", 1)[-1]  # strip scheme/host
+        if isinstance(body, (bytes, bytearray)):
+            payload = json.loads(body.decode("utf-8"))
+        else:
+            payload = None
+        # Routes
+        if method == "POST" and path.startswith("subjects/") and path.endswith("/versions"):
+            subject = path.split("/", 2)[1]
+            sch = payload["schema"] if isinstance(payload, dict) else "{}"
+            sid = next_id["val"]
+            next_id["val"] += 1
+            state.setdefault(subject, []).append((sid, sch))
+            return _Resp({"id": sid})
+        if method == "GET" and path.startswith("subjects/") and path.endswith("/versions/latest"):
+            subject = path.split("/", 2)[1]
+            versions = state.get(subject) or []
+            if not versions:
+                return _Resp({"id": 0, "schema": "{}", "version": 0})
+            sid, sch = versions[-1]
+            return _Resp({"id": sid, "schema": sch, "version": len(versions)})
+        if method == "GET" and path.startswith("schemas/ids/"):
+            sid = int(path.split("/")[-1])
+            for subj, versions in state.items():
+                for idv, sch in versions:
+                    if idv == sid:
+                        return _Resp({"schema": sch})
+            return _Resp({"schema": "{}"})
+        raise AssertionError(f"unexpected request: {method} {path}")
+
+    # Patch env and urlopen
+    monkeypatch.setenv("QMTL_SCHEMA_REGISTRY_URL", "http://mock")
+    import urllib.request as _req
+
+    monkeypatch.setattr(_req, "urlopen", fake_urlopen)
+
+    # Create client from env and exercise endpoints
+    client = SchemaRegistryClient.from_env()
+    # register -> returns id; latest -> reflects last
+    s1 = client.register("prices", json.dumps({"a": 1}))
+    assert s1.id >= 100 and s1.version >= 1
+    latest = client.latest("prices")
+    assert latest and latest.id == s1.id and json.loads(latest.schema)["a"] == 1
+    # second register should compute version 2
+    s2 = client.register("prices", json.dumps({"a": 1, "b": 2}))
+    assert s2.version >= s1.version
+    # get by id
+    g = client.get_by_id(s1.id)
+    assert g and json.loads(g.schema)["a"] == 1
+
+
+def test_compatibility_recursive_and_types():
+    # Nested dict key addition allowed
+    assert SchemaRegistryClient.is_backward_compatible(
+        json.dumps({"a": {"b": 1}}), json.dumps({"a": {"b": 1, "c": 2}})
+    )
+    # Removing required nested key fails
+    assert not SchemaRegistryClient.is_backward_compatible(
+        json.dumps({"a": {"b": 1}}), json.dumps({"a": {}})
+    )
+    # Scalar type change fails
+    assert not SchemaRegistryClient.is_backward_compatible(
+        json.dumps({"a": 1}), json.dumps({"a": "1"})
+    )
+    # Numeric type changes are allowed (int<->float)
+    assert SchemaRegistryClient.is_backward_compatible(
+        json.dumps({"a": 1}), json.dumps({"a": 1.0})
+    )
+    assert SchemaRegistryClient.is_backward_compatible(
+        json.dumps({"a": 1.0}), json.dumps({"a": 2})
+    )
+    # Lists: structure presence only (no deep check)
+    assert SchemaRegistryClient.is_backward_compatible(
+        json.dumps({"a": [1, 2]}), json.dumps({"a": ["x"]})
+    )


### PR DESCRIPTION
Adds remote client E2E tests (monkeypatched urlopen), deeper compatibility tests, and a reference page for Schema Registry. Updates mkdocs nav.\n\nFixes #620