### PR TITLE
feat: validate node dataframes on feed

### DIFF
--- a/docs/reference/node_schema_validation.md
+++ b/docs/reference/node_schema_validation.md
@@ -1,0 +1,51 @@
+---
+title: "Node DataFrame Schema Validation"
+tags: []
+author: "QMTL Team"
+last_modified: 2025-09-08
+---
+
+{{ nav_links() }}
+
+# Node DataFrame Schema Validation
+
+Nodes may declare an `expected_schema` to validate incoming pandas
+`DataFrame` payloads. Schemas map column names to dtype strings and are
+checked automatically when data is fed into a node.
+
+## Declaring Schemas
+
+```python
+from qmtl.sdk import SourceNode
+
+price = SourceNode(
+    interval="1s",
+    period=1,
+    expected_schema={"ts": "int64", "close": "float64"},
+)
+```
+
+## Enforcement Modes
+
+Schema checking is controlled by the Runner via the
+`schema_enforcement` flag. Available modes are:
+
+- `fail` (default): raise `NodeValidationError` on mismatch
+- `warn`: log a warning but continue
+- `off`: skip validation
+
+```python
+from qmtl.sdk import Runner
+
+Runner.offline(MyStrategy, schema_enforcement="warn")
+```
+
+## Error Messages
+
+In `fail` mode, errors include node context for easier debugging:
+
+```
+Node abc123: missing columns: ['close']
+```
+
+{{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Templates: reference/templates.md
       - World API: reference/api_world.md
       - Enhanced Validation: reference/enhanced_validation.md
+      - Node Schema Validation: reference/node_schema_validation.md
       - Backtest Validation: reference/backtest_validation.md
       - Lean-like Features: reference/lean_like_features.md
       - Commit Log: reference/commit_log.md

--- a/qmtl/sdk/node_validation.py
+++ b/qmtl/sdk/node_validation.py
@@ -39,6 +39,7 @@ def validate_node_params(
     period: int | None,
     config: dict | None,
     schema: dict | None,
+    expected_schema: dict | None,
 ) -> tuple[str | None, list[str], int | None, int | None]:
     """Validate common ``Node`` constructor arguments."""
     interval_val = parse_interval(interval) if interval is not None else None
@@ -62,6 +63,8 @@ def validate_node_params(
         raise InvalidParameterError("config must be a dictionary")
     if schema is not None and not isinstance(schema, dict):
         raise InvalidParameterError("schema must be a dictionary")
+    if expected_schema is not None and not isinstance(expected_schema, dict):
+        raise InvalidParameterError("expected_schema must be a dictionary")
 
     if interval_val is not None and period_val is not None and period_val < 1:
         raise InvalidParameterError(

--- a/qmtl/sdk/schema_validation.py
+++ b/qmtl/sdk/schema_validation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from .exceptions import NodeValidationError
+
+__all__ = ["validate_schema"]
+
+def validate_schema(df: pd.DataFrame, expected_schema: Dict[str, str]) -> None:
+    """Validate ``df`` against ``expected_schema``.
+
+    ``expected_schema`` maps column names to pandas dtype strings. Raises
+    :class:`NodeValidationError` if columns are missing or dtypes mismatch.
+    """
+    if not isinstance(df, pd.DataFrame):
+        raise NodeValidationError("payload must be a pandas DataFrame")
+
+    missing = [col for col in expected_schema if col not in df.columns]
+    if missing:
+        raise NodeValidationError(f"missing columns: {missing}")
+
+    mismatched: Dict[str, tuple[str, str]] = {}
+    for col, dtype in expected_schema.items():
+        if col in df.columns and str(df[col].dtype) != dtype:
+            mismatched[col] = (dtype, str(df[col].dtype))
+    if mismatched:
+        details = ", ".join(
+            f"{col} (expected {exp}, got {got})" for col, (exp, got) in mismatched.items()
+        )
+        raise NodeValidationError(f"dtype mismatch: {details}")

--- a/tests/test_enhanced_validation.py
+++ b/tests/test_enhanced_validation.py
@@ -136,13 +136,23 @@ class TestParameterValidation:
     def test_valid_config_and_schema(self):
         """Test that valid config and schema are accepted."""
         node = SourceNode(
-            config={"key": "value"}, 
-            schema={"type": "object"}, 
-            interval="1s", 
+            config={"key": "value"},
+            schema={"type": "object"},
+            interval="1s",
             period=1
         )
         assert node.config == {"key": "value"}
         assert node.schema == {"type": "object"}
+
+    def test_invalid_expected_schema_parameter_type(self):
+        """Test that non-dict expected_schema parameter raises error."""
+        with pytest.raises(InvalidParameterError, match="expected_schema must be a dictionary"):
+            SourceNode(expected_schema="not_a_dict", interval="1s", period=1)
+
+    def test_valid_expected_schema(self):
+        """Test that valid expected_schema is accepted."""
+        node = SourceNode(interval="1s", period=1, expected_schema={"a": "int64"})
+        assert node.expected_schema == {"a": "int64"}
 
 
 class TestIntervalValidation:

--- a/tests/test_node_schema_validation.py
+++ b/tests/test_node_schema_validation.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import pytest
+
+from qmtl.sdk import SourceNode, Runner, Strategy, NodeValidationError
+
+
+class _SchemaStrategy(Strategy):
+    def setup(self):
+        self.src = SourceNode(interval="1s", period=1, expected_schema={"a": "int64"})
+        self.add_nodes([self.src])
+
+
+def test_schema_violation_fail_mode():
+    node = SourceNode(interval="1s", period=1, expected_schema={"a": "int64"})
+    df = pd.DataFrame({"b": [1]})
+    with pytest.raises(NodeValidationError) as exc:
+        node.feed("u", 1, 1, df)
+    assert "missing columns" in str(exc.value)
+    assert node.node_id in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_schema_violation_warn_mode(caplog):
+    strategy = await Runner.offline_async(_SchemaStrategy, schema_enforcement="warn")
+    node = strategy.src
+    df = pd.DataFrame({"b": [1]})
+    with caplog.at_level("WARNING"):
+        node.feed("u", 1, 1, df)
+    assert any("missing columns" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add optional `expected_schema` for nodes and validate DataFrame payloads
- allow Runner to control schema enforcement (off|warn|fail)
- document declaring node schemas

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 --ignore=tests/e2e/world_smoke`
- `uv run -m pytest -W error -p no:unraisableexception -n auto --ignore=tests/e2e/world_smoke`
- `uv run mkdocs build`

Closes #857

------
https://chatgpt.com/codex/tasks/task_e_68beff9fd30883299864cef0f0bf6dd5