### PR TITLE
Add bracket order helper with OCO exits

### DIFF
--- a/docs/reference/bracket_order.md
+++ b/docs/reference/bracket_order.md
@@ -1,0 +1,38 @@
+# Bracket Order Helper
+
+The `BracketOrder` utility submits an entry order and, once filled, manages
+linked take-profit and stop-loss exits as an `OCOOrder`.
+
+Example usage:
+
+```python
+from qmtl.brokerage import BracketOrder, Order, OrderType, TimeInForce
+
+entry = Order(
+    symbol="AAPL",
+    quantity=100,
+    price=100.0,
+    type=OrderType.LIMIT,
+    tif=TimeInForce.GTC,
+    limit_price=100.0,
+)
+take_profit = Order(
+    symbol="AAPL",
+    quantity=-100,
+    price=100.0,
+    type=OrderType.LIMIT,
+    tif=TimeInForce.GTC,
+    limit_price=110.0,
+)
+stop_loss = Order(
+    symbol="AAPL",
+    quantity=-100,
+    price=100.0,
+    type=OrderType.STOP,
+    tif=TimeInForce.GTC,
+    stop_price=90.0,
+)
+bracket = BracketOrder(entry, take_profit, stop_loss)
+```
+
+See `qmtl/examples/brokerage_demo/bracket_demo.py` for a runnable example.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Brokerage API: reference/api/brokerage.md
       - Brokerage Assumptions: reference/brokerage_assumptions.md
       - Order & Fill Events: reference/api/order_events.md
+      - Bracket Order Helper: reference/bracket_order.md
       - Portfolio & Position API: reference/api/portfolio.md
       - Inventory: reference/_inventory.md
       - Changelog: reference/CHANGELOG.md

--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -7,6 +7,7 @@ from .interfaces import BuyingPowerModel, FeeModel, SlippageModel, FillModel
 from .buying_power import CashBuyingPowerModel, CashWithSettlementBuyingPowerModel
 from .cashbook import Cashbook, CashEntry
 from .oco import OCOOrder
