### PR TITLE
Refactor async waits to event-driven signals

### DIFF
--- a/tests/test_grpc_stream.py
+++ b/tests/test_grpc_stream.py
@@ -19,7 +19,7 @@ async def test_resume_requeues_unacked_chunks():
     stream._last_ack = AckStatus.TIMEOUT  # simulate timeout
     stream.resume_from_last_offset()
     assert stream.ack_status() is AckStatus.OK
-    assert await asyncio.wait_for(stream.queue.get(), timeout=0.1) is chunk
+    assert await stream.queue.get() is chunk
 
 
 @pytest.mark.asyncio
@@ -38,7 +38,7 @@ async def test_resume_skips_acknowledged_chunks():
     stream.resume_from_last_offset()
 
     # Only second chunk should be replayed
-    assert await asyncio.wait_for(stream.queue.get(), timeout=0.1) is second
+    assert await stream.queue.get() is second
 
     # After acknowledging, resume should not replay anything
     stream.ack()

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -25,20 +25,23 @@ async def test_ws_client_updates_state():
     async def handler(websocket):
         for e in events:
             await websocket.send(json.dumps(e))
-        await asyncio.sleep(0.05)
+        await websocket.wait_closed()
 
     server = await websockets.serve(handler, "localhost", 0)
     port = server.sockets[0].getsockname()[1]
     url = f"ws://localhost:{port}"
     try:
         received: list[dict] = []
+        done = asyncio.Event()
 
         async def on_msg(data):
             received.append(data)
+            if (data.get("event") or data.get("type")) == "queue_update":
+                done.set()
 
         client = WebSocketClient(url, on_message=on_msg)
         await client.start()
-        await asyncio.sleep(0.2)
+        await asyncio.wait_for(done.wait(), timeout=1)
         await client.stop()
         assert client.queue_topics == {"n1": "t1"}
         assert client.sentinel_weights == {"s1": 0.75}
@@ -82,9 +85,11 @@ async def test_ws_client_reconnects(monkeypatch):
     monkeypatch.setattr(websockets, "connect", fake_connect)
 
     received: list[dict] = []
+    done = asyncio.Event()
 
     async def on_msg(data: dict) -> None:
         received.append(data)
+        done.set()
 
     client = WebSocketClient(
         "ws://dummy",
@@ -93,7 +98,7 @@ async def test_ws_client_reconnects(monkeypatch):
         base_delay=0.01,
     )
     await client.start()
-    await asyncio.sleep(0.1)
+    await asyncio.wait_for(done.wait(), timeout=1)
     await client.stop()
 
     assert len(connects) == 2
@@ -102,8 +107,11 @@ async def test_ws_client_reconnects(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ws_client_stop_closes_session():
+    connected = asyncio.Event()
+
     async def handler(websocket):
-        await asyncio.sleep(1)
+        connected.set()
+        await websocket.wait_closed()
 
     server = await websockets.serve(handler, "localhost", 0)
     port = server.sockets[0].getsockname()[1]
@@ -111,7 +119,7 @@ async def test_ws_client_stop_closes_session():
     try:
         client = WebSocketClient(url)
         await client.start()
-        await asyncio.sleep(0.1)
+        await asyncio.wait_for(connected.wait(), timeout=1)
         start = asyncio.get_running_loop().time()
         await client.stop()
         assert asyncio.get_running_loop().time() - start < 0.5
@@ -127,16 +135,22 @@ async def test_ws_client_logs_invalid_weight(caplog):
     async def handler(websocket):
         for e in events:
             await websocket.send(json.dumps(e))
-        await asyncio.sleep(0.05)
+        await websocket.wait_closed()
 
     server = await websockets.serve(handler, "localhost", 0)
     port = server.sockets[0].getsockname()[1]
     url = f"ws://localhost:{port}"
     try:
         client = WebSocketClient(url)
+        done = asyncio.Event()
+
+        async def on_msg(data):
+            done.set()
+
+        client.on_message = on_msg
         with caplog.at_level(logging.WARNING):
             await client.start()
-            await asyncio.sleep(0.2)
+            await asyncio.wait_for(done.wait(), timeout=1)
             await client.stop()
         assert client.sentinel_weights == {}
         assert any("s1" in r.getMessage() and "bad" in r.getMessage() for r in caplog.records)
@@ -153,7 +167,6 @@ async def test_ws_client_sends_token(monkeypatch):
         close_timeout = 0
 
         async def recv(self) -> str:
-            await asyncio.sleep(0.01)
             raise websockets.ConnectionClosed(1000, "")
 
         async def close(self) -> None:
@@ -165,16 +178,19 @@ async def test_ws_client_sends_token(monkeypatch):
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
+    connected = asyncio.Event()
+
     def fake_connect(url: str, extra_headers=None):
         nonlocal headers
         headers = extra_headers
+        connected.set()
         return DummyWS()
 
     monkeypatch.setattr(websockets, "connect", fake_connect)
 
     client = WebSocketClient("ws://dummy", token="abc")
     await client.start()
-    await asyncio.sleep(0.05)
+    await asyncio.wait_for(connected.wait(), timeout=1)
     await client.stop()
 
     assert headers == {"Authorization": "Bearer abc"}


### PR DESCRIPTION
## Summary
- replace WebSocketClient timeout waiting with event-driven `asyncio.wait`
- test gRPC stream replay without relying on short timeouts
- rewrite WebSocketClient tests to wait on explicit events instead of sleeps

## Testing
- `uv run --extra dev -m pytest -W error` *(fails: history pre-warmup unresolved in strict mode and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b95d10154883298443f41ecd484acc