### PR TITLE
Brokerage: clean up simple module references

### DIFF
--- a/qmtl/brokerage/simple.py
+++ b/qmtl/brokerage/simple.py
@@ -28,12 +28,6 @@ class CashWithSettlementBuyingPowerModel(BuyingPowerModel):
         return self.settlement.available_cash(account) >= required
 
 
-# Deprecated PerShareFeeModel was removed; use qmtl.brokerage.fees.PerShareFeeModel
-
-
-# Deprecated VolumeShareSlippageModel was removed; use qmtl.brokerage.slippage.VolumeShareSlippageModel
-
-
 class ImmediateFillModel(FillModel):
     """Fill the entire order at the given price."""
 

--- a/qmtl/sdk/brokerage_backtest.py
+++ b/qmtl/sdk/brokerage_backtest.py
@@ -148,7 +148,7 @@ def make_brokerage_model_for_compat(params: ExecCompatParams) -> BrokerageModel:
     - Fill model: UnifiedFillModel (covers market/limit/stop/stop-limit)
     - Buying power: injected by caller if needed; default allows all (via lambda)
     """
-    from qmtl.brokerage.simple import CashBuyingPowerModel
+    from qmtl.brokerage import CashBuyingPowerModel
 
     class _AllBP(CashBuyingPowerModel):
         def has_sufficient_buying_power(self, account: Account, order: BrOrder) -> bool:  # type: ignore[override]

--- a/tests/test_pretrade_metrics.py
+++ b/tests/test_pretrade_metrics.py
@@ -5,8 +5,7 @@ import asyncio
 from qmtl.sdk import metrics as sdk_metrics
 from qmtl.sdk.pretrade import check_pretrade, Activation
 from qmtl.common.pretrade import RejectionReason
-from qmtl.brokerage import BrokerageModel
-from qmtl.brokerage.simple import CashBuyingPowerModel
+from qmtl.brokerage import BrokerageModel, CashBuyingPowerModel
 from qmtl.brokerage.fees import PercentFeeModel
 from qmtl.brokerage.slippage import NullSlippageModel
 from qmtl.brokerage.fill_models import MarketFillModel


### PR DESCRIPTION
## Summary
- remove stale comments from brokerage.simple
- import `CashBuyingPowerModel` via `qmtl.brokerage` for consistency

## Testing
- `uv run -m pytest -W error` (fails: tests.gateways.test_api::test_ingest_and_status, tests.runner.test_execution::test_offline_executes_nodes, tests.runner.test_run_pipeline::test_run_offline_pipeline, tests.runner.test_run_pipeline::test_run_no_kafka_pipeline, tests.test_runner::test_no_gateway_same_ids, tests.test_runner::test_cli_execution, tests.test_runner::test_backtest_on_missing_fail)

Closes #661

------
https://chatgpt.com/codex/tasks/task_e_68b97226ecf883298cfedf07c3359e59