### PR TITLE
Add HttpPoster facade for trade order posting

### DIFF
--- a/qmtl/sdk/http.py
+++ b/qmtl/sdk/http.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""HTTP utilities for SDK components."""
+
+from typing import Any
+
+import httpx
+
+from . import runtime
+
+
+class HttpPoster:
+    """Facade for HTTP POST operations.
+
+    Uses a short-lived ``httpx.Client`` configured with the global timeout
+    to avoid per-call timeout arguments while keeping tests easy to patch.
+    """
+
+    @staticmethod
+    def post(url: str, *, json: Any) -> httpx.Response:
+        """POST ``json`` payload to ``url`` using a session-level timeout."""
+        with httpx.Client(timeout=runtime.HTTP_TIMEOUT_SECONDS) as client:
+            return client.post(url, json=json)

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -5,7 +5,6 @@ import json
 import time
 from typing import Optional, Iterable
 import logging
-import httpx
 
 from opentelemetry import trace
 
@@ -23,6 +22,7 @@ from .tag_manager_service import TagManagerService
 from .activation_manager import ActivationManager
 from .history_loader import HistoryLoader
 from . import runtime, metrics as sdk_metrics
+from .http import HttpPoster
 from . import snapshot as snap
 
 try:  # Optional aiokafka dependency
@@ -44,6 +44,7 @@ if "_trade_execution_service" not in globals():
 
 class Runner:
     """Execute strategies in various modes."""
+
     _ray_available = ray is not None
     _kafka_available = AIOKafkaConsumer is not None
     _gateway_client: GatewayClient = GatewayClient()
@@ -59,9 +60,7 @@ class Runner:
     # ------------------------------------------------------------------
 
     @classmethod
-    def set_gateway_circuit_breaker(
-        cls, cb: AsyncCircuitBreaker | None
-    ) -> None:
+    def set_gateway_circuit_breaker(cls, cb: AsyncCircuitBreaker | None) -> None:
         """Configure circuit breaker for Gateway communication."""
         cls._gateway_client.set_circuit_breaker(cb)
 
@@ -154,9 +153,7 @@ class Runner:
         # Guard against infinite warm-up if provider never clears pre_warmup
         deadline = time.monotonic() + 60.0
         while node.pre_warmup:
-            cov = await provider.coverage(
-                node_id=node.node_id, interval=node.interval
-            )
+            cov = await provider.coverage(node_id=node.node_id, interval=node.interval)
             missing = Runner._missing_ranges(cov, start, end, node.interval)
             if not missing:
                 await node.load_history(start, end)
@@ -170,7 +167,7 @@ class Runner:
             if time.monotonic() > deadline:
                 logger.warning(
                     "history warm-up timed out for %s; proceeding with available data",
-                    getattr(node, "node_id", "<unknown>")
+                    getattr(node, "node_id", "<unknown>"),
                 )
                 break
             if stop_on_ready:
@@ -178,7 +175,9 @@ class Runner:
                 break
         if node.pre_warmup:
             try:
-                cov = await provider.coverage(node_id=node.node_id, interval=node.interval)
+                cov = await provider.coverage(
+                    node_id=node.node_id, interval=node.interval
+                )
             except Exception:
                 cov = []
             if cov:
@@ -430,7 +429,9 @@ class Runner:
             # Event-local values: node_id -> {interval: [(ts, payload|result)]}
             event_values: dict[str, dict[int, list[tuple[int, any]]]] = {}
             for src, payload in seeds:
-                event_values.setdefault(src.node_id, {}).setdefault(src.interval, []).append((ts, payload))
+                event_values.setdefault(src.node_id, {}).setdefault(
+                    src.interval, []
+                ).append((ts, payload))
 
             progressed = True
             while progressed:
@@ -464,7 +465,9 @@ class Runner:
                     uid = getattr(node, "node_id", None)
                     ival = getattr(node, "interval", None)
                     if uid is not None and ival is not None:
-                        event_values.setdefault(uid, {}).setdefault(ival, []).append((ts, result))
+                        event_values.setdefault(uid, {}).setdefault(ival, []).append(
+                            (ts, result)
+                        )
                         progressed = True
 
     @staticmethod
@@ -583,18 +586,23 @@ class Runner:
                     )
                 await Runner._activation_manager.start()
             except Exception:
-                logger.warning("Activation manager failed to start; proceeding with gates OFF by default")
+                logger.warning(
+                    "Activation manager failed to start; proceeding with gates OFF by default"
+                )
 
         # Hydrate and warm up from history to satisfy periods
         Runner._hydrate_snapshots(strategy)
         # Determine strict mode: only enforce when offline and history providers are present
         from .node import StreamInput
+
         has_provider = any(
-            isinstance(n, StreamInput) and getattr(n, "history_provider", None) is not None
+            isinstance(n, StreamInput)
+            and getattr(n, "history_provider", None) is not None
             for n in strategy.nodes
         )
         # Strict gap handling is opt-in via env/flag only
         from . import runtime as _rt
+
         strict_mode = bool(_rt.FAIL_ON_HISTORY_GAP)
 
         # Apply explicit history ranges if provided; otherwise use defaults
@@ -612,6 +620,7 @@ class Runner:
             # ensure_history with deterministic defaults to satisfy tests that
             # assert load_history invocations.
             from .node import StreamInput
+
             has_cached = False
             for n in strategy.nodes:
                 if isinstance(n, StreamInput):
@@ -644,9 +653,12 @@ class Runner:
             # After replay, enforce strict gap handling if requested
             if strict_mode:
                 from .node import StreamInput
+
                 for n in strategy.nodes:
                     if isinstance(n, StreamInput) and getattr(n, "pre_warmup", False):
-                        raise RuntimeError("history pre-warmup unresolved in strict mode")
+                        raise RuntimeError(
+                            "history pre-warmup unresolved in strict mode"
+                        )
                 # Additionally, detect non-contiguous gaps when a provider is present
                 for n in strategy.nodes:
                     if not isinstance(n, StreamInput):
@@ -657,7 +669,9 @@ class Runner:
                         snap = n.cache._snapshot()[n.node_id].get(n.interval, [])
                         ts_sorted = sorted(ts for ts, _ in snap)
                         # Compare against provider coverage density
-                        cov = await n.history_provider.coverage(node_id=n.node_id, interval=n.interval)  # type: ignore[attr-defined]
+                        cov = await n.history_provider.coverage(
+                            node_id=n.node_id, interval=n.interval
+                        )  # type: ignore[attr-defined]
                         if cov:
                             s = min(c[0] for c in cov)
                             e = max(c[1] for c in cov)
@@ -665,12 +679,16 @@ class Runner:
                                 expected = int((e - s) // n.interval) + 1
                                 actual = len([t for t in ts_sorted if s <= t <= e])
                                 if actual < expected:
-                                    raise RuntimeError("history gap detected in strict mode")
+                                    raise RuntimeError(
+                                        "history gap detected in strict mode"
+                                    )
                         else:
                             # No coverage reported but we have data; fall back to contiguous check
                             for a, b in zip(ts_sorted, ts_sorted[1:]):
                                 if n.interval and (b - a) != n.interval:
-                                    raise RuntimeError("history gap detected in strict mode")
+                                    raise RuntimeError(
+                                        "history gap detected in strict mode"
+                                    )
                         # If coverage present, also ensure we have at least 'period' samples
                         if cov:
                             needed = getattr(n, "period", 1) or 1
@@ -794,7 +812,7 @@ class Runner:
     def _handle_alpha_performance(result: dict) -> None:
         """Handle alpha performance metrics."""
         from . import metrics as sdk_metrics
-        
+
         if isinstance(result, dict):
             if "sharpe" in result:
                 sdk_metrics.alpha_sharpe.set(result["sharpe"])
@@ -824,8 +842,7 @@ class Runner:
         # Submit via HTTP if URL is configured
         if cls._trade_order_http_url is not None:
             try:
-                # Use client defaults; avoid per-call kwargs that break test doubles
-                httpx.post(cls._trade_order_http_url, json=order)
+                HttpPoster.post(cls._trade_order_http_url, json=order)
             except Exception:
                 logger.warning("trade order HTTP submit failed; dropping order")
 
@@ -838,14 +855,14 @@ class Runner:
         """Postprocess computation results from nodes."""
         if result is None:
             return
-            
+
         # Handle different node types
         node_class_name = node.__class__.__name__
-        
+
         # Check if this is an alpha performance node
-        if 'AlphaPerformance' in node_class_name:
+        if "AlphaPerformance" in node_class_name:
             Runner._handle_alpha_performance(result)
-            
-        # Check if this is a trade order publisher node  
-        if 'TradeOrderPublisher' in node_class_name:
+
+        # Check if this is a trade order publisher node
+        if "TradeOrderPublisher" in node_class_name:
             Runner._handle_trade_order(result)

--- a/qmtl/sdk/trade_execution_service.py
+++ b/qmtl/sdk/trade_execution_service.py
@@ -7,6 +7,8 @@ import time
 
 import httpx
 
+from .http import HttpPoster
+
 
 class TradeExecutionService:
     """Post trade orders to a broker with retry logic."""
@@ -21,7 +23,7 @@ class TradeExecutionService:
         attempt = 0
         while True:
             try:
-                response = httpx.post(self.url, json=order, timeout=10.0)
+                response = HttpPoster.post(self.url, json=order)
                 response.raise_for_status()
                 return response
             except Exception:

--- a/tests/test_runner_postprocess.py
+++ b/tests/test_runner_postprocess.py
@@ -43,6 +43,7 @@ def test_run_hooks_offline(monkeypatch):
 
     def fake_alpha(result):
         collected.append(result)
+
     def fake_order(order):
         orders.append(order)
 
@@ -62,10 +63,16 @@ def test_run_hooks_offline(monkeypatch):
         "init",
         lambda self, strategy: DummyManager(),
     )
-    monkeypatch.setattr("qmtl.sdk.runner.Runner._handle_alpha_performance", staticmethod(fake_alpha))
-    monkeypatch.setattr("qmtl.sdk.runner.Runner._handle_trade_order", staticmethod(fake_order))
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.Runner._handle_alpha_performance", staticmethod(fake_alpha)
+    )
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.Runner._handle_trade_order", staticmethod(fake_order)
+    )
 
-    strategy = Runner.run(DummyStrategy, world_id="w", gateway_url="http://gw", offline=True)
+    strategy = Runner.run(
+        DummyStrategy, world_id="w", gateway_url="http://gw", offline=True
+    )
     _trigger(strategy)
 
     Runner.set_trade_order_http_url(None)
@@ -87,15 +94,16 @@ class FakeKafkaProducer:
 def test_handle_trade_order_http_and_kafka(monkeypatch):
     posted: dict[str, Any] = {}
 
-    def fake_post(url, json):  # pragma: no cover - minimal stub
+    def fake_post(url, *, json):  # pragma: no cover - minimal stub
         posted["url"] = url
         posted["json"] = json
 
     import importlib
     import qmtl.sdk.runner as runner_module
+
     runner_module = importlib.reload(runner_module)
-    monkeypatch.setattr(runner_module.httpx, "post", fake_post)
-    assert runner_module.httpx.post is fake_post
+    monkeypatch.setattr(runner_module.HttpPoster, "post", fake_post)
+    assert runner_module.HttpPoster.post is fake_post
 
     runner = runner_module.Runner
     producer = FakeKafkaProducer()
@@ -120,6 +128,7 @@ def test_run_hooks_live_like(monkeypatch):
 
     def fake_alpha(result):
         collected.append(result)
+
     def fake_order(order):
         orders.append(order)
 
@@ -134,16 +143,24 @@ def test_run_hooks_live_like(monkeypatch):
         "qmtl.sdk.runner.Runner._gateway_client.post_strategy",
         fake_gateway,
     )
-    monkeypatch.setattr("qmtl.sdk.runner.Runner.run_pipeline", staticmethod(lambda s: None))
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.Runner.run_pipeline", staticmethod(lambda s: None)
+    )
     monkeypatch.setattr(
         TagManagerService,
         "init",
         lambda self, strategy: DummyManager(),
     )
-    monkeypatch.setattr("qmtl.sdk.runner.Runner._handle_alpha_performance", staticmethod(fake_alpha))
-    monkeypatch.setattr("qmtl.sdk.runner.Runner._handle_trade_order", staticmethod(fake_order))
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.Runner._handle_alpha_performance", staticmethod(fake_alpha)
+    )
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.Runner._handle_trade_order", staticmethod(fake_order)
+    )
 
-    strategy = Runner.run(DummyStrategy, world_id="w", gateway_url="http://gw", offline=True)
+    strategy = Runner.run(
+        DummyStrategy, world_id="w", gateway_url="http://gw", offline=True
+    )
     _trigger(strategy)
 
     Runner.set_trade_order_http_url(None)

--- a/tests/test_trade_execution_service.py
+++ b/tests/test_trade_execution_service.py
@@ -20,13 +20,13 @@ class DummyResponse:
 def test_service_retries_on_failure(monkeypatch):
     calls = {"count": 0}
 
-    def fake_post(url: str, json: dict, timeout: float):
+    def fake_post(url: str, *, json: dict):
         calls["count"] += 1
         if calls["count"] == 1:
             raise httpx.HTTPError("boom")
         return DummyResponse()
 
-    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(runner_module.HttpPoster, "post", fake_post)
     monkeypatch.setattr(time, "sleep", lambda s: None)
     service = TradeExecutionService("http://broker", max_retries=2)
     service.post_order({"id": 1})
@@ -34,10 +34,10 @@ def test_service_retries_on_failure(monkeypatch):
 
 
 def test_service_raises_after_retries(monkeypatch):
-    def fake_post(url: str, json: dict, timeout: float):
+    def fake_post(url: str, *, json: dict):
         raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(runner_module.HttpPoster, "post", fake_post)
     monkeypatch.setattr(time, "sleep", lambda s: None)
     service = TradeExecutionService("http://broker", max_retries=1)
     with pytest.raises(httpx.HTTPError):
@@ -55,7 +55,7 @@ def test_runner_delegates_to_service(monkeypatch):
         def post_order(self, order):
             self.orders.append(order)
 
-    monkeypatch.setattr(httpx, "post", boom)
+    monkeypatch.setattr(runner_module.HttpPoster, "post", boom)
     service = DummyService()
     importlib.reload(runner_module)
     runner_module.Runner.set_trade_execution_service(service)


### PR DESCRIPTION
## Summary
- centralize SDK HTTP POSTs through new `HttpPoster` helper
- remove per-call timeouts from trade order HTTP submissions
- cover trade order path with updated unit tests

## Testing
- `uv run -m pytest -W error tests/test_runner_postprocess.py::test_handle_trade_order_http_and_kafka tests/test_trade_execution_service.py::test_service_retries_on_failure tests/test_trade_execution_service.py::test_service_raises_after_retries tests/test_trade_execution_service.py::test_runner_delegates_to_service -q`
- `uv run -m pytest -W error -q` *(fails: tests/runner/test_execution.py::test_offline_executes_nodes, tests/runner/test_run_pipeline.py::test_run_offline_pipeline, tests/runner/test_run_pipeline.py::test_run_no_kafka_pipeline)*

Fixes #684

------
https://chatgpt.com/codex/tasks/task_e_68b971f91bf88329a99eaabc93fe6157