### PR TITLE
tests(world-smoke): switch mean_rev to Runner.offline; remove dry-run fallback

### DIFF
--- a/.github/ISSUE_DRAFTS/001-rfc-exchange-node-sets.md
+++ b/.github/ISSUE_DRAFTS/001-rfc-exchange-node-sets.md
@@ -1,0 +1,35 @@
+Title: RFC: Exchange Node Sets and Feedback Without Cycles
+Labels: rfc, architecture, execution
+
+Summary
+- Specify how post-signal execution is composed as an exchange-specific Node Set (attachable subgraph) while preserving DAG acyclicity and WS/DM boundaries.
+
+Motivation
+- Strategies need realistic execution with feedback (portfolio/risk/timing). Direct cycles violate DM constraints. We need a standard, reusable pattern.
+
+Scope
+- Finalize design in docs:
+  - docs/architecture/exchange_node_sets.md (added)
+  - docs/reference/api/order_events.md (added)
+- Define node contracts: PreTradeGateNode, SizingNode, ExecutionNode, OrderPublishNode, FillIngestNode, PortfolioNode, RiskControlNode, TimingGateNode.
+- Feedback model: delayed edges (t−1) and/or compacted state topics (trade.portfolio, trade.open_orders).
+- WS/DM role boundaries, portfolio scope (strategy vs world), freeze/drain semantics.
+
+Non‑Goals
+- WS managing orders/fills/portfolio; DM ingesting broker webhooks.
+
+Design Notes
+- Activation gating from WS is enforced; stale → OFF by default.
+- Modes: simulate/paper/live with consistent contracts.
+- Idempotency: Runner key + server-side key; topic partitioning guidance.
+
+Deliverables
+- [x] Architecture doc: exchange_node_sets.md
+- [x] Reference event schemas: order_events.md
+- [ ] Review and sign-off from owners of Gateway/WS/DM
+
+Acceptance Criteria
+- Docs reviewed; responsibilities and data flows unambiguous.
+- No changes required to DM core invariants; WS keeps activation-only role.
+- Clear extension points for new exchanges.
+

--- a/.github/ISSUE_DRAFTS/002-implement-execution-layer-nodes.md
+++ b/.github/ISSUE_DRAFTS/002-implement-execution-layer-nodes.md
@@ -1,0 +1,30 @@
+Title: Implement Execution-Layer Nodes (PreTrade/Sizing/Execution/FillIngest/Portfolio/Risk/Timing)
+Labels: feature, execution, sdk, nodes
+
+Summary
+Implement the node wrappers specified in the RFC so strategies can attach an exchange Node Set after a signal node.
+
+Tasks
+- PreTradeGateNode
+  - Wrap `qmtl/sdk/pretrade.py` and integrate `qmtl/common/pretrade.py` reasons.
+  - Inputs: activation, providers; Output: pass-through or rejection.
+- SizingNode
+  - Use `qmtl/sdk/portfolio.py` helpers (value/percent/target_percent).
+- ExecutionNode
+  - Sim/paper: `qmtl/sdk/execution_modeling.py` + `qmtl/brokerage/*` profile.
+  - Live: pass-through OrderPayload to OrderPublishNode.
+- OrderPublishNode
+  - Reuse existing `TradeOrderPublisherNode` or extend for Node Set metadata.
+- FillIngestNode
+  - StreamInput consuming `trade.fills` topic; normalize shape to `ExecutionFillEvent`.
+- PortfolioNode
+  - Apply fills using `Portfolio.apply_fill`; output compacted snapshots.
+- RiskControlNode, TimingGateNode
+  - Wrap `qmtl/sdk/risk_management.py` and `qmtl/sdk/timing_controls.py`.
+
+Acceptance Criteria
+- Unit tests per node (deterministic inputs → outputs).
+- Offline simulate path produces fills and updates portfolio.
+- Live path can no-op ExecutionNode and rely on FillIngestNode.
+- Docs cross-linked from node classes to architecture.
+

