### PR TITLE
Add token refresh handling for event WebSocket

### DIFF
--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -226,6 +226,18 @@ ws_acks_total = Counter(
     registry=global_registry,
 )
 
+ws_refreshes_total = Counter(
+    "ws_refreshes_total",
+    "Total number of WebSocket token refresh requests",
+    registry=global_registry,
+)
+
+ws_refresh_failures_total = Counter(
+    "ws_refresh_failures_total",
+    "Total number of failed WebSocket token refresh attempts",
+    registry=global_registry,
+)
+
 sentinel_skew_seconds = Gauge(
     "sentinel_skew_seconds",
     "Seconds between sentinel weight update and observed traffic ratio",
@@ -457,6 +469,8 @@ def reset_metrics() -> None:
     ws_auth_failures_total._value.set(0)  # type: ignore[attr-defined]
     ws_heartbeats_total._value.set(0)  # type: ignore[attr-defined]
     ws_acks_total._value.set(0)  # type: ignore[attr-defined]
+    ws_refreshes_total._value.set(0)  # type: ignore[attr-defined]
+    ws_refresh_failures_total._value.set(0)  # type: ignore[attr-defined]
     sentinel_skew_seconds.clear()
     sentinel_skew_seconds._vals = {}  # type: ignore[attr-defined]
     pretrade_attempts_total.clear()

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -145,6 +145,15 @@ class WebSocketHub:
         metrics.record_ws_drop()
         await self._recalc_subscriber_metrics()
 
+    async def set_topics(
+        self, websocket: WebSocket, topics: Optional[Set[str]]
+    ) -> None:
+        """Update topic subscriptions for an existing WebSocket client."""
+        async with self._lock:
+            if websocket in self._clients:
+                self._topics[websocket] = topics
+        await self._recalc_subscriber_metrics()
+
     async def _recalc_subscriber_metrics(self) -> None:
         """Recompute subscriber gauge metrics."""
         counts: Dict[str, int] = {}

--- a/tests/gateway/test_ws_evt_refresh.py
+++ b/tests/gateway/test_ws_evt_refresh.py
@@ -1,0 +1,64 @@
+import time
+import pytest
+from fastapi import FastAPI, WebSocketDisconnect
+from fastapi.testclient import TestClient
+
+from qmtl.gateway.event_handlers import create_event_router
+from qmtl.gateway.event_descriptor import EventDescriptorConfig, sign_event_token
+from qmtl.gateway.ws import WebSocketHub
+from qmtl.gateway import metrics as gw_metrics
+
+
+def _make_token(cfg: EventDescriptorConfig, *, world: str, strat: str, topics=None) -> str:
+    now = int(time.time())
+    claims = {
+        "aud": "controlbus",
+        "sub": strat,
+        "world_id": world,
+        "strategy_id": strat,
+        "topics": topics or [],
+        "jti": "j1",
+        "iat": now,
+        "exp": now + 60,
+    }
+    return sign_event_token(claims, cfg)
+
+
+def test_refresh_updates_topics_and_filters():
+    gw_metrics.reset_metrics()
+    hub = WebSocketHub()
+    cfg = EventDescriptorConfig(keys={"k": "secret"}, active_kid="k")
+    app = FastAPI()
+    app.include_router(create_event_router(hub, cfg))
+
+    tok1 = _make_token(cfg, world="w1", strat="s1", topics=[])
+    tok2 = _make_token(cfg, world="w2", strat="s2", topics=["policy"])
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/evt", headers={"Authorization": f"Bearer {tok1}"}) as ws:
+            ws.send_json({"type": "refresh", "token": tok2})
+            ack = ws.receive_json()
+            assert ack["type"] == "refresh_ack"
+            topics = next(iter(hub._topics.values()))
+            assert topics == {"policy"}
+            filt = next(iter(hub._filters.values()))
+            assert filt["world_id"] == "w2"
+            assert filt["strategy_id"] == "s2"
+
+
+def test_invalid_refresh_closes_connection():
+    gw_metrics.reset_metrics()
+    hub = WebSocketHub()
+    cfg = EventDescriptorConfig(keys={"k": "secret"}, active_kid="k")
+    app = FastAPI()
+    app.include_router(create_event_router(hub, cfg))
+
+    tok = _make_token(cfg, world="w1", strat="s1", topics=[])
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/evt", headers={"Authorization": f"Bearer {tok}"}) as ws:
+            ws.send_json({"type": "refresh", "token": "bad"})
+            with pytest.raises(WebSocketDisconnect) as exc:
+                ws.receive_json()
+            assert exc.value.code == 1008
+    assert gw_metrics.ws_refresh_failures_total._value.get() == 1


### PR DESCRIPTION
## Summary
- allow `/ws/evt` clients to refresh tokens in-place and update scope
- track refresh attempts and failures in gateway metrics
- cover refresh success and failure scenarios with tests

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest tests/gateway/test_ws_evt_refresh.py -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto tests/gateway/test_ws_evt_refresh.py`

Fixes #782

------
https://chatgpt.com/codex/tasks/task_e_68bda4b65bb483299dc128bdfb2ed79f