### PR TITLE
Use event-based polling in DAG Manager loops

### DIFF
--- a/qmtl/dagmanager/completion.py
+++ b/qmtl/dagmanager/completion.py
@@ -22,24 +22,34 @@ class QueueCompletionMonitor:
     _stalled: Dict[str, int] = field(default_factory=dict)
     _completed: set[str] = field(default_factory=set)
     _task: Optional[asyncio.Task] = None
+    _stop_event: asyncio.Event = field(
+        default_factory=asyncio.Event, init=False, repr=False
+    )
 
     async def start(self) -> None:
         if self._task is None:
+            self._stop_event.clear()
             self._task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
         if self._task is not None:
-            self._task.cancel()
+            self._stop_event.set()
             try:
                 await self._task
             finally:
                 self._task = None
+                self._stop_event = asyncio.Event()
 
     async def _run(self) -> None:
         try:
-            while True:
+            while not self._stop_event.is_set():
                 await self.check_once()
-                await asyncio.sleep(self.interval)
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=self.interval
+                    )
+                except asyncio.TimeoutError:
+                    pass
         except asyncio.CancelledError:  # pragma: no cover - background task
             pass
 

--- a/qmtl/dagmanager/gc_scheduler.py
+++ b/qmtl/dagmanager/gc_scheduler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from .garbage_collector import GarbageCollector
@@ -14,28 +14,38 @@ class GCScheduler:
     gc: GarbageCollector
     interval: float = 60.0
     _task: Optional[asyncio.Task] = None
+    _stop_event: asyncio.Event = field(
+        default_factory=asyncio.Event, init=False, repr=False
+    )
 
     async def start(self) -> None:
         """Begin scheduling in the background."""
         if self._task is None:
+            self._stop_event.clear()
             self._task = asyncio.create_task(self._run())
 
     async def _run(self) -> None:
         try:
-            while True:
+            while not self._stop_event.is_set():
                 self.gc.collect()
-                await asyncio.sleep(self.interval)
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=self.interval
+                    )
+                except asyncio.TimeoutError:
+                    pass
         except asyncio.CancelledError:  # pragma: no cover - background task
             pass
 
     async def stop(self) -> None:
         """Stop the scheduler."""
         if self._task is not None:
-            self._task.cancel()
+            self._stop_event.set()
             try:
                 await self._task
             finally:
                 self._task = None
+                self._stop_event = asyncio.Event()
 
 
 __all__ = ["GCScheduler"]

--- a/qmtl/dagmanager/metrics.py
+++ b/qmtl/dagmanager/metrics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import deque
 from typing import Deque, List
 import time
+import threading
 import argparse
 
 from prometheus_client import Gauge, Counter, generate_latest, start_http_server, REGISTRY as global_registry
@@ -163,12 +164,15 @@ def start_metrics_server(port: int = 8000) -> None:
     """Start a background HTTP server to expose metrics."""
     start_http_server(port, registry=global_registry)
 
+_stop_event = threading.Event()
 
-def _run_forever() -> None:
+
+def _run_forever(stop_event: threading.Event | None = None) -> None:
     """Block the main thread so the HTTP server stays alive."""
+    stop_event = stop_event or _stop_event
     try:
-        while True:
-            time.sleep(3600)
+        while not stop_event.wait(3600):
+            pass
     except KeyboardInterrupt:  # pragma: no cover - manual stop
         pass
 

--- a/qmtl/dagmanager/neo4j_metrics.py
+++ b/qmtl/dagmanager/neo4j_metrics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Background tasks to record Neo4j graph counts."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, TYPE_CHECKING
 import asyncio
 
@@ -41,26 +41,36 @@ class GraphCountScheduler:
     collector: GraphCountCollector
     interval: float = 60.0
     _task: Optional[asyncio.Task] = None
+    _stop_event: asyncio.Event = field(
+        default_factory=asyncio.Event, init=False, repr=False
+    )
 
     async def start(self) -> None:
         if self._task is None:
+            self._stop_event.clear()
             self._task = asyncio.create_task(self._run())
 
     async def _run(self) -> None:
         try:
-            while True:
+            while not self._stop_event.is_set():
                 self.collector.record_counts()
-                await asyncio.sleep(self.interval)
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=self.interval
+                    )
+                except asyncio.TimeoutError:
+                    pass
         except asyncio.CancelledError:  # pragma: no cover - background task
             pass
 
     async def stop(self) -> None:
         if self._task is not None:
-            self._task.cancel()
+            self._stop_event.set()
             try:
                 await self._task
             finally:
                 self._task = None
+                self._stop_event = asyncio.Event()
 
 
 __all__ = ["GraphCountCollector", "GraphCountScheduler"]

--- a/tests/gc/test_scheduler.py
+++ b/tests/gc/test_scheduler.py
@@ -7,9 +7,11 @@ from qmtl.dagmanager.gc_scheduler import GCScheduler
 class DummyGC:
     def __init__(self):
         self.calls = 0
+        self.event = asyncio.Event()
 
     def collect(self):
         self.calls += 1
+        self.event.set()
         return []
 
 
@@ -18,6 +20,8 @@ async def test_gc_scheduler_runs_collect():
     gc = DummyGC()
     sched = GCScheduler(gc, interval=0.01)
     await sched.start()
-    await asyncio.sleep(0.03)
+    await asyncio.wait_for(gc.event.wait(), timeout=1)
+    gc.event.clear()
+    await asyncio.wait_for(gc.event.wait(), timeout=1)
     await sched.stop()
     assert gc.calls >= 2

--- a/tests/test_monitor_loop.py
+++ b/tests/test_monitor_loop.py
@@ -7,9 +7,11 @@ from qmtl.dagmanager.monitor import MonitorLoop
 class DummyMonitor:
     def __init__(self):
         self.called = 0
+        self.event = asyncio.Event()
 
     async def check_once(self) -> None:
         self.called += 1
+        self.event.set()
 
 
 @pytest.mark.asyncio
@@ -17,6 +19,8 @@ async def test_monitor_loop_runs_periodically():
     mon = DummyMonitor()
     loop = MonitorLoop(mon, interval=0.01)  # type: ignore[arg-type]
     await loop.start()
-    await asyncio.sleep(0.03)
+    await asyncio.wait_for(mon.event.wait(), timeout=1)
+    mon.event.clear()
+    await asyncio.wait_for(mon.event.wait(), timeout=1)
     await loop.stop()
     assert mon.called >= 2


### PR DESCRIPTION
## Summary
- replace sleep calls in DAG Manager loops with asyncio.Event-based polling
- allow metrics server loop to exit promptly via threading.Event
- update scheduler tests to await events instead of using sleep

## Testing
- `uv run -m pytest -W error` *(fails: Failed: DID NOT RAISE <class 'RuntimeError'>, among others)*
- `uv run -m pytest tests/test_monitor_loop.py tests/gc/test_scheduler.py tests/buffer/test_buffer_scheduler.py tests/test_neo4j_metrics.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b97153f48c832987829f6509955ba3