### PR TITLE
P2: Test-mode budgets (QMTL_TEST_MODE) to avoid hangs

### DIFF
--- a/docs/guides/strategy_workflow.md
+++ b/docs/guides/strategy_workflow.md
@@ -189,6 +189,20 @@ await Runner.shutdown_async(strategy)
 ```
 
 The helpers are idempotent and safe to call even if no background services are active.
+
+### Test Mode Budgets
+
+Set `QMTL_TEST_MODE=1` when running tests to apply conservative client-side time budgets that reduce the chance of hangs in flaky environments:
+
+- HTTP clients: short default timeout (≈1.5s)
+- WebSocket client: shorter receive timeout and overall max runtime (≈5s)
+
+Example:
+
+```bash
+export QMTL_TEST_MODE=1
+uv run -m pytest -W error
+```
 ```
 
 > **테스트 작성 가이드**

--- a/qmtl/sdk/activation_manager.py
+++ b/qmtl/sdk/activation_manager.py
@@ -13,6 +13,7 @@ from typing import Optional, Dict
 import httpx
 
 from .ws_client import WebSocketClient
+from . import runtime
 
 
 @dataclass
@@ -67,13 +68,13 @@ class ActivationManager:
             return
         subscribe_url = self.gateway_url.rstrip("/") + "/events/subscribe"
         try:
-            async with httpx.AsyncClient(timeout=2.0) as client:
+            async with httpx.AsyncClient(timeout=runtime.HTTP_TIMEOUT_SECONDS) as client:
                 payload = {
                     "topics": ["activation"],
                     "world_id": self.world_id or "",
                     "strategy_id": self.strategy_id or "",
                 }
-                resp = await client.post(subscribe_url, json=payload, timeout=2.0)
+                resp = await client.post(subscribe_url, json=payload)
                 if resp.status_code == 200:
                     data = resp.json()
                     stream_url = data.get("stream_url")

--- a/qmtl/sdk/gateway_client.py
+++ b/qmtl/sdk/gateway_client.py
@@ -8,6 +8,7 @@ import httpx
 from opentelemetry.propagate import inject
 
 from qmtl.common import AsyncCircuitBreaker, crc32_of_list
+from . import runtime
 
 
 class GatewayClient:
@@ -40,9 +41,9 @@ class GatewayClient:
         headers: dict[str, str] = {}
         inject(headers)
         try:
-            client = httpx.AsyncClient(headers=headers, timeout=2.0)
+            client = httpx.AsyncClient(headers=headers, timeout=runtime.HTTP_TIMEOUT_SECONDS)
         except TypeError:
-            client = httpx.AsyncClient(timeout=2.0)
+            client = httpx.AsyncClient(timeout=runtime.HTTP_TIMEOUT_SECONDS)
         try:
             client.headers.update(headers)  # type: ignore[attr-defined]
         except Exception:

--- a/qmtl/sdk/runtime.py
+++ b/qmtl/sdk/runtime.py
@@ -1,4 +1,21 @@
 """Shared runtime flags for SDK features."""
 
+import os
+
 # Global flag to disable Ray usage across SDK components.
 NO_RAY: bool = False
+
+# Enable conservative time budgets in tests to avoid hangs.
+# Set QMTL_TEST_MODE=1 (or true/yes/on) to activate.
+TEST_MODE: bool = str(os.getenv("QMTL_TEST_MODE", "")).strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+
+# Default client-side timeouts used by SDK components. These are intentionally
+# small under TEST_MODE to surface issues quickly and prevent hangs.
+HTTP_TIMEOUT_SECONDS: float = 1.5 if TEST_MODE else 2.0
+WS_RECV_TIMEOUT_SECONDS: float = 5.0 if TEST_MODE else 30.0
+WS_MAX_TOTAL_TIME_SECONDS: float | None = 5.0 if TEST_MODE else None

--- a/qmtl/sdk/tagquery_manager.py
+++ b/qmtl/sdk/tagquery_manager.py
@@ -7,6 +7,7 @@ from .node import MatchMode
 from qmtl.common.tagquery import split_tags, normalize_match_mode, normalize_queues
 
 from .ws_client import WebSocketClient
+from . import runtime
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .node import TagQueryNode
@@ -58,7 +59,7 @@ class TagQueryManager:
             return
 
         url = self.gateway_url.rstrip("/") + "/queues/by_tag"
-        async with httpx.AsyncClient(timeout=2.0) as client:
+        async with httpx.AsyncClient(timeout=runtime.HTTP_TIMEOUT_SECONDS) as client:
             for (tags, interval, match_mode), nodes in self._nodes.items():
                 params = {
                     "tags": ",".join(tags),
@@ -109,7 +110,7 @@ class TagQueryManager:
 
         subscribe_url = self.gateway_url.rstrip("/") + "/events/subscribe"
         try:
-            async with httpx.AsyncClient(timeout=2.0) as client:
+            async with httpx.AsyncClient(timeout=runtime.HTTP_TIMEOUT_SECONDS) as client:
                 payload = {
                     "topics": ["queues"],
                     "world_id": self.world_id or "",

--- a/qmtl/sdk/ws_client.py
+++ b/qmtl/sdk/ws_client.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse, urlunparse
 
 import websockets
 import logging
+from . import runtime
 
 if TYPE_CHECKING:  # pragma: no cover - only for typing
     from .node import TagQueryNode
@@ -46,7 +47,7 @@ class WebSocketClient:
         self._stop_event = asyncio.Event()
         self._ws: websockets.WebSocketClientProtocol | None = None
         self.max_retries = max_retries
-        self.max_total_time = max_total_time
+        self.max_total_time = max_total_time if max_total_time is not None else runtime.WS_MAX_TOTAL_TIME_SECONDS
         self._base_delay = base_delay
         self._backoff_factor = backoff_factor
         self._max_delay = max_delay
@@ -93,7 +94,7 @@ class WebSocketClient:
                     while not self._stop_event.is_set():
                         try:
                             try:
-                                msg = await asyncio.wait_for(ws.recv(), timeout=30)
+                                msg = await asyncio.wait_for(ws.recv(), timeout=runtime.WS_RECV_TIMEOUT_SECONDS)
                             except asyncio.TimeoutError:
                                 # No message within timeout; trigger reconnect loop
                                 break


### PR DESCRIPTION
Adds QMTL_TEST_MODE=1 support to clamp SDK client timeouts during tests:

- HTTP clients use short default timeouts (~1.5s)
- WebSocket client uses shorter receive timeout and a small overall cap (~5s)
- No per-call timeout changes to keep existing test doubles compatible
- Docs updated to include usage example

Refs #666