### PR TITLE
refactor: remove brokerage.simple duplicates

### DIFF
--- a/qmtl/brokerage/profile.py
+++ b/qmtl/brokerage/profile.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from .brokerage_model import BrokerageModel
 from .interfaces import BuyingPowerModel, FillModel, SlippageModel, FeeModel
-from .simple import CashBuyingPowerModel, ImmediateFillModel
+from . import CashBuyingPowerModel, ImmediateFillModel
 from .fees import PerShareFeeModel
 from .slippage import SpreadBasedSlippageModel
 from .symbols import SymbolPropertiesProvider

--- a/qmtl/brokerage/simple.py
+++ b/qmtl/brokerage/simple.py
@@ -28,12 +28,6 @@ class CashWithSettlementBuyingPowerModel(BuyingPowerModel):
         return self.settlement.available_cash(account) >= required
 
 
-# Deprecated PerShareFeeModel was removed; use qmtl.brokerage.fees.PerShareFeeModel
-
-
-# Deprecated VolumeShareSlippageModel was removed; use qmtl.brokerage.slippage.VolumeShareSlippageModel
-
-
 class ImmediateFillModel(FillModel):
     """Fill the entire order at the given price."""
 

--- a/qmtl/sdk/brokerage_backtest.py
+++ b/qmtl/sdk/brokerage_backtest.py
@@ -148,7 +148,7 @@ def make_brokerage_model_for_compat(params: ExecCompatParams) -> BrokerageModel:
     - Fill model: UnifiedFillModel (covers market/limit/stop/stop-limit)
     - Buying power: injected by caller if needed; default allows all (via lambda)
     """
-    from qmtl.brokerage.simple import CashBuyingPowerModel
+    from qmtl.brokerage import CashBuyingPowerModel
 
     class _AllBP(CashBuyingPowerModel):
         def has_sufficient_buying_power(self, account: Account, order: BrOrder) -> bool:  # type: ignore[override]

--- a/tests/test_pretrade_metrics.py
+++ b/tests/test_pretrade_metrics.py
@@ -5,8 +5,7 @@ import asyncio
 from qmtl.sdk import metrics as sdk_metrics
 from qmtl.sdk.pretrade import check_pretrade, Activation
 from qmtl.common.pretrade import RejectionReason
-from qmtl.brokerage import BrokerageModel
-from qmtl.brokerage.simple import CashBuyingPowerModel
+from qmtl.brokerage import BrokerageModel, CashBuyingPowerModel
 from qmtl.brokerage.fees import PercentFeeModel
 from qmtl.brokerage.slippage import NullSlippageModel
 from qmtl.brokerage.fill_models import MarketFillModel


### PR DESCRIPTION
## Summary
- drop legacy comments from `brokerage.simple`
- use canonical `qmtl.brokerage` imports in profile, SDK helper, and tests

Fixes #661
Refs #666

## Testing
- `uv run -m pytest -W error` *(fails: tests/test_runner.py::test_no_gateway_same_ids etc.)*
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b97210f0f48329ac2148ad4712d1ac