### PR TITLE
chore: remove obsolete data_io re-export comment

### DIFF
--- a/qmtl/sdk/data_io.py
+++ b/qmtl/sdk/data_io.py
@@ -78,7 +78,6 @@ class EventRecorder(ABC):
         ...
 
 
-# re-export concrete implementations for backward compatibility
 __all__ = [
     "DataFetcher",
     "HistoryProvider",


### PR DESCRIPTION
## Summary
- remove comment about re-exporting concrete implementations in data_io
- ensure `__all__` lists only interface types

## Testing
- `uv run -m pytest -W error` *(fails: ExceptionGroup: multiple unraisable exception warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b66dd25883298f1aa4e77a832890