### PR TITLE
feat: add websocket heartbeat

### DIFF
--- a/qmtl/sdk/runtime.py
+++ b/qmtl/sdk/runtime.py
@@ -17,5 +17,5 @@ TEST_MODE: bool = str(os.getenv("QMTL_TEST_MODE", "")).strip().lower() in {
 # Default client-side timeouts used by SDK components. These are intentionally
 # small under TEST_MODE to surface issues quickly and prevent hangs.
 HTTP_TIMEOUT_SECONDS: float = 1.5 if TEST_MODE else 2.0
-WS_RECV_TIMEOUT_SECONDS: float = 5.0 if TEST_MODE else 30.0
+WS_HEARTBEAT_INTERVAL_SECONDS: float = 0.5 if TEST_MODE else 30.0
 WS_MAX_TOTAL_TIME_SECONDS: float | None = 5.0 if TEST_MODE else None


### PR DESCRIPTION
## Summary
- add configurable heartbeat pings to WebSocketClient
- expose `WS_HEARTBEAT_INTERVAL_SECONDS` in runtime settings
- update websocket client tests to simulate heartbeat failure

## Testing
- `uv run -m pytest tests/test_ws_client.py tests/gateway/test_queue_update_ws_execution.py tests/tagquery/test_runner_live_updates.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b95d0eb42083299a8b255969352ef6