--- a/.github/ISSUE_DRAFTS/003-node-set-ccxt-generic-spot.md
+++ b/.github/ISSUE_DRAFTS/003-node-set-ccxt-generic-spot.md
@@ -1,0 +1,20 @@
+Title: Node Set: CCXT Generic (Spot)
+Labels: feature, connectors, brokerage, ccxt
+
+Summary
+Provide a ready-made Node Set builder for spot exchanges via CCXT, parameterized by exchange id and credentials.
+
+Tasks
+- Builder `CcxtSpotNodeSet.attach(signal_node, world_id, **opts)`
+  - Wires the standard nodes with CCXT `CcxtBrokerageClient`.
+  - Options: `sandbox`, `apiKey/secret`, `time_in_force`, reduceOnly support where applicable.
+- Profiles
+  - Choose sensible defaults for `qmtl/brokerage` profile (slippage/fees/hours).
+- Examples & Docs
+  - Example strategy in `qmtl/examples/strategies/ccxt_spot_nodeset_strategy.py`.
+  - Guidance in docs: link to `docs/architecture/exchange_node_sets.md`.
+
+Acceptance Criteria
+- Demo runs in simulate and (optionally) sandbox live mode with environment vars.
+- Clear failure modes for missing credentials.
+

--- a/.github/ISSUE_DRAFTS/004-node-set-binance-futures-usdtm.md
+++ b/.github/ISSUE_DRAFTS/004-node-set-binance-futures-usdtm.md
@@ -1,0 +1,18 @@
+Title: Node Set: Binance Futures (USDT‑M)
+Labels: feature, connectors, brokerage, futures, ccxt
+
+Summary
+Provide a Futures Node Set via `FuturesCcxtBrokerageClient` with leverage/margin/hedge mode support.
+
+Tasks
+- Builder `BinanceFuturesNodeSet.attach(signal_node, world_id, **opts)`
+  - Options: `leverage`, `margin_mode` (cross/isolated), `hedge_mode`, `sandbox`.
+  - Map `positionSide`, `reduceOnly`, on-the-fly leverage when supported.
+- Profiles
+  - Futures-friendly brokerage profile (fees/slippage/hours) with configurable maker/taker.
+- Examples & Docs
+  - `qmtl/examples/brokerage_demo/ccxt_binance_futures_sandbox_demo.py` linkage.
+
+Acceptance Criteria
+- Simulate and sandbox examples execute and publish orders; fills are ingested into portfolio snapshots.
+

--- a/.github/ISSUE_DRAFTS/005-gateway-fills-webhook-and-kafka.md
+++ b/.github/ISSUE_DRAFTS/005-gateway-fills-webhook-and-kafka.md
@@ -1,0 +1,20 @@
+Title: Gateway: /fills Webhook → Kafka (trade.fills)
+Labels: gateway, feature, security
+
+Summary
+Add an optional webhook on Gateway to accept authenticated fill/cancel events from brokers/executors and forward to `trade.fills`.
+
+Tasks
+- Route: `POST /fills`
+  - Auth: JWT or HMAC signature verification; world-/strategy-scoped RBAC.
+  - Validate against `ExecutionFillEvent` shape; drop/flag unknown fields.
+- Produce to Kafka
+  - Topic `trade.fills`, key `world_id|strategy_id|symbol|order_id`.
+  - Include runtime fingerprint header when possible.
+- Docs & Runbook
+  - Security guidance, example payloads, failure handling.
+
+Acceptance Criteria
+- End-to-end demo: POST → Kafka → FillIngestNode → Portfolio updates.
+- Metrics and structured logs emitted on accept/reject.
+

