### PR TITLE
refactor: drop brokerage simple shim

### DIFF
--- a/docs/alphadocs_registry.yml
+++ b/docs/alphadocs_registry.yml
@@ -38,7 +38,8 @@
 - doc: docs/architecture/lean_brokerage_model.md
   status: implemented
   modules:
-    - qmtl/brokerage/simple.py
+    - qmtl/brokerage/buying_power.py
+    - qmtl/brokerage/fill_models.py
     - qmtl/brokerage/__init__.py
     - qmtl/brokerage/order.py
     - qmtl/brokerage/interfaces.py

--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -4,14 +4,23 @@
 
 from .order import Order, Fill, Account, OrderType, TimeInForce
 from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
-from .simple import (
-    CashBuyingPowerModel,
+from .buying_power import CashBuyingPowerModel, CashWithSettlementBuyingPowerModel
+from .fill_models import (
     ImmediateFillModel,
-    CashWithSettlementBuyingPowerModel,
+    BaseFillModel,
+    MarketFillModel,
+    LimitFillModel,
+    StopMarketFillModel,
+    StopLimitFillModel,
+    UnifiedFillModel,
 )
 from .fees import PerShareFeeModel, PercentFeeModel, CompositeFeeModel, IBKRFeeModel
-from .slippage import NullSlippageModel, ConstantSlippageModel, SpreadBasedSlippageModel, VolumeShareSlippageModel
-from .fill_models import BaseFillModel, MarketFillModel, LimitFillModel, StopMarketFillModel, StopLimitFillModel, UnifiedFillModel
+from .slippage import (
+    NullSlippageModel,
+    ConstantSlippageModel,
+    SpreadBasedSlippageModel,
+    VolumeShareSlippageModel,
+)
 from .symbols import SymbolPropertiesProvider, SymbolProperties
 from .exchange_hours import ExchangeHoursProvider
 from .shortable import ShortableProvider, StaticShortableProvider

--- a/qmtl/brokerage/buying_power.py
+++ b/qmtl/brokerage/buying_power.py
@@ -1,11 +1,11 @@
-"""Simple brokerage model implementations."""
+"""Buying power model implementations."""
 
 # Source: docs/architecture/lean_brokerage_model.md
 
 from __future__ import annotations
 
-from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
-from .order import Account, Order, Fill
+from .interfaces import BuyingPowerModel
+from .order import Account, Order
 from .settlement import SettlementModel
 
 
@@ -26,10 +26,3 @@ class CashWithSettlementBuyingPowerModel(BuyingPowerModel):
     def has_sufficient_buying_power(self, account: Account, order: Order) -> bool:
         required = order.price * order.quantity
         return self.settlement.available_cash(account) >= required
-
-
-class ImmediateFillModel(FillModel):
-    """Fill the entire order at the given price."""
-
-    def fill(self, order: Order, market_price: float) -> Fill:
-        return Fill(symbol=order.symbol, quantity=order.quantity, price=market_price)

--- a/qmtl/brokerage/fill_models.py
+++ b/qmtl/brokerage/fill_models.py
@@ -11,6 +11,13 @@ from .interfaces import FillModel
 from .order import Order, Fill, OrderType, TimeInForce
 
 
+class ImmediateFillModel(FillModel):
+    """Fill the entire order at the given price."""
+
+    def fill(self, order: Order, market_price: float) -> Fill:
+        return Fill(symbol=order.symbol, quantity=order.quantity, price=market_price)
+
+
 @dataclass
 class BaseFillModel(FillModel):
     """Base fill model with optional liquidity cap for IOC partials.

--- a/qmtl/brokerage/profile.py
+++ b/qmtl/brokerage/profile.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 
 from .brokerage_model import BrokerageModel
 from .interfaces import BuyingPowerModel, FillModel, SlippageModel, FeeModel
-from . import CashBuyingPowerModel, ImmediateFillModel
+from .buying_power import CashBuyingPowerModel
+from .fill_models import ImmediateFillModel
 from .fees import PerShareFeeModel
 from .slippage import SpreadBasedSlippageModel
 from .symbols import SymbolPropertiesProvider


### PR DESCRIPTION
## Summary
- move cash buying power helpers to dedicated module
- fold immediate fill logic into fill_models and drop deprecated `brokerage.simple`
- update brokerage exports and Alphadocs registry

Fixes #661
Refs #666

## Testing
- `uv run scripts/check_doc_sync.py` *(fails: Docs listed but missing; qmtl/common/pretrade.py annotation not registered)*
- `uv run -m pytest -W error` *(fails: multiple tests fail, e.g. ASGITransport TypeError and assertion errors)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b988fe6a1083298ce92d3d07d95f99