### PR TITLE
runner: support fixed now for deterministic history warm-up

### DIFF
--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -201,7 +201,7 @@ class Runner:
         from .node import StreamInput
 
         tasks = []
-        now = int(time.time())
+        now = runtime.FIXED_NOW if runtime.FIXED_NOW is not None else int(time.time())
         for n in strategy.nodes:
             if not isinstance(n, StreamInput):
                 continue

--- a/qmtl/sdk/runtime.py
+++ b/qmtl/sdk/runtime.py
@@ -14,6 +14,13 @@ TEST_MODE: bool = str(os.getenv("QMTL_TEST_MODE", "")).strip().lower() in {
     "on",
 }
 
+# When set, override wall-clock 'now' used by history warm-up.
+_fixed_now = os.getenv("QMTL_FIXED_NOW", "").strip()
+try:
+    FIXED_NOW: int | None = int(_fixed_now) if _fixed_now else None
+except ValueError:
+    FIXED_NOW = None
+
 # Default client-side timeouts used by SDK components. These are intentionally
 # small under TEST_MODE to surface issues quickly and prevent hangs.
 HTTP_TIMEOUT_SECONDS: float = 1.5 if TEST_MODE else 2.0

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -397,6 +397,7 @@ def test_load_history_called(monkeypatch):
 
 def test_cli_execution(monkeypatch):
     import sys
+    monkeypatch.setenv("QMTL_TEST_MODE", "1")
     from qmtl.sdk.cli import main
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -432,6 +433,10 @@ def test_cli_execution(monkeypatch):
         "w",
         "--gateway-url",
         "http://gw",
+        "--history-start",
+        "1",
+        "--history-end",
+        "2",
     ]
     monkeypatch.setattr(sys, "argv", argv)
     main()


### PR DESCRIPTION
## Summary
- allow overriding wall-clock during warm-up via `QMTL_FIXED_NOW`
- exercise CLI history range flags for deterministic history loading

## Testing
- `uv run -m pytest tests/test_runner.py::test_load_history_called tests/test_runner.py::test_cli_execution -W error`

Fixes #685

------
https://chatgpt.com/codex/tasks/task_e_68b971f6ac0c832992c834f0d8ec4e81