### PR TITLE
P3: Docs (FAQ) and test teardown improvements

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -13,4 +13,13 @@ last_modified: 2025-08-21
 
 `TagQueryNode`는 Runner가 생성하는 `TagQueryManager`가 Gateway와 통신하여 큐 목록을 갱신합니다. 월드 주도 실행에서 전략은 `Runner.run(world_id=..., gateway_url=...)`로 시작하며, 이때 TagQueryManager가 초기 큐 조회와 WebSocket 구독을 설정합니다. Gateway/WorldService가 연결되지 않으면 전략은 안전기본(compute‑only, 주문 게이트 OFF)으로 유지됩니다. `Runner.offline()` 은 Gateway 없이 로컬 실행으로, 태그 기반 노드는 빈 큐 목록으로 초기화됩니다.
 
+## 테스트가 가끔 hang 되거나 자원이 해제되지 않는 것 같습니다. 어떻게 방지하나요?
+
+- 테스트 종료 시 백그라운드 서비스 정리:
+  - `Runner.shutdown(strategy)` 또는 `await Runner.shutdown_async(strategy)`를 호출하여 `TagQueryManager`/`ActivationManager`를 정리하세요.
+- 보수적인 타임아웃 적용:
+  - 테스트 실행 전에 `QMTL_TEST_MODE=1`을 설정하면 SDK의 기본 HTTP/WS 타임아웃이 짧게 설정되어 hang 가능성이 줄어듭니다.
+- ASGI/Transport 자원 정리:
+  - `httpx.ASGITransport` 등을 사용했다면 테스트 마지막에 `await transport.aclose()`로 명시적으로 자원을 해제하세요.
+
 {{ nav_links() }}


### PR DESCRIPTION
Add guidance to prevent test hangs and adopt new shutdown helpers.\n\n- FAQ: how to avoid hangs (Runner.shutdown, QMTL_TEST_MODE, transport close)\n- tests/tagquery/test_runner_live_updates.py: use Runner.shutdown_async for clean teardown\n\nRefs #666