### PR TITLE
Tests: disable background loops in gateway app fixtures

### DIFF
--- a/tests/gateway/test_api.py
+++ b/tests/gateway/test_api.py
@@ -29,7 +29,7 @@ class FakeDB(Database):
 @pytest.fixture
 def app(fake_redis):
     db = FakeDB()
-    return create_app(redis_client=fake_redis, database=db)
+    return create_app(redis_client=fake_redis, database=db, enable_background=False)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_metrics.py
+++ b/tests/gateway/test_metrics.py
@@ -30,7 +30,7 @@ class FakeDB(Database):
 @pytest.fixture
 def app(fake_redis):
     db = FakeDB()
-    return create_app(redis_client=fake_redis, database=db)
+    return create_app(redis_client=fake_redis, database=db, enable_background=False)
 
 
 def test_metrics_endpoint(app):
@@ -69,7 +69,7 @@ def test_lost_requests_counter(monkeypatch, fake_redis):
 
     monkeypatch.setattr(redis, "rpush", fail)
     db = FakeDB()
-    app = create_app(redis_client=redis, database=db)
+    app = create_app(redis_client=redis, database=db, enable_background=False)
     with TestClient(app, raise_server_exceptions=False) as client:
         payload = StrategySubmit(
             dag_json="{}",

--- a/tests/gateway/test_nodeid.py
+++ b/tests/gateway/test_nodeid.py
@@ -34,7 +34,7 @@ class FakeDB(Database):
 @pytest.fixture
 def client_and_redis(fake_redis):
     db = FakeDB()
-    app = create_app(redis_client=fake_redis, database=db)
+    app = create_app(redis_client=fake_redis, database=db, enable_background=False)
     with TestClient(app) as c:
         yield c, fake_redis
 
@@ -90,7 +90,7 @@ async def test_sentinel_inserted(client_and_redis):
 async def test_sentinel_skip(fake_redis):
     redis = fake_redis
     db = FakeDB()
-    app = create_app(redis_client=redis, database=db, insert_sentinel=False)
+    app = create_app(redis_client=redis, database=db, insert_sentinel=False, enable_background=False)
     with TestClient(app) as client:
         dag = {"nodes": []}
         payload = StrategySubmit(

--- a/tests/integrity/test_checksum.py
+++ b/tests/integrity/test_checksum.py
@@ -26,7 +26,7 @@ class FakeDB(Database):
 @pytest.fixture
 def client(fake_redis):
     db = FakeDB()
-    app = create_app(redis_client=fake_redis, database=db)
+    app = create_app(redis_client=fake_redis, database=db, enable_background=False)
     with TestClient(app) as c:
         yield c
 

--- a/tests/strategy/test_conflict.py
+++ b/tests/strategy/test_conflict.py
@@ -26,7 +26,7 @@ class FakeDB(Database):
 @pytest.fixture
 def client(fake_redis):
     db = FakeDB()
-    app = create_app(redis_client=fake_redis, database=db)
+    app = create_app(redis_client=fake_redis, database=db, enable_background=False)
     with TestClient(app) as c:
         yield c
 


### PR DESCRIPTION
Pass enable_background=False to qmtl.gateway.api.create_app in common test fixtures to avoid starting background tasks (ws hub, commit-log consumer) during unit tests. This reduces ResourceWarnings and unclosed loop warnings.\n\nUpdated files:\n- tests/gateway/test_api.py\n- tests/gateway/test_metrics.py\n- tests/strategy/test_conflict.py\n- tests/integrity/test_checksum.py\n- tests/gateway/test_nodeid.py\n\nRefs #683