### PR TITLE
SDK: Activation default OFF; remove allow-all fallback

### DIFF
--- a/qmtl/sdk/activation_manager.py
+++ b/qmtl/sdk/activation_manager.py
@@ -17,8 +17,8 @@ from .ws_client import WebSocketClient
 
 @dataclass
 class ActivationState:
-    long_active: bool = True
-    short_active: bool = True
+    long_active: bool = False
+    short_active: bool = False
     etag: Optional[str] = None
 
 
@@ -83,7 +83,7 @@ class ActivationManager:
                         await self.client.start()
                         self._started = True
         except Exception:
-            # Silent fallback; allow all sides by default
+            # Safe default: keep sides gated OFF until activation arrives
             return
 
     async def stop(self) -> None:


### PR DESCRIPTION
This sets ActivationState defaults to OFF (long/short inactive) and preserves safe default on WS errors.\n\nCloses #659