### PR TITLE
feat: add GTD TIF and new order types

### DIFF
--- a/docs/reference/api/brokerage.md
+++ b/docs/reference/api/brokerage.md
@@ -86,8 +86,8 @@ fee = IBKRFeeModel(minimum=1.0)
 
 ## Time-in-Force and Order Types
 
-- Time-in-Force: DAY, GTC, IOC, FOK. IOC partially fills up to immediate liquidity; FOK requires full fill.
-- Order types: market, limit, stop, stop-limit. Limit/StopLimit use `limit_price` and `stop_price` on Order.
+- Time-in-Force: DAY, GTC, GTD, IOC, FOK. IOC partially fills up to immediate liquidity; FOK requires full fill. GTD orders expire at the provided `expire_at` timestamp.
+- Order types: market, limit, stop, stop-limit, market-on-open, market-on-close, trailing-stop. Limit/StopLimit use `limit_price` and `stop_price` on Order; trailing-stop uses `trail_amount`.
 
 ## Profiles
 

--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -13,6 +13,9 @@ from .fill_models import (
     StopMarketFillModel,
     StopLimitFillModel,
     UnifiedFillModel,
+    MarketOnOpenFillModel,
+    MarketOnCloseFillModel,
+    TrailingStopFillModel,
 )
 from .fees import (
     PerShareFeeModel,
@@ -67,6 +70,9 @@ __all__ = [
     "StopMarketFillModel",
     "StopLimitFillModel",
     "UnifiedFillModel",
+    "MarketOnOpenFillModel",
+    "MarketOnCloseFillModel",
+    "TrailingStopFillModel",
     "SymbolProperties",
     "SymbolPropertiesProvider",
     "ExchangeHoursProvider",

--- a/qmtl/brokerage/brokerage_model.py
+++ b/qmtl/brokerage/brokerage_model.py
@@ -83,7 +83,9 @@ class BrokerageModel:
             raise ValueError("Order rejected by pre-trade checks")
 
         price_with_slippage = self.slippage_model.apply(order, market_price)
-        fill = self.fill_model.fill(order, price_with_slippage)
+        fill = self.fill_model.fill(
+            order, price_with_slippage, ts=ts, exchange_hours=self.hours
+        )
 
         if fill.quantity == 0:
             # Nothing executed

--- a/qmtl/brokerage/interfaces.py
+++ b/qmtl/brokerage/interfaces.py
@@ -5,8 +5,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Optional
 
 from .order import Account, Order, Fill
+from .exchange_hours import ExchangeHoursProvider
 
 
 class BuyingPowerModel(ABC):
@@ -37,5 +40,12 @@ class FillModel(ABC):
     """Determine fill quantity and base price."""
 
     @abstractmethod
-    def fill(self, order: Order, market_price: float) -> Fill:
+    def fill(
+        self,
+        order: Order,
+        market_price: float,
+        *,
+        ts: Optional[datetime] = None,
+        exchange_hours: Optional[ExchangeHoursProvider] = None,
+    ) -> Fill:
         """Return fill details for ``order`` at ``market_price``."""

--- a/qmtl/brokerage/order.py
+++ b/qmtl/brokerage/order.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
+from datetime import datetime
 
 
 class OrderType(str, Enum):
@@ -16,6 +17,9 @@ class OrderType(str, Enum):
     LIMIT = "limit"
     STOP = "stop"
     STOP_LIMIT = "stop_limit"
+    MOO = "market_on_open"
+    MOC = "market_on_close"
+    TRAILING_STOP = "trailing_stop"
 
 
 class TimeInForce(str, Enum):
@@ -23,6 +27,7 @@ class TimeInForce(str, Enum):
 
     DAY = "day"
     GTC = "gtc"
+    GTD = "gtd"
     IOC = "ioc"
     FOK = "fok"
 
@@ -39,6 +44,8 @@ class Order:
         tif: Time-in-Force policy.
         limit_price: Limit price for limit/stop-limit orders.
         stop_price: Stop trigger for stop/stop-limit orders.
+        expire_at: Expiration timestamp for GTD orders.
+        trail_amount: Trailing offset for trailing stop orders.
     """
 
     symbol: str
@@ -48,6 +55,8 @@ class Order:
     tif: TimeInForce = TimeInForce.DAY
     limit_price: Optional[float] = None
     stop_price: Optional[float] = None
+    expire_at: Optional[datetime] = None
+    trail_amount: Optional[float] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- support Good-Til-Date time in force with expiration timestamp
- add Market-On-Open, Market-On-Close, and trailing-stop order types with fill model handling
- document and test new order behaviors

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: ExceptionGroup: multiple unraisable exception warnings)*
- `uv run -m pytest tests/test_brokerage_orders_tif.py -W error -n auto`
- `uv run mkdocs build`

Fixes #511

------
https://chatgpt.com/codex/tasks/task_e_68beaa650cd0832980354f1431cac49c