### PR TITLE
SDK: Remove deprecated shim qmtl/sdk/generators.py

### DIFF
--- a/qmtl/sdk/generators.py
+++ b/qmtl/sdk/generators.py
@@ -1,3 +1,0 @@
-"""Deprecated module. Use ``qmtl.generators`` instead."""
-from qmtl.generators import *  # noqa: F401,F403
-


### PR DESCRIPTION
Delete the re-export shim; use qmtl.generators directly.\n\nCloses #660