### PR TITLE
feat: await consumer availability

### DIFF
--- a/qmtl/gateway/commit_log_consumer.py
+++ b/qmtl/gateway/commit_log_consumer.py
@@ -76,7 +76,10 @@ class CommitLogConsumer:
     async def _poll_raw(
         self, timeout_ms: int | None = None
     ) -> list[tuple[str, int, str, Any]]:
-        result = await self._consumer.getmany(timeout_ms=timeout_ms)
+        if timeout_ms is None:
+            result = await self._consumer.getmany()
+        else:
+            result = await self._consumer.getmany(timeout_ms=timeout_ms)
         records: list[tuple[str, int, str, Any]] = []
         for messages in result.values():
             for msg in messages:

--- a/tests/gateway/test_commit_log_consumer.py
+++ b/tests/gateway/test_commit_log_consumer.py
@@ -75,7 +75,7 @@ class _FakeConsumer:
     async def stop(self) -> None:
         return None
 
-    async def getmany(self, timeout_ms: int | None = None):  # noqa: D401 - test shim
+    async def getmany(self):  # noqa: D401 - test shim
         if self._batches:
             return {None: self._batches.popleft()}
         return {}

--- a/tests/gateway/test_commit_log_flow.py
+++ b/tests/gateway/test_commit_log_flow.py
@@ -47,7 +47,7 @@ class _FakeConsumer:
     async def stop(self) -> None:
         self.stopped = True
 
-    async def getmany(self, timeout_ms: int | None = None):
+    async def getmany(self):
         if self._batches:
             return {None: self._batches.pop(0)}
         return {}

--- a/tests/gateway/test_commit_log_soak.py
+++ b/tests/gateway/test_commit_log_soak.py
@@ -36,7 +36,7 @@ class C:
     async def stop(self):
         return None
 
-    async def getmany(self, timeout_ms=None):
+    async def getmany(self):
         if self._batches:
             return {None: self._batches.pop(0)}
         return {}

--- a/tests/gateway/test_worker_ownership_metrics.py
+++ b/tests/gateway/test_worker_ownership_metrics.py
@@ -87,7 +87,7 @@ class _FakeConsumer:
     async def stop(self) -> None:
         return None
 
-    async def getmany(self, timeout_ms: int | None = None):  # noqa: D401 - test shim
+    async def getmany(self):  # noqa: D401 - test shim
         if self._batches:
             return {None: self._batches.popleft()}
         return {}


### PR DESCRIPTION
## Summary
- await Kafka consumer availability in Runner instead of polling with a timeout
- allow CommitLogConsumer to call getmany without a timeout
- update commit log tests for the event-driven consumer API

## Testing
- `uv run -m pytest -W error` *(fails: history pre-warmup unresolved in strict mode, unraisable exception warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b95d07d9e883298504b6b9d881ad7f