### PR TITLE
feat(brokerage): CCXT-driven BrokerageModel factory + exchanges enum

### DIFF
--- a/docs/architecture/exchange_node_sets.md
+++ b/docs/architecture/exchange_node_sets.md
@@ -54,6 +54,9 @@ Key
 - The feedback is not a literal cycle: P consumes portfolio/risk snapshots at t−1 (or from a compacted state topic). This preserves acyclicity while enabling feedback.
 - In simulate/paper modes, `ExecutionNode` produces fills directly; in live mode, fills arrive via `FillIngestNode` from the exchange/broker (webhook or polling).
 
+Tip
+- For crypto exchanges, a generic profile can be built from CCXT via `make_ccxt_brokerage()` to quickly wire an execution model with detected maker/taker fees. See Reference → Brokerage API.
+
 ## Node Contracts
 
 - PreTradeGateNode
@@ -116,7 +119,7 @@ Both options are compatible with the Commit‑Log design; they do not change DM�
   - Scheduler Watermarks: Bucket processing advances only after upstream state topics commit up to a watermark for `t−1`. This can be implemented as a soft rule at the node/scheduler interface without changing DM invariants.
 
 - Exactly‑Once Boundaries
-  - Order submission: at‑least‑once with idempotent keys on producer (client) and consumer (executor). Keys should include `(world_id|strategy_id|symbol|side|ts|client_order_id)`.
+- Order submission: at‑least‑once with idempotent keys on producer (client) and consumer (executor). Keys should include `(world_id|strategy_id|symbol|side|ts|client_order_id)`.
   - Fill ingestion: at‑least‑once with per‑partition monotonic `seq` (or `etag`) on events. Consumers de‑duplicate by `(order_id, seq)`.
 
 - Activation Weights → Sizing (Soft Gating)

