### PR TITLE
feat(metrics): add world label to pretrade metrics

### DIFF
--- a/docs/operations/activation.md
+++ b/docs/operations/activation.md
@@ -39,6 +39,7 @@ last_modified: 2025-08-29
 ## Alerts & Dashboards
 - Alerts: promotion_fail_total, activation_skew_seconds, stale_decision_cache
 - Dashboards: world_decide_latency_ms_p95, event fanout lag, gateway proxy error rates
+- Use world-scoped metrics such as `pretrade_attempts_total{world_id="demo"}` to verify activation state per world.
 
 {{ nav_links() }}
 

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -570,6 +570,7 @@ class Runner:
         strategy = Runner._prepare(strategy_cls)
         tag_service = TagManagerService(gateway_url)
         manager = tag_service.init(strategy, world_id=world_id)
+        sdk_metrics.set_world_id(world_id)
         logger.info(f"[RUN] {strategy_cls.__name__} world={world_id}")
         dag = strategy.serialize()
         logger.info("Sending DAG to service: %s", [n["node_id"] for n in dag["nodes"]])


### PR DESCRIPTION
## Summary
- label SDK and Gateway pretrade metrics by world_id and expose helper to set it
- propagate world_id into Runner and tests
- document world-scoped metric usage

Fixes #736

## Testing
- `uv run --extra dev -m pytest`
- `python -m pylint qmtl/sdk/metrics.py qmtl/gateway/metrics.py`
- `uv run --extra dev mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b9b12f6780832998228ef71fc1a42a