### PR TITLE
Docs: Python 3.11 + uv guidance; HTTPX 0.28 usage policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,39 @@ uv run scripts/check_doc_sync.py
 
 Run the script from the repository root and fix any reported issues.
 
+## Python and Tooling
+
+- Use `uv` to manage Python and dependencies for all tasks.
+- Required Python: `>=3.11`. Pin the local project to Python 3.11 to ensure consistent behavior:
+
+```bash
+uv python install 3.11
+uv python pin 3.11
+uv pip install -e .[dev]
+```
+
+- Run tests via `uv run` so the pinned interpreter is used:
+
+```bash
+uv run -m pytest -W error
+```
+
+## HTTPX Usage (tests and examples)
+
+QMTL targets httpx 0.28.x. To avoid regressions across environments:
+
+- The project pins `httpx>=0.28,<0.29` in `pyproject.toml`.
+- In asynchronous tests using ASGI apps, always use the context-managed `ASGITransport` introduced in 0.28:
+
+```python
+async with httpx.ASGITransport(app=app) as transport:
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/status")
+```
+
+- Do not instantiate `ASGITransport(app)` without a context manager, and do not call `aclose()` manually on the transport; the context handles cleanup.
+- For backend stubs, prefer `httpx.MockTransport` over ad-hoc servers.
+
 ## Network and Asynchronous Operations
 
 Use explicit state polling or event-driven communication instead of unconditional `sleep` calls or arbitrary timeouts in network or asynchronous code. Utilities such as `asyncio.wait_for` and `asyncio.Event.wait` help manage these workflows:

--- a/docs/guides/httpx_usage.md
+++ b/docs/guides/httpx_usage.md
@@ -1,0 +1,45 @@
+# HTTPX Usage
+
+QMTL targets httpx 0.28.x and uses its updated ASGI testing APIs. This page documents the required patterns to keep tests and examples consistent and future‑proof.
+
+## Version policy
+
+- Dependency pin: `httpx>=0.28,<0.29`
+- Rationale: httpx 0.28 introduced context-managed `ASGITransport` and related changes; pinning to 0.28.x avoids accidental breakage from future minor releases.
+
+## ASGI testing pattern (async)
+
+Use the context-manager form of `ASGITransport` and nest an `AsyncClient`:
+
+```python
+import httpx
+
+async with httpx.ASGITransport(app=app) as transport:
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/status")
+        assert resp.status_code == 200
+```
+
+Do not instantiate `ASGITransport(app)` without a context manager and do not manually call `aclose()`; the context takes care of cleanup.
+
+## Mocking upstream services
+
+Prefer `httpx.MockTransport` in tests over ad‑hoc servers:
+
+```python
+async def handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, json={"ok": True})
+
+transport = httpx.MockTransport(handler)
+client = httpx.AsyncClient(transport=transport)
+```
+
+## WebSockets
+
+When testing WebSocket endpoints exposed by FastAPI/Starlette, continue using `fastapi.testclient.TestClient` for sync tests, and the `ASGITransport` pattern above for async HTTP interactions around them.
+
+## Migration notes (pre‑0.28 → 0.28)
+
+- Replace `transport = httpx.ASGITransport(app)` + manual `aclose()` with the context-manager form shown above.
+- Ensure `base_url` is set on the client when targeting ASGI apps.
+

--- a/docs/guides/python_environment.md
+++ b/docs/guides/python_environment.md
@@ -1,0 +1,27 @@
+# Python Environment
+
+This project standardizes on Python 3.11 and the `uv` package manager to ensure consistent behavior across development machines and CI.
+
+- Required version: Python >= 3.11
+- Manager: `uv` (fast, reproducible Python and dependency management)
+
+## Quickstart
+
+```bash
+# Install and pin Python 3.11 for this project
+uv python install 3.11
+uv python pin 3.11
+
+# Install dev dependencies in editable mode
+uv pip install -e .[dev]
+
+# Run tests using the pinned interpreter
+uv run -m pytest -W error
+```
+
+## Notes
+
+- The project’s `pyproject.toml` sets `requires-python = ">=3.11"`.
+- Prefer `uv run` for all commands (tests, tools) so the pinned interpreter is used consistently.
+- CI should also run with Python 3.11 to minimize environment drift.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,8 @@ nav:
       - SDK Tutorial: guides/sdk_tutorial.md
       - Strategy Workflow: guides/strategy_workflow.md
       - Migration (BC Removal): guides/migration_bc_removal.md
+      - Python Environment: guides/python_environment.md
+      - HTTPX Usage: guides/httpx_usage.md
   - Operations:
       - Overview: operations/README.md
       - Backfill: operations/backfill.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "xarray",
     "networkx",
     "numpy",
-    "httpx",
+    "httpx>=0.28,<0.29",
     "fastapi",
     "uvicorn",
     "redis",


### PR DESCRIPTION
Summary: Add consistent guidance for Python environment management and httpx usage.\n\n- Pin  to ensure stable behavior with the 0.28 ASGITransport API.\n- Add docs/guides/python_environment.md with uv-based Python 3.11 pin + run instructions.\n- Add docs/guides/httpx_usage.md documenting the required ASGITransport context-manager pattern and MockTransport for stubs.\n- Update CONTRIBUTING.md with concise sections for Python + httpx usage.\n- Update mkdocs.yml navigation and validate build.\n\nThis aligns tests and local dev usage with the recent httpx 0.28 changes so contributors get consistent results across machines.\n\nFixes #664