### PR TITLE
chore: remove backtest defaults from strategy analysis notebook

### DIFF
--- a/notebooks/strategy_analysis_example.ipynb
+++ b/notebooks/strategy_analysis_example.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Strategy Analysis Example\n",
-    "\n",
-    "Execute the single indicator template via Runner.run through the WorldService and plot the results."
+    "# Strategy Analysis Example\n\nExecute the single indicator template via Runner.run through the WorldService and plot the results."
    ]
   },
   {
@@ -15,19 +13,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import inspect\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from qmtl.examples.templates.single_indicator import SingleIndicatorStrategy\n",
-    "from qmtl.examples.defaults import load_backtest_defaults\n",
     "from qmtl.sdk import Runner\n",
     "\n",
-    "cfg = load_backtest_defaults(inspect.getfile(SingleIndicatorStrategy))\n",
     "strategy = Runner.run(\n",
     "    SingleIndicatorStrategy,\n",
-    "    history_start=cfg.get('start_time'),\n",
-    "    history_end=cfg.get('end_time'),\n",
     "    world_id='analysis',\n",
     "    gateway_url='http://localhost:8000',\n",
     ")\n",

--- a/qmtl/examples/notebooks/strategy_analysis_example.ipynb
+++ b/qmtl/examples/notebooks/strategy_analysis_example.ipynb
@@ -1,55 +1,52 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Strategy Analysis Example\n",
-        "\n",
-        "Run a backtest on the single indicator template and plot the results."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import inspect\n",
-        "import pandas as pd\n",
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "from qmtl.examples.templates.single_indicator import SingleIndicatorStrategy\n",
-        "from qmtl.sdk import Runner\n",
-        "\n",
-        "strategy = Runner.run(\n",
-        "    SingleIndicatorStrategy,\n",
-        "    world_id='single_indicator_example',\n",
-        "    gateway_url='http://localhost:8000'\n",
-        ")\n",
-        "\n",
-        "price_snap = strategy.nodes[0].cache._snapshot()[strategy.nodes[0].node_id][strategy.nodes[0].interval]\n",
-        "ema_snap = strategy.nodes[1].cache._snapshot()[strategy.nodes[1].node_id][strategy.nodes[1].interval]\n",
-        "price = pd.DataFrame(price_snap, columns=['ts', 'payload'])\n",
-        "price['close'] = price['payload'].apply(lambda p: p['close'])\n",
-        "ema = pd.DataFrame(ema_snap, columns=['ts', 'ema'])\n",
-        "merged = pd.merge(price[['ts', 'close']], ema, on='ts')\n",
-        "merged.set_index('ts')[['close', 'ema']].plot()\n",
-        "plt.show()\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Strategy Analysis Example\n\nExecute the single indicator template via Runner.run through the WorldService and plot the results."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from qmtl.examples.templates.single_indicator import SingleIndicatorStrategy\n",
+    "from qmtl.sdk import Runner\n",
+    "\n",
+    "strategy = Runner.run(\n",
+    "    SingleIndicatorStrategy,\n",
+    "    world_id='single_indicator_example',\n",
+    "    gateway_url='http://localhost:8000'\n",
+    ")\n",
+    "\n",
+    "price_snap = strategy.nodes[0].cache._snapshot()[strategy.nodes[0].node_id][strategy.nodes[0].interval]\n",
+    "ema_snap = strategy.nodes[1].cache._snapshot()[strategy.nodes[1].node_id][strategy.nodes[1].interval]\n",
+    "price = pd.DataFrame(price_snap, columns=['ts', 'payload'])\n",
+    "price['close'] = price['payload'].apply(lambda p: p['close'])\n",
+    "ema = pd.DataFrame(ema_snap, columns=['ts', 'ema'])\n",
+    "merged = pd.merge(price[['ts', 'close']], ema, on='ts')\n",
+    "merged.set_index('ts')[['close', 'ema']].plot()\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
## Summary
- drop load_backtest_defaults usage from analysis notebooks
- promote WS-driven Runner.run usage

## Testing
- `uv run -m pytest -W error` *(fails: ASGITransport.__init__() got an unexpected keyword argument 'default_headers', assert failures, etc.)*
- `uv run mkdocs build`

Closes #662

------
https://chatgpt.com/codex/tasks/task_e_68b988f9c03c8329b85dae94e86fc42c