### PR TITLE
feat: add dataframe schema validator

### DIFF
--- a/docs/reference/schemas.md
+++ b/docs/reference/schemas.md
@@ -20,6 +20,38 @@ last_modified: 2025-08-29
 - Validation (WVG): reference/schemas/validation.schema.json
 - DecisionEvent (WVG): reference/schemas/decision_event.schema.json
 
+## Node I/O Schemas
+
+Standard DataFrame contracts ensure consistent columns, dtypes and timezone
+handling between nodes. All schemas require a timezone-aware ``ts`` column in
+UTC.
+
+| Schema | Columns |
+| ------ | ------- |
+| ``bar`` | ``ts`` (UTC ``datetime64[ns]``), ``open`` ``float64``, ``high`` ``float64``, ``low`` ``float64``, ``close`` ``float64``, ``volume`` ``float64`` |
+| ``quote`` | ``ts`` (UTC ``datetime64[ns]``), ``bid`` ``float64``, ``ask`` ``float64``, ``bid_size`` ``float64``, ``ask_size`` ``float64`` |
+| ``trade`` | ``ts`` (UTC ``datetime64[ns]``), ``price`` ``float64``, ``size`` ``float64`` |
+
+Example:
+
+```python
+import pandas as pd
+from qmtl.schema import validate_schema
+
+df = pd.DataFrame(
+    {
+        "ts": pd.date_range("2024-01-01", periods=1, tz="UTC"),
+        "open": [1.0],
+        "high": [1.0],
+        "low": [1.0],
+        "close": [1.0],
+        "volume": [1.0],
+    }
+)
+
+validate_schema(df, "bar")
+```
+
 ## Registry Integration (optional)
 
 When `QMTL_SCHEMA_REGISTRY_URL` is set, components can resolve `schema_id`s via

--- a/qmtl/schema/__init__.py
+++ b/qmtl/schema/__init__.py
@@ -1,4 +1,10 @@
 from .registry import SchemaRegistryClient, Schema
+from .validator import SCHEMAS, validate_schema
 
-__all__ = ["SchemaRegistryClient", "Schema"]
+__all__ = [
+    "SchemaRegistryClient",
+    "Schema",
+    "SCHEMAS",
+    "validate_schema",
+]
 

--- a/qmtl/schema/validator.py
+++ b/qmtl/schema/validator.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import pandas as pd
+from pandas.api.types import DatetimeTZDtype
+
+from qmtl.sdk.exceptions import InvalidSchemaError
+
+# Built-in DataFrame schemas for node I/O
+SCHEMAS: dict[str, dict[str, str]] = {
+    "bar": {
+        "ts": "datetime64[ns, UTC]",
+        "open": "float64",
+        "high": "float64",
+        "low": "float64",
+        "close": "float64",
+        "volume": "float64",
+    },
+    "quote": {
+        "ts": "datetime64[ns, UTC]",
+        "bid": "float64",
+        "ask": "float64",
+        "bid_size": "float64",
+        "ask_size": "float64",
+    },
+    "trade": {
+        "ts": "datetime64[ns, UTC]",
+        "price": "float64",
+        "size": "float64",
+    },
+}
+
+
+def _resolve_schema(expected: str | Mapping[str, str]) -> Mapping[str, str]:
+    if isinstance(expected, str):
+        try:
+            return SCHEMAS[expected]
+        except KeyError as e:  # pragma: no cover - defensive
+            raise InvalidSchemaError(f"unknown schema: {expected}") from e
+    return expected
+
+
+def validate_schema(df: pd.DataFrame, expected: str | Mapping[str, str]) -> None:
+    """Validate that ``df`` conforms to ``expected`` schema.
+
+    Parameters
+    ----------
+    df:
+        Input ``pandas.DataFrame``.
+    expected:
+        Built-in schema name (``"bar"``, ``"quote"`` or ``"trade"``) or a
+        mapping of column names to ``pandas`` dtypes.
+
+    Raises
+    ------
+    InvalidSchemaError
+        If the dataframe is missing required columns, has unexpected columns or
+        column dtypes do not match the schema.
+    """
+
+    spec = _resolve_schema(expected)
+
+    missing = [col for col in spec if col not in df.columns]
+    if missing:
+        raise InvalidSchemaError(f"missing columns: {', '.join(missing)}")
+
+    unexpected = [col for col in df.columns if col not in spec]
+    if unexpected:
+        raise InvalidSchemaError(f"unexpected columns: {', '.join(unexpected)}")
+
+    for col, dtype in spec.items():
+        series = df[col]
+        if col == "ts":
+            if not isinstance(series.dtype, DatetimeTZDtype):
+                raise InvalidSchemaError("ts column must be timezone-aware")
+            if str(series.dtype.tz) != "UTC":
+                raise InvalidSchemaError("ts column must be in UTC")
+            continue
+        if str(series.dtype) != dtype:
+            raise InvalidSchemaError(
+                f"column '{col}' expected dtype {dtype}, got {series.dtype}"
+            )
+

--- a/qmtl/sdk/exceptions.py
+++ b/qmtl/sdk/exceptions.py
@@ -2,12 +2,13 @@
 
 __all__ = [
     "QMTLValidationError",
-    "NodeValidationError", 
+    "NodeValidationError",
     "InvalidParameterError",
     "InvalidTagError",
     "InvalidIntervalError",
     "InvalidPeriodError",
     "InvalidNameError",
+    "InvalidSchemaError",
 ]
 
 
@@ -44,3 +45,9 @@ class InvalidPeriodError(NodeValidationError):
 class InvalidNameError(NodeValidationError):
     """Raised when name validation fails."""
     pass
+
+
+class InvalidSchemaError(NodeValidationError):
+    """Raised when dataframe schema validation fails."""
+    pass
+

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import pytest
+
+from qmtl.schema import validate_schema
+from qmtl.sdk.exceptions import InvalidSchemaError
+
+
+def test_missing_column_raises_friendly_error():
+    df = pd.DataFrame(
+        {
+            "ts": pd.date_range("2024-01-01", periods=1, tz="UTC"),
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            # volume column intentionally omitted
+        }
+    )
+
+    with pytest.raises(InvalidSchemaError) as exc:
+        validate_schema(df, "bar")
+    assert "missing columns: volume" in str(exc.value)
+
+
+def test_valid_bar_schema_passes():
+    df = pd.DataFrame(
+        {
+            "ts": pd.date_range("2024-01-01", periods=1, tz="UTC"),
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [1.0],
+        }
+    )
+
+    validate_schema(df, "bar")  # should not raise
+


### PR DESCRIPTION
## Summary
- add utility to validate bar/quote/trade DataFrame schemas
- document standard node I/O schemas with example usage
- raise InvalidSchemaError with friendly messages

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest --collect-only -q`
- `uv run -m pytest -W error -n auto` *(fails: unraisable socket warnings in tests/runner/test_run_pipeline.py::test_run_offline_pipeline)*
- `uv run mkdocs build`

Fixes #796

------
https://chatgpt.com/codex/tasks/task_e_68bef776f5788329ada07a416d68cf4b