### PR TITLE
docs: add learning path summary and MVP example

### DIFF
--- a/docs/guides/sdk_tutorial.md
+++ b/docs/guides/sdk_tutorial.md
@@ -7,6 +7,14 @@ last_modified: 2025-08-24
 
 {{ nav_links() }}
 
+# **러닝 경로 요약**
+
+1. [MVP 전략 예제](../../qmtl/examples/templates/single_indicator.py)
+   - `qmtl init --path mvp --strategy single_indicator --with-sample-data`
+   - `uv run python strategy.py` 실행 후 `uv run qmtl report run.log`로 리포트 생성
+2. [전략 템플릿 모음](../reference/templates.md)
+3. [아키텍처 상세](../architecture/architecture.md)
+
 # SDK 사용 가이드
 
 본 문서는 QMTL SDK를 이용해 전략을 구현하고 실행하는 기본 절차를 소개합니다. 보다 상세한 아키텍처 설명과 예시는 [architecture.md](../architecture/architecture.md)와 `qmtl/examples/` 디렉터리를 참고하세요.

--- a/docs/reference/templates.md
+++ b/docs/reference/templates.md
@@ -12,6 +12,8 @@ last_modified: 2025-08-21
 # Strategy Templates
 
 QMTL ships with starter strategies that can be used when running `qmtl init`.
+For a step-by-step introduction and a minimal working example, see the
+[SDK 사용 가이드](../guides/sdk_tutorial.md).
 List them with:
 
 ```bash
@@ -49,6 +51,7 @@ graph LR
 ```
 
 *Single EMA indicator.* Shows how to attach one indicator to a price stream.
+Recommended as the [MVP 전략 예제](../guides/sdk_tutorial.md) starting point.
 
 ```bash
 qmtl init --path my_proj --strategy single_indicator


### PR DESCRIPTION
## Summary
- highlight 3-stage learning path with MVP strategy and cross-links
- reference templates from the tutorial and vice versa

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: ExceptionGroup: multiple unraisable exception warnings)*
- `uv run mkdocs build` *(warning: link to example outside docs)*

Fixes #801

------
https://chatgpt.com/codex/tasks/task_e_68bf0eea709c8329a0574128db80466e