### PR TITLE
Remove backtest-specific SDK CLI flags

### DIFF
--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -4,6 +4,7 @@ import importlib
 
 import asyncio
 import logging
+import os
 from typing import List
 from .runner import Runner
 from . import runtime
@@ -21,8 +22,6 @@ async def _main(argv: List[str] | None = None) -> int:
     run_p.add_argument("--world-id", required=True)
     run_p.add_argument("--gateway-url", required=True, help="Gateway base URL")
     run_p.add_argument("--no-ray", action="store_true", help="Disable Ray-based features")
-    run_p.add_argument("--history-start", dest="history_start", help="Explicit history start (test/deterministic runs)")
-    run_p.add_argument("--history-end", dest="history_end", help="Explicit history end (test/deterministic runs)")
 
     off_p = sub.add_parser("offline", help="Run locally without Gateway/WS")
     off_p.add_argument("strategy", help="Import path as module:Class")
@@ -38,9 +37,9 @@ async def _main(argv: List[str] | None = None) -> int:
     strategy_cls = getattr(module, class_name)
 
     if args.cmd == "run":
-        # In test mode, default to deterministic placeholders when not provided
-        h_start = args.history_start
-        h_end = args.history_end
+        # Internal hooks for deterministic history ranges via env vars only
+        h_start = os.getenv("QMTL_HISTORY_START")
+        h_end = os.getenv("QMTL_HISTORY_END")
         if runtime.TEST_MODE and h_start is None and h_end is None:
             h_start, h_end = "1", "2"
         await Runner.run_async(


### PR DESCRIPTION
## Summary
- streamline SDK CLI by removing backtest-only `--history-start/--history-end` options
- allow deterministic history ranges only through `QMTL_HISTORY_START`/`QMTL_HISTORY_END` env vars for internal tooling

## Testing
- `uv run --extra dev -m pytest -W error tests/test_health.py`
- `uv run mkdocs build`

Fixes #656

------
https://chatgpt.com/codex/tasks/task_e_68b972400b4c83298a69caccad6bda46