### PR TITLE
feat: add strategy lifecycle hooks

### DIFF
--- a/docs/guides/strategy_callbacks.md
+++ b/docs/guides/strategy_callbacks.md
@@ -1,0 +1,35 @@
+# Strategy Callbacks
+
+QMTL strategies can react to lifecycle events via optional callbacks on the
+`Strategy` base class. These hooks enable stateful position management without
+embedding imperative logic in the DAG nodes.
+
+## Available Hooks
+
+* `on_start()` – invoked once before the strategy begins processing.
+* `on_signal(signal)` – handle trade signal dictionaries such as those created
+  by `buy_signal`.
+* `on_fill(order, fill)` – update state when an order receives a fill.
+* `on_error(error)` – called if the runner encounters an unrecoverable error.
+* `on_finish()` – executed after the run completes successfully.
+
+## Example
+
+```python
+from qmtl.sdk import Strategy, buy_signal
+
+class MyStrategy(Strategy):
+    def __init__(self):
+        super().__init__(default_interval="1m", default_period=1)
+        self.in_position = False
+
+    def on_signal(self, signal):
+        if signal.get("action") == "BUY":
+            self.in_position = True
+
+    def on_fill(self, order, fill):
+        self.in_position = order.get("action") == "BUY"
+
+    def generate(self, price):
+        return buy_signal(price > 0)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Overview: guides/README.md
       - SDK Tutorial & World ID: guides/sdk_tutorial.md
       - Strategy Workflow: guides/strategy_workflow.md
+      - Strategy Callbacks: guides/strategy_callbacks.md
       - Migration (BC Removal): guides/migration_bc_removal.md
       - Migration (NodeID BLAKE3): guides/migration_nodeid_blake3.md
       - Python Environment: guides/python_environment.md

--- a/qmtl/examples/strategies/callback_state_strategy.py
+++ b/qmtl/examples/strategies/callback_state_strategy.py
@@ -1,0 +1,38 @@
+"""Strategy demonstrating lifecycle callbacks for state management."""
+
+from qmtl.sdk import Strategy, StreamInput, ProcessingNode, buy_signal
+
+
+class CallbackStateStrategy(Strategy):
+    """Simple strategy using callbacks to track position state."""
+
+    def __init__(self):
+        super().__init__(default_interval="1s", default_period=1)
+        self.in_position = False
+
+    def setup(self):
+        price = StreamInput()
+        # Echo node just forwards the latest price
+        echo = ProcessingNode(input=price, compute_fn=lambda v: v, name="echo")
+        self.add_nodes([price, echo])
+
+    def on_start(self) -> None:
+        self.in_position = False
+
+    def on_signal(self, signal) -> None:
+        # Update internal state based on generated signals
+        action = signal.get("action")
+        if action == "BUY":
+            self.in_position = True
+        elif action == "SELL":
+            self.in_position = False
+
+    def on_fill(self, order, fill) -> None:
+        # Sync state when an order fill occurs
+        self.in_position = order.get("action") == "BUY"
+
+    def on_finish(self) -> None:
+        self.in_position = False
+
+
+__all__ = ["CallbackStateStrategy", "buy_signal"]

--- a/qmtl/examples/strategies/rebalance_strategy.py
+++ b/qmtl/examples/strategies/rebalance_strategy.py
@@ -37,6 +37,10 @@ def compute_rebalance_quantity(
     price: float
         Current execution price used for sizing.
     """
+    # Ensure the portfolio reflects the latest price before sizing the order
+    pos = portfolio.get_position(symbol)
+    if pos is not None:
+        pos.market_price = price
     return pf.order_target_percent(portfolio, symbol, target_weight, price)
 
 

--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -12,7 +12,7 @@ from .node import (
 from .arrow_cache import NodeCacheArrow
 from .backfill_state import BackfillState
 from .cache_view import CacheView
-from .strategy import Strategy
+from .strategy import Strategy, buy_signal
 from .runner import Runner
 from .tagquery_manager import TagQueryManager
 from .cli import main as _cli
@@ -66,6 +66,7 @@ __all__ = [
     "BackfillState",
     "CacheView",
     "Strategy",
+    "buy_signal",
     "Runner",
     "TagQueryManager",
     "WebSocketClient",

--- a/qmtl/sdk/strategy.py
+++ b/qmtl/sdk/strategy.py
@@ -38,6 +38,23 @@ class Strategy:
 
         self.nodes.extend(nodes)
 
+    # ------------------------------------------------------------------
+    # Lifecycle hooks ---------------------------------------------------
+    def on_start(self) -> None:  # pragma: no cover - default no-op
+        """Called once when the strategy begins running."""
+
+    def on_signal(self, signal) -> None:  # pragma: no cover - default no-op
+        """Handle a generated trading signal."""
+
+    def on_fill(self, order, fill) -> None:  # pragma: no cover - default no-op
+        """Handle an order fill event."""
+
+    def on_error(self, error: Exception) -> None:  # pragma: no cover - default no-op
+        """Handle an unrecoverable error during execution."""
+
+    def on_finish(self) -> None:  # pragma: no cover - default no-op
+        """Called when the strategy run completes."""
+
     def setup(self):
         raise NotImplementedError
 
@@ -47,3 +64,19 @@ class Strategy:
         return {
             "nodes": [node.to_dict() for node in self.nodes],
         }
+
+
+def buy_signal(condition: bool, target_percent: float = 1.0) -> dict:
+    """Convenience helper to create a BUY/HOLD signal.
+
+    Parameters
+    ----------
+    condition:
+        If ``True`` a BUY action is returned; otherwise ``HOLD``.
+    target_percent:
+        Target portfolio percentage when buying.
+    """
+
+    if condition:
+        return {"action": "BUY", "target_percent": float(target_percent)}
+    return {"action": "HOLD"}

--- a/tests/test_strategy_callbacks.py
+++ b/tests/test_strategy_callbacks.py
@@ -1,0 +1,68 @@
+import pytest
+
+from qmtl.sdk import Strategy, StreamInput, ProcessingNode, Runner, buy_signal
+
+
+class CallbackStrategy(Strategy):
+    def __init__(self):
+        super().__init__(default_interval="1s", default_period=1)
+        self.events = []
+
+    def setup(self):
+        src = StreamInput()
+        node = ProcessingNode(input=src, compute_fn=lambda v: v, name="n")
+        self.add_nodes([src, node])
+
+    def on_start(self):
+        self.events.append("start")
+
+    def on_finish(self):
+        self.events.append("finish")
+
+
+class ErrorStrategy(Strategy):
+    instances = []
+
+    def __init__(self):
+        super().__init__(default_interval="1s", default_period=1)
+        self.error = None
+        ErrorStrategy.instances.append(self)
+
+    def setup(self):
+        src = StreamInput()
+        node = ProcessingNode(input=src, compute_fn=lambda v: v, name="n")
+        self.add_nodes([src, node])
+
+    def on_error(self, exc):
+        self.error = exc
+
+
+def test_lifecycle_hooks_called(monkeypatch):
+    class DummyManager:
+        async def resolve_tags(self, offline=False):
+            return None
+
+    monkeypatch.setattr(
+        "qmtl.sdk.runner.TagManagerService.init",
+        lambda self, strategy, world_id=None: DummyManager(),
+    )
+
+    strategy = Runner.run(CallbackStrategy, world_id="w", gateway_url=None, offline=True)
+    assert strategy.events == ["start", "finish"]
+
+
+def test_on_error_called(monkeypatch):
+    def fail_init(self, strategy, world_id=None):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr("qmtl.sdk.runner.TagManagerService.init", fail_init)
+
+    with pytest.raises(RuntimeError):
+        Runner.run(ErrorStrategy, world_id="w", gateway_url=None, offline=True)
+
+    assert isinstance(ErrorStrategy.instances[-1].error, RuntimeError)
+
+
+def test_buy_signal_builder():
+    assert buy_signal(True, 0.5) == {"action": "BUY", "target_percent": 0.5}
+    assert buy_signal(False, 0.5) == {"action": "HOLD"}


### PR DESCRIPTION
## Summary
- add lifecycle hooks and helper `buy_signal`
- document and showcase callbacks with example strategy
- fix rebalance helper to refresh position prices

## Testing
- `uv run mkdocs build`
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: ExceptionGroup in tests/e2e/test_world_isolation.py)*

Closes #795

------
https://chatgpt.com/codex/tasks/task_e_68be99fd62d48329a17fa0840d9fc290