--- a/.github/ISSUE_DRAFTS/006-runner-pretrade-chain-toggle-and-metrics.md
+++ b/.github/ISSUE_DRAFTS/006-runner-pretrade-chain-toggle-and-metrics.md
@@ -1,0 +1,20 @@
+Title: Runner: Optional Pre‑Trade Chain Toggle + Metrics Standardization
+Labels: sdk, runner, feature
+
+Summary
+Add an opt-in Runner flag to pass `TradeOrderPublisherNode` outputs through a default pre‑trade chain (Activation → PreTrade → Timing → Sizing) before routing, and standardize metrics.
+
+Tasks
+- Runner flag (env or API): `QMTL_PRETRADE_CHAIN=on` (default off)
+- Chain components
+  - ActivationManager already enforced; expose reason codes on block.
+  - Call `check_pretrade(...)` and emit rejection metrics.
+  - Timing gate via `TimingController.validate_timing` with override hints.
+- Metrics
+  - Counters for attempts/rejections by `RejectionReason`.
+  - Latency histograms for order processing and webhook ingestion.
+
+Acceptance Criteria
+- Backward compatible (off by default).
+- Unit tests: blocked orders do not route; reasons recorded.
+

--- a/.github/ISSUE_DRAFTS/007-event-schemas-and-schema-registry.md
+++ b/.github/ISSUE_DRAFTS/007-event-schemas-and-schema-registry.md
@@ -1,0 +1,16 @@
+Title: Finalize Order/Fill/Portfolio Schemas and Register in Schema Registry
+Labels: api, schemas, reference
+
+Summary
+Promote the informal shapes in `docs/reference/api/order_events.md` to versioned JSON Schemas and register them in the Schema Registry.
+
+Tasks
+- Define JSON Schemas: `OrderPayload`, `OrderAck`, `ExecutionFillEvent`, `PortfolioSnapshot`.
+- Add to `docs/reference/schemas.md` and the registry storage/location used by Gateway/SDK.
+- Provide Python pydantic models or dataclasses for convenience.
+- Add conformance tests for producers/consumers (SDK and Gateway webhook).
+
+Acceptance Criteria
+- Schemas versioned and published; CI validates examples.
+- Producers/consumers accept unknown fields and validate required ones.
+

--- a/.github/ISSUE_DRAFTS/008-portfolio-scope-option-and-cross-strategy-risk.md
+++ b/.github/ISSUE_DRAFTS/008-portfolio-scope-option-and-cross-strategy-risk.md
@@ -1,0 +1,15 @@
+Title: Portfolio Scope Option (Strategy vs World) and Cross‑Strategy Risk
+Labels: architecture, risk, execution
+
+Summary
+Introduce an explicit portfolio scope option for Exchange Node Sets: strategy‑scoped (default) or world‑scoped. Define cross‑strategy risk constraints when world‑scoped.
+
+Tasks
+- Scope parameter plumbing through Node Set builders and PortfolioNode keys.
+- RiskControlNode: support portfolio‑level concentration/leverage across strategies under world‑scope.
+- Docs: Update `docs/architecture/exchange_node_sets.md` with scope implications and examples.
+
+Acceptance Criteria
+- Deterministic keys for snapshots and fills under both scopes.
+- Tests for sharing portfolio across two strategies in the same world.
+

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -18,6 +18,7 @@ last_modified: 2025-08-24
 - [Lean Brokerage Model](lean_brokerage_model.md)
 - [WorldService](worldservice.md)
 - [ControlBus](controlbus.md)
+- [Exchange Node Sets](exchange_node_sets.md)
 
 ---
 
@@ -89,7 +90,7 @@ flowchart LR
 
 참고 문서
 - 운영 가이드: [리스크 관리](../operations/risk_management.md), [타이밍 컨트롤](../operations/timing_controls.md)
-- 레퍼런스: [Brokerage API (실행/슬리피지/수수료)](../reference/api/brokerage.md), [Commit‑Log 설계](../reference/commit_log.md), [World/Activation API](../reference/api_world.md)
+- 레퍼런스: [Brokerage API (실행/슬리피지/수수료)](../reference/api/brokerage.md), [Commit‑Log 설계](../reference/commit_log.md), [World/Activation API](../reference/api_world.md), [Order & Fill Event Schemas](../reference/api/order_events.md)
 
 ### 1.2 시퀀스: SDK/Runner ↔ Gateway ↔ DAG Manager ↔ WorldService
 

