### PR TITLE
feat: add world scope portfolio risk

### DIFF
--- a/docs/architecture/exchange_node_sets.md
+++ b/docs/architecture/exchange_node_sets.md
@@ -224,10 +224,27 @@ Freeze/Drain Semantics
 
 ## Portfolio Scoping
 
-- Strategy‑Scoped (default): `scope = (world_id, strategy_id)`
-- World‑Scoped (optional): `scope = (world_id)` to share cash/limits across strategies
+- Exchange Node Sets accept a ``portfolio_scope`` option controlling how
+  portfolio state is keyed and shared.
+- ``strategy`` (default): snapshots and fills are keyed by
+  ``(world_id, strategy_id, symbol)`` and each strategy maintains isolated
+  cash and risk limits.
+- ``world``: snapshots and fills are keyed by ``(world_id, symbol)`` so all
+  strategies in the same world draw from a shared portfolio.
 
-Node Sets must declare scope explicitly. World‑scope increases coupling but enables cross‑strategy limits.
+When ``portfolio_scope="world"``, ``RiskControlNode`` evaluates leverage and
+concentration across the combined positions of every participating strategy.
+This enables cross‑strategy limits such as capping aggregate symbol exposure
+or total leverage.
+
+Example:
+
+```python
+builder = make_ccxt_node_set(portfolio_scope="world")
+```
+
+Deterministic key composition ensures snapshots and fills are unique under
+either scope.
 
 ## Gateway Webhook & Security (Enhancements)
 


### PR DESCRIPTION
## Summary
- support world-scoped portfolio evaluation and aggregation in risk manager
- document portfolio scope options for exchange node sets
- test cross-strategy concentration limits under world scope

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest tests/test_risk_management.py::TestRiskManager::test_validate_world_risk_concentration_violation -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto tests/test_risk_management.py::TestRiskManager::test_validate_world_risk_concentration_violation`
- `uv run mkdocs build`

Fixes #827

------
https://chatgpt.com/codex/tasks/task_e_68bf0f71b5e88329a5bf5f3676f128f3