### PR TITLE
docs: replace timeout references with status polling

### DIFF
--- a/docs/architecture/dag-manager.md
+++ b/docs/architecture/dag-manager.md
@@ -231,8 +231,7 @@ Note: Control updates (e.g., queue/tag changes, traffic weights) are published t
 | --------------------- | --------------- | ----------------------------- | -------------------------------------- | ---------- |
 | Neo4j leader down     | Diff 거절         | `raft_leader_is_null`         | Automat. leader election               | PagerDuty  |
 | Kafka ZK session loss | 토픽 생성 실패        | `kafka_zookeeper_disconnects` | Retry exponential, fallback admin node | Slack #ops |
-| Diff Stream stall     | Gateway timeout | `ack_status=timeout`          | Resume from last ACK offset            | Opsgenie   |
-
+| Diff Stream stall     | Gateway status polling failure | `ack_status=timeout`          | Resume from last ACK offset            | Opsgenie |
 ---
 
 각 행은 Runbook 마크다운 파일과 대응되는 ID를 가지며, Grafana Dashboard URL과

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -247,7 +247,7 @@ Gateway remains the single public boundary for SDKs. It proxies WorldService end
 - Caching & TTLs:
   - Per‑world decision cache honors envelope TTL (default 300s if unspecified); stale decisions → safe fallback (compute‑only, orders gated OFF)
   - Activation cache: stale/unknown → orders gated OFF; ActivationEnvelope MAY include `state_hash` for quick divergence checks
-- Circuit breakers & budgets: independent timeouts/retries for WorldService and DAG Manager backends (defaults: WS 300 ms, 2 retries with jitter; DM 500 ms, 1 retry)
+- Circuit breakers & budgets: Gateway periodically polls WorldService and DAG Manager status to drive circuit breakers.
 - `/status` exposes circuit breaker states for dependencies, including WorldService.
 
 - Strategy submission and worlds:

--- a/docs/architecture/implementation_todos.md
+++ b/docs/architecture/implementation_todos.md
@@ -16,7 +16,7 @@ Related specs:
 - Worlds Proxy API in Gateway:
   - Implement GET "/worlds/{id}/decide" and "/worlds/{id}/activation" with TTL/etag caching and safe fallbacks when stale. Enforce live guard (header "X-Allow-Live: true" or CLI "--allow-live").
   - Implement POST "/worlds/{id}/evaluate" (read-only) and POST "/worlds/{id}/apply" (2-phase apply with "run_id", idempotent). Forward caller identity (JWT subject/claims) to WorldService.
-  - Config: add "worldservice_url", timeouts/retry budgets separate from DAG Manager. Metrics: cache hit ratio, proxy latency p95.
+  - Config: add "worldservice_url", status polling hooks separate from DAG Manager. Metrics: cache hit ratio, proxy latency p95.
   - Spec refs: architecture/gateway.md §S6; architecture/worldservice.md §2–§6; reference/api_world.md; reference/schemas.md.
 
 - Event Stream Descriptor endpoint:
@@ -50,7 +50,7 @@ Related specs:
   - Gateway event relay metrics: fanout rate, dropped subscribers, partition skew.
 
 - Circuit budgets & degradation policies (WorldService):
-  - Add independent timeouts/retries for WorldService proxy calls (defaults: WS 300 ms 2x; DM 500 ms 1x). Integrate with existing "AsyncCircuitBreaker". Surface states in "/status".
+  - Add status polling hooks for WorldService proxy calls. Integrate with existing "AsyncCircuitBreaker". Surface states in "/status".
 
 
 ---
@@ -70,7 +70,7 @@ Related specs:
 - Gateway additions/changes:
   - "qmtl/gateway/api.py": add "/worlds/*", "/events/subscribe", integrate WS endpoints; identity propagation and live guard.
   - "qmtl/gateway/ws.py": extend to ActivationUpdated/PolicyUpdated; integrate with FastAPI lifecycle.
-  - "qmtl/gateway/config.py": add "worldservice_url", "controlbus" settings, timeouts/retries.
+  - "qmtl/gateway/config.py": add "worldservice_url", "controlbus" settings, status polling hooks.
   - "qmtl/gateway/dagmanager_client.py": keep; ensure NodeID recompute occurs before Diff (new helper module if needed).
   - New: "qmtl/gateway/controlbus_consumer.py" (subscribe, dedupe, metrics) — config-driven; optional in dev.
   - New: "qmtl/common/nodeid.py" (deterministic NodeID computation, SHA-3 fallback).

--- a/docs/architecture/worldservice.md
+++ b/docs/architecture/worldservice.md
@@ -150,7 +150,7 @@ Skew Metrics
 - `activation_skew_seconds` is measured as the difference between the event `ts` and the time the SDK processes it, aggregated p95 per world.
 
 Alerts
-- Decision failures, apply timeouts, stale activation cache at Gateway
+- Decision failures, explicit status polling failures, stale activation cache at Gateway
 
 ---
 

--- a/docs/guides/strategy_workflow.md
+++ b/docs/guides/strategy_workflow.md
@@ -194,7 +194,7 @@ The helpers are idempotent and safe to call even if no background services are a
 
 Set `QMTL_TEST_MODE=1` when running tests to apply conservative client-side time budgets that reduce the chance of hangs in flaky environments:
 
-- HTTP clients: short default timeout (≈1.5s)
+- HTTP clients: 짧은 폴링 주기 및 명시적 상태 확인
 - WebSocket client: shorter receive timeout and overall max runtime (≈5s)
 
 Example:


### PR DESCRIPTION
## Summary
- clarify that Gateway polls WorldService and DAG Manager instead of relying on independent timeouts
- rename DAG Manager fault to Gateway status polling failure
- adjust docs and guides to reference status polling hooks

## Testing
- `uv run --extra dev mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b9715a2f588329af5e60ad33e1feb9