### PR TITLE
docs: reference qmtl sdk

### DIFF
--- a/docs/world/world.md
+++ b/docs/world/world.md
@@ -437,7 +437,7 @@ SDK는 오직 Gateway와만 통신한다. ControlBus는 내부 제어 버스이�
 
 ### 15.5 개발 단위 매핑
 
-- sdk/
+- qmtl/sdk/
   - Runner: `run_async(world_id)`, `OrderGateNode`, TagQueryManager(WS/폴백)
 - gateway/
   - api: `/worlds/*` 프록시, `/events/subscribe`, ControlBus 구독자, 캐시/서킷


### PR DESCRIPTION
## Summary
- point world docs at `qmtl/sdk/` to avoid implying a legacy `sdk/` package

## Testing
- `uv run mkdocs build`
- `uv run -m pytest -W error` *(fails: 7 failed, 585 passed)*

Fixes #675

------
https://chatgpt.com/codex/tasks/task_e_68b97207c4848329ba5177975d4b8296