### PR TITLE
sdk: remove StreamInput event_recorder back-compat; require EventRecorderService (Fixes #624)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,14 @@ and cannot be reassigned later. The same guide covers persisting data via
 Example injection:
 
 ```python
-from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder
+from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder, EventRecorderService
 
 stream = StreamInput(
     interval="60s",
     history_provider=QuestDBLoader(dsn="postgresql://user:pass@localhost:8812/qdb"),
-    event_recorder=QuestDBRecorder(dsn="postgresql://user:pass@localhost:8812/qdb"),
+    event_service=EventRecorderService(
+        QuestDBRecorder(dsn="postgresql://user:pass@localhost:8812/qdb")
+    ),
 )
 ```
 
@@ -292,4 +294,3 @@ loader = QuestDBLoader(
     fetcher=fetcher,
 )
 ```
-

--- a/docs/operations/backfill.md
+++ b/docs/operations/backfill.md
@@ -107,7 +107,7 @@ SDK.
 Historical data and event recording can be supplied when creating a `StreamInput`:
 
 ```python
-from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder
+from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder, EventRecorderService
 
 stream = StreamInput(
     interval="60s",
@@ -115,8 +115,10 @@ stream = StreamInput(
         dsn="postgresql://user:pass@localhost:8812/qdb",
         fetcher=fetcher,
     ),
-    event_recorder=QuestDBRecorder(
-        dsn="postgresql://user:pass@localhost:8812/qdb",
+    event_service=EventRecorderService(
+        QuestDBRecorder(
+            dsn="postgresql://user:pass@localhost:8812/qdb",
+        )
     ),
 )
 ```
@@ -125,9 +127,9 @@ When the QuestDB loader or recorder is created without a ``table`` argument it
 automatically uses ``stream.node_id`` as the table name.  Pass ``table="name"``
 explicitly to override this behaviour.
 
-``StreamInput`` binds the provider and recorder during construction and then
-treats them as read-only. Attempting to modify ``history_provider`` or
-``event_recorder`` after creation will raise an ``AttributeError``.
+``StreamInput`` binds the provider and recorder service during construction and
+then treats them as read-only. Attempting to modify ``history_provider`` or
+``event_service`` after creation will raise an ``AttributeError``.
 
 ## Running a Backfill
 
@@ -211,4 +213,3 @@ engine emits metrics such as ``backfill_jobs_in_progress``,
 
 
 {{ nav_links() }}
-

--- a/qmtl/examples/metrics/metrics_recorder_example.py
+++ b/qmtl/examples/metrics/metrics_recorder_example.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from qmtl.sdk import Strategy, Node, StreamInput, Runner, metrics
+from qmtl.sdk import Strategy, Node, StreamInput, Runner, metrics, EventRecorderService
 from qmtl.io import QuestDBLoader, QuestDBRecorder
 
 
@@ -14,8 +14,10 @@ class RecorderStrategy(Strategy):
             history_provider=QuestDBLoader(
                 dsn="postgresql://localhost:8812/qdb",
             ),
-            event_recorder=QuestDBRecorder(
-                dsn="postgresql://localhost:8812/qdb",
+            event_service=EventRecorderService(
+                QuestDBRecorder(
+                    dsn="postgresql://localhost:8812/qdb",
+                )
             ),
         )
 

--- a/qmtl/examples/parallel/questdb_parallel_example.py
+++ b/qmtl/examples/parallel/questdb_parallel_example.py
@@ -4,7 +4,7 @@ import asyncio
 import pandas as pd
 
 from qmtl.io import QuestDBRecorder
-from qmtl.sdk import StreamInput, Node, Runner, metrics
+from qmtl.sdk import StreamInput, Node, Runner, metrics, EventRecorderService
 from qmtl.examples.parallel_strategies_example import MA1 as BaseMA1, MA2 as BaseMA2
 
 
@@ -13,8 +13,10 @@ class MA1(BaseMA1):
         price = StreamInput(
             interval="60s",
             period=30,
-            event_recorder=QuestDBRecorder(
-                dsn="postgresql://localhost:8812/qdb",
+            event_service=EventRecorderService(
+                QuestDBRecorder(
+                    dsn="postgresql://localhost:8812/qdb",
+                )
             ),
         )
 
@@ -31,8 +33,10 @@ class MA2(BaseMA2):
         price = StreamInput(
             interval="60s",
             period=60,
-            event_recorder=QuestDBRecorder(
-                dsn="postgresql://localhost:8812/qdb",
+            event_service=EventRecorderService(
+                QuestDBRecorder(
+                    dsn="postgresql://localhost:8812/qdb",
+                )
             ),
         )
 

--- a/qmtl/examples/strategies/cross_market_lag_strategy.py
+++ b/qmtl/examples/strategies/cross_market_lag_strategy.py
@@ -1,4 +1,4 @@
-from qmtl.sdk import Strategy, Node, StreamInput, Runner
+from qmtl.sdk import Strategy, Node, StreamInput, Runner, EventRecorderService
 from qmtl.io import QuestDBLoader, QuestDBRecorder
 import pandas as pd
 
@@ -11,8 +11,10 @@ class CrossMarketLagStrategy(Strategy):
             history_provider=QuestDBLoader(
                 dsn="postgresql://localhost:8812/qdb",
             ),
-            event_recorder=QuestDBRecorder(
-                dsn="postgresql://localhost:8812/qdb",
+            event_service=EventRecorderService(
+                QuestDBRecorder(
+                    dsn="postgresql://localhost:8812/qdb",
+                )
             ),
         )
         mstr_price = StreamInput(
@@ -22,8 +24,10 @@ class CrossMarketLagStrategy(Strategy):
             history_provider=QuestDBLoader(
                 dsn="postgresql://localhost:8812/qdb",
             ),
-            event_recorder=QuestDBRecorder(
-                dsn="postgresql://localhost:8812/qdb",
+            event_service=EventRecorderService(
+                QuestDBRecorder(
+                    dsn="postgresql://localhost:8812/qdb",
+                )
             ),
         )
         def lagged_corr(view):

--- a/qmtl/examples/strategies/general_strategy.py
+++ b/qmtl/examples/strategies/general_strategy.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from qmtl.examples.defaults import load_backtest_defaults
 from qmtl.io import QuestDBLoader, QuestDBRecorder
-from qmtl.sdk import Strategy, Node, StreamInput, Runner
+from qmtl.sdk import Strategy, Node, StreamInput, Runner, EventRecorderService
 
 class GeneralStrategy(Strategy):
     def __init__(self):
@@ -14,8 +14,10 @@ class GeneralStrategy(Strategy):
             history_provider=QuestDBLoader(
                 dsn="postgresql://localhost:8812/qdb",
             ),
-            event_recorder=QuestDBRecorder(
-                dsn="postgresql://localhost:8812/qdb",
+            event_service=EventRecorderService(
+                QuestDBRecorder(
+                    dsn="postgresql://localhost:8812/qdb",
+                )
             ),
         )
 

--- a/qmtl/examples/strategies/multi_asset_lag_strategy.py
+++ b/qmtl/examples/strategies/multi_asset_lag_strategy.py
@@ -1,4 +1,4 @@
-from qmtl.sdk import Strategy, Node, StreamInput, Runner
+from qmtl.sdk import Strategy, Node, StreamInput, Runner, EventRecorderService
 from qmtl.io import QuestDBLoader, QuestDBRecorder
 import pandas as pd
 
@@ -9,14 +9,14 @@ class MultiAssetLagStrategy(Strategy):
             interval="60s",
             period=120,
             history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+            event_service=EventRecorderService(QuestDBRecorder("postgresql://localhost:8812/qdb")),
         )
         mstr_price = StreamInput(
             tags=["MSTR", "price", "nasdaq"],
             interval="60s",
             period=120,
             history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+            event_service=EventRecorderService(QuestDBRecorder("postgresql://localhost:8812/qdb")),
         )
         def lagged_corr(view):
             btc = pd.DataFrame([v for _, v in view[btc_price][60]])

--- a/qmtl/examples/strategies/recorder_strategy.py
+++ b/qmtl/examples/strategies/recorder_strategy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from qmtl.sdk import Strategy, Node, StreamInput, Runner, metrics
+from qmtl.sdk import Strategy, Node, StreamInput, Runner, metrics, EventRecorderService
 from qmtl.io import QuestDBLoader, QuestDBRecorder
 
 
@@ -12,7 +12,7 @@ class RecorderStrategy(Strategy):
             interval="60s",
             period=30,
             history_provider=QuestDBLoader("postgresql://localhost:8812/qdb"),
-            event_recorder=QuestDBRecorder("postgresql://localhost:8812/qdb"),
+            event_service=EventRecorderService(QuestDBRecorder("postgresql://localhost:8812/qdb")),
         )
 
         def momentum(view) -> pd.DataFrame:

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -6,6 +6,7 @@ from qmtl.sdk import (
     QuestDBRecorder,
     HistoryProvider,
     EventRecorder,
+    EventRecorderService,
 )
 from tests.dummy_fetcher import DummyDataFetcher
 
@@ -179,8 +180,7 @@ def test_stream_input_records_on_feed():
         async def persist(self, node_id, interval, timestamp, payload):
             events.append((node_id, interval, timestamp, payload))
 
-    s = StreamInput(interval="60s", period=1, event_recorder=DummyRecorder())
+    s = StreamInput(interval="60s", period=1, event_service=EventRecorderService(DummyRecorder()))
 
     s.feed("s", 60, 1, {"v": 1})
     assert events == [(s.node_id, 60, 1, {"v": 1})]
-

--- a/tests/test_binance_integration.py
+++ b/tests/test_binance_integration.py
@@ -1,4 +1,4 @@
-from qmtl.sdk import StreamInput
+from qmtl.sdk import StreamInput, EventRecorderService
 from qmtl.io import QuestDBLoader, QuestDBRecorder, BinanceFetcher
 from qmtl.io import binance_fetcher as bf_mod
 
@@ -11,7 +11,7 @@ def test_binance_stream_components(monkeypatch) -> None:
         interval="1m",
         period=120,
         history_provider=QuestDBLoader("db", fetcher=fetcher),
-        event_recorder=QuestDBRecorder("db"),
+        event_service=EventRecorderService(QuestDBRecorder("db")),
     )
     assert isinstance(stream.history_provider.fetcher, BinanceFetcher)
     assert stream.history_provider.dsn == "db"

--- a/tests/test_stream_binding.py
+++ b/tests/test_stream_binding.py
@@ -1,5 +1,5 @@
 import pytest
-from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder
+from qmtl.sdk import StreamInput, QuestDBLoader, QuestDBRecorder, EventRecorderService
 
 
 def test_questdb_table_defaults_to_node_id():
@@ -7,7 +7,7 @@ def test_questdb_table_defaults_to_node_id():
         interval="60s",
         period=1,
         history_provider=QuestDBLoader("db"),
-        event_recorder=QuestDBRecorder("db"),
+        event_service=EventRecorderService(QuestDBRecorder("db")),
     )
     assert stream.history_provider.table == stream.node_id
     assert stream.event_recorder.table == stream.node_id
@@ -20,8 +20,7 @@ def test_questdb_explicit_table_override():
         interval="60s",
         period=1,
         history_provider=loader,
-        event_recorder=recorder,
+        event_service=EventRecorderService(recorder),
     )
     assert loader.table == "t"
     assert recorder.table == "t"
-


### PR DESCRIPTION
This PR removes the deprecated event_recorder= shim from StreamInput and requires callers to pass event_service=EventRecorderService(recorder).\n\n- Drop event_recorder from StreamInput signature and delete implicit wrapping\n- Keep read-only event_recorder property for introspection via service.recorder\n- Enforce event_service immutability on StreamInput\n- Update examples, README and backfill docs\n- Update tests to construct EventRecorderService and continue asserting recorder table behavior\n\nFixes #624