### PR TITLE
chore(dev): add pytest-xdist to dev extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-asyncio",
+    "pytest-xdist",
     "fakeredis",
     "grpcio-tools>=1.74.0",
     "pyarrow",


### PR DESCRIPTION
Summary: Include `pytest-xdist` in the `[project.optional-dependencies].dev` extra so contributors get parallel test support out of the box.\n\nContext: Follow-up to docs PR (#741) that standardized parallel pytest usage (`-n auto`). This change ensures `uv pip install -e .[dev]` installs xdist by default.\n\nChange:\n- pyproject.toml: add `pytest-xdist` to `dev` extras.\n\nImpact:\n- Local and CI environments using dev extras will have xdist available without extra steps.\n\nValidation:\n- Verified extras list and updated guidance already references `-n auto`.\n\nCloses #? (optional)