### PR TITLE
Add brokerage E2E demo and document assumptions

### DIFF
--- a/docs/reference/brokerage_assumptions.md
+++ b/docs/reference/brokerage_assumptions.md
@@ -1,0 +1,26 @@
+# Brokerage Model Assumptions
+
+QMTL's brokerage layer keeps the initial implementation intentionally simple.
+These defaults make examples runnable without large datasets while leaving clear
+extension points.
+
+- **Tick and lot sizes:** `SymbolPropertiesProvider` applies asset-class
+  defaults (`0.01` tick, `1` lot for equities, etc.).  Orders are validated
+  against these values and can be overridden by supplying a custom table or
+  file.
+- **Exchange hours & calendar:** `ExchangeHoursProvider.with_us_sample_holidays`
+  offers a compact US‑equity schedule with a few holidays and an early close.
+  It is not exhaustive; provide a full calendar for production use.
+- **Short selling:** If no `ShortableProvider` is given, sells are assumed to be
+  shortable with unlimited quantity.  Plug in `StaticShortableProvider` or a
+  custom provider to enforce borrow limits and fees.
+- **Slippage & fees:** Examples use `ConstantSlippageModel` and
+  `PercentFeeModel` for brevity.  Swap these for more realistic models such as
+  `SpreadBasedSlippageModel`, `IBKRFeeModel`, or `CompositeFeeModel`.
+- **Settlement:** `SettlementModel` defaults to immediate cash movement.  To
+  simulate T+N with reserved cash, enable `defer_cash=True` and pair with
+  `CashWithSettlementBuyingPowerModel`.
+
+These assumptions complement the API details in
+[Brokerage API](api/brokerage.md) and the design notes in
+[Lean Brokerage Model](../architecture/lean_brokerage_model.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Lean-like Features: reference/lean_like_features.md
       - Commit Log: reference/commit_log.md
       - Brokerage API: reference/api/brokerage.md
+      - Brokerage Assumptions: reference/brokerage_assumptions.md
       - Order & Fill Events: reference/api/order_events.md
       - Portfolio & Position API: reference/api/portfolio.md
       - Inventory: reference/_inventory.md

--- a/qmtl/examples/brokerage_demo/README.md
+++ b/qmtl/examples/brokerage_demo/README.md
@@ -1,6 +1,10 @@
 # Brokerage Demo
 
-Minimal example demonstrating the brokerage model usage and validation chain.
+Examples demonstrating the brokerage model:
+
+- `run_demo.py` – minimal market order walkthrough.
+- `advanced_demo.py` – covers IOC/FOK/MOO/MOC, holiday closures,
+  slippage/fees and deferred settlement.
 
 Run tests:
 

--- a/qmtl/examples/brokerage_demo/advanced_demo.py
+++ b/qmtl/examples/brokerage_demo/advanced_demo.py
@@ -1,0 +1,87 @@
+"""Comprehensive brokerage demo covering order types, fees, slippage, hours and settlement.
+
+Run with:
+    uv run python qmtl/examples/brokerage_demo/advanced_demo.py
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashWithSettlementBuyingPowerModel,
+    ConstantSlippageModel,
+    PercentFeeModel,
+    SymbolPropertiesProvider,
+    ExchangeHoursProvider,
+    UnifiedFillModel,
+    SettlementModel,
+    Order,
+    OrderType,
+    TimeInForce,
+)
+
+
+def build_model() -> tuple[BrokerageModel, SettlementModel]:
+    """Return a demo brokerage model with deferred settlement."""
+
+    settlement = SettlementModel(days=1, defer_cash=True)
+    model = BrokerageModel(
+        CashWithSettlementBuyingPowerModel(settlement),
+        PercentFeeModel(rate=0.001, minimum=1.0),
+        ConstantSlippageModel(0.01),
+        UnifiedFillModel(liquidity_cap=50),
+        symbols=SymbolPropertiesProvider(),
+        hours=ExchangeHoursProvider.with_us_sample_holidays(require_regular_hours=True),
+        settlement=settlement,
+    )
+    return model, settlement
+
+
+def main() -> None:
+    model, settlement = build_model()
+    acct = Account(cash=100_000.0)
+    hours = model.hours  # type: ignore[attr-defined]
+    today = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    open_ts = datetime.combine(today.date(), hours.market_hours.regular_start, tzinfo=timezone.utc)
+    close_time = hours.early_closes.get(today.date(), hours.market_hours.regular_end)
+    close_ts = datetime.combine(today.date(), close_time, tzinfo=timezone.utc)
+
+    order_moo = Order("AAPL", 10, 100.0, OrderType.MOO)
+    fill_moo = model.execute_order(acct, order_moo, 100.0, ts=open_ts)
+
+    in_session = open_ts + timedelta(minutes=1)
+    order_ioc = Order("AAPL", 100, 100.0, OrderType.MARKET, tif=TimeInForce.IOC)
+    fill_ioc = model.execute_order(acct, order_ioc, 100.0, ts=in_session)
+
+    order_fok = Order("AAPL", 60, 100.0, OrderType.MARKET, tif=TimeInForce.FOK)
+    fill_fok = model.execute_order(acct, order_fok, 100.0, ts=in_session)
+
+    order_moc = Order("AAPL", 10, 100.0, OrderType.MOC)
+    fill_moc = model.execute_order(acct, order_moc, 100.0, ts=close_ts)
+
+    try:
+        holiday_ts = datetime(2024, 7, 4, 15, 0, tzinfo=timezone.utc)
+        model.can_submit_order(acct, order_moo, ts=holiday_ts)
+        closed = None
+    except ValueError as exc:  # market closed
+        closed = str(exc)
+
+    settlement.apply_due(acct, now=close_ts + timedelta(days=1))
+
+    print(
+        {
+            "moo": fill_moo,
+            "ioc": fill_ioc,
+            "fok": fill_fok,
+            "moc": fill_moc,
+            "closed": closed,
+            "cash": acct.cash,
+        }
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demo
+    main()

--- a/qmtl/examples/tests/test_brokerage_e2e.py
+++ b/qmtl/examples/tests/test_brokerage_e2e.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from qmtl.brokerage import Account, Order, OrderType, TimeInForce
+from qmtl.examples.brokerage_demo.advanced_demo import build_model
+
+
+def test_brokerage_e2e_scenarios():
+    model, settlement = build_model()
+    acct = Account(cash=100_000.0)
+    hours = model.hours  # type: ignore[attr-defined]
+
+    day = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    open_ts = datetime.combine(day.date(), hours.market_hours.regular_start, tzinfo=timezone.utc)
+    close_time = hours.early_closes.get(day.date(), hours.market_hours.regular_end)
+    close_ts = datetime.combine(day.date(), close_time, tzinfo=timezone.utc)
+
+    # MOO fills at open with slippage and fee
+    order_moo = Order("AAPL", 10, 100.0, OrderType.MOO)
+    fill_moo = model.execute_order(acct, order_moo, 100.0, ts=open_ts)
+    assert fill_moo.quantity == 10
+    assert fill_moo.price > 100.0
+    assert fill_moo.fee >= 1.0
+
+    # IOC partially fills up to liquidity cap
+    in_session = open_ts + timedelta(minutes=1)
+    order_ioc = Order("AAPL", 100, 100.0, OrderType.MARKET, tif=TimeInForce.IOC)
+    fill_ioc = model.execute_order(acct, order_ioc, 100.0, ts=in_session)
+    assert fill_ioc.quantity == 50
+
+    # FOK fails when full quantity unavailable
+    order_fok = Order("AAPL", 60, 100.0, OrderType.MARKET, tif=TimeInForce.FOK)
+    fill_fok = model.execute_order(acct, order_fok, 100.0, ts=in_session)
+    assert fill_fok.quantity == 0
+
+    # MOC fills only at close
+    before_close = close_ts - timedelta(minutes=1)
+    early = model.execute_order(acct, Order("AAPL", 10, 100.0, OrderType.MOC), 100.0, ts=before_close)
+    assert early.quantity == 0
+    order_moc = Order("AAPL", 10, 100.0, OrderType.MOC)
+    fill_moc = model.execute_order(acct, order_moc, 100.0, ts=close_ts)
+    assert fill_moc.quantity == 10
+
+    # Market closed on holiday
+    holiday_ts = datetime(2024, 7, 4, 15, 0, tzinfo=timezone.utc)
+    with pytest.raises(ValueError, match="Market is closed"):
+        model.can_submit_order(acct, order_moo, ts=holiday_ts)
+
+    # Deferred settlement keeps cash unchanged until applied
+    assert acct.cash == pytest.approx(100_000.0)
+    settlement.apply_due(acct, now=close_ts + timedelta(days=1))
+    assert acct.cash < 100_000.0


### PR DESCRIPTION
## Summary
- document simplifying assumptions and extension points for the brokerage model
- add advanced brokerage demo plus end-to-end test covering IOC/FOK/MOO/MOC, holidays, fees, slippage and settlement
- reference new demo from example README and expose docs via mkdocs navigation

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: ExceptionGroup in tests/runner/test_run_pipeline.py)*
- `uv run mkdocs build`

Closes #521

------
https://chatgpt.com/codex/tasks/task_e_68bee1bfc0dc8329bb5655e1f1fc691e