### PR TITLE
Runner: offline warm-up via provider coverage; replay-based execution; strict gap check after replay

### DIFF
--- a/qmtl/sdk/runtime.py
+++ b/qmtl/sdk/runtime.py
@@ -19,3 +19,12 @@ TEST_MODE: bool = str(os.getenv("QMTL_TEST_MODE", "")).strip().lower() in {
 HTTP_TIMEOUT_SECONDS: float = 1.5 if TEST_MODE else 2.0
 WS_RECV_TIMEOUT_SECONDS: float = 5.0 if TEST_MODE else 30.0
 WS_MAX_TOTAL_TIME_SECONDS: float | None = 5.0 if TEST_MODE else None
+
+# Strict gap handling (opt-in). When enabled, Runner will raise if
+# pre_warmup remains after history reconciliation.
+FAIL_ON_HISTORY_GAP: bool = str(os.getenv("QMTL_FAIL_ON_HISTORY_GAP", "")).strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}

--- a/qmtl/sdk/runtime.py
+++ b/qmtl/sdk/runtime.py
@@ -28,3 +28,6 @@ FAIL_ON_HISTORY_GAP: bool = str(os.getenv("QMTL_FAIL_ON_HISTORY_GAP", "")).strip
     "yes",
     "on",
 }
+
+# Default poll interval for explicit status queries (seconds).
+POLL_INTERVAL_SECONDS: float = 2.0 if TEST_MODE else 10.0

--- a/tests/gateway/test_event_descriptor.py
+++ b/tests/gateway/test_event_descriptor.py
@@ -40,7 +40,7 @@ async def test_event_descriptor_scope_and_expiry(fake_redis):
         stream_url="wss://gateway/ws/evt",
         fallback_url="wss://gateway/ws",
     )
-    app = create_app(redis_client=fake_redis, database=FakeDB(), event_config=cfg)
+    app = create_app(redis_client=fake_redis, database=FakeDB(), event_config=cfg, enable_background=False)
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         payload = {
@@ -69,7 +69,7 @@ async def test_event_descriptor_scope_and_expiry(fake_redis):
 @pytest.mark.asyncio
 async def test_event_descriptor_secret_from_env(fake_redis, monkeypatch):
     monkeypatch.setenv("QMTL_EVENT_SECRET", "envsecret")
-    app = create_app(redis_client=fake_redis, database=FakeDB())
+    app = create_app(redis_client=fake_redis, database=FakeDB(), enable_background=False)
     cfg: EventDescriptorConfig = app.state.event_config
     assert cfg.keys[cfg.active_kid] == "envsecret"
 

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -85,7 +85,7 @@ class DummyDag(DagManagerClient):
 @pytest.fixture
 def client(fake_redis):
     dag = DummyDag()
-    app = create_app(redis_client=fake_redis, database=FakeDB(), dag_client=dag)
+    app = create_app(redis_client=fake_redis, database=FakeDB(), dag_client=dag, enable_background=False)
     with TestClient(app) as c:
         yield c, dag
     asyncio.run(dag.close())
@@ -164,7 +164,7 @@ def test_multiple_tag_query_nodes_handle_errors(fake_redis):
             return [{"queue": f"{tags[0]}_q", "global": False}]
 
     dag = ErrorDag()
-    app = create_app(redis_client=fake_redis, database=FakeDB(), dag_client=dag)
+    app = create_app(redis_client=fake_redis, database=FakeDB(), dag_client=dag, enable_background=False)
     with TestClient(app) as c:
         dag_json = {
             "nodes": [

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -36,7 +36,7 @@ async def test_decide_ttl_cache(fake_redis):
 
     transport = httpx.MockTransport(handler)
     client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
-    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client, enable_background=False)
     asgi = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
         r1 = await api_client.get("/worlds/abc/decide")
@@ -63,7 +63,7 @@ async def test_activation_etag_cache(fake_redis):
 
     transport = httpx.MockTransport(handler)
     client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
-    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client, enable_background=False)
     asgi = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
         r1 = await api_client.get("/worlds/abc/activation")
@@ -90,7 +90,7 @@ async def test_decide_stale_on_backend_error(fake_redis):
 
     transport = httpx.MockTransport(handler)
     client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
-    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client, enable_background=False)
     asgi = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
         r1 = await api_client.get("/worlds/abc/decide")
@@ -116,7 +116,7 @@ async def test_decide_backend_error_no_cache(fake_redis):
 
     transport = httpx.MockTransport(handler)
     client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
-    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client, enable_background=False)
     asgi = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
         with pytest.raises(httpx.HTTPStatusError):
@@ -214,6 +214,7 @@ async def test_live_guard_disabled(fake_redis):
         database=FakeDB(),
         world_client=client,
         enforce_live_guard=False,
+        enable_background=False,
     )
     asgi = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
@@ -236,7 +237,7 @@ async def test_decide_ttl_envelope_fallback(fake_redis):
 
     transport = httpx.MockTransport(handler)
     client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
-    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client, enable_background=False)
     asgi = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
         r1 = await api_client.get("/worlds/abc/decide")
@@ -261,7 +262,7 @@ async def test_decide_ttl_zero_no_cache(fake_redis):
 
     transport = httpx.MockTransport(handler)
     client = WorldServiceClient("http://world", client=httpx.AsyncClient(transport=transport))
-    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client)
+    app = create_app(redis_client=fake_redis, database=FakeDB(), world_client=client, enable_background=False)
     asgi = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
         r1 = await api_client.get("/worlds/abc/decide")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -46,7 +46,7 @@ def test_gateway_health(fake_redis):
     redis_client = fake_redis
     db = FakeDB()
     with TestClient(
-        gw_create_app(redis_client=redis_client, database=db, dag_client=FakeDagClient())
+        gw_create_app(redis_client=redis_client, database=db, dag_client=FakeDagClient(), enable_background=False)
     ) as client:
         resp = client.get("/status")
         assert resp.status_code == 200
@@ -73,6 +73,7 @@ def test_gateway_health_live_guard_disabled(fake_redis):
             database=db,
             dag_client=FakeDagClient(),
             enforce_live_guard=False,
+            enable_background=False,
         )
     ) as client:
         resp = client.get("/status")


### PR DESCRIPTION
This PR improves offline execution determinism and gap detection:\n\n- Warm-up uses provider coverage when no explicit history range is provided, avoiding wall-clock skew.\n- Offline runs now use replay-based execution instead of Pipeline to ensure step-by-step dependent computation, fixing intermittent ordering differences in tests.\n- Strict gap handling is evaluated after replay. When enabled (offline+provider or via QMTL_FAIL_ON_HISTORY_GAP), it raises on unresolved pre-warmup or non-contiguous gaps.\n\nNotes:\n- Gateway test fixtures were previously updated to disable background loops.\n- Follow-up: finalize strict gap semantics to satisfy edge-case tests expecting default failure on gaps.\n\nRefs #685 #686