### PR TITLE
Replace sleeps with polling across services

### DIFF
--- a/qmtl/sdk/trade_execution_service.py
+++ b/qmtl/sdk/trade_execution_service.py
@@ -26,6 +26,32 @@ class TradeExecutionService:
                 return response
             except Exception:
                 attempt += 1
+                status = self.poll_order_status(order)
+                if status is not None:
+                    return status
                 if attempt > self.max_retries:
                     raise
-                time.sleep(self.backoff * attempt)
+
+    def poll_order_status(self, order: Any) -> httpx.Response | None:
+        """Query broker for the status of ``order`` until completion.
+
+        Returns the status response when the order is reported as completed,
+        otherwise ``None`` if the order is not found or still pending.
+        """
+        order_id = getattr(order, "id", None)
+        if order_id is None:
+            order_id = order.get("id") if isinstance(order, dict) else None
+        if order_id is None:
+            return None
+        deadline = time.time() + (self.backoff * self.max_retries)
+        while time.time() < deadline:
+            try:
+                resp = httpx.get(f"{self.url}/{order_id}", timeout=10.0)
+                resp.raise_for_status()
+                data = resp.json()
+                if data.get("status") in {"filled", "done", "completed"}:
+                    return resp
+            except Exception:
+                pass
+            time.sleep(self.backoff)
+        return None

--- a/tests/test_backfill_engine.py
+++ b/tests/test_backfill_engine.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 import logging
 import pandas as pd
 import pytest
@@ -14,6 +13,7 @@ class DummySource:
         self.delay = delay
         self.fail = fail
         self.calls = 0
+        self.ready_calls = 0
 
     async def fetch(self, start: int, end: int, *, node_id: str, interval: int) -> pd.DataFrame:
         self.calls += 1
@@ -21,6 +21,11 @@ class DummySource:
             raise RuntimeError("fail")
         await asyncio.sleep(self.delay)
         return self.df
+
+    async def ready(self) -> bool:
+        self.ready_calls += 1
+        await asyncio.sleep(0)
+        return True
 
 
 @pytest.mark.asyncio
@@ -59,6 +64,7 @@ async def test_retry_logic():
     engine.submit(node, 60, 60)
     await engine.wait()
     assert src.calls == 2
+    assert src.ready_calls >= 1
     assert node.cache.latest(node.node_id, 60) == (60, {"ts": 60, "v": 1})
 
 

--- a/tests/test_trade_execution_service.py
+++ b/tests/test_trade_execution_service.py
@@ -4,7 +4,6 @@ import httpx
 import pytest
 
 import importlib
-import time
 
 import qmtl.sdk.runner as runner_module
 from qmtl.sdk import TradeExecutionService
@@ -27,7 +26,7 @@ def test_service_retries_on_failure(monkeypatch):
         return DummyResponse()
 
     monkeypatch.setattr(httpx, "post", fake_post)
-    monkeypatch.setattr(time, "sleep", lambda s: None)
+    monkeypatch.setattr(TradeExecutionService, "poll_order_status", lambda self, order: None)
     service = TradeExecutionService("http://broker", max_retries=2)
     service.post_order({"id": 1})
     assert calls["count"] == 2
@@ -38,7 +37,7 @@ def test_service_raises_after_retries(monkeypatch):
         raise httpx.HTTPError("boom")
 
     monkeypatch.setattr(httpx, "post", fake_post)
-    monkeypatch.setattr(time, "sleep", lambda s: None)
+    monkeypatch.setattr(TradeExecutionService, "poll_order_status", lambda self, order: None)
     service = TradeExecutionService("http://broker", max_retries=1)
     with pytest.raises(httpx.HTTPError):
         service.post_order({"id": 1})

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -62,6 +62,9 @@ async def test_ws_client_reconnects(monkeypatch):
                 return self._messages.pop(0)
             raise websockets.ConnectionClosed(1000, "")
 
+        async def ping(self) -> None:  # pragma: no cover - no behavior
+            return None
+
         async def close(self) -> None:  # pragma: no cover - no behavior
             pass
 
@@ -76,6 +79,8 @@ async def test_ws_client_reconnects(monkeypatch):
     def fake_connect(url: str, extra_headers=None):
         connects.append(url)
         if len(connects) == 1:
+            return DummyWS([])
+        if len(connects) == 2:
             return DummyWS([])
         return DummyWS([json.dumps({"event": "queue_update"})])
 
@@ -96,7 +101,7 @@ async def test_ws_client_reconnects(monkeypatch):
     await asyncio.sleep(0.1)
     await client.stop()
 
-    assert len(connects) == 2
+    assert len(connects) >= 3
     assert any((d.get("event") or d.get("type")) == "queue_update" for d in received)
 
 
@@ -155,6 +160,9 @@ async def test_ws_client_sends_token(monkeypatch):
         async def recv(self) -> str:
             await asyncio.sleep(0.01)
             raise websockets.ConnectionClosed(1000, "")
+
+        async def ping(self) -> None:  # pragma: no cover - no behavior
+            return None
 
         async def close(self) -> None:
             pass


### PR DESCRIPTION
## Summary
- poll broker for order status instead of sleeping on order retries
- add stoppable eviction threads for Arrow cache
- poll data source and server health instead of using fixed delays

## Testing
- `uv run -m pytest tests/test_trade_execution_service.py tests/test_backfill_engine.py tests/test_ws_client.py -W error`
- `uv run -m pytest tests/test_arrow_cache.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b97155cf348329a345664cfcd2c00a