+from .bracket import BracketOrder
 from .fill_models import (
     ImmediateFillModel,
     BaseFillModel,
@@ -50,6 +51,7 @@ __all__ = [
     "TimeInForce",
     "AccountType",
     "OCOOrder",
+    "BracketOrder",
     "BuyingPowerModel",
     "FeeModel",
     "SlippageModel",

--- a/qmtl/brokerage/bracket.py
+++ b/qmtl/brokerage/bracket.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Bracket order helper built atop :class:`OCOOrder`."""
+
+from dataclasses import dataclass, replace
+from typing import Optional, Tuple
+
+from .order import Order, Fill, Account
+from .brokerage_model import BrokerageModel
+from .oco import OCOOrder
+
+
+@dataclass
+class BracketOrder:
+    """Container for entry with attached take-profit and stop-loss exits.
+
+    The entry order executes first. After shares are filled, an
+    :class:`OCOOrder` of take-profit and stop-loss orders is created sized to
+    the cumulative filled quantity. Subsequent calls adjust the exit orders
+    if additional partial fills arrive. The bracket completes when either exit
+    leg fills, automatically cancelling the opposite leg.
+    """
+
+    entry: Order
+    take_profit: Order
+    stop_loss: Order
+    oco: Optional[OCOOrder] = None
+    filled_qty: int = 0
+
+    def execute(
+        self,
+        brokerage: BrokerageModel,
+        account: Account,
+        market_price: float,
+        *,
+        ts=None,
+        bar_volume: Optional[int] = None,
+    ) -> Tuple[Fill, Fill, Fill]:
+        """Execute the bracket and return fills for entry and both exit legs."""
+
+        # Submit remaining entry quantity if any
+        fill_entry = Fill(symbol=self.entry.symbol, quantity=0, price=market_price)
+        remaining = self.entry.quantity - self.filled_qty
+        if remaining != 0:
+            entry_order = replace(self.entry, quantity=remaining)
+            fill_entry = brokerage.execute_order(
+                account, entry_order, market_price, ts=ts, bar_volume=bar_volume
+            )
+            if fill_entry.quantity != 0:
+                self.filled_qty += fill_entry.quantity
+                qty = -self.filled_qty
+                tp = replace(self.take_profit, quantity=qty)
+                sl = replace(self.stop_loss, quantity=qty)
+                self.oco = OCOOrder(tp, sl)
+
+        # Execute exits if OCO active
+        if self.oco is not None:
+            fill_tp, fill_sl = self.oco.execute(
+                brokerage, account, market_price, ts=ts, bar_volume=bar_volume
+            )
+            if fill_tp.quantity != 0 or fill_sl.quantity != 0:
+                # Bracket completed
+                self.oco = None
+        else:
+            fill_tp = Fill(symbol=self.take_profit.symbol, quantity=0, price=market_price)
+            fill_sl = Fill(symbol=self.stop_loss.symbol, quantity=0, price=market_price)
+
+        return fill_entry, fill_tp, fill_sl

--- a/qmtl/examples/brokerage_demo/bracket_demo.py
+++ b/qmtl/examples/brokerage_demo/bracket_demo.py
@@ -1,0 +1,62 @@
+"""
+Run with: uv run python qmtl/examples/brokerage_demo/bracket_demo.py
+"""
+
+from __future__ import annotations
+
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashBuyingPowerModel,
+    PerShareFeeModel,
+    NullSlippageModel,
+    UnifiedFillModel,
+    Order,
+    OrderType,
+    TimeInForce,
+    BracketOrder,
+)
+
+
+def main() -> None:
+    brk = BrokerageModel(
+        CashBuyingPowerModel(),
+        PerShareFeeModel(fee_per_share=0.0),
+        NullSlippageModel(),
+        UnifiedFillModel(),
+    )
+    acct = Account(cash=1_000_000.0)
+
+    entry = Order(
+        symbol="AAPL",
+        quantity=100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.GTC,
+        limit_price=100.0,
+    )
+    take_profit = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.GTC,
+        limit_price=110.0,
+    )
+    stop_loss = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.STOP,
+        tif=TimeInForce.GTC,
+        stop_price=90.0,
+    )
+    bracket = BracketOrder(entry, take_profit, stop_loss)
+
+    fill_entry, fill_tp, fill_sl = bracket.execute(brk, acct, market_price=100.0)
+    fill_entry, fill_tp, fill_sl = bracket.execute(brk, acct, market_price=110.0)
+    print({"entry": fill_entry, "take_profit": fill_tp, "stop_loss": fill_sl, "cash": acct.cash})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_brokerage_bracket.py
+++ b/tests/test_brokerage_bracket.py
@@ -1,0 +1,105 @@
+from qmtl.brokerage import (
+    Account,
+    BrokerageModel,
+    CashBuyingPowerModel,
+    PerShareFeeModel,
+    NullSlippageModel,
+    UnifiedFillModel,
+    Order,
+    OrderType,
+    TimeInForce,
+    BracketOrder,
+)
+
+
+def make_brokerage(*, liquidity_cap: int | None = None) -> BrokerageModel:
+    return BrokerageModel(
+        CashBuyingPowerModel(),
+        PerShareFeeModel(fee_per_share=0.0),
+        NullSlippageModel(),
+        UnifiedFillModel(liquidity_cap=liquidity_cap),
+    )
+
+
+def test_bracket_full_fill_and_exit() -> None:
+    account = Account(cash=1_000_000)
+    entry = Order(
+        symbol="AAPL",
+        quantity=100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.DAY,
+        limit_price=100.0,
+    )
+    take_profit = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.DAY,
+        limit_price=110.0,
+    )
+    stop_loss = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.STOP,
+        tif=TimeInForce.DAY,
+        stop_price=90.0,
+    )
+    bracket = BracketOrder(entry, take_profit, stop_loss)
+    brk = make_brokerage()
+
+    fill_entry, fill_tp, fill_sl = bracket.execute(brk, account, market_price=100.0)
+    assert fill_entry.quantity == 100
+    assert fill_tp.quantity == 0
+    assert fill_sl.quantity == 0
+
+    fill_entry, fill_tp, fill_sl = bracket.execute(brk, account, market_price=110.0)
+    assert fill_entry.quantity == 0
+    assert fill_tp.quantity == -100
+    assert fill_sl.quantity == 0
+
+
+def test_bracket_partials_adjust_oco() -> None:
+    account = Account(cash=1_000_000)
+    entry = Order(
+        symbol="AAPL",
+        quantity=100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.DAY,
+        limit_price=100.0,
+    )
+    take_profit = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.LIMIT,
+        tif=TimeInForce.DAY,
+        limit_price=110.0,
+    )
+    stop_loss = Order(
+        symbol="AAPL",
+        quantity=-100,
+        price=100.0,
+        type=OrderType.STOP,
+        tif=TimeInForce.DAY,
+        stop_price=90.0,
+    )
+    bracket = BracketOrder(entry, take_profit, stop_loss)
+    brk = make_brokerage(liquidity_cap=50)
+
+    fill_entry, fill_tp, fill_sl = bracket.execute(brk, account, market_price=100.0)
+    assert fill_entry.quantity == 50
+    assert bracket.oco is not None
+    assert bracket.oco.first.quantity == -50
+    assert fill_tp.quantity == 0
+    assert fill_sl.quantity == 0
+
+    fill_entry, fill_tp, fill_sl = bracket.execute(brk, account, market_price=100.0)
+    assert fill_entry.quantity == 50
+    assert bracket.oco is not None
+    assert bracket.oco.first.quantity == -100
+    assert fill_tp.quantity == 0
+    assert fill_sl.quantity == 0


### PR DESCRIPTION
## Summary
- Implement `BracketOrder` that attaches OCO take-profit and stop-loss exits sized to fills
- Document and provide a demo for the new bracket order helper
- Cover bracket order behavior with unit tests for full and partial fills

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 --ignore=tests/e2e`
- `uv run -m pytest tests/test_brokerage_bracket.py -W error -n auto`
- `uv run mkdocs build`
- `uv run -m pytest -W error -n auto --ignore=tests/e2e` *(fails: ExceptionGroup: multiple unraisable exception warnings in tests/gateway/test_api.py)*

Closes #856

------
https://chatgpt.com/codex/tasks/task_e_68beffa22d14832985d08e02e6aef5d9