### PR TITLE
Ensure ASGI transports close cleanly to avoid ResourceWarnings

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -2,7 +2,7 @@
 title: "FAQ"
 tags: []
 author: "QMTL Team"
-last_modified: 2025-09-04
+last_modified: 2025-09-05
 ---
 
 {{ nav_links() }}
@@ -23,7 +23,7 @@ See [Migration: Removing Legacy Modes and Backward Compatibility](../guides/migr
 - 보수적인 타임아웃 적용:
   - 테스트 실행 전에 `QMTL_TEST_MODE=1`을 설정하면 SDK의 기본 HTTP/WS 타임아웃이 짧게 설정되어 hang 가능성이 줄어듭니다.
 - ASGI/Transport 자원 정리:
-  - FastAPI 수명 주기를 적용하려면 `httpx.ASGITransport(app, lifespan='on')` 를 사용하고 테스트 마지막에 `await transport.aclose()`로 명시적으로 자원을 해제하세요.
+  - FastAPI 수명 주기를 적용하려면 `async with httpx.ASGITransport(app) as transport:` 블록을 사용하고, 그 안에서 `async with httpx.AsyncClient(transport=transport, ...)`으로 호출을 수행하세요.
   - Gateway 앱은 백그라운드 태스크를 시작하지 않도록 `create_app(enable_background=False)` 옵션을 제공합니다. 단위 테스트에서는 이 플래그를 끄면 리소스 경합과 경고를 줄일 수 있습니다.
 
 {{ nav_links() }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,6 @@
 import pytest
 import pytest_asyncio
 from fakeredis.aioredis import FakeRedis
-import warnings
-
-warnings.filterwarnings("ignore", category=pytest.PytestUnraisableExceptionWarning)
 
 @pytest_asyncio.fixture
 async def fake_redis():

--- a/tests/gateway/test_circuit_breaker_dagclient.py
+++ b/tests/gateway/test_circuit_breaker_dagclient.py
@@ -39,6 +39,9 @@ def make_diff_stub(total_failures: int = 0):
                 raise grpc.RpcError("fail")
             return gen()
 
+        async def AckChunk(self, request):
+            return None
+
     return Stub
 
 

--- a/tests/gateway/test_degradation.py
+++ b/tests/gateway/test_degradation.py
@@ -164,8 +164,6 @@ def make_app(fake_redis):
     app.state.degradation.stop = nop
     return app
 
-
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_status_includes_level(fake_redis):
     app = make_app(fake_redis)
     with TestClient(app) as client:
@@ -173,8 +171,6 @@ def test_status_includes_level(fake_redis):
         assert resp.status_code == 200
         assert resp.json()["degrade_level"] == "NORMAL"
 
-
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_minimal_blocks_submission(fake_redis):
     app = make_app(fake_redis)
     app.state.degradation.level = DegradationLevel.MINIMAL
@@ -187,8 +183,6 @@ def test_minimal_blocks_submission(fake_redis):
         resp = client.post("/strategies", json=payload.model_dump())
         assert resp.status_code == 503
 
-
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_static_returns_204(fake_redis):
     app = make_app(fake_redis)
     app.state.degradation.level = DegradationLevel.STATIC

--- a/tests/gateway/test_event_descriptor.py
+++ b/tests/gateway/test_event_descriptor.py
@@ -28,9 +28,6 @@ class FakeDB(Database):
         return None
 
 
-pytestmark = pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-
-
 @pytest.mark.asyncio
 async def test_event_descriptor_scope_and_expiry(fake_redis):
     cfg = EventDescriptorConfig(
@@ -41,15 +38,14 @@ async def test_event_descriptor_scope_and_expiry(fake_redis):
         fallback_url="wss://gateway/ws",
     )
     app = create_app(redis_client=fake_redis, database=FakeDB(), event_config=cfg, enable_background=False)
-    transport = httpx.ASGITransport(app=app, lifespan="on")
-    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        payload = {
-            "world_id": "w1",
-            "strategy_id": "s1",
-            "topics": ["activation"],
-        }
-        resp = await client.post("/events/subscribe", json=payload)
-    await transport.aclose()
+    async with httpx.ASGITransport(app=app) as transport:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            payload = {
+                "world_id": "w1",
+                "strategy_id": "s1",
+                "topics": ["activation"],
+            }
+            resp = await client.post("/events/subscribe", json=payload)
     assert resp.status_code == 200
     data = resp.json()
     assert data["stream_url"] == cfg.stream_url

--- a/tests/gateway/test_nodeid.py
+++ b/tests/gateway/test_nodeid.py
@@ -8,9 +8,6 @@ from qmtl.common import compute_node_id, crc32_of_list
 from qmtl.gateway.api import create_app, Database
 from qmtl.gateway.models import StrategySubmit
 
-# Ignore unraisable exception warnings produced by event loop cleanup in TestClient
-pytestmark = pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-
 
 class FakeDB(Database):
     def __init__(self) -> None:

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -206,7 +206,6 @@ def test_multiple_tag_query_nodes_handle_errors(fake_redis):
 
 
 @pytest.mark.asyncio
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 async def test_dag_client_queries_grpc():
     driver = _FakeDriver([{"topic": "q1"}, {"topic": "q2"}])
     admin = _FakeAdmin()
@@ -226,10 +225,7 @@ async def test_dag_client_queries_grpc():
         await server.wait_for_termination()
         client = None
         server = None
-        import warnings
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", ResourceWarning)
-            gc.collect()
+        gc.collect()
 
 
 def test_repository_match_modes():


### PR DESCRIPTION
## Summary
- use context-managed `httpx.ASGITransport` in gateway tests to exercise FastAPI lifespan
- remove blanket `PytestUnraisableExceptionWarning` filters and add missing `AckChunk` stub
- document proper ASGITransport usage for tests

## Testing
- `QMTL_TEST_MODE=1 uv run -m pytest -W error tests/gateway`
- `uv run mkdocs build`

Fixes #683

------
https://chatgpt.com/codex/tasks/task_e_68b98902e51c8329ab31dbee9b13cf21