### PR TITLE
feat: add exchange calendar lunch breaks and early close support

### DIFF
--- a/docs/operations/exchange_calendars.md
+++ b/docs/operations/exchange_calendars.md
@@ -1,0 +1,42 @@
+---
+title: "Exchange Calendars"
+tags: [timing]
+author: "QMTL Team"
+last_modified: 2025-09-08
+---
+
+{{ nav_links() }}
+
+# Exchange Calendars
+
+This guide lists example trading hours for several common exchanges and shows how
+to configure `MarketHours` with lunch breaks and early closes.
+
+| Exchange | Pre-Market | Regular Hours | Lunch Break | Post-Market | Timezone |
+|----------|------------|---------------|-------------|-------------|----------|
+| NYSE/NASDAQ | 04:00 | 09:30–16:00 | — | 16:00–20:00 | US/Eastern |
+| CME | — | 09:30–16:00 | — | 16:00–16:15 | US/Central |
+| JPX | — | 09:00–11:30 / 12:30–15:00 | 11:30–12:30 | — | Asia/Tokyo |
+| KRX | — | 09:00–11:30 / 12:30–15:30 | 11:30–12:30 | — | Asia/Seoul |
+
+```python
+from datetime import date, time
+from qmtl.sdk.timing_controls import MarketHours
+
+hours = MarketHours(
+    pre_market_start=time(4, 0),
+    regular_start=time(9, 30),
+    regular_end=time(16, 0),
+    post_market_end=time(20, 0),
+    lunch_start=time(11, 30),
+    lunch_end=time(12, 30),
+    early_closes={date(2024, 12, 24): time(13, 0)},
+)
+```
+
+Use `lunch_start` and `lunch_end` to mark midday closures. `early_closes` maps
+specific dates to early `regular_end` times.
+
+{{ nav_links() }}
+
+

--- a/docs/operations/timing_controls.md
+++ b/docs/operations/timing_controls.md
@@ -17,13 +17,16 @@ This document outlines the timing utilities available in QMTL for managing marke
 
 ```python
 from qmtl.sdk.timing_controls import MarketHours, MarketSession
-from datetime import datetime, time, timezone
+from datetime import date, datetime, time, timezone
 
 hours = MarketHours(
     pre_market_start=time(4, 0),
     regular_start=time(9, 30),
     regular_end=time(16, 0),
-    post_market_end=time(20, 0)
+    post_market_end=time(20, 0),
+    lunch_start=time(11, 30),
+    lunch_end=time(12, 30),
+    early_closes={date(2024, 12, 24): time(13, 0)},
 )
 
 # Wednesday 10:00 AM UTC
@@ -31,6 +34,10 @@ ts = datetime(2024, 1, 3, 10, 0, tzinfo=timezone.utc)
 session = hours.get_session(ts)
 assert session is MarketSession.REGULAR
 ```
+
+Lunch breaks and one-off early closes can be configured using `lunch_start`,
+`lunch_end`, and the `early_closes` mapping. See [Exchange Calendars](exchange_calendars.md)
+for example hours across major markets.
 
 ## TimingController
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - World Activation Runbook: operations/activation.md
       - Risk Management: operations/risk_management.md
       - Timing Controls: operations/timing_controls.md
+      - Exchange Calendars: operations/exchange_calendars.md
       - Release: operations/release.md
       - CI: operations/ci.md
   - Reference:

--- a/qmtl/examples/tests/test_rebalance_strategy.py
+++ b/qmtl/examples/tests/test_rebalance_strategy.py
@@ -29,6 +29,9 @@ def test_compute_rebalance_quantity_progresses_toward_target():
     assert math.isclose(qty, 5.0)
     p.apply_fill("AAPL", quantity=qty, price=50.0)
 
+    # Update market price for subsequent sizing
+    p.positions["AAPL"].market_price = 60.0
+
     # Now target 50% weight at new price $60
     # Portfolio value: cash 1_000 - 250 = 750 + market 5 * 60 = 300 => 1,050
     # Desired value 50% * 1,050 = 525; current value 5 * 60 = 300; delta = 225 -> 3.75 shares

