### PR TITLE
Docs: default to parallel pytest (-n auto) + xdist guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,21 @@ For general contribution and testing policies, see the repository root [AGENTS.m
 - Validate docs with `uv run mkdocs build` before committing. Ensure `mkdocs-macros-plugin`
   and `mkdocs-breadcrumbs-plugin` are installed via `uv pip install -e .[dev]`.
 
+## Testing
+
+- Always run tests in parallel with `pytest-xdist` for faster feedback:
+  `uv run -m pytest -W error -n auto`
+- If `pytest-xdist` is not installed, add it temporarily with
+  `uv pip install pytest-xdist` (or add it to your local extras).
+- For suites with shared resources, prefer `--dist loadscope` or cap workers
+  (e.g., `-n 2`). Mark must‑be‑serial tests and run them separately.
+
 ## Example Projects
 
 Example strategies under `qmtl/examples/` follow the same conventions as the rest of the
 project:
 
-- Run tests with `uv run -m pytest -W error`.
+- Run tests with `uv run -m pytest -W error -n auto`.
 - Place node processors under `nodes/` and tests under `tests/`.
 - Keep functions pure and free of side effects.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,13 @@ uv pip install -e .[dev]
 - Run tests via `uv run` so the pinned interpreter is used:
 
 ```bash
-uv run -m pytest -W error
+uv run -m pytest -W error -n auto
+```
+
+If `pytest-xdist` is missing, install it with:
+
+```bash
+uv pip install pytest-xdist
 ```
 
 ## HTTPX Usage (tests and examples)

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ Here’s a short workflow summary based on the repository’s guidelines:
 
    This command ensures all development dependencies are available.
 
-2. **Testing** – Run the tests via `uv` before committing:
+2. **Testing** – Run the tests in parallel via `uv` before committing:
 
    ```bash
-   uv run -m pytest
+   uv run -m pytest -n auto
    ```
 
    Commit only after tests pass.
@@ -152,20 +152,20 @@ Bring up the stack with Docker Compose:
 docker compose -f tests/docker-compose.e2e.yml up -d
 ```
 
-Run the tests using uv:
+Run the tests in parallel using uv:
 
 ```bash
-uv run -m pytest tests/e2e
+uv run -m pytest -n auto tests/e2e
 ```
 
 See [docs/operations/e2e_testing.md](docs/operations/e2e_testing.md) for the full guide.
 
 ## Running the Test Suite
 
-Run all unit and integration tests with:
+Run all unit and integration tests in parallel with:
 
 ```bash
-uv run -m pytest
+uv run -m pytest -n auto
 ```
 
 ## Monitoring

--- a/docs/guides/python_environment.md
+++ b/docs/guides/python_environment.md
@@ -15,13 +15,13 @@ uv python pin 3.11
 # Install dev dependencies in editable mode
 uv pip install -e .[dev]
 
-# Run tests using the pinned interpreter
-uv run -m pytest -W error
+# Run tests in parallel using the pinned interpreter
+uv run -m pytest -W error -n auto
 ```
 
 ## Notes
 
 - The project’s `pyproject.toml` sets `requires-python = ">=3.11"`.
 - Prefer `uv run` for all commands (tests, tools) so the pinned interpreter is used consistently.
+- For faster feedback, run tests in parallel (`-n auto`). Install `pytest-xdist` if missing: `uv pip install pytest-xdist`.
 - CI should also run with Python 3.11 to minimize environment drift.
-

--- a/docs/guides/strategy_workflow.md
+++ b/docs/guides/strategy_workflow.md
@@ -141,10 +141,10 @@ or using the `parallel_strategies_example.py` script.
 
 ## 5. Test Your Implementation
 
-Always run the unit tests before committing code:
+Always run the unit tests in parallel before committing code:
 
 ```bash
-uv run -m pytest -W error
+uv run -m pytest -W error -n auto
 ```
 
 A sample execution inside the container finished successfully:
@@ -157,7 +157,7 @@ End‑to‑end tests require Docker. Start the stack and execute the tests:
 
 ```bash
 docker compose -f tests/docker-compose.e2e.yml up -d
-uv run -m pytest tests/e2e
+uv run -m pytest -n auto tests/e2e
 ```
 
 For details on the test environment refer to
@@ -167,7 +167,7 @@ tests if desired:
 ```bash
 # Example of running wheels and tests in parallel
 uv pip wheel . &
-uv run -m pytest -W error
+uv run -m pytest -W error -n auto
 wait
 
 ### Test Teardown and Shutdown
@@ -202,7 +202,7 @@ Example:
 
 ```bash
 export QMTL_TEST_MODE=1
-uv run -m pytest -W error
+uv run -m pytest -W error -n auto
 ```
 ```
 

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -5,6 +5,8 @@ Continuous Integration runs on Python 3.11 via uv-managed virtualenvs. Tests run
 - Python: 3.11 (managed by `uv python install 3.11` + `uv venv`)
 - Dependency install: `uv pip install -e .[dev]`
 - Protobuf generation: `uv run python -m grpc_tools.protoc ...`
-- Tests: `PYTHONPATH=qmtl/proto uv run pytest -W error -q tests`
+- Tests: `PYTHONPATH=qmtl/proto uv run pytest -W error -n auto -q tests`
+
+Parallelization uses `pytest-xdist`; ensure it is installed in the CI image.
 
 See `.github/workflows/ci.yml` for the authoritative configuration.

--- a/docs/operations/e2e_testing.md
+++ b/docs/operations/e2e_testing.md
@@ -47,13 +47,32 @@ Manager gRPC endpoint is available on `50051`.
 Execute the end-to-end tests within the uv environment:
 
 ```bash
-uv run -m pytest tests/e2e
+uv run -m pytest -n auto tests/e2e
 ```
+
+To specifically validate WorldService-first wiring and event subscription,
+run the smoke test added under `tests/e2e/test_worldservice_smoke.py`:
+
+```bash
+uv run -m pytest -n auto tests/e2e/test_worldservice_smoke.py -q
+```
+
+The test performs:
+
+- Health check against the Gateway `/status` endpoint
+- Token issuance via `/events/subscribe` for two distinct `world_id`s and JWT claim check
+- WebSocket handshake to `/ws/evt` for both tokens
+- Strategy submissions per-world using the Gateway proxy
+
+It does not require ControlBus or a running WorldService.
 
 To execute the entire test suite run:
 
 ```bash
-uv run -m pytest -q tests
+uv run -m pytest -n auto -q tests
+
+Note: Parallel execution requires `pytest-xdist`. If not installed, add it with
+`uv pip install pytest-xdist` or include it in your dev extras.
 ```
 
 ## Backfills

--- a/qmtl/examples/README.md
+++ b/qmtl/examples/README.md
@@ -26,10 +26,10 @@ python strategies/my_strategy.py
 
 ## Testing
 
-Run the test suite and treat warnings as errors:
+Run the test suite in parallel and treat warnings as errors:
 
 ```bash
-uv run -m pytest -W error
+uv run -m pytest -W error -n auto
 ```
 
 ## Directory Layout

--- a/qmtl/examples/brokerage_demo/README.md
+++ b/qmtl/examples/brokerage_demo/README.md
@@ -5,6 +5,5 @@ Minimal example demonstrating the brokerage model usage and validation chain.
 Run tests:
 
 ```
-uv run -m pytest -q tests
+uv run -m pytest -n auto -q tests
 ```
-


### PR DESCRIPTION
Summary: Clarify and standardize guidance to run tests in parallel using pytest-xdist and the `-n auto` flag across contributor and operations docs.\n\nChanges:\n- AGENTS.md: Add Testing section with parallelization defaults and tips.\n- CONTRIBUTING.md: Use `uv run -m pytest -W error -n auto`; add install note for `pytest-xdist`.\n- README.md: Parallelize test commands in Development Workflow, E2E, and suite sections.\n- docs/operations/ci.md: CI command uses `-n auto`; note ensuring xdist in image.\n- docs/guides/strategy_workflow.md: Parallelize unit/e2e and wheels+tests example.\n- docs/operations/e2e_testing.md: Parallelize e2e commands and mention xdist installation.\n- docs/guides/python_environment.md: Quickstart uses parallel tests; add xdist note.\n- qmtl/examples/*/README.md: Parallelize example test commands.\n\nRationale:\n- Faster feedback locally and in CI while keeping warnings-as-errors.\n- Guidance included for suites with shared resources (`--dist loadscope`, capping workers).\n\nValidation:\n- Searched and updated remaining `pytest` invocations to use `-n auto` in project docs.\n\nNotes:\n- If desired, we can also add `pytest-xdist` to `[project.optional-dependencies].dev` in `pyproject.toml` for out-of-the-box installs.