### PR TITLE
SDK: GatewayClient drop run_type (Runner updated)

### DIFF
--- a/qmtl/sdk/gateway_client.py
+++ b/qmtl/sdk/gateway_client.py
@@ -26,7 +26,6 @@ class GatewayClient:
         gateway_url: str,
         dag: dict,
         meta: Optional[dict],
-        run_type: Optional[str] = None,
         world_id: Optional[str] = None,
     ) -> dict:
         """Submit a strategy DAG to the gateway."""
@@ -38,8 +37,6 @@ class GatewayClient:
         }
         if world_id is not None:
             payload["world_id"] = world_id
-        if run_type is not None:
-            payload["run_type"] = run_type
         headers: dict[str, str] = {}
         inject(headers)
         try:

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -90,7 +90,6 @@ class Runner:
             gateway_url=gateway_url,
             dag=dag,
             meta=meta,
-            run_type="backtest",
         )
         if isinstance(queue_map, dict) and "error" in queue_map:
             raise RuntimeError(queue_map["error"])
@@ -166,7 +165,6 @@ class Runner:
             gateway_url=gateway_url,
             dag=dag,
             meta=meta,
-            run_type="dry-run",
         )
         if isinstance(queue_map, dict) and "error" in queue_map:
             raise RuntimeError(queue_map["error"])
@@ -237,7 +235,6 @@ class Runner:
             gateway_url=gateway_url,
             dag=dag,
             meta=meta,
-            run_type="live",
         )
         if isinstance(queue_map, dict) and "error" in queue_map:
             raise RuntimeError(queue_map["error"])


### PR DESCRIPTION
Remove run_type from client payload/signature. Runner no longer passes run_type.\n\nCloses #657