### PR TITLE
Expand IBKR fee model with venue and liquidity components

### DIFF
--- a/docs/reference/api/brokerage.md
+++ b/docs/reference/api/brokerage.md
@@ -18,7 +18,7 @@ Legacy shortcuts under `qmtl.brokerage.simple` have been removed. See [Migration
 - Interfaces: BuyingPowerModel, FillModel, SlippageModel, FeeModel
 - Fill models: MarketFillModel, LimitFillModel, StopMarketFillModel, StopLimitFillModel (IOC/FOK supported via TIF)
 - Slippage models: NullSlippageModel, ConstantSlippageModel, SpreadBasedSlippageModel, VolumeShareSlippageModel
-- Fee models: PerShareFeeModel, PercentFeeModel, MakerTakerFeeModel, TieredExchangeFeeModel, BorrowFeeModel, CompositeFeeModel, IBKRFeeModel (tiered per-share)
+- Fee models: PerShareFeeModel, PercentFeeModel, MakerTakerFeeModel, TieredExchangeFeeModel, BorrowFeeModel, CompositeFeeModel, IBKRFeeModel (tiered per-share with venue/regulatory fees and liquidity rebates)
 - Providers: SymbolPropertiesProvider (tick/lot/min), ExchangeHoursProvider (regular/pre/post), ShortableProvider
   (daily shortable quantities via ``StaticShortableProvider`` + ``ShortableLot``)
 - Profiles: BrokerageProfile, SecurityInitializer, ibkr_equities_like_profile()
@@ -73,7 +73,7 @@ model = BrokerageModel(
 
 # Optional: tiered IBKR-like fees
 from qmtl.brokerage import IBKRFeeModel
-fee = IBKRFeeModel(minimum=1.0)
+fee = IBKRFeeModel(minimum=1.0, exchange_fee_remove=0.0008, exchange_fee_add=-0.0002, regulatory_fee_remove=0.0001)
 ```
 
 ### Fee Model Matrix
@@ -85,7 +85,7 @@ fee = IBKRFeeModel(minimum=1.0)
 | MakerTakerFeeModel | % of notional | Separate maker/taker rates |
 | TieredExchangeFeeModel | % of notional | Rate determined by notional tiers |
 | BorrowFeeModel | % of notional | Applied on short sales |
-| IBKRFeeModel | per share | Tiered per-share schedule |
+| IBKRFeeModel | per share | Tiered per-share schedule with venue/regulatory fees & liquidity rebates |
 | CompositeFeeModel | n/a | Sum multiple fee models |
 
 ## Time-in-Force and Order Types

--- a/qmtl/brokerage/order.py
+++ b/qmtl/brokerage/order.py
@@ -48,6 +48,9 @@ class Order:
         stop_price: Stop trigger for stop/stop-limit orders.
         expire_at: Expiration timestamp for GTD orders.
         trail_amount: Trailing offset for trailing stop orders.
+        adds_liquidity: Whether the order adds (maker) or removes (taker)
+            liquidity. If ``None``, market orders are treated as removing
+            liquidity and other types as adding.
     """
 
     symbol: str
@@ -59,6 +62,7 @@ class Order:
     stop_price: Optional[float] = None
     expire_at: Optional[datetime] = None
     trail_amount: Optional[float] = None
+    adds_liquidity: Optional[bool] = None
 
 
 @dataclass

--- a/tests/test_brokerage_ibkr_fee.py
+++ b/tests/test_brokerage_ibkr_fee.py
@@ -1,12 +1,28 @@
-from qmtl.brokerage import IBKRFeeModel
+import pytest
+from qmtl.brokerage import IBKRFeeModel, OrderType
 
 
-def test_ibkr_fee_applies_tiers_and_minimum():
-    fee = IBKRFeeModel(tiers=[(300000, 0.0035)], minimum=1.0, exchange_fees=0.0)
-    # Small order -> minimum
-    assert fee.calculate(order=type('O', (), {'quantity': 10})(), fill_price=100.0) == 1.0
-    # Medium order inside first tier
-    assert fee.calculate(order=type('O', (), {'quantity': 1000})(), fill_price=100.0) == 1000 * 0.0035
-    # Beyond first tier uses last_rate 0.0020
-    assert fee.calculate(order=type('O', (), {'quantity': 300500})(), fill_price=100.0) == 300000 * 0.0035 + 500 * 0.0020
+def test_ibkr_fee_tiers_and_liquidity_components():
+    fee = IBKRFeeModel(
+        tiers=[(300000, 0.0035)],
+        minimum=1.0,
+        exchange_fee_remove=0.0008,
+        exchange_fee_add=-0.0002,
+        regulatory_fee_remove=0.0001,
+    )
+    # Small market order -> minimum broker fee + venue/regulatory charges
+    small = type("O", (), {"quantity": 10, "type": OrderType.MARKET})()
+    assert fee.calculate(small, 100.0) == pytest.approx(1.0 + 10 * (0.0008 + 0.0001))
+    # Large market order crosses tier and adds per-share charges
+    large = type("O", (), {"quantity": 300500, "type": OrderType.MARKET})()
+    expected = 300000 * 0.0035 + 500 * 0.0020 + 300500 * (0.0008 + 0.0001)
+    assert fee.calculate(large, 100.0) == pytest.approx(expected)
+
+
+def test_ibkr_fee_add_liquidity_rebate():
+    fee = IBKRFeeModel(exchange_fee_add=-0.01, minimum=0.0)
+    order = type(
+        "O", (), {"quantity": 100, "type": OrderType.LIMIT, "adds_liquidity": True}
+    )()
+    assert fee.calculate(order, 100.0) == pytest.approx(100 * 0.0035 - 1.0)
 


### PR DESCRIPTION
## Summary
- add `adds_liquidity` flag to `Order` for maker/taker classification
- extend `IBKRFeeModel` to include venue/regulatory per-share fees and maker rebates
- document and test new IBKR fee components

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: tests/e2e/test_world_isolation.py::test_world_isolation - ExceptionGroup: multiple unraisable exception warnings)*
- `uv run mkdocs build`

Closes #516

------
https://chatgpt.com/codex/tasks/task_e_68becee51c9c8329be3b7fb4d3467f0a