### PR TITLE
docs: document world id propagation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ nav:
   - Maintenance Schedule: MAINTENANCE_SCHEDULE.md
   - Architecture:
       - Overview: architecture/README.md
-      - Architecture & Ownership: architecture/architecture.md
+      - Architecture & World ID Flow: architecture/architecture.md
       - Glossary: architecture/glossary.md
       - DAG Manager: architecture/dag-manager.md
       - Gateway: architecture/gateway.md
@@ -14,7 +14,7 @@ nav:
       - Brokerage API: reference/api/brokerage.md
   - Guides:
       - Overview: guides/README.md
-      - SDK Tutorial: guides/sdk_tutorial.md
+      - SDK Tutorial & World ID: guides/sdk_tutorial.md
       - Strategy Workflow: guides/strategy_workflow.md
       - Migration (BC Removal): guides/migration_bc_removal.md
       - Python Environment: guides/python_environment.md


### PR DESCRIPTION
## Summary
- illustrate how `world_id` flows from Runner into TagQueryManager/ActivationManager and down to nodes and metrics
- document `qmtl sdk run --world-id` usage with environment and config injection examples
- update mkdocs navigation and verify build

## Testing
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b9b2e7c76083299192acb6166c1ebc