--- a/qmtl/sdk/timing_controls.py
+++ b/qmtl/sdk/timing_controls.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, time, timezone
-from typing import Optional, Tuple
+from datetime import date, datetime, time, timezone
+from typing import Dict, Optional, Tuple
 from dataclasses import dataclass
 from enum import Enum
 
@@ -13,8 +13,10 @@ logger = logging.getLogger(__name__)
 
 class MarketSession(str, Enum):
     """Market session types."""
+
     PRE_MARKET = "pre_market"
     REGULAR = "regular"
+    LUNCH = "lunch"
     POST_MARKET = "post_market"
     CLOSED = "closed"
 
@@ -22,31 +24,44 @@ class MarketSession(str, Enum):
 @dataclass
 class MarketHours:
     """Market hours configuration."""
-    
+
     pre_market_start: time
     regular_start: time
     regular_end: time
     post_market_end: time
+    lunch_start: Optional[time] = None
+    lunch_end: Optional[time] = None
+    early_closes: Optional[Dict[date, time]] = None
     timezone: str = "US/Eastern"
-    
+
     def get_session(self, timestamp: datetime) -> MarketSession:
         """Determine market session for a given timestamp."""
         # Convert timestamp to market timezone
         if timestamp.tzinfo is None:
             timestamp = timestamp.replace(tzinfo=timezone.utc)
-        
+
         # Convert to market time (simplified - assumes US/Eastern)
         market_time = timestamp.time()
-        
+
+        regular_end = self.regular_end
+        if self.early_closes and timestamp.date() in self.early_closes:
+            regular_end = self.early_closes[timestamp.date()]
+
         # Check if it's a weekend (simplified)
         if timestamp.weekday() >= 5:  # Saturday = 5, Sunday = 6
             return MarketSession.CLOSED
-        
+
         if market_time < self.pre_market_start:
             return MarketSession.CLOSED
         elif market_time < self.regular_start:
             return MarketSession.PRE_MARKET
-        elif market_time <= self.regular_end:
+        elif market_time <= regular_end:
+            if (
+                self.lunch_start
+                and self.lunch_end
+                and self.lunch_start <= market_time < self.lunch_end
+            ):
+                return MarketSession.LUNCH
             return MarketSession.REGULAR
         elif market_time <= self.post_market_end:
             return MarketSession.POST_MARKET
@@ -56,7 +71,7 @@ class MarketHours:
 
 class TimingController:
     """Controls timing aspects of trade execution."""
-    
+
     def __init__(
         self,
         *,
@@ -67,7 +82,7 @@ class TimingController:
         require_regular_hours: bool = False,
     ):
         """Initialize timing controller.
-        
+
         Parameters
         ----------
         market_hours : MarketHours, optional
@@ -82,46 +97,52 @@ class TimingController:
             Whether to require regular market hours for execution.
         """
         self.market_hours = market_hours or MarketHours(
-            pre_market_start=time(4, 0),     # 4:00 AM
-            regular_start=time(9, 30),       # 9:30 AM
-            regular_end=time(16, 0),         # 4:00 PM
-            post_market_end=time(20, 0),     # 8:00 PM
+            pre_market_start=time(4, 0),  # 4:00 AM
+            regular_start=time(9, 30),  # 9:30 AM
+            regular_end=time(16, 0),  # 4:00 PM
+            post_market_end=time(20, 0),  # 8:00 PM
         )
         self.min_execution_delay_ms = min_execution_delay_ms
         self.max_execution_delay_ms = max_execution_delay_ms
         self.allow_pre_post_market = allow_pre_post_market
         self.require_regular_hours = require_regular_hours
-    
+
     def validate_timing(self, timestamp: datetime) -> Tuple[bool, str, MarketSession]:
         """Validate if execution is allowed at given timestamp.
-        
+
         Returns
         -------
         Tuple[bool, str, MarketSession]
             (is_valid, reason, market_session)
         """
         session = self.market_hours.get_session(timestamp)
-        
-        if session == MarketSession.CLOSED:
-            return False, "Market is closed", session
-        
+
+        if session in {MarketSession.CLOSED, MarketSession.LUNCH}:
+            reason = "Market is closed"
+            if session is MarketSession.LUNCH:
+                reason = "Market closed for lunch"
+            return False, reason, session
+
         if self.require_regular_hours and session != MarketSession.REGULAR:
             return False, "Regular market hours required", session
