### PR TITLE
feat: add world policy engine and apply API

### DIFF
--- a/docs/world/policy_engine.md
+++ b/docs/world/policy_engine.md
@@ -1,0 +1,38 @@
+# Policy Engine
+
+This guide describes how to define and apply world policies.
+
+## Sample Policy
+
+A sample policy is provided in [`sample_policy.yml`](./sample_policy.yml):
+
+```yaml
+thresholds:
+  sharpe:
+    metric: sharpe
+    min: 0.5
+  drawdown:
+    metric: drawdown
+    max: 0.2
+top_k:
+  metric: sharpe
+  k: 3
+correlation:
+  max: 0.8
+hysteresis:
+  metric: sharpe
+  enter: 0.6
+  exit: 0.4
+```
+
+## Applying a Policy
+
+Use the World Service API to apply a policy and evaluate strategies:
+
+```bash
+curl -X POST /worlds/alpha/apply \
+  -H 'Content-Type: application/json' \
+  -d '{"policy": { ... }, "metrics": { ... }}'
+```
+
+The response contains the active strategies after evaluation.

--- a/docs/world/sample_policy.yml
+++ b/docs/world/sample_policy.yml
@@ -1,0 +1,16 @@
+thresholds:
+  sharpe:
+    metric: sharpe
+    min: 0.5
+  drawdown:
+    metric: drawdown
+    max: 0.2
+top_k:
+  metric: sharpe
+  k: 3
+correlation:
+  max: 0.8
+hysteresis:
+  metric: sharpe
+  enter: 0.6
+  exit: 0.4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
   - World:
       - Spec: world/world.md
       - Realm Terminology Evaluation: world/realm_rename_eval.md
+      - Policy Engine: world/policy_engine.md
   - Archive: archive/README.md
   - Tags: tags.md
   - Template: templates/template.md

--- a/qmtl/worldservice/__init__.py
+++ b/qmtl/worldservice/__init__.py
@@ -1,0 +1,4 @@
+from .policy_engine import Policy, evaluate_policy, parse_policy
+from .api import create_app
+
+__all__ = ["Policy", "evaluate_policy", "parse_policy", "create_app"]

--- a/qmtl/worldservice/api.py
+++ b/qmtl/worldservice/api.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .policy_engine import Policy, evaluate_policy
+from .controlbus_producer import ControlBusProducer
+
+
+class ApplyRequest(BaseModel):
+    policy: Policy
+    metrics: Dict[str, Dict[str, float]]
+    previous: List[str] | None = None
+    correlations: Dict[tuple[str, str], float] | None = None
+
+
+class ApplyResponse(BaseModel):
+    active: List[str]
+
+
+def create_app(*, bus: ControlBusProducer | None = None) -> FastAPI:
+    """Return a FastAPI app exposing policy application APIs."""
+    app = FastAPI()
+    store: Dict[str, ApplyResponse] = {}
+    policies: Dict[str, Policy] = {}
+
+    @app.get("/worlds/{world_id}/apply", response_model=ApplyResponse)
+    async def get_apply(world_id: str) -> ApplyResponse:
+        if world_id not in store:
+            raise HTTPException(status_code=404, detail="world not found")
+        return store[world_id]
+
+    @app.post("/worlds/{world_id}/apply", response_model=ApplyResponse)
+    async def post_apply(world_id: str, payload: ApplyRequest) -> ApplyResponse:
+        policy = payload.policy
+        policies[world_id] = policy
+        prev = payload.previous or store.get(world_id, ApplyResponse(active=[])).active
+        active = evaluate_policy(payload.metrics, policy, prev, payload.correlations)
+        resp = ApplyResponse(active=active)
+        store[world_id] = resp
+        if bus:
+            await bus.publish_policy_update(world_id, active)
+        return resp
+
+    return app
+
+
+__all__ = ["ApplyRequest", "ApplyResponse", "create_app"]

