### PR TITLE
docs: add migration guide for legacy surface removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `coverage()` and `fill_missing()` interfaces for history providers and removed `start`/`end` arguments from `StreamInput`.
 - `TagQueryNode.resolve()` has been removed. Use `TagQueryManager.resolve_tags()` to fetch queue mappings before execution.
 - Added `Node.add_tag()` to attach tags after node creation.
+- Added migration guide for removing legacy Runner/CLI/Gateway surfaces. See [docs/guides/migration_bc_removal.md](docs/guides/migration_bc_removal.md).
 
 ---
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -4,7 +4,7 @@ tags:
   - guide
   - overview
 author: "QMTL Team"
-last_modified: 2025-08-21
+last_modified: 2025-09-04
 ---
 
 {{ nav_links() }}
@@ -15,6 +15,7 @@ Tutorials and workflow guides for using QMTL.
 
 - [SDK Tutorial](sdk_tutorial.md): Build strategies with the SDK.
 - [Strategy Workflow](strategy_workflow.md): Recommended development flow.
+- [Migration: Removing Legacy Modes](migration_bc_removal.md): Update code for Runner/CLI/Gateway changes.
 
 {{ nav_links() }}
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -3,3 +3,4 @@
 - [README](/guides/README/)
 - [sdk_tutorial](/guides/sdk_tutorial/)
 - [strategy_workflow](/guides/strategy_workflow/)
+- [migration_bc_removal](/guides/migration_bc_removal/)

--- a/docs/guides/migration_bc_removal.md
+++ b/docs/guides/migration_bc_removal.md
@@ -9,16 +9,85 @@ last_modified: 2025-09-04
 
 # Migration: Removing Legacy Modes and Backward Compatibility
 
-This guide summarizes changes and how to migrate your code.
+This guide summarizes the removal of legacy compatibility layers and shows how to migrate your code.
 
-- Runner API: replace `Runner.backtest/dryrun/live` with `Runner.run(world_id=..., gateway_url=...)` or `Runner.offline(...)`.
-- CLI: replace `qmtl sdk --mode <...>` with `qmtl sdk run --world-id <id> --gateway-url <url>` or `qmtl sdk offline`.
-- Gateway `/strategies`: stop sending `run_type`; optionally include `world_id` for correlation.
-- Brokerage imports: use `from qmtl.brokerage import PerShareFeeModel, VolumeShareSlippageModel` (canonical modules), not `qmtl.brokerage.simple` duplicates.
+## Runner API
 
-Quick check
-- Search your repo for `Runner.backtest|Runner.dryrun|Runner.live|--mode|run_type`.
-- Update example scripts to accept `--world-id/--gateway-url` or use `Runner.offline` for local runs.
+**Before**
+
+```python
+from qmtl import Runner
+
+runner = Runner(...)
+runner.backtest(strategy)
+```
+
+**After**
+
+```python
+from qmtl import Runner
+
+runner = Runner(...)
+runner.run(strategy, world_id="demo", gateway_url="http://localhost:8000")
+# or for local runs
+runner.offline(strategy)
+```
+
+## CLI
+
+**Before**
+
+```bash
+qmtl sdk --mode backtest --world-id demo --gateway-url http://localhost:8000
+```
+
+**After**
+
+```bash
+qmtl sdk run --world-id demo --gateway-url http://localhost:8000
+qmtl sdk offline  # local execution
+```
+
+## Gateway `/strategies`
+
+**Before**
+
+```json
+{
+  "run_type": "backtest",
+  "strategy": {...}
+}
+```
+
+**After**
+
+```json
+{
+  "world_id": "demo",
+  "strategy": {...}
+}
+```
+
+## Brokerage Imports
+
+**Before**
+
+```python
+from qmtl.brokerage.simple import PerShareFeeModel, VolumeShareSlippageModel
+```
+
+**After**
+
+```python
+from qmtl.brokerage import PerShareFeeModel, VolumeShareSlippageModel
+```
+
+## Checklist
+
+- [ ] Replace `Runner.backtest`, `Runner.dryrun`, and `Runner.live` with `Runner.run` or `Runner.offline`.
+- [ ] Update CLI usage from `--mode` to `run`/`offline` subcommands.
+- [ ] Drop `run_type` from Gateway `/strategies` requests and pass `world_id` if needed.
+- [ ] Import brokerage helpers from `qmtl.brokerage`, not `qmtl.brokerage.simple`.
 
 {{ nav_links() }}
 

--- a/docs/reference/api/brokerage.md
+++ b/docs/reference/api/brokerage.md
@@ -2,7 +2,7 @@
 title: "Brokerage API"
 tags: [api]
 author: "QMTL Team"
-last_modified: 2025-08-31
+last_modified: 2025-09-04
 ---
 
 {{ nav_links() }}
@@ -10,6 +10,8 @@ last_modified: 2025-08-31
 # Brokerage API
 
 This page describes QMTL’s brokerage layer: how orders are validated and executed with realistic constraints (ticks/lots, hours, shortability), and how slippage, fees, and settlement are applied. It complements the high-level design in architecture/lean_brokerage_model.md.
+
+Legacy shortcuts under `qmtl.brokerage.simple` have been removed. See [Migration: Removing Legacy Modes and Backward Compatibility](../../guides/migration_bc_removal.md) for upgrade steps.
 
 ## Components
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -2,7 +2,7 @@
 title: "FAQ"
 tags: []
 author: "QMTL Team"
-last_modified: 2025-08-21
+last_modified: 2025-09-04
 ---
 
 {{ nav_links() }}
@@ -12,6 +12,8 @@ last_modified: 2025-08-21
 ## 태그 기반 노드는 월드 주도 실행에서 어떻게 동작하나요?
 
 `TagQueryNode`는 Runner가 생성하는 `TagQueryManager`가 Gateway와 통신하여 큐 목록을 갱신합니다. 월드 주도 실행에서 전략은 `Runner.run(world_id=..., gateway_url=...)`로 시작하며, 이때 TagQueryManager가 초기 큐 조회와 WebSocket 구독을 설정합니다. Gateway/WorldService가 연결되지 않으면 전략은 안전기본(compute‑only, 주문 게이트 OFF)으로 유지됩니다. `Runner.offline()` 은 Gateway 없이 로컬 실행으로, 태그 기반 노드는 빈 큐 목록으로 초기화됩니다.
+
+See [Migration: Removing Legacy Modes and Backward Compatibility](../guides/migration_bc_removal.md) for guidance on updating code that previously used `Runner.backtest` or CLI `--mode`.
 
 ## 테스트가 가끔 hang 되거나 자원이 해제되지 않는 것 같습니다. 어떻게 방지하나요?
 


### PR DESCRIPTION
## Summary
- document migration from Runner.backtest/dryrun/live, CLI `--mode`, and Gateway `run_type`
- cross-link migration guide from API reference pages and changelog

## Testing
- `uv run --extra dev mkdocs build`

Fixes #665

------
https://chatgpt.com/codex/tasks/task_e_68b97218354c832998fdaa3fe402b9e5