-        
-        if not self.allow_pre_post_market and session in [MarketSession.PRE_MARKET, MarketSession.POST_MARKET]:
+
+        if not self.allow_pre_post_market and session in [
+            MarketSession.PRE_MARKET,
+            MarketSession.POST_MARKET,
+        ]:
             return False, "Pre/post market trading not allowed", session
-        
+
         return True, "Valid timing", session
-    
+
     def calculate_execution_delay(
-        self, 
+        self,
         timestamp: datetime,
         order_size: float,
         market_session: MarketSession,
-        base_delay_ms: Optional[int] = None
+        base_delay_ms: Optional[int] = None,
     ) -> int:
         """Calculate realistic execution delay based on market conditions.
-        
+
         Parameters
         ----------
         timestamp : datetime
@@ -132,7 +153,7 @@ class TimingController:
             Current market session.
         base_delay_ms : int, optional
             Base delay to add to. If None, uses min_execution_delay_ms.
-            
+
         Returns
         -------
         int
@@ -140,76 +161,76 @@ class TimingController:
         """
         if base_delay_ms is None:
             base_delay_ms = self.min_execution_delay_ms
-        
+
         # Base delay
         delay = base_delay_ms
-        
+
         # Add delay for market session
         if market_session == MarketSession.PRE_MARKET:
             delay += 100  # Higher latency in pre-market
         elif market_session == MarketSession.POST_MARKET:
             delay += 150  # Higher latency in post-market
-        
+
         # Add delay based on order size (larger orders take longer)
         if order_size > 10000:
             delay += 200  # Large order penalty
         elif order_size > 1000:
-            delay += 50   # Medium order penalty
-        
+            delay += 50  # Medium order penalty
+
         # Ensure within bounds
-        delay = max(self.min_execution_delay_ms, min(delay, self.max_execution_delay_ms))
-        
+        delay = max(
+            self.min_execution_delay_ms, min(delay, self.max_execution_delay_ms)
+        )
+
         return delay
-    
+
     def get_next_valid_execution_time(
-        self, 
-        timestamp: datetime,
-        look_ahead_hours: int = 24
+        self, timestamp: datetime, look_ahead_hours: int = 24
     ) -> Optional[datetime]:
         """Find next valid execution time if current time is invalid.
-        
+
         Parameters
         ----------
         timestamp : datetime
             Current timestamp.
         look_ahead_hours : int
             Hours to look ahead for valid execution time.
-            
+
         Returns
         -------
         Optional[datetime]
             Next valid execution time, or None if none found.
         """
         from datetime import timedelta
-        
+
         current = timestamp
         end_time = timestamp + timedelta(hours=look_ahead_hours)
-        
+
         # Start by checking every 30 minutes for the first few hours,
         # then every hour to cover more ground
         increment = timedelta(minutes=30)
-        
+
         while current <= end_time:
             is_valid, _, _ = self.validate_timing(current)
             if is_valid:
                 return current
-            
+
             current += increment
-            
+
             # After 6 hours, switch to hourly increments
             if current > timestamp + timedelta(hours=6):
                 increment = timedelta(hours=1)
-        
+
         return None
 
 
 def validate_backtest_timing(
     strategy,
     timing_controller: Optional[TimingController] = None,
-    fail_on_invalid_timing: bool = False
+    fail_on_invalid_timing: bool = False,
 ) -> dict[str, list]:
     """Validate timing of all data points in strategy for realistic execution.
-    
+
     Parameters
     ----------
     strategy : Strategy
@@ -218,55 +239,61 @@ def validate_backtest_timing(
         Timing controller for validation. Uses default if None.
     fail_on_invalid_timing : bool
         Whether to raise exception on invalid timing.
-        
+
     Returns
     -------
     dict[str, list]
         Mapping from node name to list of invalid timing issues.
-        
+
     Raises
     ------
     ValueError
         If fail_on_invalid_timing=True and invalid timing found.
     """
     from .node import StreamInput
-    
+
     controller = timing_controller or TimingController()
     issues = {}
-    
+
     for node in strategy.nodes:
         if isinstance(node, StreamInput) and node.interval is not None:
             node_issues = []