--- a/qmtl/worldservice/controlbus_producer.py
+++ b/qmtl/worldservice/controlbus_producer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import Any, Iterable
+
+
+class ControlBusProducer:
+    """Publish policy updates to the internal ControlBus."""
+
+    def __init__(self, *, brokers: Iterable[str] | None = None, topic: str = "policy", producer: Any | None = None) -> None:
+        self.brokers = list(brokers or [])
+        self.topic = topic
+        self._producer = producer
+
+    async def start(self) -> None:
+        if self._producer is not None or not self.brokers:
+            return
+        try:  # pragma: no cover - optional dependency
+            from aiokafka import AIOKafkaProducer
+        except Exception:
+            return
+        self._producer = AIOKafkaProducer(bootstrap_servers=self.brokers)
+        await self._producer.start()
+
+    async def stop(self) -> None:
+        if self._producer is None:
+            return
+        with contextlib.suppress(Exception):  # pragma: no cover - best effort
+            await self._producer.stop()
+        self._producer = None
+
+    async def publish_policy_update(self, world_id: str, strategies: Iterable[str]) -> None:
+        if self._producer is None:
+            return
+        payload = {"world_id": world_id, "strategies": list(strategies)}
+        data = json.dumps(payload).encode()
+        key = world_id.encode()
+        await self._producer.send_and_wait(self.topic, data, key=key)
+
+
+__all__ = ["ControlBusProducer"]

--- a/qmtl/worldservice/policy_engine.py
+++ b/qmtl/worldservice/policy_engine.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import math
+import yaml
+from pydantic import BaseModel, Field
+
+
+class ThresholdRule(BaseModel):
+    metric: str
+    min: float | None = None
+    max: float | None = None
+
+
+class TopKRule(BaseModel):
+    metric: str
+    k: int = Field(gt=0)
+
+
+class CorrelationRule(BaseModel):
+    max: float = Field(ge=-1.0, le=1.0)
+
+
+class HysteresisRule(BaseModel):
+    metric: str
+    enter: float
+    exit: float
+
+
+class Policy(BaseModel):
+    thresholds: dict[str, ThresholdRule] = Field(default_factory=dict)
+    top_k: TopKRule | None = None
+    correlation: CorrelationRule | None = None
+    hysteresis: HysteresisRule | None = None
+
+
+def parse_policy(raw: str | bytes | dict) -> Policy:
+    """Parse a policy from YAML/JSON string or pre-parsed dict."""
+    data: dict
+    if isinstance(raw, (str, bytes)):
+        data = yaml.safe_load(raw)
+    else:
+        data = raw
+    return Policy.model_validate(data)
+
+
+def _apply_thresholds(metrics: Dict[str, Dict[str, float]], policy: Policy) -> List[str]:
+    result: List[str] = []
+    for sid, vals in metrics.items():
+        ok = True
+        for rule in policy.thresholds.values():
+            v = vals.get(rule.metric)
+            if v is None:
+                ok = False
+                break
+            if rule.min is not None and v < rule.min:
+                ok = False
+                break
+            if rule.max is not None and v > rule.max:
+                ok = False
+                break
+        if ok:
+            result.append(sid)
+    return result
+
+
+def _apply_topk(metrics: Dict[str, Dict[str, float]], candidates: Iterable[str], rule: TopKRule) -> List[str]:
+    scored = [(sid, metrics.get(sid, {}).get(rule.metric, -math.inf)) for sid in candidates]
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return [sid for sid, _ in scored[: rule.k]]
+
+
+def _apply_correlation(
+    correlations: Dict[Tuple[str, str], float] | None,
+    candidates: Iterable[str],
+    rule: CorrelationRule,
+) -> List[str]:
+    if not correlations:
+        return list(candidates)
+    selected: List[str] = []
+    for sid in candidates:
+        if all(abs(correlations.get(tuple(sorted((sid, other))), 0.0)) <= rule.max for other in selected):
+            selected.append(sid)
+    return selected
+
+
+def _apply_hysteresis(
+    metrics: Dict[str, Dict[str, float]],
+    candidates: Iterable[str],
+    prev_active: Iterable[str] | None,
+    rule: HysteresisRule,
+) -> List[str]:
+    prev = set(prev_active or [])
+    result: List[str] = []
+    for sid in candidates:
+        val = metrics.get(sid, {}).get(rule.metric)
+        if val is None:
+            continue
+        if sid in prev:
+            if val >= rule.exit:
+                result.append(sid)
+        else:
+            if val >= rule.enter:
+                result.append(sid)
+    return result
+
+
+def evaluate_policy(
+    metrics: Dict[str, Dict[str, float]],
+    policy: Policy,
+    prev_active: Iterable[str] | None = None,
+    correlations: Dict[Tuple[str, str], float] | None = None,
+) -> List[str]:
+    """Return strategy ids that satisfy the policy.
+
+    Args:
+        metrics: per-strategy metric mapping.
+        policy: policy definition.
+        prev_active: previously active strategies for hysteresis.
+        correlations: optional pairwise correlation matrix keyed by tuple(sorted((a,b))).
+    """
+    candidates = _apply_thresholds(metrics, policy)
+    if policy.top_k:
+        candidates = _apply_topk(metrics, candidates, policy.top_k)
+    if policy.correlation:
+        candidates = _apply_correlation(correlations, candidates, policy.correlation)
+    if policy.hysteresis:
+        candidates = _apply_hysteresis(metrics, candidates, prev_active, policy.hysteresis)
+    return list(candidates)
+
+
+__all__ = [
+    "Policy",
+    "ThresholdRule",
+    "TopKRule",
+    "CorrelationRule",
+    "HysteresisRule",
+    "parse_policy",
+    "evaluate_policy",
+]

