### PR TITLE
feat: require WebSocketClient token

### DIFF
--- a/docs/guides/sdk_tutorial.md
+++ b/docs/guides/sdk_tutorial.md
@@ -34,12 +34,16 @@ SDK를 사용하려면 `Strategy` 클래스를 상속하고 `setup()` 메서드�
 Gateway 상태 변화를 실시간으로 수신하기 위한 클래스입니다. 기본 사용법은 다음과 같습니다.
 
 ```python
-client = WebSocketClient("ws://localhost:8000", on_message=my_handler)
+client = WebSocketClient(
+    "ws://localhost:8000",
+    token="<JWT>",
+    on_message=my_handler,
+)
 ```
 
-`url`은 WebSocket 엔드포인트 주소이며 `on_message`는 수신 메시지를 처리할 비동기 함수입니다. `start()`를 호출하면 백그라운드에서 연결을 유지하며 메시지를 받고, `stop()`을 호출하면 연결이 종료됩니다.
+`url`은 WebSocket 엔드포인트 주소이며 `on_message`는 수신 메시지를 처리할 비동기 함수입니다. `token`은 `/events/subscribe` 호출이 반환한 JWT로, Gateway 스트림 구독 시 항상 전달되어야 합니다. `start()`를 호출하면 백그라운드에서 연결을 유지하며 메시지를 받고, `stop()`을 호출하면 연결이 종료됩니다.
 
-`TagQueryManager`는 이 객체를 생성하거나 주입받아 `handle_message()`를 콜백으로 등록합니다. 각 이벤트에는 디스크립터와 토큰이 포함되며, 큐 업데이트(`queue_update`)와 센티널 가중치(`sentinel_weight`) 이벤트가 도착하면 해당 `TagQueryNode`에 `update_queues()`가 호출되고, 가중치 값은 `WebSocketClient.sentinel_weights`에 저장됩니다.
+`TagQueryManager`는 이 객체를 생성하거나 주입받아 `handle_message()`를 콜백으로 등록합니다. 이벤트 설명자와 토큰을 자동으로 전달하므로 커스텀 클라이언트 구현도 `token` 매개변수를 지원해야 합니다. 큐 업데이트(`queue_update`)와 센티널 가중치(`sentinel_weight`) 이벤트가 도착하면 해당 `TagQueryNode`에 `update_queues()`가 호출되고, 가중치 값은 `WebSocketClient.sentinel_weights`에 저장됩니다.
 
 ### Gateway Event Subscription
 

--- a/qmtl/sdk/tagquery_manager.py
+++ b/qmtl/sdk/tagquery_manager.py
@@ -125,15 +125,9 @@ class TagQueryManager:
                     stream_url = data.get("stream_url")
                     token = data.get("token")
                     if stream_url:
-                        try:
-                            self.client = WebSocketClient(
-                                stream_url, on_message=self.handle_message, token=token
-                            )
-                        except TypeError:
-                            # Older or test clients may not accept a token parameter
-                            self.client = WebSocketClient(
-                                stream_url, on_message=self.handle_message
-                            )
+                        self.client = WebSocketClient(
+                            stream_url, on_message=self.handle_message, token=token
+                        )
                         await self.client.start()
                         return
         except Exception:

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -37,8 +37,9 @@ class TQStrategy(Strategy):
 @pytest.mark.asyncio
 async def test_live_auto_subscribes(monkeypatch, fake_redis):
     class DummyWS:
-        def __init__(self, url, *, on_message=None):
+        def __init__(self, url, *, token=None, on_message=None):
             self.on_message = on_message
+            self.token = token
 
         async def start(self):
             pass
@@ -67,8 +68,10 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
             })
 
     client = DummyWS("ws://dummy")
-    def ws_factory(url, *, on_message=None):
+
+    def ws_factory(url, *, on_message=None, token=None):
         client.on_message = on_message
+        client.token = token
         return client
     hub = DummyHub(client)
     redis = fake_redis


### PR DESCRIPTION
## Summary
- remove tokenless WebSocketClient fallback in TagQueryManager
- update token handling in runner live updates test
- document token requirement for WebSocketClient in SDK tutorial

## Testing
- `uv run -m pytest -W error` *(fails: ExceptionGroup: multiple unraisable exception warnings (3 sub-exceptions))*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b8b67ec79c8329a31e0dc5060ae4d4