-            
+
             # Get cached data
             cache_snapshot = node.cache._snapshot()
-            
+
             for upstream_id, intervals in cache_snapshot.items():
                 if node.interval in intervals:
                     interval_data = intervals[node.interval]
-                    
+
                     for timestamp_ms, data in interval_data:
                         # Convert timestamp to datetime
-                        timestamp = datetime.fromtimestamp(timestamp_ms / 1000.0, tz=timezone.utc)
-                        
+                        timestamp = datetime.fromtimestamp(
+                            timestamp_ms / 1000.0, tz=timezone.utc
+                        )
+
                         # Validate timing
-                        is_valid, reason, session = controller.validate_timing(timestamp)
-                        
+                        is_valid, reason, session = controller.validate_timing(
+                            timestamp
+                        )
+
                         if not is_valid:
-                            node_issues.append({
-                                "timestamp": timestamp_ms,
-                                "reason": reason,
-                                "session": session.value,
-                                "datetime": timestamp.isoformat()
-                            })
-            
+                            node_issues.append(
+                                {
+                                    "timestamp": timestamp_ms,
+                                    "reason": reason,
+                                    "session": session.value,
+                                    "datetime": timestamp.isoformat(),
+                                }
+                            )
+
             if node_issues:
                 issues[node.name or node.node_id] = node_issues
-                
+
                 if fail_on_invalid_timing:
                     raise ValueError(
                         f"Invalid timing found in node '{node.name or node.node_id}': "
                         f"{len(node_issues)} issues detected"
                     )
-    
+
     return issues

--- a/tests/test_timing_controls_dst.py
+++ b/tests/test_timing_controls_dst.py
@@ -21,7 +21,11 @@ def test_dst_boundary_does_not_break_session_detection():
     # Monday after DST change (still considered regular day)
     t2 = datetime(2024, 3, 11, 14, 0, tzinfo=timezone.utc)  # Monday
     ok, _, sess = ctrl.validate_timing(t2)
-    assert sess in {MarketSession.PRE_MARKET, MarketSession.REGULAR, MarketSession.POST_MARKET}
+    assert sess in {
+        MarketSession.PRE_MARKET,
+        MarketSession.REGULAR,
+        MarketSession.POST_MARKET,
+    }
 
 
 def test_early_close_behaves_as_post_market_after_cutoff():
@@ -32,10 +36,25 @@ def test_early_close_behaves_as_post_market_after_cutoff():
         regular_end=time(13, 0),  # early close
         post_market_end=time(17, 0),
     )
-    ctrl = TimingController(market_hours=hours, allow_pre_post_market=True)
+    ctrl = TimingController(market_hours=hours, require_regular_hours=True)
 
-    # At 14:00 on a weekday, session should be post-market under early close
+    # At 14:00 on a weekday, order should be rejected as post-market under early close
     t = datetime(2024, 1, 3, 14, 0, tzinfo=timezone.utc)  # Wednesday
     ok, _, sess = ctrl.validate_timing(t)
-    assert ok and sess == MarketSession.POST_MARKET
+    assert not ok and sess == MarketSession.POST_MARKET
 
+
+def test_lunch_break_results_in_closed_session():
+    hours = MarketHours(
+        pre_market_start=time(4, 0),
+        regular_start=time(9, 30),
+        regular_end=time(16, 0),
+        post_market_end=time(20, 0),
+        lunch_start=time(11, 30),
+        lunch_end=time(12, 30),
+    )
+    ctrl = TimingController(market_hours=hours)
+
+    t = datetime(2024, 1, 3, 12, 0, tzinfo=timezone.utc)  # Wednesday
+    ok, _, sess = ctrl.validate_timing(t)
+    assert not ok and sess == MarketSession.LUNCH


### PR DESCRIPTION
## Summary
- handle lunch sessions and per-day early closes in `MarketHours`
- reject trades during lunch and validate early close days
- document exchange calendars and link from timing controls

## Testing
- `uv run scripts/check_doc_sync.py` *(fails: Docs listed but missing, annotations not registered)*
- `uv run mkdocs build`
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: ExceptionGroup: multiple unraisable exception warnings)*

Closes #793

------
https://chatgpt.com/codex/tasks/task_e_68be99f01e4083299cdc5c7ce5d2c31a