--- a/docs/architecture/exchange_node_sets.md
+++ b/docs/architecture/exchange_node_sets.md
@@ -1,0 +1,154 @@
+---
+title: "Exchange Node Sets — Execution Layer Composition"
+tags:
+  - architecture
+  - execution
+  - nodes
+last_modified: 2025-09-08
+---
+
+{{ nav_links() }}
+
+# Exchange Node Sets — Execution Layer Composition
+
+This document specifies how post-signal trade execution is composed as a reusable, exchange‑specific "Node Set" that can be attached behind a strategy’s signal node while preserving QMTL’s DAG semantics and the WS/DM responsibility boundaries.
+
+## Motivation
+
+After a strategy emits trade signals, realistic execution requires feedback between multiple concerns (activation, pre‑trade checks, sizing, execution, fills, portfolio, risk, timing). Naively wiring these as a loop creates graph cycles. QMTL maintains DAG invariants by modeling feedback with delayed edges and event‑sourced state topics.
+
+Goals
+- Keep the DAG acyclic; express feedback via time‑shifted inputs.
+- Encapsulate exchange nuances behind thin connectors; provide ready‑made Node Sets.
+- Preserve responsibilities: DAG Manager (queues/graph), WorldService (activation/policy), SDK (execution wiring).
+
+Non‑Goals
+- WS does not own orders/fills/portfolio state; it remains an activation/policy SSOT.
+- DM does not ingest broker webhooks; it manages queues and orchestrates compute.
+
+## Composition Overview
+
+```mermaid
+flowchart LR
+  subgraph Signals
+    S[Signal Node]
+  end
+  subgraph Execution
+    P[PreTradeGateNode]
+    Z[SizingNode]
+    X[ExecutionNode]
+    O[OrderPublishNode]
+    F[FillIngestNode]
+    PF[PortfolioNode]
+    R[RiskControlNode]
+    T[TimingGateNode]
+  end
+
+  S --> P --> Z --> X --> O
+  O -.->|live only| F --> PF --> R --> T --> P
+
+  classDef dim fill:#f8f8f8,stroke:#333,stroke-width:1px;
+```
+
+Key
+- The feedback is not a literal cycle: P consumes portfolio/risk snapshots at t−1 (or from a compacted state topic). This preserves acyclicity while enabling feedback.
+- In simulate/paper modes, `ExecutionNode` produces fills directly; in live mode, fills arrive via `FillIngestNode` from the exchange/broker (webhook or polling).
+
+## Node Contracts
+
+- PreTradeGateNode
+  - Inputs: Activation (from WS via Gateway), Symbol/Hours/Shortable providers, Account/BuyingPower
+  - Output: Either a pass‑through order intent or a structured rejection with `RejectionReason`
+  - Backed by: `qmtl/sdk/pretrade.py`, `qmtl/common/pretrade.py`, `qmtl/brokerage/*`
+
+- SizingNode
+  - Inputs: Order intent, Portfolio snapshot (t−1)
+  - Output: Sized order (quantity) using helpers (value/percent/target_percent)
+  - Backed by: `qmtl/sdk/portfolio.py`
+
+- ExecutionNode
+  - Inputs: Sized order, Market data (OHLCV/quotes), Brokerage profile
+  - Outputs: Execution fills (simulate/paper) or OrderPayload (live)
+  - Backed by: `qmtl/brokerage/*`, `qmtl/sdk/execution_modeling.py`
+
+- OrderPublishNode
+  - Inputs: OrderPayload
+  - Outputs: Routed orders (HTTP/Kafka/custom service) via Runner hooks
+  - Backed by: `qmtl/transforms/publisher.py`, `qmtl/sdk/runner.py`
+
+- FillIngestNode
+  - Inputs: Broker fill/partial/cancel events via webhook→Kafka or client polling
+  - Outputs: Normalized fill stream
+
+- PortfolioNode
+  - Inputs: Fills stream
+  - Outputs: Portfolio/positions snapshot stream (compacted), risk features
+  - Backed by: `qmtl/sdk/portfolio.py`
+
+- RiskControlNode
+  - Inputs: Portfolio snapshots, per‑symbol metrics
+  - Outputs: Limit/adjust decisions (e.g., clamp position size)
+  - Backed by: `qmtl/sdk/risk_management.py`
+
+- TimingGateNode
+  - Inputs: Timestamp, calendar/hours policy
+  - Outputs: Allow/deny with reason, next valid time hint
+  - Backed by: `qmtl/sdk/timing_controls.py`
+
+## Feedback Without Cycles
+
+Two patterns are supported to keep the DAG acyclic:
+
+1) Delayed Edge (t−1 snap)
+- `PortfolioNode` publishes snapshots keyed by `(world_id, scope, symbol)`.
+- `PreTradeGateNode` (and `SizingNode`) consume the latest snapshot strictly older than current bucket, i.e., `<= t−1`.
+
+2) Event‑Sourced State Topic
+- Use compacted topics (e.g., `trade.portfolio`, `trade.open_orders`) and rebuild state on node start.
+- Consumers must handle duplicates and reorders within partition constraints.
+
+Both options are compatible with the Commit‑Log design; they do not change DM’s SSOT or WS’s SSOT.
+
+## WorldService and DAG Manager Boundaries
+
+- WorldService
+  - Owns activation/policy. Emits `ActivationUpdated` (and decisions) on ControlBus.
+  - Does not store orders/fills/portfolio. Node Sets subscribe to activation and enforce gates.
+- DAG Manager
+  - Owns graph/queues. Diff/plan/assign queues; does not terminate into broker webhooks.
+  - State topics for fills/portfolio are ordinary data streams the SDK nodes consume.
+
+This preserves current responsibilities while enabling rich execution flows.
+
+## Portfolio Scoping
+
+- Strategy‑Scoped (default): `scope = (world_id, strategy_id)`
+- World‑Scoped (optional): `scope = (world_id)` to share cash/limits across strategies
+
+Node Sets must declare scope explicitly. World‑scope increases coupling but enables cross‑strategy limits.
+
+## Operating Modes
+
+- simulate: ExecutionNode simulates fills; OrderPublishNode is a no‑op.
+- paper: ExecutionNode simulates, but OrderPublishNode may also post to a paper endpoint for parity.
+- live: OrderPublishNode routes orders; FillIngestNode consumes real fills; PortfolioNode mirrors live PnL.
+
+## Order & Fill Events (Reference)
+
+See Reference → Order & Fill Events for JSON Schemas and topic guidance.
+
+## Security & Idempotency
+
+- Webhooks must be authenticated (JWT/HMAC) and validated by Gateway before producing to Kafka.
+- Idempotency keys: compose `(world_id|strategy_id|symbol|side|ts|client_order_id)`; Runner provides a lightweight client‑side guard.
+
+## Implementation Plan (Phased)
+
+1) Add node wrappers: PreTradeGateNode, SizingNode, ExecutionNode, FillIngestNode, PortfolioNode, RiskControlNode, TimingGateNode.
+2) Provide Node Set builders: CCXT‑Generic(spot), Binance‑Futures(USDT‑M), IBKR‑like.
+3) Reference topics: `trade.orders`, `trade.fills`, `trade.portfolio` with JSON Schemas.
+4) Gateway optional webhook `/fills` → Kafka producer with RBAC/signature checks.
+5) Runner optional pre‑trade chain toggle for simple strategies.
+
+{{ nav_links() }}
+

