### PR TITLE
docs: prefer event-driven async waiting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,14 @@ uv run scripts/check_doc_sync.py
 
 Run the script from the repository root and fix any reported issues.
 
+## Network and Asynchronous Operations
+
+Use explicit state polling or event-driven communication instead of unconditional `sleep` calls or arbitrary timeouts in network or asynchronous code. Utilities such as `asyncio.wait_for` and `asyncio.Event.wait` help manage these workflows:
+
+```python
+await asyncio.wait_for(event.wait(), timeout=5)
+```
+
 ## Documentation
 
 When adding new markdown files under `docs/`, copy `docs/templates/template.md` and update the front matter fields (`title`, `tags`, `author`, `last_modified`).


### PR DESCRIPTION
## Summary
- document preferred async patterns: use event-driven waits instead of unconditional sleeps

## Testing
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b9715ca4948329ab49038ed24878b1