### PR TITLE
feat: add optional strict gap handling

### DIFF
--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -23,15 +23,27 @@ async def _main(argv: List[str] | None = None) -> int:
     run_p.add_argument("--no-ray", action="store_true", help="Disable Ray-based features")
     run_p.add_argument("--history-start", dest="history_start", help="Explicit history start (test/deterministic runs)")
     run_p.add_argument("--history-end", dest="history_end", help="Explicit history end (test/deterministic runs)")
+    run_p.add_argument(
+        "--fail-on-history-gap",
+        action="store_true",
+        help="Raise error if history gaps remain after warm-up",
+    )
 
     off_p = sub.add_parser("offline", help="Run locally without Gateway/WS")
     off_p.add_argument("strategy", help="Import path as module:Class")
     off_p.add_argument("--no-ray", action="store_true", help="Disable Ray-based features")
+    off_p.add_argument(
+        "--fail-on-history-gap",
+        action="store_true",
+        help="Raise error if history gaps remain after warm-up",
+    )
 
     args = parser.parse_args(argv)
 
     if args.no_ray:
         runtime.NO_RAY = True
+    if getattr(args, "fail_on_history_gap", False):
+        runtime.FAIL_ON_HISTORY_GAP = True
 
     module_name, class_name = args.strategy.split(":")
     module = importlib.import_module(module_name)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -640,7 +640,8 @@ def test_backtest_on_missing_fail(monkeypatch):
             src = StreamInput(interval="60s", period=2, history_provider=GapProvider())
             node = ProcessingNode(input=src, compute_fn=lambda v: v, name="n", interval="60s", period=2)
             self.add_nodes([src, node])
-
+    from qmtl.sdk import runtime
+    monkeypatch.setattr(runtime, "FAIL_ON_HISTORY_GAP", True)
     with pytest.raises(RuntimeError):
         Runner.run(Strat, world_id="w", gateway_url="http://gw", offline=True)
 


### PR DESCRIPTION
## Summary
- add `--fail-on-history-gap` to CLI to opt into strict coverage checks
- propagate strict flag through runner history loaders and raise on gaps
- enable strict mode in gap test

## Testing
- `uv run -m pytest -W error tests/test_runner.py::test_backtest_on_missing_fail`
- `uv run -m pytest -W error` *(fails: tests/gateway/test_api::test_ingest_and_status, tests/runner/test_execution.py::test_offline_executes_nodes, tests/runner/test_run_pipeline.py::test_run_offline_pipeline, tests/runner/test_run_pipeline.py::test_run_no_kafka_pipeline, tests/test_runner.py::test_no_gateway_same_ids, tests/test_runner.py::test_cli_execution)*

Closes #686

------
https://chatgpt.com/codex/tasks/task_e_68b971f3e7ac8329bcb486053d4ba3b3