### PR TITLE
sdk(tagquery): remove /queues/watch fallback; unify queue keys (Fixes #625)

### DIFF
--- a/qmtl/common/tagquery.py
+++ b/qmtl/common/tagquery.py
@@ -35,10 +35,10 @@ def normalize_queues(raw: Iterable[Any]) -> list[str]:
         if isinstance(q, dict):
             if q.get("global"):
                 continue
-            val = q.get("queue") or q.get("topic")
+            # Only accept unified 'queue' key; legacy 'topic' is not supported
+            val = q.get("queue")
             if val:
                 queues.append(str(val))
         else:
             queues.append(str(q))
     return queues
-

--- a/qmtl/sdk/tag_manager_service.py
+++ b/qmtl/sdk/tag_manager_service.py
@@ -43,7 +43,7 @@ class TagManagerService:
                         if isinstance(q, dict):
                             if q.get("global"):
                                 continue
-                            val = q.get("queue") or q.get("topic")
+                            val = q.get("queue")
                             if val:
                                 merged.append(val)
                         else:
@@ -56,7 +56,7 @@ class TagManagerService:
                 queue = None
                 global_flag = False
                 if isinstance(mapping_val, dict):
-                    queue = mapping_val.get("queue") or mapping_val.get("topic")
+                    queue = mapping_val.get("queue")
                     global_flag = bool(mapping_val.get("global"))
                 else:
                     queue = mapping_val


### PR DESCRIPTION
This PR removes the legacy /queues/watch fallback from the SDK's TagQueryManager and drops dual-key handling for queue/topic.\n\n- TagQueryManager now relies solely on /events/subscribe with WebSocketClient.\n- normalize_queues accepts only the unified 'queue' key.\n- TagManagerService.apply_queue_map updated accordingly.\n\nFixes #625