### PR TITLE
feat: add Runner session context manager

### DIFF
--- a/docs/guides/strategy_workflow.md
+++ b/docs/guides/strategy_workflow.md
@@ -172,20 +172,21 @@ wait
 
 ### Test Teardown and Shutdown
 
-When a test starts background services (e.g., TagQueryManager subscriptions or ActivationManager), call the shutdown helper in teardown to ensure no lingering tasks or sockets remain:
+When a test starts background services (e.g., TagQueryManager subscriptions or ActivationManager), prefer the session context manager to ensure everything is cleaned up:
 
 ```python
-# sync tests
+async with Runner.session(MyStrategy, world_id="w", gateway_url="http://gw", offline=True) as strategy:
+    ...  # assertions
+```
+
+If you cannot use ``async with`` (e.g., in synchronous tests), fall back to the explicit helpers:
+
+```python
 strategy = Runner.run(MyStrategy, world_id="w", gateway_url="http://gw", offline=True)
 try:
     ...  # assertions
 finally:
     Runner.shutdown(strategy)
-
-# async tests
-strategy = await Runner.run_async(MyStrategy, world_id="w", gateway_url="http://gw")
-...
-await Runner.shutdown_async(strategy)
 ```
 
 The helpers are idempotent and safe to call even if no background services are active.

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -16,7 +16,8 @@ last_modified: 2025-08-21
 ## 테스트가 가끔 hang 되거나 자원이 해제되지 않는 것 같습니다. 어떻게 방지하나요?
 
 - 테스트 종료 시 백그라운드 서비스 정리:
-  - `Runner.shutdown(strategy)` 또는 `await Runner.shutdown_async(strategy)`를 호출하여 `TagQueryManager`/`ActivationManager`를 정리하세요.
+  - `async with Runner.session(...):`을 사용하면 `TagQueryManager`/`ActivationManager`가 자동으로 정리됩니다.
+  - 또는 `Runner.shutdown(strategy)`나 `await Runner.shutdown_async(strategy)`를 호출해 수동으로 정리하세요.
 - 보수적인 타임아웃 적용:
   - 테스트 실행 전에 `QMTL_TEST_MODE=1`을 설정하면 SDK의 기본 HTTP/WS 타임아웃이 짧게 설정되어 hang 가능성이 줄어듭니다.
 - ASGI/Transport 자원 정리:

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from contextlib import asynccontextmanager
 from typing import Optional, Iterable
 import logging
 import httpx
@@ -727,6 +728,25 @@ class Runner:
         Runner._write_snapshots(strategy)
         await Runner._replay_history(strategy, None, None)
         return strategy
+
+    # ------------------------------------------------------------------
+    # Convenience context manager for tests
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    @asynccontextmanager
+    async def session(strategy_cls: type[Strategy], **kwargs):
+        """Run ``strategy_cls`` and ensure cleanup on exit.
+
+        Yields the initialized strategy and guarantees that
+        :meth:`shutdown_async` is invoked after the ``async with`` block
+        exits, simplifying test teardown.
+        """
+        strategy = await Runner.run_async(strategy_cls, **kwargs)
+        try:
+            yield strategy
+        finally:
+            await Runner.shutdown_async(strategy)
 
     # ------------------------------------------------------------------
     # Cleanup helpers for tests and graceful shutdown

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -103,32 +103,31 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
     monkeypatch.setattr("qmtl.sdk.tagquery_manager.httpx.AsyncClient", DummyClient)
     monkeypatch.setattr(Runner, "_kafka_available", True)
 
-    strat = await Runner.run_async(TQStrategy, world_id="tq_live_updates", gateway_url="http://gw")
+    async with Runner.session(
+        TQStrategy, world_id="tq_live_updates", gateway_url="http://gw"
+    ) as strat:
+        await asyncio.sleep(0.1)
 
-    await asyncio.sleep(0.1)
-
-    await hub.send_queue_update(
-        ["t1"],
-        60,
-        [{"queue": "q1", "global": False}],
-        MatchMode.ANY,
-    )
-    await strat.tag_query_manager.handle_message(
-        {
-            "type": "queue_update",
-            "data": {
-                "tags": ["t1"],
-                "interval": 60,
-                "queues": [{"queue": "q1", "global": False}],
-                "match_mode": "any",
-            },
-        }
-    )
-    await asyncio.sleep(0.1)
-    node = strat.tq
-    assert node.upstreams == ["q1"]
-    assert node.execute
-    assert hasattr(strat, "tag_query_manager")
-    # Clean shutdown to avoid lingering tasks/sockets
-    await Runner.shutdown_async(strat)
+        await hub.send_queue_update(
+            ["t1"],
+            60,
+            [{"queue": "q1", "global": False}],
+            MatchMode.ANY,
+        )
+        await strat.tag_query_manager.handle_message(
+            {
+                "type": "queue_update",
+                "data": {
+                    "tags": ["t1"],
+                    "interval": 60,
+                    "queues": [{"queue": "q1", "global": False}],
+                    "match_mode": "any",
+                },
+            }
+        )
+        await asyncio.sleep(0.1)
+        node = strat.tq
+        assert node.upstreams == ["q1"]
+        assert node.execute
+        assert hasattr(strat, "tag_query_manager")
     await transport.aclose()


### PR DESCRIPTION
## Summary
- add `Runner.session` async context manager for automatic shutdown
- document session helper and update live update test

## Testing
- `uv run -m pytest -W error` (fails: 6 failed, 632 passed, 2 skipped, 1 error)
- `uv run -m pytest tests/tagquery/test_runner_live_updates.py -W error`
- `uv run mkdocs build`

Fixes #687

------
https://chatgpt.com/codex/tasks/task_e_68b971f121188329822c5f031fb4e81f