### PR TITLE
Add maker/taker fee model for brokerage

### DIFF
--- a/docs/reference/api/brokerage.md
+++ b/docs/reference/api/brokerage.md
@@ -2,7 +2,7 @@
 title: "Brokerage API"
 tags: [api]
 author: "QMTL Team"
-last_modified: 2025-09-04
+last_modified: 2025-09-07
 ---
 
 {{ nav_links() }}
@@ -18,7 +18,7 @@ Legacy shortcuts under `qmtl.brokerage.simple` have been removed. See [Migration
 - Interfaces: BuyingPowerModel, FillModel, SlippageModel, FeeModel
 - Fill models: MarketFillModel, LimitFillModel, StopMarketFillModel, StopLimitFillModel (IOC/FOK supported via TIF)
 - Slippage models: NullSlippageModel, ConstantSlippageModel, SpreadBasedSlippageModel, VolumeShareSlippageModel
-- Fee models: PerShareFeeModel, PercentFeeModel, CompositeFeeModel, IBKRFeeModel (tiered per-share)
+- Fee models: PerShareFeeModel, PercentFeeModel, MakerTakerFeeModel, TieredExchangeFeeModel, BorrowFeeModel, CompositeFeeModel, IBKRFeeModel (tiered per-share)
 - Providers: SymbolPropertiesProvider (tick/lot/min), ExchangeHoursProvider (regular/pre/post), ShortableProvider
 - Profiles: BrokerageProfile, SecurityInitializer, ibkr_equities_like_profile()
 
@@ -52,6 +52,7 @@ from qmtl.brokerage import (
     CashBuyingPowerModel,
     MarketFillModel,
     PerShareFeeModel,
+    MakerTakerFeeModel,
     NullSlippageModel,
     SymbolPropertiesProvider,
     ExchangeHoursProvider,
@@ -59,7 +60,7 @@ from qmtl.brokerage import (
 
 model = BrokerageModel(
     CashBuyingPowerModel(),
-    PerShareFeeModel(fee_per_share=0.005, minimum=1.0),
+    MakerTakerFeeModel(maker_rate=0.0002, taker_rate=0.0007),
     NullSlippageModel(),
     MarketFillModel(),
     symbols=SymbolPropertiesProvider(),
@@ -70,6 +71,18 @@ model = BrokerageModel(
 from qmtl.brokerage import IBKRFeeModel
 fee = IBKRFeeModel(minimum=1.0)
 ```
+
+### Fee Model Matrix
+
+| Model | Basis | Notes |
+| --- | --- | --- |
+| PercentFeeModel | % of notional | Rate with minimum |
+| PerShareFeeModel | per share | Optional min/max |
+| MakerTakerFeeModel | % of notional | Separate maker/taker rates |
+| TieredExchangeFeeModel | % of notional | Rate determined by notional tiers |
+| BorrowFeeModel | % of notional | Applied on short sales |
+| IBKRFeeModel | per share | Tiered per-share schedule |
+| CompositeFeeModel | n/a | Sum multiple fee models |
 
 ## Time-in-Force and Order Types
 
@@ -89,6 +102,5 @@ model = profile.build()
 
 - See `tests/test_brokerage_orders_tif.py` for TIF and crossing logic.
 - See `tests/test_brokerage_extras.py` for shortable/profile usage.
-```
 
 {{ nav_links() }}

--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -14,7 +14,15 @@ from .fill_models import (
     StopLimitFillModel,
     UnifiedFillModel,
 )
-from .fees import PerShareFeeModel, PercentFeeModel, CompositeFeeModel, IBKRFeeModel
+from .fees import (
+    PerShareFeeModel,
+    PercentFeeModel,
+    CompositeFeeModel,
+    IBKRFeeModel,
+    MakerTakerFeeModel,
+    TieredExchangeFeeModel,
+    BorrowFeeModel,
+)
 from .slippage import (
     NullSlippageModel,
     ConstantSlippageModel,
@@ -46,6 +54,9 @@ __all__ = [
     "PercentFeeModel",
     "CompositeFeeModel",
     "IBKRFeeModel",
+    "MakerTakerFeeModel",
+    "TieredExchangeFeeModel",
+    "BorrowFeeModel",
     "NullSlippageModel",
     "ConstantSlippageModel",
     "SpreadBasedSlippageModel",

--- a/qmtl/examples/strategies/rebalance_strategy.py
+++ b/qmtl/examples/strategies/rebalance_strategy.py
@@ -37,6 +37,9 @@ def compute_rebalance_quantity(
     price: float
         Current execution price used for sizing.
     """
+    pos = portfolio.get_position(symbol)
+    if pos is not None:
+        pos.market_price = price
     return pf.order_target_percent(portfolio, symbol, target_weight, price)
 
 

--- a/tests/test_brokerage_maker_taker_fee.py
+++ b/tests/test_brokerage_maker_taker_fee.py
@@ -1,0 +1,43 @@
+"""Tests for maker/taker fee model."""
+
+import pytest
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashBuyingPowerModel,
+    ImmediateFillModel,
+    MakerTakerFeeModel,
+    NullSlippageModel,
+    Order,
+    OrderType,
+)
+
+
+def test_maker_taker_fee_affects_pnl():
+    maker_account = Account(cash=10000)
+    taker_account = Account(cash=10000)
+    fee_model = MakerTakerFeeModel(maker_rate=0.001, taker_rate=0.002)
+    brokerage = BrokerageModel(
+        CashBuyingPowerModel(),
+        fee_model,
+        NullSlippageModel(),
+        ImmediateFillModel(),
+    )
+
+    limit_order = Order(
+        symbol="AAPL",
+        quantity=10,
+        price=100,
+        type=OrderType.LIMIT,
+        limit_price=100,
+    )
+    market_order = Order(symbol="AAPL", quantity=10, price=100, type=OrderType.MARKET)
+
+    fill_maker = brokerage.execute_order(maker_account, limit_order, market_price=100)
+    fill_taker = brokerage.execute_order(taker_account, market_order, market_price=100)
+
+    assert fill_taker.fee > fill_maker.fee
+    assert maker_account.cash - taker_account.cash == pytest.approx(
+        fill_taker.fee - fill_maker.fee
+    )


### PR DESCRIPTION
## Summary
- support maker/taker fees and tiered exchange/borrow fee models
- document available fee models and maker/taker usage
- update rebalance helper to mark positions with latest price

## Testing
- `uv run --with mkdocs --with mkdocs-material --with mkdocs-macros-plugin --with mkdocs-breadcrumbs-plugin mkdocs build`
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout --with pytest-asyncio --with fakeredis -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run --with pytest-asyncio --with fakeredis --with pytest-xdist -m pytest -W error -n auto -W ignore::pytest.PytestUnraisableExceptionWarning`

Closes #794

------
https://chatgpt.com/codex/tasks/task_e_68be99f793088329ba8931e2196ebb5d