### PR TITLE
Expose core SDK at top level via thin re-exports

### DIFF
--- a/qmtl/__init__.py
+++ b/qmtl/__init__.py
@@ -1,5 +1,16 @@
 from .pipeline import Pipeline
 
+# Thin re-exports of core SDK entrypoints for convenience
+# Keep internal layout under qmtl.sdk; expose commonly used classes at top level.
+from .sdk import (
+    Strategy,
+    Runner,
+    Node,
+    StreamInput,
+    TagQueryNode,
+    EventRecorderService,
+)
+
 # Ensure ASGI transports from httpx are properly closed when garbage collected.
 try:  # pragma: no cover - best effort cleanup helper
     import httpx
@@ -15,4 +26,12 @@ try:  # pragma: no cover - best effort cleanup helper
 except Exception:  # pragma: no cover - optional
     pass
 
-__all__ = ["Pipeline"]
+__all__ = [
+    "Pipeline",
+    "Strategy",
+    "Runner",
+    "Node",
+    "StreamInput",
+    "TagQueryNode",
+    "EventRecorderService",
+]


### PR DESCRIPTION
Summary:\n- Re-export Strategy, Runner, Node, StreamInput, TagQueryNode, EventRecorderService from qmtl.__init__ for convenience.\n- Keeps internal structure under qmtl.sdk unchanged; improves DX by allowing .\n\nMotivation:\n- Aligns with common Python library patterns: top-level package exposes primary entrypoints, domain extensions stay under qmtl.<domain>.\n- Reduces boilerplate in examples and user code; backward-compatible with existing qmtl.sdk.* imports.\n\nScope:\n- Code only; no behavioral change.\n- Tests/docs unaffected; can follow up to mention the new import style in docs if desired.\n