### PR TITLE
config: remove deprecated breaker key filtering (Fixes #627)

### DIFF
--- a/qmtl/config.py
+++ b/qmtl/config.py
@@ -54,15 +54,7 @@ def load_config(path: str) -> UnifiedConfig:
     if not isinstance(dm_data, dict):
         raise TypeError("dagmanager section must be a mapping")
 
-    # Breaker timeouts were removed; services now reset breakers manually
-    # based on explicit success signals.
-    for key in (
-        "kafka_breaker_timeout",
-        "neo4j_breaker_timeout",
-        "kafka_breaker_threshold",
-    ):
-        gw_data.pop(key, None)
-        dm_data.pop(key, None)
+    # Deprecated breaker keys are no longer filtered; invalid keys should be surfaced
 
     gateway_cfg = GatewayConfig(**gw_data)
     dagmanager_cfg = DagManagerConfig(**dm_data)

--- a/qmtl/dagmanager/config.py
+++ b/qmtl/dagmanager/config.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional
+import logging
+import yaml
 
 
 @dataclass
@@ -37,7 +39,4 @@ def load_dagmanager_config(path: str) -> DagManagerConfig:
         raise
     if not isinstance(data, dict):
         raise TypeError("DAG Manager config must be a mapping")
-    # Breaker settings are deprecated; reset breakers manually on success.
-    data.pop("kafka_breaker_timeout", None)
-    data.pop("kafka_breaker_threshold", None)
     return DagManagerConfig(**data)

--- a/tests/test_dagmanager_config.py
+++ b/tests/test_dagmanager_config.py
@@ -39,12 +39,9 @@ def test_load_config_dagmanager_yaml(tmp_path: Path) -> None:
     }
     config_file = tmp_path / "dm.yml"
     config_file.write_text(yaml.safe_dump({"dagmanager": data}))
-    cfg = load_config(str(config_file)).dagmanager
-    assert cfg.neo4j_dsn == data["neo4j_dsn"]
-    assert cfg.kafka_dsn == "kafka:9092"
-    assert cfg.grpc_port == 6000
-    assert not hasattr(cfg, "kafka_breaker_timeout")
-    assert not hasattr(cfg, "kafka_breaker_threshold")
+    # Deprecated breaker keys should cause strict parsing errors now
+    with pytest.raises(TypeError):
+        load_config(str(config_file))
 
 
 def test_load_config_missing_file() -> None:
@@ -65,4 +62,3 @@ def test_load_config_yaml_error(tmp_path: Path, caplog) -> None:
     with caplog.at_level(logging.ERROR):
         with pytest.raises(ValueError, match="Failed to parse configuration file"):
             load_config(str(config_file))
-

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -20,11 +20,9 @@ def test_load_unified_config_yaml(tmp_path: Path) -> None:
     }
     config_file = tmp_path / "cfg.yml"
     config_file.write_text(yaml.safe_dump(data))
-    config = load_config(str(config_file))
-    assert config.gateway.redis_dsn == data["gateway"]["redis_dsn"]
-    assert config.dagmanager.neo4j_dsn == data["dagmanager"]["neo4j_dsn"]
-    assert not hasattr(config.dagmanager, "kafka_breaker_threshold")
-    assert not hasattr(config.dagmanager, "kafka_breaker_timeout")
+    # Deprecated breaker keys under dagmanager should now be rejected
+    with pytest.raises(TypeError):
+        load_config(str(config_file))
 
 
 def test_load_unified_config_json(tmp_path: Path) -> None:


### PR DESCRIPTION
Strict config parsing: remove implicit filtering of kafka_breaker_* keys in both DagManager and Unified config loaders. Update tests to expect errors when deprecated keys are provided.\n\nFixes #627