### PR TITLE
Expand execution model with open-order state machine and TIF support

### DIFF
--- a/docs/architecture/execution_state.md
+++ b/docs/architecture/execution_state.md
@@ -27,11 +27,24 @@ stateDiagram-v2
     PARTIALLY_FILLED --> EXPIRED: tif window end
 ```
 
+## State Transitions
+
+| Current           | Event                     | Next              |
+|-------------------|---------------------------|-------------------|
+| NEW               | fill(q < qty)             | PARTIALLY_FILLED  |
+| NEW               | fill(q == qty)            | FILLED            |
+| NEW               | cancel()                  | CANCELED          |
+| NEW               | tif unmet                 | EXPIRED           |
+| PARTIALLY_FILLED  | fill(q < remaining)       | PARTIALLY_FILLED  |
+| PARTIALLY_FILLED  | fill(q == remaining)      | FILLED            |
+| PARTIALLY_FILLED  | cancel()                  | CANCELED          |
+| PARTIALLY_FILLED  | tif window end            | EXPIRED           |
+
 ## TIF Examples
 
 - GTC: Remaining quantity carries over across bars until filled or canceled.
-- IOC: Immediately attempt to fill; any remainder is canceled.
-- FOK: Fill entire order immediately or cancel the order; no partial fills persist.
+- IOC: Immediately attempt to fill; any remainder is canceled and the order moves to **EXPIRED**.
+- FOK: Fill entire order immediately or cancel the order; if not fully filled in one attempt the order transitions to **EXPIRED** with zero fills.
 
 See also: [Brokerage API](../reference/api/brokerage.md) and [Lean Brokerage Model](lean_brokerage_model.md).
 


### PR DESCRIPTION
## Summary
- model open orders with TimeInForce policies and state tracking
- add unit tests for GTC partial fills and IOC/FOK behavior
- document execution state transitions and TIF examples

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: multiple unraisable exception warnings)*
- `uv run mkdocs build`

Fixes #790

------
https://chatgpt.com/codex/tasks/task_e_68bdcc3a647c8329bc3d11287dd1a083