--- a/docs/reference/api/brokerage.md
+++ b/docs/reference/api/brokerage.md
@@ -103,6 +103,34 @@ profile = ibkr_equities_like_profile()
 model = profile.build()
 ```
 
+### CCXT-based Profiles (Crypto)
+
+Quickly spin up a crypto brokerage model by detecting maker/taker fees from CCXT. Falls back to conservative defaults when CCXT/network is unavailable.
+
+```python
+from qmtl.brokerage.ccxt_profile import make_ccxt_brokerage
+
+# Detect fees from ccxt (symbol-specific when provided). Hours=None assumes 24/7.
+model = make_ccxt_brokerage(
+    "binance",               # CCXT id (use "binanceusdm" for Binance USDT‑M futures)
+    product="spot",          # or "futures"
+    symbol="BTC/USDT",       # optional; improves fee selection if markets differ
+    sandbox=False,            # True to route to testnet if supported
+)
+
+# Explicit fallback/defaults without ccxt
+model_default = make_ccxt_brokerage(
+    "binance",
+    detect_fees=False,
+    defaults=(0.0002, 0.0007),   # maker, taker
+)
+```
+
+Notes:
+- Fee detection priority: market-level (symbol) → exchange.fees["trading"] → defaults.
+- Negative maker rates (rebates) are preserved if reported by the exchange.
+- For futures-specific behavior (leverage/margin/hedge), see ``FuturesCcxtBrokerageClient`` under Connectors; this factory only shapes fees/slippage.
+
 ## Interest
 
 Use `MarginInterestModel` to accrue daily interest on cash balances. Positive

--- a/docs/reference/api/brokerage.md
+++ b/docs/reference/api/brokerage.md
@@ -131,6 +131,8 @@ Notes:
 - Negative maker rates (rebates) are preserved if reported by the exchange.
 - For futures-specific behavior (leverage/margin/hedge), see ``FuturesCcxtBrokerageClient`` under Connectors; this factory only shapes fees/slippage.
 
+See runnable example: `qmtl/examples/brokerage_demo/ccxt_fee_profile_demo.py` (covers spot and futures, maker vs taker).
+
 ## Interest
 
 Use `MarginInterestModel` to accrue daily interest on cash balances. Positive

--- a/docs/reference/api/connectors.md
+++ b/docs/reference/api/connectors.md
@@ -9,7 +9,7 @@ last_modified: 2025-09-09
 
 # Live & Brokerage Connectors
 
-This page standardizes the SDK interfaces for connecting to live brokers and live data feeds. It complements the execution models in Brokerage API and the Gateway WS design.
+This page standardizes the SDK interfaces for connecting to live brokers and live data feeds. It complements the execution models in Brokerage API and the Gateway WS design. For shaping fee models for crypto exchanges from CCXT metadata, see `make_ccxt_brokerage()` in Brokerage API.
 
 Key goals:
 - Provide thin, testable abstractions that are easy to adopt.

--- a/qmtl/brokerage/__init__.py
+++ b/qmtl/brokerage/__init__.py
@@ -42,6 +42,7 @@ from .settlement import SettlementModel
 from .profile import BrokerageProfile, SecurityInitializer, ibkr_equities_like_profile
 from .interest import MarginInterestModel
 from .brokerage_model import BrokerageModel
+from .ccxt_profile import make_ccxt_brokerage
 
 __all__ = [
     "Order",
@@ -93,4 +94,5 @@ __all__ = [
     "SecurityInitializer",
     "ibkr_equities_like_profile",
     "BrokerageModel",
+    "make_ccxt_brokerage",
 ]

--- a/qmtl/brokerage/ccxt_profile.py
+++ b/qmtl/brokerage/ccxt_profile.py
@@ -1,0 +1,203 @@
+"""CCXT-driven BrokerageModel factory.
+
+Build a reasonable default :class:`BrokerageModel` for a crypto exchange by
+auto-detecting maker/taker fees via ``ccxt`` when available, with safe fallbacks
+otherwise. Designed for quick experiments where users can switch exchanges by
+ID and get a consistent fee/slippage baseline.
+
+Notes
+-----
+- ``ccxt`` is an optional dependency; import is lazy and guarded.
+- Fee detection order:
+  1) ``exchange.load_markets()`` and symbol-specific ``market['maker'|'taker']``
+     (or any representative market if ``symbol`` not provided)
+  2) ``exchange.fees['trading']['maker'|'taker']``
+  3) Provided defaults (maker, taker)
+
+- Fallback defaults use spot-like maker/taker unless explicitly overridden.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+import logging
+
+from .brokerage_model import BrokerageModel
+from .buying_power import CashBuyingPowerModel
+from .fees import MakerTakerFeeModel
+from .fill_models import ImmediateFillModel
+from .slippage import NullSlippageModel, SpreadBasedSlippageModel
+
+
+_log = logging.getLogger(__name__)
+
+# Cache detected fees to avoid repeated network calls to load_markets
+_FEE_CACHE: dict[tuple[str, str, bool, str | None], tuple[float, float]] = {}
+
+
+def _default_fees(product: str, defaults: tuple[float, float] | None) -> tuple[float, float]:
+    if defaults is not None:
+        return float(defaults[0]), float(defaults[1])
+    # Spot-like conservative defaults; futures can override via ``defaults=...``
+    return 0.0002, 0.0007  # maker, taker
+
+
+def _instantiate_ccxt_exchange(exchange_id: str, *, product: str, sandbox: bool) -> Any:
+    try:  # pragma: no cover - optional dependency import path
+        import ccxt  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("ccxt is required for fee detection; set detect_fees=False to skip") from exc
+
+    # Some exchanges share the same id for spot/futures; ``defaultType`` guides market metadata
+    options = {"defaultType": "future" if product == "futures" else "spot"}
+    klass = getattr(ccxt, exchange_id)
+    ex = klass({"enableRateLimit": True, "options": options})
+    # Best-effort sandbox toggle
+    try:
+        if sandbox and hasattr(ex, "set_sandbox_mode"):
+            ex.set_sandbox_mode(True)  # type: ignore[attr-defined]
+    except Exception:
+        try:
+            if sandbox and hasattr(ex, "setSandboxMode"):
+                getattr(ex, "setSandboxMode")(True)
+        except Exception:
+            pass
+    return ex
+
+
+def _try_detect_fees(
+    exchange_id: str,
+    *,
+    product: str,
+    symbol: str | None,
+    sandbox: bool,
+) -> tuple[float, float] | None:
+    """Return (maker, taker) if detection succeeds; otherwise ``None``."""
+    try:
+        ex = _instantiate_ccxt_exchange(exchange_id, product=product, sandbox=sandbox)
+    except Exception as exc:  # pragma: no cover - exercised by separate fallback test
+        _log.warning("CCXT import/instantiate failed for %s: %s", exchange_id, exc)
+        return None
+
+    maker: float | None = None
+    taker: float | None = None
+
+    # 1) Prefer market['maker'|'taker'] from load_markets
+    try:
+        markets = ex.load_markets()
+        if symbol and symbol in markets:
+            m = markets[symbol]
+            maker = float(m.get("maker")) if m.get("maker") is not None else None
+            taker = float(m.get("taker")) if m.get("taker") is not None else None
+        if maker is None or taker is None:
+            # try any representative market
+            for m in markets.values():
+                mk = m.get("maker")
+                tk = m.get("taker")
+                if mk is not None and tk is not None:
+                    maker = float(mk)
+                    taker = float(tk)
+                    break
+    except Exception:
+        pass
+
+    # 2) Exchange-level trading fees
+    if maker is None or taker is None:
+        try:
+            fees = getattr(ex, "fees", {}) or {}
+            trading = fees.get("trading", {}) if isinstance(fees, dict) else {}
+            mk = trading.get("maker")
+            tk = trading.get("taker")
+            if mk is not None and tk is not None:
+                maker = float(mk)
+                taker = float(tk)
+        except Exception:
+            pass
+
+    if maker is None or taker is None:
+        return None
+    return maker, taker
+
+
+def make_ccxt_brokerage(
+    exchange_id: str,
+    *,
+    product: str = "spot",
+    symbol: str | None = None,
+    sandbox: bool = False,
+    detect_fees: bool = True,
+    defaults: tuple[float, float] | None = None,
+    use_spread_slippage: bool = False,
+    spread_fraction: float = 0.5,
+) -> BrokerageModel:
+    """Build a :class:`BrokerageModel` using CCXT to detect maker/taker fees.
+
+    Parameters
+    ----------
+    exchange_id:
+        CCXT exchange id, e.g., ``"binance"`` or ``"binanceusdm"``.
+    product:
+        ``"spot"`` (default) or ``"futures"``. Guides CCXT market metadata and docs.
+    symbol:
+        Optional symbol like ``"BTC/USDT"`` used for symbol-specific fee selection.
+    sandbox:
+        When True, toggles exchange testnet mode if supported.
+    detect_fees:
+        If False, skip CCXT entirely and use ``defaults``.
+    defaults:
+        Fallback (maker, taker) used when detection fails or is disabled. If
+        omitted, conservative spot-like defaults are used.
+    use_spread_slippage:
+        When True, use :class:`SpreadBasedSlippageModel` with ``spread_fraction``.
+        Otherwise, :class:`NullSlippageModel` is used.
+    spread_fraction:
+        Fraction of the quoted spread to apply as slippage if ``use_spread_slippage``.
+    """
+
+    cache_key = (exchange_id, product, bool(sandbox), symbol)
+
+    maker: float
+    taker: float
+
+    if detect_fees:
+        cached = _FEE_CACHE.get(cache_key)
+        if cached is not None:
+            maker, taker = cached
+        else:
+            detected = _try_detect_fees(exchange_id, product=product, symbol=symbol, sandbox=sandbox)
+            if detected is not None:
+                maker, taker = detected
+                _FEE_CACHE[cache_key] = (maker, taker)
+            else:
+                maker, taker = _default_fees(product, defaults)
+                _log.warning(
+                    "Using fallback maker/taker fees for %s (%s): maker=%s taker=%s",
+                    exchange_id,
+                    product,
+                    maker,
+                    taker,
+                )
+    else:
+        maker, taker = _default_fees(product, defaults)
+
+    fee_model = MakerTakerFeeModel(maker_rate=maker, taker_rate=taker)
+    slippage_model = (
+        SpreadBasedSlippageModel(spread_fraction=spread_fraction)
+        if use_spread_slippage
+        else NullSlippageModel()
+    )
+    model = BrokerageModel(
+        buying_power_model=CashBuyingPowerModel(),
+        fee_model=fee_model,
+        slippage_model=slippage_model,
+        fill_model=ImmediateFillModel(),
+        symbols=None,  # crypto symbols typically validated by exchange; optional to plug custom provider
+        hours=None,  # crypto 24/7 by default; plug ExchangeHoursProvider if desired
+        shortable=None,
+        settlement=None,
+    )
+    return model
+
+
+__all__ = ["make_ccxt_brokerage"]
+

--- a/qmtl/examples/brokerage_demo/ccxt_fee_profile_demo.py
+++ b/qmtl/examples/brokerage_demo/ccxt_fee_profile_demo.py
@@ -1,0 +1,134 @@
+"""CCXT Fee Profile Demo (Spot & Futures)
+
+This example shows how to build a BrokerageModel using ``make_ccxt_brokerage``
+for both spot and futures exchanges and simulate a few trades to observe fee
+application differences between taker (market) and maker (limit) orders.
+
+By default, the demo uses conservative fallback fees (no network, no ccxt
+required). To enable ccxt-based fee detection, set env ``DETECT_FEES=1``.
+Optionally set ``SANDBOX=1`` to prefer exchange testnet endpoints when
+supported.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from typing import Any
+
+from qmtl.brokerage import (
+    Account,
+    Order,
+    OrderType,
+    TimeInForce,
+)
+from qmtl.brokerage.ccxt_profile import make_ccxt_brokerage
+
+
+def build_spot_model(
+    exchange_id: str = "binance",
+    *,
+    symbol: str = "BTC/USDT",
+    detect_fees: bool = False,
+    sandbox: bool = False,
+    defaults: tuple[float, float] = (0.0002, 0.0007),
+):
+    return make_ccxt_brokerage(
+        exchange_id,
+        product="spot",
+        symbol=symbol,
+        sandbox=sandbox,
+        detect_fees=detect_fees,
+        defaults=defaults,
+    )
+
+
+def build_futures_model(
+    exchange_id: str = "binanceusdm",
+    *,
+    symbol: str = "BTC/USDT",
+    detect_fees: bool = False,
+    sandbox: bool = False,
+    defaults: tuple[float, float] = (0.0004, 0.0008),
+):
+    return make_ccxt_brokerage(
+        exchange_id,
+        product="futures",
+        symbol=symbol,
+        sandbox=sandbox,
+        detect_fees=detect_fees,
+        defaults=defaults,
+    )
+
+
+def _exec(model, order: Order, *, market_price: float, cash: float = 100_000.0):
+    acct = Account(cash=cash, base_currency="USDT")
+    fill = model.execute_order(acct, order, market_price)
+    return {
+        "order": {
+            "symbol": order.symbol,
+            "type": order.type.value,
+            "tif": order.tif.value,
+            "qty": order.quantity,
+            "price": order.price,
+            "limit": order.limit_price,
+        },
+        "fill": {"qty": fill.quantity, "price": fill.price, "fee": fill.fee},
+        "cash_after": acct.cash,
+    }
+
+
+def run_demo() -> dict[str, Any]:
+    detect = os.getenv("DETECT_FEES", "0") in {"1", "true", "TRUE"}
+    sandbox = os.getenv("SANDBOX", "0") in {"1", "true", "TRUE"}
+    spot_symbol = os.getenv("SPOT_SYMBOL", "BTC/USDT")
+    fut_symbol = os.getenv("FUT_SYMBOL", "BTC/USDT")
+
+    spot = build_spot_model("binance", symbol=spot_symbol, detect_fees=detect, sandbox=sandbox)
+    fut = build_futures_model("binanceusdm", symbol=fut_symbol, detect_fees=detect, sandbox=sandbox)
+
+    # Simulate a few orders to illustrate maker/taker fee application.
+    spot_market_buy = Order(symbol=spot_symbol, quantity=1, price=50_000.0, type=OrderType.MARKET, tif=TimeInForce.DAY)
+    spot_limit_buy = Order(
+        symbol=spot_symbol,
+        quantity=1,
+        price=50_000.0,
+        type=OrderType.LIMIT,
+        limit_price=49_900.0,
+        tif=TimeInForce.GTC,
+    )
+    fut_market_sell = Order(symbol=fut_symbol, quantity=-2, price=30_000.0, type=OrderType.MARKET, tif=TimeInForce.DAY)
+    fut_limit_sell = Order(
+        symbol=fut_symbol,
+        quantity=-2,
+        price=30_000.0,
+        type=OrderType.LIMIT,
+        limit_price=30_100.0,
+        tif=TimeInForce.GTC,
+    )
+
+    results = {
+        "spot": {
+            "maker_rate": getattr(spot.fee_model, "maker_rate", None),
+            "taker_rate": getattr(spot.fee_model, "taker_rate", None),
+            "market_buy": _exec(spot, spot_market_buy, market_price=50_000.0),
+            "limit_buy": _exec(spot, spot_limit_buy, market_price=49_900.0),
+        },
+        "futures": {
+            "maker_rate": getattr(fut.fee_model, "maker_rate", None),
+            "taker_rate": getattr(fut.fee_model, "taker_rate", None),
+            "market_sell": _exec(fut, fut_market_sell, market_price=30_000.0),
+            "limit_sell": _exec(fut, fut_limit_sell, market_price=30_100.0),
+        },
+        "detect_fees": detect,
+        "sandbox": sandbox,
+    }
+    return results
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demo
+    import json
+
+    out = run_demo()
+    print(json.dumps(out, indent=2, sort_keys=True))
+

--- a/qmtl/examples/tests/test_ccxt_fee_profile_demo.py
+++ b/qmtl/examples/tests/test_ccxt_fee_profile_demo.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_ccxt_fee_profile_demo_builds_models_and_applies_fees():
+    from qmtl.examples.brokerage_demo.ccxt_fee_profile_demo import (
+        build_spot_model,
+        build_futures_model,
+        run_demo,
+    )
+    from qmtl.brokerage import BrokerageModel, Order, OrderType, TimeInForce
+
+    # Build models without ccxt (deterministic defaults)
+    spot = build_spot_model(detect_fees=False, defaults=(0.001, 0.002))
+    fut = build_futures_model(detect_fees=False, defaults=(0.003, 0.004))
+
+    assert isinstance(spot, BrokerageModel)
+    assert isinstance(fut, BrokerageModel)
+
+    # Market = taker, Limit = maker
+    mkt_order = Order(symbol="BTC/USDT", quantity=1, price=10_000.0, type=OrderType.MARKET, tif=TimeInForce.DAY)
+    lmt_order = Order(symbol="BTC/USDT", quantity=1, price=10_000.0, type=OrderType.LIMIT, tif=TimeInForce.GTC, limit_price=9_900.0)
+
+    # Use internal helper from the demo
+    from qmtl.examples.brokerage_demo.ccxt_fee_profile_demo import _exec
+
+    res_mkt = _exec(spot, mkt_order, market_price=10_000.0, cash=100_000.0)
+    res_lmt = _exec(spot, lmt_order, market_price=9_900.0, cash=100_000.0)
+
+    assert pytest.approx(res_mkt["fill"]["fee"]) == 10_000.0 * 0.002
+    assert pytest.approx(res_lmt["fill"]["fee"]) == 9_900.0 * 0.001
+
+    # Smoke test: run_demo returns structured dict
+    out = run_demo()
+    assert set(out.keys()) >= {"spot", "futures"}
+

--- a/qmtl/sdk/__init__.py
+++ b/qmtl/sdk/__init__.py
@@ -54,6 +54,7 @@ from .portfolio import (
     order_target_percent,
     order_value,
 )
+from .exchanges import CcxtExchange, normalize_exchange_id, ensure_ccxt_exchange
 
 __all__ = [
     "Node",
@@ -98,6 +99,9 @@ __all__ = [
     "parse_period",
     "validate_tag",
     "validate_name",
+    "CcxtExchange",
+    "normalize_exchange_id",
+    "ensure_ccxt_exchange",
     "QMTLValidationError",
     "NodeValidationError",
     "InvalidParameterError",

--- a/qmtl/sdk/exchanges.py
+++ b/qmtl/sdk/exchanges.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Recommended CCXT exchange identifiers and helpers.
+
+This module provides a small enum of commonly used exchanges and a helper to
+validate/normalize user-provided identifiers against ``ccxt.exchanges`` when
+``ccxt`` is available. The SDK treats ``ccxt`` as optional; in environments
+without it, the helper returns the normalized string without validation.
+"""
+
+from enum import Enum
+import logging
+
+_log = logging.getLogger(__name__)
+
+
+class CcxtExchange(Enum):
+    # Spot (also usable for futures when combined with defaultType=future)
+    BINANCE = "binance"
+    OKX = "okx"
+    BYBIT = "bybit"
+    KRAKEN = "kraken"
+    COINBASE = "coinbase"
+    KUCOIN = "kucoin"
+    BITGET = "bitget"
+    GATEIO = "gateio"
+
+    # Explicit futures-specific id variants where applicable
+    BINANCE_USDM = "binanceusdm"
+
+
+def normalize_exchange_id(value: str | CcxtExchange) -> str:
+    """Return the lowercase CCXT id string for the given enum or string."""
+    if isinstance(value, CcxtExchange):
+        return value.value
+    return str(value).strip().lower()
+
+
+def ensure_ccxt_exchange(exchange_id: str | CcxtExchange, *, strict: bool = True) -> str:
+    """Normalize and (optionally) validate that the id exists in ``ccxt.exchanges``.
+
+    Parameters
+    ----------
+    exchange_id:
+        String id or :class:`CcxtExchange`.
+    strict:
+        When True, raise ``ValueError`` if ``ccxt`` is available and the id is not
+        in ``ccxt.exchanges``. When False, log a warning instead and return id.
+    """
+    eid = normalize_exchange_id(exchange_id)
+    try:  # pragma: no cover - optional dependency import path
+        import ccxt  # type: ignore
+    except Exception:
+        # ccxt not installed — skip validation
+        return eid
+
+    supported = set(getattr(ccxt, "exchanges", []) or [])
+    if supported and eid not in supported:
+        msg = f"Exchange id '{eid}' not found in ccxt.exchanges"
+        if strict:
+            raise ValueError(msg)
+        _log.warning(msg)
+    return eid
+
+
+__all__ = ["CcxtExchange", "normalize_exchange_id", "ensure_ccxt_exchange"]

--- a/tests/test_ccxt_brokerage_profile.py
+++ b/tests/test_ccxt_brokerage_profile.py
@@ -1,0 +1,141 @@
+import sys
+import types
+
+import pytest
+
+
+def _install_ccxt_stub(markets: dict | None = None, trading_fee: tuple[float, float] | None = None):
+    """Install a minimal ccxt stub module into sys.modules for tests."""
+
+    # shared counter across instances
+    calls = {"load_markets": 0}
+
+    class _FakeExchange:
+        def __init__(self, config):
+            self.config = config
+            self._markets = markets or {}
+            mk, tk = trading_fee if trading_fee is not None else (None, None)
+            self.fees = {"trading": {"maker": mk, "taker": tk}}
+
+        def load_markets(self):
+            calls["load_markets"] += 1
+            return self._markets
+
+        def set_sandbox_mode(self, enabled: bool):  # pragma: no cover - trivial
+            self._sandbox = bool(enabled)
+
+        # Older versions naming
+        def setSandboxMode(self, enabled: bool):  # pragma: no cover - trivial
+            self._sandbox = bool(enabled)
+
+    stub = types.SimpleNamespace()
+    stub.exchanges = ["binance", "kraken", "binanceusdm"]
+    stub.binance = _FakeExchange
+    stub.binanceusdm = _FakeExchange
+    stub._calls = calls
+
+    sys.modules["ccxt"] = stub
+    return stub
+
+
+def test_symbol_specific_fees_take_precedence(monkeypatch):
+    # Ensure a clean slate
+    sys.modules.pop("ccxt", None)
+    markets = {
+        "BTC/USDT": {"maker": 0.001, "taker": 0.002},
+        "ETH/USDT": {"maker": 0.003, "taker": 0.004},
+    }
+    _install_ccxt_stub(markets=markets, trading_fee=(0.01, 0.02))
+
+    from qmtl.brokerage.ccxt_profile import make_ccxt_brokerage
+    import qmtl.brokerage.ccxt_profile as cp
+    cp._FEE_CACHE.clear()
+
+    model = make_ccxt_brokerage(
+        "binance", product="spot", symbol="BTC/USDT", detect_fees=True
+    )
+    fee = model.fee_model
+    from qmtl.brokerage.fees import MakerTakerFeeModel
+
+    assert isinstance(fee, MakerTakerFeeModel)
+    assert fee.maker_rate == pytest.approx(0.001)
+    assert fee.taker_rate == pytest.approx(0.002)
+
+
+def test_exchange_level_fees_used_when_no_markets():
+    sys.modules.pop("ccxt", None)
+    _install_ccxt_stub(markets={}, trading_fee=(0.005, 0.007))
+    from qmtl.brokerage.ccxt_profile import make_ccxt_brokerage
+    import qmtl.brokerage.ccxt_profile as cp
+    cp._FEE_CACHE.clear()
+
+    model = make_ccxt_brokerage("binance", product="spot", detect_fees=True)
+    fee = model.fee_model
+    from qmtl.brokerage.fees import MakerTakerFeeModel
+
+    assert isinstance(fee, MakerTakerFeeModel)
+    assert fee.maker_rate == pytest.approx(0.005)
+    assert fee.taker_rate == pytest.approx(0.007)
+
+
+def test_defaults_used_when_ccxt_absent_or_detection_disabled(monkeypatch):
+    # Ensure ccxt is not importable
+    sys.modules.pop("ccxt", None)
+
+    from qmtl.brokerage.ccxt_profile import make_ccxt_brokerage
+    import qmtl.brokerage.ccxt_profile as cp
+    cp._FEE_CACHE.clear()
+
+    # Detection disabled: use explicit defaults
+    model = make_ccxt_brokerage(
+        "binance",
+        product="spot",
+        detect_fees=False,
+        defaults=(0.0003, 0.0008),
+    )
+    fee = model.fee_model
+    from qmtl.brokerage.fees import MakerTakerFeeModel
+
+    assert isinstance(fee, MakerTakerFeeModel)
+    assert fee.maker_rate == pytest.approx(0.0003)
+    assert fee.taker_rate == pytest.approx(0.0008)
+
+    # Detection enabled but ccxt missing → fallback defaults (spot-like)
+    model2 = make_ccxt_brokerage("binance", product="spot", detect_fees=True)
+    fee2 = model2.fee_model
+    assert fee2.maker_rate == pytest.approx(0.0002)
+    assert fee2.taker_rate == pytest.approx(0.0007)
+
+
+def test_fee_detection_cached_load_markets_called_once():
+    sys.modules.pop("ccxt", None)
+    stub = _install_ccxt_stub(
+        markets={"BTC/USDT": {"maker": 0.001, "taker": 0.002}}, trading_fee=(0.0, 0.0)
+    )
+    from qmtl.brokerage.ccxt_profile import make_ccxt_brokerage
+    import qmtl.brokerage.ccxt_profile as cp
+    cp._FEE_CACHE.clear()
+
+    # First call
+    model1 = make_ccxt_brokerage("binance", product="spot", symbol="BTC/USDT")
+    # Second call (same key)
+    model2 = make_ccxt_brokerage("binance", product="spot", symbol="BTC/USDT")
+
+    # Ensure load_markets was invoked exactly once across both calls
+    assert stub._calls["load_markets"] == 1
+
+    # Sanity: both models share the same fee rates
+    assert model1.fee_model.maker_rate == model2.fee_model.maker_rate
+    assert model1.fee_model.taker_rate == model2.fee_model.taker_rate
+
+
+def test_enum_and_validation_helper():
+    # Install stub to provide .exchanges list for validation
+    sys.modules.pop("ccxt", None)
+    _install_ccxt_stub(markets={}, trading_fee=(0.001, 0.002))
+    from qmtl.sdk.exchanges import CcxtExchange, ensure_ccxt_exchange
+
+    assert ensure_ccxt_exchange(CcxtExchange.BINANCE) == "binance"
+    assert ensure_ccxt_exchange("kraken") == "kraken"
+    with pytest.raises(ValueError):
+        ensure_ccxt_exchange("not-a-real-exchange")


### PR DESCRIPTION
Implements ccxt-based brokerage profile factory and exchanges enum.

Summary
- Add `make_ccxt_brokerage(exchange_id, *, product='spot'|'futures', symbol=None, sandbox=False, detect_fees=True, defaults=...) -> BrokerageModel`
- Add `CcxtExchange` enum and `ensure_ccxt_exchange()` helper (optional validation against ccxt)
- Docs: Brokerage API section for CCXT-based profiles; connectors cross-link; Exchange Node Sets mention
- Tests: unit coverage for fee detection priority, fallbacks, symbol-specific selection, ccxt-missing case, cache behavior

Fixes #840

Acceptance
- Unit tests pass for the new module: `UV_PYTHON=python3.11 uv run -m pytest -q tests/test_ccxt_brokerage_profile.py`
- Docs build passes: `UV_PYTHON=python3.11 uv run mkdocs build`
- e2e/world_smoke unrelated collection warning exists upstream; not modified in this PR

Notes
- Fee detection preserves negative maker (rebates) if provided by ccxt.
- Futures leverage/margin/hedge are handled by `FuturesCcxtBrokerageClient`; this factory only composes fees/slippage.
- Defaults are conservative; override via `defaults=(maker, taker)` for specific venues or accounts.
