### PR TITLE
feat: migrate NodeID to BLAKE3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `TagQueryNode.resolve()` has been removed. Use `TagQueryManager.resolve_tags()` to fetch queue mappings before execution.
 - Added `Node.add_tag()` to attach tags after node creation.
 - Added migration guide for removing legacy Runner/CLI/Gateway surfaces. See [docs/guides/migration_bc_removal.md](docs/guides/migration_bc_removal.md).
+- NodeID now uses BLAKE3 with a `blake3:` prefix and no longer includes `world_id`. Legacy SHA-based IDs remain temporarily supported. See [docs/guides/migration_nodeid_blake3.md](docs/guides/migration_nodeid_blake3.md).
 
 ---
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -16,6 +16,7 @@ Tutorials and workflow guides for using QMTL.
 - [SDK Tutorial](sdk_tutorial.md): Build strategies with the SDK.
 - [Strategy Workflow](strategy_workflow.md): Recommended development flow.
 - [Migration: Removing Legacy Modes](migration_bc_removal.md): Update code for Runner/CLI/Gateway changes.
+- [Migration: BLAKE3 NodeID](migration_nodeid_blake3.md): Update NodeID hashing and remove ``world_id`` inputs.
 
 {{ nav_links() }}
 

--- a/docs/guides/migration_nodeid_blake3.md
+++ b/docs/guides/migration_nodeid_blake3.md
@@ -1,0 +1,25 @@
+---
+title: "Migration: BLAKE3 NodeID"
+tags: [migration]
+author: "QMTL Team"
+last_modified: 2025-09-07
+---
+
+{{ nav_links() }}
+
+# Migration: BLAKE3 NodeID
+
+The NodeID algorithm now uses BLAKE3 with a mandatory `blake3:` prefix and no longer includes `world_id`. Legacy SHA-based IDs are temporarily accepted but deprecated.
+
+## Changes
+
+- `compute_node_id` now returns `blake3:<digest>` computed from `(node_type, code_hash, config_hash, schema_hash)` without `world_id`.
+- Legacy IDs can be produced via `compute_legacy_node_id` and are accepted by the Gateway during the deprecation window.
+
+## Actions
+
+- Remove `world_id` arguments from `compute_node_id` calls.
+- Update stored NodeIDs to the new `blake3:` form.
+- Plan migration away from `compute_legacy_node_id`; support will be removed in a future release.
+
+{{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       - SDK Tutorial & World ID: guides/sdk_tutorial.md
       - Strategy Workflow: guides/strategy_workflow.md
       - Migration (BC Removal): guides/migration_bc_removal.md
+      - Migration (NodeID BLAKE3): guides/migration_nodeid_blake3.md
       - Python Environment: guides/python_environment.md
       - HTTPX Usage: guides/httpx_usage.md
   - Operations:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "opentelemetry-instrumentation-httpx",
     "opentelemetry-instrumentation-grpc",
     "cachetools",
+    "blake3",
 ]
 
 [project.optional-dependencies]

--- a/qmtl/common/__init__.py
+++ b/qmtl/common/__init__.py
@@ -13,7 +13,7 @@ def crc32_of_list(items: Iterable[str]) -> int:
 from .reconnect import ReconnectingRedis, ReconnectingNeo4j
 from .circuit_breaker import AsyncCircuitBreaker
 from .four_dim_cache import FourDimCache
-from .nodeid import compute_node_id
+from .nodeid import compute_node_id, compute_legacy_node_id
 
 __all__ = [
     "crc32_of_list",
@@ -22,4 +22,5 @@ __all__ = [
     "AsyncCircuitBreaker",
     "FourDimCache",
     "compute_node_id",
+    "compute_legacy_node_id",
 ]

--- a/qmtl/common/nodeid.py
+++ b/qmtl/common/nodeid.py
@@ -5,8 +5,37 @@ from __future__ import annotations
 import hashlib
 from typing import Iterable
 
+from blake3 import blake3
+
 
 def compute_node_id(
+    node_type: str,
+    code_hash: str,
+    config_hash: str,
+    schema_hash: str,
+    existing_ids: Iterable[str] | None = None,
+) -> str:
+    """Return canonical BLAKE3-based NodeID with ``blake3:`` prefix.
+
+    Parameters
+    ----------
+    node_type, code_hash, config_hash, schema_hash : str
+        Components defining the node.
+    existing_ids : Iterable[str] | None
+        Previously generated IDs to detect collisions. If the computed digest
+        already exists in this set, a different digest is produced by hashing
+        a domain-separated payload.
+    """
+    data = f"{node_type}:{code_hash}:{config_hash}:{schema_hash}".encode()
+    digest = blake3(data).hexdigest()
+    node_id = f"blake3:{digest}"
+    if existing_ids and node_id in set(existing_ids):
+        digest = blake3(data + b"|1").hexdigest()
+        node_id = f"blake3:{digest}"
+    return node_id
+
+
+def compute_legacy_node_id(
     node_type: str,
     code_hash: str,
     config_hash: str,
@@ -14,19 +43,11 @@ def compute_node_id(
     world_id: str,
     existing_ids: Iterable[str] | None = None,
 ) -> str:
-    """Return deterministic node ID with SHA-256 and SHA-3 fallback.
+    """Return legacy SHA-256/sha3 NodeID that includes ``world_id``.
 
-    Parameters
-    ----------
-    node_type, code_hash, config_hash, schema_hash : str
-        Components defining the node.
-    world_id : str
-        Identifier of the world this node belongs to.
-    existing_ids : Iterable[str] | None
-        Previously generated IDs to detect collisions. If the computed SHA-256
-        hash already exists in this set, SHA-3-256 is used instead.
+    This is provided for temporary compatibility while migrating to the
+    canonical BLAKE3 NodeID.
     """
-    # Include world_id to guarantee isolation across worlds
     data = f"{world_id}:{node_type}:{code_hash}:{config_hash}:{schema_hash}".encode()
     try:
         sha = hashlib.sha256(data).hexdigest()
@@ -38,4 +59,4 @@ def compute_node_id(
     return sha
 
 
-__all__ = ["compute_node_id"]
+__all__ = ["compute_node_id", "compute_legacy_node_id"]

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -80,7 +80,11 @@ def create_api_router(
                 detail={"code": "E_SCHEMA_INVALID", "errors": verrors},
             )
 
-        from qmtl.common import crc32_of_list, compute_node_id
+        from qmtl.common import (
+            crc32_of_list,
+            compute_node_id,
+            compute_legacy_node_id,
+        )
 
         crc = crc32_of_list(n.get("node_id") for n in dag.get("nodes", []))
         if crc != payload.node_ids_crc32:
@@ -102,8 +106,11 @@ def create_api_router(
             )
             if not all(required):
                 continue
-            expected = compute_node_id(*required, payload.world_id or "")
-            if node.get("node_id") != expected:
+            expected = compute_node_id(*required)
+            legacy = compute_legacy_node_id(
+                *required, payload.world_id or ""
+            )
+            if node.get("node_id") not in {expected, legacy}:
                 mismatches.append(
                     {"index": idx, "node_id": node.get("node_id", ""), "expected": expected}
                 )

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -521,7 +521,6 @@ class Node:
             self.code_hash,
             self.config_hash,
             self.schema_hash,
-            self.world_id or "",
         )
 
     # --- runtime cache handling -----------------------------------------

--- a/tests/test_dagmanager.py
+++ b/tests/test_dagmanager.py
@@ -1,22 +1,29 @@
-from qmtl.dagmanager import compute_node_id
-from qmtl.dagmanager.neo4j_init import get_schema_queries
+from blake3 import blake3
 import hashlib
 
+from qmtl.dagmanager import compute_node_id
+from qmtl.common import compute_legacy_node_id
+from qmtl.dagmanager.neo4j_init import get_schema_queries
 
-def test_compute_node_id_sha256():
-    node_id = compute_node_id("type", "code", "cfg", "schema", "w1")
+
+def test_compute_node_id_blake3():
+    node_id = compute_node_id("type", "code", "cfg", "schema")
+    expected = blake3(b"type:code:cfg:schema").hexdigest()
+    assert node_id == f"blake3:{expected}"
+
+
+def test_compute_node_id_collision():
+    data = ("A", "B", "C", "D")
+    first = compute_node_id(*data)
+    second = compute_node_id(*data, existing_ids={first})
+    assert first != second
+    assert second.startswith("blake3:")
+
+
+def test_compute_legacy_node_id_sha256():
+    node_id = compute_legacy_node_id("type", "code", "cfg", "schema", "w1")
     expected = hashlib.sha256(b"w1:type:code:cfg:schema").hexdigest()
     assert node_id == expected
-
-
-def test_compute_node_id_sha3_fallback():
-    data = ("A", "B", "C", "D", "W")
-    sha256_id = compute_node_id(*data)
-    # same components would normally yield the same sha256, but the existing id
-    # forces a fallback to sha3
-    second_id = compute_node_id(*data, existing_ids={sha256_id})
-    expected = hashlib.sha3_256(b"W:A:B:C:D").hexdigest()
-    assert second_id == expected
 
 
 def test_schema_queries():

--- a/tests/test_node_id.py
+++ b/tests/test_node_id.py
@@ -3,7 +3,8 @@ from qmtl.sdk import SourceNode, ProcessingNode, StreamInput, Strategy
 def test_node_id_generation():
     node = SourceNode(compute_fn=lambda x: x, name="n", interval="1s", period=1)
     node_id = node.node_id
-    assert len(node_id) == 64
+    assert node_id.startswith("blake3:")
+    assert len(node_id) == 71
     assert node_id == node.node_id  # deterministic
 
 
@@ -20,4 +21,4 @@ def test_strategy_serialize():
     dag = s.serialize()
     assert "nodes" in dag
     ids = [n["node_id"] for n in dag["nodes"]]
-    assert all(len(i) == 64 for i in ids)
+    assert all(i.startswith("blake3:") for i in ids)

--- a/tests/test_world_scope.py
+++ b/tests/test_world_scope.py
@@ -6,11 +6,11 @@ from qmtl.gateway.dagmanager_client import DagManagerClient
 
 
 @pytest.mark.asyncio
-async def test_world_scoping_changes_ids_and_topics(monkeypatch):
-    data = ("T", "code", "cfg", "schema", "w1")
+async def test_world_scoping_topics(monkeypatch):
+    data = ("T", "code", "cfg", "schema")
     nid1 = compute_node_id(*data)
-    nid2 = compute_node_id("T", "code", "cfg", "schema", "w2")
-    assert nid1 != nid2
+    nid2 = compute_node_id(*data)
+    assert nid1 == nid2
 
     client = DagManagerClient("dummy")
 


### PR DESCRIPTION
## Summary
- use BLAKE3 for canonical NodeIDs and remove world_id input
- accept legacy SHA-based IDs in Gateway for migration
- document NodeID migration and update docs navigation

## Testing
- `uv run mkdocs build`
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: unclosed event loop warnings in tests)*


------
https://chatgpt.com/codex/tasks/task_e_68bda4b3a83483298cec55251b30d34a