--- a/docs/reference/api/order_events.md
+++ b/docs/reference/api/order_events.md
@@ -1,0 +1,103 @@
+---
+title: "Order & Fill Event Schemas"
+tags: [api, events]
+author: "QMTL Team"
+last_modified: 2025-09-08
+---
+
+{{ nav_links() }}
+
+# Order & Fill Event Schemas
+
+This page standardizes minimal JSON shapes for orders, acks/status, and fills used by Exchange Node Sets. These schemas complement the Brokerage API and Connectors.
+
+## Topics & Keys
+
+- `trade.orders` (append‑only)
+  - key: `world_id|strategy_id|symbol|client_order_id` (or deterministic hash)
+  - value: `OrderPayload`
+
+- `trade.fills` (append‑only)
+  - key: `world_id|strategy_id|symbol|order_id`
+  - value: `ExecutionFillEvent`
+
+- `trade.portfolio` (compacted)
+  - key: `world_id|[strategy_id]|snapshot`
+  - value: `PortfolioSnapshot`
+
+Partitioning: Choose keys to keep per‑strategy (or per‑world) order while allowing horizontal scale. Compaction is only for snapshots.
+
+## Schemas (informal)
+
+OrderPayload
+```json
+{
+  "world_id": "arch_world",
+  "strategy_id": "strat_001",
+  "symbol": "BTC/USDT",
+  "side": "BUY",             // BUY | SELL
+  "type": "limit",           // market | limit | stop | stop_limit
+  "quantity": 0.01,
+  "limit_price": 25000.0,
+  "stop_price": null,
+  "time_in_force": "GTC",    // DAY | GTC | IOC | FOK
+  "client_order_id": "c-abc123",
+  "timestamp": 1694102400000,
+  "reduce_only": false,
+  "position_side": null,      // LONG | SHORT (futures)
+  "metadata": {"source": "node_set/binance_spot"}
+}
+```
+
+OrderAck / Status
+```json
+{
+  "order_id": "exch-7890",
+  "client_order_id": "c-abc123",
+  "status": "accepted",      // accepted | rejected | canceled | filled | partially_filled | expired
+  "reason": null,
+  "broker": "binance",
+  "raw": {"provider_payload": "..."}
+}
+```
+
+ExecutionFillEvent
+```json
+{
+  "order_id": "exch-7890",
+  "client_order_id": "c-abc123",
+  "symbol": "BTC/USDT",
+  "side": "BUY",
+  "quantity": 0.005,
+  "price": 24990.5,
+  "commission": 0.02,
+  "slippage": 0.5,
+  "market_impact": 0.0,
+  "tif": "GTC",
+  "fill_time": 1694102401100,
+  "status": "partially_filled"
+}
+```
+
+PortfolioSnapshot (compacted)
+```json
+{
+  "world_id": "arch_world",
+  "strategy_id": "strat_001",
+  "as_of": 1694102402000,
+  "cash": 100000.0,
+  "positions": {
+    "BTC/USDT": {"qty": 0.01, "avg_cost": 25010.0, "mark": 24995.0}
+  },
+  "metrics": {"exposure": 0.25, "leverage": 1.1}
+}
+```
+
+## Notes
+
+- Time‑in‑force semantics align with Execution State doc.
+- `client_order_id` is optional but recommended for idempotency and reconciliation.
+- Providers may add fields in `metadata` or `raw`; downstream consumers should ignore unknown keys.
+
+{{ nav_links() }}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - World Service: architecture/worldservice.md
       - ControlBus: architecture/controlbus.md
       - Lean Brokerage Model: architecture/lean_brokerage_model.md
+      - Exchange Node Sets: architecture/exchange_node_sets.md
       - Execution State: architecture/execution_state.md
       - Brokerage API: reference/api/brokerage.md
       - Live & Brokerage Connectors: reference/api/connectors.md
@@ -52,6 +53,7 @@ nav:
       - Lean-like Features: reference/lean_like_features.md
       - Commit Log: reference/commit_log.md
       - Brokerage API: reference/api/brokerage.md
+      - Order & Fill Events: reference/api/order_events.md
       - Portfolio & Position API: reference/api/portfolio.md
       - Inventory: reference/_inventory.md
       - Changelog: reference/CHANGELOG.md


### PR DESCRIPTION
Summary: Align world smoke script with WS-first SDK entrypoints. Replace deprecated dry-run probe with Runner.offline and keep a safe SDK fallback.

Changes
- Use Runner.offline with a minimal no-op Strategy
- Remove legacy dry-run branches and comments
- Preserve artifact shape (world_id/run_id/log) and timing sleep

Rationale
- Follows epic conclusion for WS-first APIs
- Keeps tests deterministic and dependency-free

Refs #666
