### PR TITLE
feat: add basic OCO order support

### DIFF
--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -6,6 +6,7 @@ from .order import Order, Fill, Account, OrderType, TimeInForce, AccountType
 from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
 from .buying_power import CashBuyingPowerModel, CashWithSettlementBuyingPowerModel
 from .cashbook import Cashbook, CashEntry
+from .oco import OCOOrder
 from .fill_models import (
     ImmediateFillModel,
     BaseFillModel,
@@ -48,6 +49,7 @@ __all__ = [
     "OrderType",
     "TimeInForce",
     "AccountType",
+    "OCOOrder",
     "BuyingPowerModel",
     "FeeModel",
     "SlippageModel",

--- a/qmtl/brokerage/oco.py
+++ b/qmtl/brokerage/oco.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Utility for One-Cancels-Other order groups."""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from .order import Order, Fill, Account
+from .brokerage_model import BrokerageModel
+
+
+@dataclass
+class OCOOrder:
+    """Container for an OCO (one-cancels-other) order pair.
+
+    Orders are submitted sequentially. If the first order fills, the second is
+    automatically cancelled and represented as a zero-quantity :class:`Fill`.
+    """
+
+    first: Order
+    second: Order
+
+    def execute(
+        self,
+        brokerage: BrokerageModel,
+        account: Account,
+        market_price: float,
+        *,
+        ts=None,
+        bar_volume: Optional[int] = None,
+    ) -> Tuple[Fill, Fill]:
+        """Execute the OCO group and return fills for both orders.
+
+        The unfilled leg is returned as a zero-quantity fill.
+        """
+
+        fill_first = brokerage.execute_order(
+            account, self.first, market_price, ts=ts, bar_volume=bar_volume
+        )
+        if fill_first.quantity != 0:
+            # Second leg cancelled
+            return (
+                fill_first,
+                Fill(symbol=self.second.symbol, quantity=0, price=market_price),
+            )
+
+        fill_second = brokerage.execute_order(
+            account, self.second, market_price, ts=ts, bar_volume=bar_volume
+        )
+        if fill_second.quantity != 0:
+            # First leg cancelled
+            return (
+                Fill(symbol=self.first.symbol, quantity=0, price=market_price),
+                fill_second,
+            )
+
+        return fill_first, fill_second

--- a/qmtl/examples/brokerage_demo/oco_demo.py
+++ b/qmtl/examples/brokerage_demo/oco_demo.py
@@ -1,0 +1,58 @@
+"""Demonstrate OCOOrder to manage take-profit and stop-loss.
+
+Run with: uv run python qmtl/examples/brokerage_demo/oco_demo.py
+"""
+
+from __future__ import annotations
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashBuyingPowerModel,
+    PerShareFeeModel,
+    NullSlippageModel,
+    UnifiedFillModel,
+    Order,
+    OrderType,
+    TimeInForce,
+    OCOOrder,
+)
+
+
+def main() -> None:
+    brk = BrokerageModel(
+        CashBuyingPowerModel(),
+        PerShareFeeModel(fee_per_share=0.0),
+        NullSlippageModel(),
+        UnifiedFillModel(),
+    )
+    acct = Account(cash=1_000_000.0)
+    # Enter a position
+    brk.execute_order(
+        acct,
+        Order(symbol="AAPL", quantity=100, price=100.0, type=OrderType.MARKET),
+        market_price=100.0,
+    )
+    take_profit = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.GTC,
+        limit_price=110.0,
+    )
+    stop_loss = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.STOP,
+        tif=TimeInForce.GTC,
+        stop_price=90.0,
+    )
+    oco = OCOOrder(take_profit, stop_loss)
+    fill_tp, fill_sl = oco.execute(brk, acct, market_price=110.0)
+    print({"take_profit": fill_tp, "stop_loss": fill_sl, "cash": acct.cash})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_brokerage_oco.py
+++ b/tests/test_brokerage_oco.py
@@ -1,0 +1,47 @@
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashBuyingPowerModel,
+    PerShareFeeModel,
+    NullSlippageModel,
+    UnifiedFillModel,
+    Order,
+    OrderType,
+    TimeInForce,
+    OCOOrder,
+)
+
+
+def make_brokerage():
+    return BrokerageModel(
+        CashBuyingPowerModel(),
+        PerShareFeeModel(fee_per_share=0.0),
+        NullSlippageModel(),
+        UnifiedFillModel(),
+    )
+
+
+def test_oco_cancels_unfilled_leg():
+    account = Account(cash=1_000_000)
+    take_profit = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.DAY,
+        limit_price=110.0,
+    )
+    stop_loss = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.STOP,
+        tif=TimeInForce.DAY,
+        stop_price=90.0,
+    )
+    oco = OCOOrder(take_profit, stop_loss)
+    brk = make_brokerage()
+
+    fill_tp, fill_sl = oco.execute(brk, account, market_price=110.0)
+    assert fill_tp.quantity == -100
+    assert fill_sl.quantity == 0


### PR DESCRIPTION
## Summary
- add `OCOOrder` container for one-cancels-other behavior
- include example demonstrating automatic stop/take-profit orders
- cover OCO cancellation with unit test

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n 1` *(fails: multiple unraisable exception warnings in tests/gateway/test_api.py)*

Closes #797

------
https://chatgpt.com/codex/tasks/task_e_68bef773f21c83299cfe6032d36f5840