### PR TITLE
feat: gate trade orders until activation arrives

### DIFF
--- a/tests/test_activation_manager_default.py
+++ b/tests/test_activation_manager_default.py
@@ -1,0 +1,33 @@
+import importlib
+
+import qmtl.sdk.runner as runner_module
+from qmtl.sdk.activation_manager import ActivationManager
+
+
+class FakeKafkaProducer:
+    def __init__(self) -> None:
+        self.messages = []
+
+    def send(self, topic, payload):
+        self.messages.append((topic, payload))
+
+
+def test_runner_blocks_without_activation():
+    importlib.reload(runner_module)
+    from qmtl.sdk.runner import Runner
+
+    producer = FakeKafkaProducer()
+    Runner.set_kafka_producer(producer)
+    Runner.set_trade_order_kafka_topic("orders")
+
+    am = ActivationManager()
+    Runner.set_activation_manager(am)
+
+    assert am.is_stale()
+    assert not am.allow_side("BUY")
+    assert not am.allow_side("SELL")
+
+    Runner._handle_trade_order({"side": "BUY", "quantity": 1, "timestamp": 0})
+    Runner._handle_trade_order({"side": "SELL", "quantity": 1, "timestamp": 0})
+
+    assert producer.messages == []


### PR DESCRIPTION
## Summary
- ensure ActivationManager keeps orders gated OFF until activation events
- expose `is_stale` flag to detect missing activation updates
- test Runner blocks orders when no activation has been received

## Testing
- `uv run -m pytest -W error` *(fails: DID NOT RAISE <class 'RuntimeError'>, 6 failed, 1 error)*
- `uv run -m pytest -W error tests/test_activation_manager_default.py tests/test_order_gate_integration.py`

Fixes #659

------
https://chatgpt.com/codex/tasks/task_e_68b972335194832998e278ed9a0db60e