### PR TITLE
refactor: remove schema compatibility helper

### DIFF
--- a/docs/reference/schema_registry.md
+++ b/docs/reference/schema_registry.md
@@ -50,15 +50,6 @@ The expected JSON API is similar to common registry endpoints:
 Network errors raise `RuntimeError`. Future versions may introduce a dedicated
 exception type.
 
-## Compatibility Checks
-
-`SchemaRegistryClient.is_backward_compatible(old, new)` performs a
-shallow-to-recursive check:
-
-- All keys in `old` must exist in `new` (recurse into nested dicts)
-- For lists, only structure presence is checked
-- For scalars, type must not change; numeric (int/float) changes are allowed
-
 ## Kafka Integration
 
 `qmtl.kafka.schema_producer.SchemaAwareProducer` uses `SchemaRegistryClient.from_env()`

--- a/docs/reference/schemas.md
+++ b/docs/reference/schemas.md
@@ -19,8 +19,7 @@ last_modified: 2025-08-29
 
 When `QMTL_SCHEMA_REGISTRY_URL` is set, components can resolve `schema_id`s via
 an external Schema Registry. A lightweight in-memory client is available at
-`qmtl/schema/registry.py` with a simple backward-compatibility check
-(`is_backward_compatible`). Production deployments can swap in Confluent or
+`qmtl/schema/registry.py`. Production deployments can swap in Confluent or
 Redpanda clients.
 
 ## ControlBus CloudEvents — Protobuf Migration Path

--- a/qmtl/schema/registry.py
+++ b/qmtl/schema/registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Optional, Any
+from typing import Dict, Optional
 import json
 import os
 import urllib.request
@@ -54,43 +54,6 @@ class SchemaRegistryClient:
                 if sch.id == schema_id:
                     return sch
         return None
-
-    @staticmethod
-    def is_backward_compatible(old_schema: str, new_schema: str) -> bool:
-        """Shallow-to-recursive compatibility check.
-
-        Rules:
-        - All keys in ``old`` must exist in ``new``.
-        - For dict values, recurse.
-        - For lists, only type consistency is checked (no deep item check).
-        - For scalars, type must not change.
-        Fail-closed on JSON parse errors by returning ``True`` to preserve
-        historical permissive behavior.
-        """
-        try:
-            old = json.loads(old_schema)
-            new = json.loads(new_schema)
-
-            def _compatible(a: Any, b: Any) -> bool:
-                if isinstance(a, dict) and isinstance(b, dict):
-                    for k, av in a.items():
-                        if k not in b:
-                            return False
-                        if not _compatible(av, b[k]):
-                            return False
-                    return True
-                if isinstance(a, list) and isinstance(b, list):
-                    return True  # structure presence only
-                # scalar types: allow widening within numbers
-                if isinstance(a, (int, float)) and isinstance(b, (int, float)):
-                    return True
-                return type(a) is type(b)
-
-            if not isinstance(old, dict) or not isinstance(new, dict):
-                return True
-            return _compatible(old, new)
-        except Exception:
-            return True
 
     @classmethod
     def from_env(cls) -> "SchemaRegistryClient | RemoteSchemaRegistryClient":

--- a/tests/schema/test_registry.py
+++ b/tests/schema/test_registry.py
@@ -1,11 +1,9 @@
 from qmtl.schema import SchemaRegistryClient
 
 
-def test_register_latest_and_compatibility():
+def test_register_and_latest():
     reg = SchemaRegistryClient()
     s1 = reg.register("prices", "{\"a\": 1}")
     assert s1.id > 0 and s1.version == 1
     assert reg.latest("prices").id == s1.id
-    assert SchemaRegistryClient.is_backward_compatible("{\"a\": 1}", "{\"a\": 1, \"b\": 2}")
-    assert not SchemaRegistryClient.is_backward_compatible("{\"a\": 1, \"b\": 2}", "{\"a\": 1}")
 

--- a/tests/schema/test_registry_remote.py
+++ b/tests/schema/test_registry_remote.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 import json
-import types
 
 import pytest
 
@@ -81,29 +80,3 @@ async def test_remote_registry_register_latest_get_by_id_and_from_env(monkeypatc
     # get by id
     g = client.get_by_id(s1.id)
     assert g and json.loads(g.schema)["a"] == 1
-
-
-def test_compatibility_recursive_and_types():
-    # Nested dict key addition allowed
-    assert SchemaRegistryClient.is_backward_compatible(
-        json.dumps({"a": {"b": 1}}), json.dumps({"a": {"b": 1, "c": 2}})
-    )
-    # Removing required nested key fails
-    assert not SchemaRegistryClient.is_backward_compatible(
-        json.dumps({"a": {"b": 1}}), json.dumps({"a": {}})
-    )
-    # Scalar type change fails
-    assert not SchemaRegistryClient.is_backward_compatible(
-        json.dumps({"a": 1}), json.dumps({"a": "1"})
-    )
-    # Numeric type changes are allowed (int<->float)
-    assert SchemaRegistryClient.is_backward_compatible(
-        json.dumps({"a": 1}), json.dumps({"a": 1.0})
-    )
-    assert SchemaRegistryClient.is_backward_compatible(
-        json.dumps({"a": 1.0}), json.dumps({"a": 2})
-    )
-    # Lists: structure presence only (no deep check)
-    assert SchemaRegistryClient.is_backward_compatible(
-        json.dumps({"a": [1, 2]}), json.dumps({"a": ["x"]})
-    )


### PR DESCRIPTION
## Summary
- remove `SchemaRegistryClient.is_backward_compatible`
- drop related tests and references
- update docs to describe registry without compatibility check

## Testing
- `uv run -m pytest -W error` *(fails: tests/gateway/test_tag_query.py::test_queues_by_tag_route_match_alias)*
- `uv run -m pytest tests/schema -W error`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b8b6612b888329aea0fc180c38f81e