--- a/tests/worldservice/test_policy_engine.py
+++ b/tests/worldservice/test_policy_engine.py
@@ -1,0 +1,22 @@
+from qmtl.worldservice.policy_engine import (
+    Policy,
+    ThresholdRule,
+    TopKRule,
+    evaluate_policy,
+)
+
+
+def test_threshold_filtering():
+    policy = Policy(thresholds={"sharpe": ThresholdRule(metric="sharpe", min=0.5)})
+    metrics = {"s1": {"sharpe": 0.6}, "s2": {"sharpe": 0.4}}
+    assert evaluate_policy(metrics, policy) == ["s1"]
+
+
+def test_topk_selection():
+    policy = Policy(top_k=TopKRule(metric="sharpe", k=2))
+    metrics = {
+        "s1": {"sharpe": 1.0},
+        "s2": {"sharpe": 0.8},
+        "s3": {"sharpe": 1.5},
+    }
+    assert evaluate_policy(metrics, policy) == ["s3", "s1"]

--- a/tests/worldservice/test_worldservice_api.py
+++ b/tests/worldservice/test_worldservice_api.py
@@ -1,0 +1,30 @@
+import httpx
+import pytest
+
+from qmtl.worldservice.api import create_app, ApplyRequest
+from qmtl.worldservice.controlbus_producer import ControlBusProducer
+
+
+class DummyBus(ControlBusProducer):
+    def __init__(self):
+        self.published: list[tuple[str, list[str]]] = []
+
+    async def publish_policy_update(self, world_id: str, strategies: list[str]) -> None:  # type: ignore[override]
+        self.published.append((world_id, strategies))
+
+
+@pytest.mark.asyncio
+async def test_apply_endpoint_broadcasts():
+    bus = DummyBus()
+    app = create_app(bus=bus)
+    payload = ApplyRequest(
+        policy={"top_k": {"metric": "sharpe", "k": 1}},
+        metrics={"s1": {"sharpe": 1.0}, "s2": {"sharpe": 0.5}},
+    )
+    async with httpx.ASGITransport(app=app) as asgi:
+        async with httpx.AsyncClient(transport=asgi, base_url="http://test") as client:
+            r = await client.post("/worlds/w1/apply", json=payload.model_dump())
+            assert r.json() == {"active": ["s1"]}
+            r2 = await client.get("/worlds/w1/apply")
+            assert r2.json() == {"active": ["s1"]}
+    assert bus.published == [("w1", ["s1"])]


### PR DESCRIPTION
## Summary
- implement policy engine with threshold, top-k, correlation, and hysteresis rules
- expose world apply API and publish PolicyUpdated to ControlBus
- document policy usage and provide sample policy file with tests

## Testing
- `uv run -m pytest -W error tests/worldservice`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4b882c4832998daeb9403968617