### PR TITLE
Align /queues/by_tag schema with descriptor objects

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -399,7 +399,7 @@ sequenceDiagram
     participant N as TagQueryNode
     R->>M: register TagQueryNode
     M->>G: GET /queues/by_tag
-    G-->>M: queue list
+    G-->>M: queue descriptors
     M->>N: update_queues(list)
     G-->>M: queue_update (WebSocket)
     M->>N: update_queues(list)

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -119,7 +119,11 @@ paths:
                 properties:
                   queues:
                     type: array
-                    items: { type: string }
+                    items:
+                      type: object
+                      properties:
+                        queue: { type: string }
+                        global: { type: boolean }
 ```
 Clients must specify ``match_mode`` to control tag matching behavior.
 

--- a/docs/reference/tagquery.md
+++ b/docs/reference/tagquery.md
@@ -12,9 +12,8 @@ last_modified: 2025-09-07
 - Overview: `TagQueryNode` selects upstream queues by tag set and interval. The Runner wires a per‑strategy `TagQueryManager` that resolves the initial queue list and applies live updates via WebSocket.
 - Endpoint: Gateway exposes `GET /queues/by_tag` with params `tags` (comma‑separated), `interval` (seconds), `match_mode` (`any`|`all`), and optional `world_id`.
 - Matching: `match_mode=any` selects queues containing any tag; `all` requires all tags. Tags are normalized and sorted for stable keys.
-- Normalization: Responses may contain:
-  - Strings: queue IDs, e.g. `"q1"`
-  - Objects: `{"queue": "<id>", "global": <bool>}`. Entries with `global=true` are ignored by the SDK for node execution.
+- Normalization: Gateway returns an array of descriptor objects:
+  - `{"queue": "<id>", "global": <bool>}`. Entries with `global=true` are ignored by the SDK for node execution.
 
 ## Runner Integration
 

--- a/qmtl/common/tagquery.py
+++ b/qmtl/common/tagquery.py
@@ -32,13 +32,13 @@ def normalize_match_mode(match_mode: str | None) -> MatchMode:
 def normalize_queues(raw: Iterable[Any]) -> list[str]:
     queues: list[str] = []
     for q in raw:
-        if isinstance(q, dict):
-            if q.get("global"):
-                continue
-            # Only accept unified 'queue' key; legacy 'topic' is not supported
-            val = q.get("queue")
-            if val:
-                queues.append(str(val))
-        else:
-            queues.append(str(q))
+        if not isinstance(q, dict):
+            # Canonical shape is a descriptor object; skip legacy strings
+            continue
+        if q.get("global"):
+            continue
+        # Only accept unified 'queue' key; legacy 'topic' is not supported
+        val = q.get("queue")
+        if val:
+            queues.append(str(val))
     return queues

--- a/qmtl/gateway/models.py
+++ b/qmtl/gateway/models.py
@@ -4,6 +4,11 @@ from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel, Field
+try:
+    # Pydantic v2 style config
+    from pydantic import ConfigDict  # type: ignore
+except Exception:  # pragma: no cover - fallback for older environments
+    ConfigDict = None  # type: ignore
 
 
 class StrategySubmit(BaseModel):
@@ -27,9 +32,12 @@ class StatusResponse(BaseModel):
 class QueueDescriptor(BaseModel):
     queue: str
     global_: bool = Field(alias="global")
-
-    class Config:
-        populate_by_name = True
+    # Use Pydantic v2 config; avoid deprecated class-based Config
+    if 'ConfigDict' in globals() and ConfigDict is not None:  # type: ignore
+        model_config = ConfigDict(populate_by_name=True)  # type: ignore
+    else:  # pragma: no cover - legacy fallback
+        class Config:  # type: ignore
+            populate_by_name = True
 
 
 class QueuesByTagResponse(BaseModel):

--- a/qmtl/gateway/models.py
+++ b/qmtl/gateway/models.py
@@ -24,6 +24,18 @@ class StatusResponse(BaseModel):
     status: str
 
 
+class QueueDescriptor(BaseModel):
+    queue: str
+    global_: bool = Field(alias="global")
+
+    class Config:
+        populate_by_name = True
+
+
+class QueuesByTagResponse(BaseModel):
+    queues: list[QueueDescriptor] = Field(default_factory=list)
+
+
 class EventSubscribeRequest(BaseModel):
     world_id: str
     strategy_id: str

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -17,7 +17,12 @@ from . import metrics as gw_metrics
 from .dagmanager_client import DagManagerClient
 from .degradation import DegradationManager
 from .gateway_health import get_health as gateway_health
-from .models import StrategyAck, StrategySubmit, StatusResponse
+from .models import (
+    StrategyAck,
+    StrategySubmit,
+    StatusResponse,
+    QueuesByTagResponse,
+)
 from .strategy_manager import StrategyManager
 from .ws import WebSocketHub
 from .world_client import WorldServiceClient
@@ -248,11 +253,12 @@ def create_api_router(
 
     # Legacy DAG/Gateway callback routes have been removed in favor of
     # ControlBus-driven updates; see qmtl.gateway.ws and event handlers.
-    @router.get("/queues/by_tag")
+    @router.get("/queues/by_tag", response_model=QueuesByTagResponse)
     async def queues_by_tag(
         tags: str, interval: int, match_mode: str = "any", world_id: str = ""
-    ) -> dict:
+    ) -> QueuesByTagResponse:
         from qmtl.common.tagquery import split_tags, normalize_match_mode
+
         tag_list = split_tags(tags)
         mode = normalize_match_mode(match_mode).value
         queues = await dagmanager.get_queues_by_tag(

--- a/tests/tagquery/test_manager_resolve_normalization.py
+++ b/tests/tagquery/test_manager_resolve_normalization.py
@@ -28,10 +28,10 @@ async def test_resolve_tags_normalizes_and_filters(monkeypatch):
                     return None
 
                 def json(self):
-                    # Mixed payload: strings, objects, and a global queue that must be filtered
+                    # All entries are descriptor objects; global=True must be filtered
                     return {
                         "queues": [
-                            "q1",
+                            {"queue": "q1", "global": False},
                             {"queue": "q2", "global": False},
                             {"queue": "q3", "global": True},
                         ]


### PR DESCRIPTION
## Summary
- document /queues/by_tag as returning queue descriptors
- expose QueueDescriptor in gateway models and API
- normalize TagQuery responses assuming descriptor shape

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: PydanticDeprecatedSince20 warnings treated as errors)*
- `uv run mkdocs build`

Fixes #783

------
https://chatgpt.com/codex/tasks/task_e_68bda4ba92a48329a3596ce819b01aa8