### PR TITLE
feat: await explicit gRPC acks

### DIFF
--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -73,7 +73,7 @@ class _PrintStream(StreamSender):
     def send(self, chunk) -> None:
         print(json.dumps({"queue_map": chunk.queue_map, "sentinel_id": chunk.sentinel_id}))
 
-    def wait_for_ack(self) -> AckStatus:
+    async def wait_for_ack(self) -> AckStatus:
         return AckStatus.OK
 
     def ack(self, status: AckStatus = AckStatus.OK) -> None:

--- a/qmtl/dagmanager/server.py
+++ b/qmtl/dagmanager/server.py
@@ -22,7 +22,7 @@ class _NullStream(StreamSender):
     def send(self, chunk) -> None:  # pragma: no cover - simple no-op
         pass
 
-    def wait_for_ack(self) -> AckStatus:  # pragma: no cover - noop
+    async def wait_for_ack(self) -> AckStatus:  # pragma: no cover - noop
         return AckStatus.OK
 
     def ack(self, status: AckStatus = AckStatus.OK) -> None:  # pragma: no cover - noop

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -51,7 +51,7 @@ class _FakeStream(StreamSender):
     def send(self, chunk):
         pass
 
-    def wait_for_ack(self) -> AckStatus:
+    async def wait_for_ack(self) -> AckStatus:
         return AckStatus.OK
 
     def ack(self, status: AckStatus = AckStatus.OK):

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -60,7 +60,7 @@ class FakeStream(StreamSender):
     def send(self, chunk):
         self.chunks.append(chunk)
 
-    def wait_for_ack(self) -> AckStatus:
+    async def wait_for_ack(self) -> AckStatus:
         self.waits += 1
         return AckStatus.OK
 

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -56,7 +56,7 @@ class FakeStream(StreamSender):
     def send(self, chunk):
         pass
 
-    def wait_for_ack(self) -> AckStatus:
+    async def wait_for_ack(self) -> AckStatus:
         return AckStatus.OK
 
     def ack(self, status: AckStatus = AckStatus.OK):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -110,7 +110,7 @@ async def test_grpc_health():
         def send(self, chunk):
             pass
 
-        def wait_for_ack(self) -> AckStatus:
+        async def wait_for_ack(self) -> AckStatus:
             return AckStatus.OK
 
         def ack(self, status: AckStatus = AckStatus.OK):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -51,7 +51,7 @@ class FakeStream(StreamSender):
     def send(self, chunk):
         pass
 
-    def wait_for_ack(self) -> AckStatus:
+    async def wait_for_ack(self) -> AckStatus:
         return AckStatus.OK
 
     def ack(self, status: AckStatus = AckStatus.OK):


### PR DESCRIPTION
## Summary
- replace thread-based ACK waiting with async event in gRPC stream
- await ACKs in DiffService and tests

## Testing
- `uv run -m pytest -W error` *(fails: RuntimeError: history pre-warmup unresolved in strict mode)*
- `uv run -m pytest tests/test_grpc_stream.py tests/test_grpc_server.py tests/test_diff_service.py tests/gateway/test_tag_query.py tests/test_metrics.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b95cfed05883298eb543061fdc404e