### PR TITLE
docs: update examples for Runner.run

### DIFF
--- a/BACKTEST_ENHANCEMENTS_SUMMARY.md
+++ b/BACKTEST_ENHANCEMENTS_SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This implementation significantly enhances the QMTL backtest execution accuracy by adding LEAN-inspired features for realistic market simulation. The enhancements introduce optional advanced functionality.
+This implementation significantly enhances the QMTL backtest execution accuracy by adding LEAN-inspired features for realistic market simulation. The enhancements introduce optional advanced functionality and align with the WorldService‑first `Runner.run` and local `Runner.offline` APIs.
 
 ## Key Enhancements Implemented
 

--- a/notebooks/strategy_analysis_example.ipynb
+++ b/notebooks/strategy_analysis_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Strategy Analysis Example\n",
     "\n",
-    "Run a backtest on the single indicator template and plot the results."
+    "Execute the single indicator template via Runner.run through the WorldService and plot the results."
    ]
   },
   {
@@ -24,12 +24,12 @@
     "from qmtl.sdk import Runner\n",
     "\n",
     "cfg = load_backtest_defaults(inspect.getfile(SingleIndicatorStrategy))\n",
-    "strategy = Runner.backtest(\n",
+    "strategy = Runner.run(\n",
     "    SingleIndicatorStrategy,\n",
-    "    start_time=cfg.get('start_time'),\n",
-    "    end_time=cfg.get('end_time'),\n",
-    "    on_missing=cfg.get('on_missing', 'skip'),\n",
-    "    gateway_url='http://localhost:8000'\n",
+    "    history_start=cfg.get('start_time'),\n",
+    "    history_end=cfg.get('end_time'),\n",
+    "    world_id='analysis',\n",
+    "    gateway_url='http://localhost:8000',\n",
     ")\n",
     "\n",
     "price_snap = strategy.nodes[0].cache._snapshot()[strategy.nodes[0].node_id][strategy.nodes[0].interval]\n",


### PR DESCRIPTION
## Summary
- replace Runner.backtest usage in strategy analysis notebook with Runner.run using WorldService parameters
- mention Runner.run/offline APIs in backtest enhancements summary

## Testing
- `uv run -m pytest -W error` *(fails: DID NOT RAISE RuntimeError and others)*
- `uv run mkdocs build`

Closes #676

------
https://chatgpt.com/codex/tasks/task_e_68b97203dc848329afd6f85b66315fcc