### PR TITLE
CI: Add hang-detection preflight before full test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Prepare Python and venv
+        run: |
+          uv python install 3.11
+          uv venv
+
+      - name: Install dependencies (dev)
+        run: uv pip install -e .[dev]
+
+      - name: Build docs (mkdocs)
+        run: uv run mkdocs build --strict
+
+      - name: Preflight – import/collection
+        run: uv run -m pytest --collect-only -q
+
+      - name: Preflight – hang detection
+        run: |
+          PYTHONFAULTHANDLER=1 \
+          uv run --with pytest-timeout -m pytest -q \
+            --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
+
+      - name: Run tests (warnings are errors)
+        run: PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
+


### PR DESCRIPTION
Summary\n- Add preflight stages that catch hanging tests before the full suite runs.\n\nRationale\n- A single hanging test can block CI. Using pytest-timeout + faulthandler turns hangs into fast failures with stack traces.\n\nChanges\n- Add preflight steps in .github/workflows/ci.yml:\n  1) Import/collection sanity check: `uv run -m pytest --collect-only -q`\n  2) Hang detection: `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`\n- Keep full suite unchanged with warnings-as-errors.\n- Docs already capture guidance in AGENTS.md and docs/operations/ci.md.\n\nAcceptance Criteria\n- CI runs preflight stages before full suite on push/PR.\n- A test that exceeds 60s fails fast with a traceback.\n- Authors can override per-test with @pytest.mark.timeout, and mark slow tests as needed.\n\nFixes #742