### PR TITLE
docs: remove backtest defaults from examples

### DIFF
--- a/qmtl/examples/README.md
+++ b/qmtl/examples/README.md
@@ -10,6 +10,20 @@ uv venv
 uv pip install -e qmtl[dev]
 ```
 
+## Running
+
+Run strategies against a Gateway-connected world service:
+
+```bash
+python strategies/my_strategy.py --world-id demo --gateway-url http://localhost:8000
+```
+
+For quick offline execution, omit the flags:
+
+```bash
+python strategies/my_strategy.py
+```
+
 ## Testing
 
 Run the test suite and treat warnings as errors:

--- a/qmtl/examples/config.example.yml
+++ b/qmtl/examples/config.example.yml
@@ -1,4 +1,4 @@
-backtest:
-  start_time: "2024-01-01T00:00:00Z"
-  end_time: "2024-02-01T00:00:00Z"
-  on_missing: "skip"
+# Example configuration for running example strategies via Gateway and World Service
+world_id: "example_world"
+gateway_url: "http://localhost:8000"
+


### PR DESCRIPTION
## Summary
- replace obsolete backtest config with world service options
- document world-id and gateway usage in example README

## Testing
- `uv run -m pytest -W error` *(fails: DID NOT RAISE <class 'RuntimeError'>, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b972242abc8329b78e46781c87a9de