### PR TITLE
docs: expand Binance futures example

### DIFF
--- a/docs/reference/api/connectors.md
+++ b/docs/reference/api/connectors.md
@@ -77,7 +77,7 @@ See runnable example: `qmtl/examples/brokerage_demo/ccxt_binance_sandbox_demo.py
 
 ### Futures (Binance USDT‑M Testnet)
 
-Use `FuturesCcxtBrokerageClient` targeting `binanceusdm` and enable `sandbox=True`. You can optionally set `leverage`, `margin_mode` (cross/isolated), and `hedge_mode` (dual‑side) if supported.
+Use `FuturesCcxtBrokerageClient` targeting `binanceusdm` and enable `sandbox=True`. You can optionally set `leverage`, `margin_mode` (cross/isolated), and `hedge_mode` (dual‑side) if supported. The client maps futures extras like `position_side` and `reduce_only`, and it can apply per-order leverage changes on exchanges that allow it.
 
 ```python
 from qmtl.sdk import FuturesCcxtBrokerageClient
@@ -87,7 +87,7 @@ client = FuturesCcxtBrokerageClient(
     symbol="BTC/USDT",
     leverage=5,
     margin_mode="cross",
-    hedge_mode=False,
+    hedge_mode=True,
     apiKey="<TESTNET_KEY>",
     secret="<TESTNET_SECRET>",
     sandbox=True,
@@ -101,6 +101,8 @@ resp = client.post_order({
     "limit_price": 10000.0,
     "time_in_force": "GTC",
     "reduce_only": False,
+    "position_side": "LONG",  # requires hedge_mode=True
+    "leverage": 10,  # optional per-order adjustment
 })
 ```
 

--- a/qmtl/examples/brokerage_demo/ccxt_binance_futures_sandbox_demo.py
+++ b/qmtl/examples/brokerage_demo/ccxt_binance_futures_sandbox_demo.py
@@ -10,7 +10,7 @@ Environment variables:
 
 Notes:
 - This demo submits a small LIMIT order; adjust price/qty per testnet filters.
-- Demonstrates reduceOnly and positionSide parameters.
+- Demonstrates `reduce_only`, `position_side`, and per-order leverage changes.
 """
 
 from __future__ import annotations
@@ -33,7 +33,7 @@ def main() -> None:
         symbol=symbol,
         leverage=5,
         margin_mode="cross",
-        hedge_mode=False,
+        hedge_mode=True,
         apiKey=api_key,
         secret=api_secret,
         sandbox=True,
@@ -47,7 +47,8 @@ def main() -> None:
         "limit_price": 10000.0,
         "time_in_force": "GTC",
         "reduce_only": False,
-        # When hedge_mode=True, you can also set: "position_side": "LONG" or "SHORT"
+        "position_side": "LONG",
+        "leverage": 10,
     }
     resp = client.post_order(order)
     print("create_order:", resp)


### PR DESCRIPTION
## Summary
- document position_side/reduce_only and per-order leverage for `FuturesCcxtBrokerageClient`
- enhance Binance futures demo to showcase hedge mode and dynamic leverage

## Testing
- `uv run mkdocs build`
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: PytestUnraisableExceptionWarning in two tests)*

Closes #823

------
https://chatgpt.com/codex/tasks/task_e_68bf0f40dd6083298f26da4666d36a7a