### PR TITLE
feat: add awaitable commit log consumption

### DIFF
--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -28,7 +28,7 @@ from .routes import create_api_router
 from .strategy_manager import StrategyManager
 from .world_client import Budget, WorldServiceClient
 from .ws import WebSocketHub
-from .commit_log_consumer import CommitLogConsumer
+from .commit_log_consumer import CommitLogConsumer, ConsumeStatus
 from .commit_log import CommitLogWriter
 
 logger = logging.getLogger(__name__)
@@ -136,9 +136,9 @@ def create_app(
             )
             async def _consume_loop() -> None:
                 while True:
-                    await commit_log_consumer_local.consume(
-                        handler, timeout_ms=1000
-                    )
+                    status = await commit_log_consumer_local.consume_once(handler)
+                    if status is ConsumeStatus.EMPTY:
+                        continue
 
             commit_task = asyncio.create_task(_consume_loop())
         if enable_background and ws_hub_local:

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -316,11 +316,11 @@ class Runner:
         await consumer.start()
         try:
             while not stop_event.is_set():
-                batch = await consumer.getmany(timeout_ms=200)
-                got = False
+                batch = await consumer.getmany()
+                if not batch:
+                    continue
                 for _tp, messages in batch.items():
                     for msg in messages:
-                        got = True
                         try:
                             payload = json.loads(msg.value)
                         except Exception:
@@ -333,9 +333,6 @@ class Runner:
                             ts,
                             payload,
                         )
-                if not got:
-                    # No messages; loop to re-check stop_event promptly
-                    continue
         finally:
             await consumer.stop()
 

--- a/tests/gateway/test_commit_log_cli.py
+++ b/tests/gateway/test_commit_log_cli.py
@@ -12,12 +12,13 @@ def test_cli_parser_has_expected_options():
         "g1",
         "--metrics-port",
         "9000",
-        "--poll-timeout-ms",
-        "250",
+        "--health-port",
+        "8080",
     ])
     assert ns.bootstrap == "localhost:9092"
     assert ns.topic == "commit-log"
     assert ns.group == "g1"
     assert ns.metrics_port == 9000
-    assert ns.poll_timeout_ms == 250
+    assert ns.health_port == 8080
+    assert not hasattr(ns, "poll_timeout_ms")
 

--- a/tests/gateway/test_commit_log_soak.py
+++ b/tests/gateway/test_commit_log_soak.py
@@ -3,7 +3,7 @@ import pytest
 
 from qmtl.gateway import metrics
 from qmtl.gateway.commit_log import CommitLogWriter
-from qmtl.gateway.commit_log_consumer import CommitLogConsumer
+from qmtl.gateway.commit_log_consumer import CommitLogConsumer, ConsumeStatus
 
 
 class P:
@@ -36,7 +36,7 @@ class C:
     async def stop(self):
         return None
 
-    async def getmany(self, timeout_ms=None):
+    async def getmany(self):
         if self._batches:
             return {None: self._batches.pop(0)}
         return {}
@@ -65,7 +65,8 @@ async def test_commit_log_exactly_once_soak():
         out.extend(records)
 
     await clc.start()
-    await clc.consume(handler)
+    status = await clc.consume_once(handler)
+    assert status is ConsumeStatus.RECORDS
     await clc.stop()
 
     # Only the first record survives dedup


### PR DESCRIPTION
## Summary
- add ConsumeStatus enum and awaitable consume_once for commit log polling
- adopt consume_once in API, CLI, SDK runner and tests
- drop timeout-based polling in favor of explicit empty status handling

## Testing
- `uv run --extra dev -m pytest -W error` *(fails: history pre-warmup unresolved; see tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b95d01284c83299c7476640137f9ab