### PR TITLE
gateway docs: drop run_type mention from strategy submission

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -251,7 +251,7 @@ Gateway remains the single public boundary for SDKs. It proxies WorldService end
 - `/status` exposes circuit breaker states for dependencies, including WorldService.
 
 - Strategy submission and worlds:
-  - SDKs include `world_id` when submitting a strategy. Gateway does not accept `run_type`; execution mode is determined by WorldService decisions.
+  - SDKs include `world_id` when submitting a strategy; execution mode is determined by WorldService decisions.
 
 ### Event Stream Descriptor
 


### PR DESCRIPTION
## Summary
- remove run_type mention from Gateway architecture document to reflect current /strategies schema

## Testing
- `uv pip install --system -e .[dev]`
- `uv pip install -e .[dev]`
- `uv run -m pytest -W error` *(fails: test_offline_executes_nodes, test_run_offline_pipeline, test_run_no_kafka_pipeline, test_ingest_and_status)*
- `uv run mkdocs build`

Fixes #658

------
https://chatgpt.com/codex/tasks/task_e_68b97235888483298905b917a982a957