### PR TITLE
feat: add fills webhook and replay endpoint

### DIFF
--- a/docs/operations/fills_replay.md
+++ b/docs/operations/fills_replay.md
@@ -1,0 +1,19 @@
+# Fill Replay Runbook
+
+This runbook outlines how operators can trigger re-delivery of historical fill
+events through the Gateway.
+
+## Security
+
+The `/fills` and `/fills/replay` endpoints require a Bearer token signed with
+the shared HMAC secret. The token must carry `world_id` and `strategy_id`
+claims that scope the request.
+
+## Replay Procedure
+
+1. Generate a JWT with the appropriate scope.
+2. Issue a `POST /fills/replay` request containing `from_ts` and `to_ts` Unix
+   timestamps and optional `world_id`/`strategy_id` filters.
+3. Monitor the `trade.fills` topic to verify re-delivery. Consumers should
+   handle events idempotently.
+

--- a/docs/reference/api/order_events.md
+++ b/docs/reference/api/order_events.md
@@ -121,4 +121,18 @@ Webhook and internal event transport MAY wrap payloads in CloudEvents 1.0:
 
 Consumers MUST accept both bare and CloudEvents-wrapped forms.
 
+## Gateway `/fills` Webhook
+
+The Gateway exposes a `/fills` endpoint for broker callbacks. Payloads may be
+sent as a raw `ExecutionFillEvent` or wrapped in a CloudEvents 1.0 envelope.
+Requests must include a HMAC-signed JWT whose `world_id` and `strategy_id`
+claims match the payload. Out-of-scope requests are rejected.
+
+### Replay Endpoint
+
+Operators can trigger re-delivery by calling `POST /fills/replay` with
+`from_ts` and `to_ts` fields plus optional `world_id`/`strategy_id` filters.
+Matching fills are published to `trade.fills`, enabling idempotent consumer
+rebuilds.
+
 {{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - DAG Snapshot: operations/dag_snapshot.md
       - Release: operations/release.md
       - CI: operations/ci.md
+      - Fill Replay: operations/fills_replay.md
   - Reference:
       - Overview: reference/README.md
       - FAQ: reference/faq.md

--- a/tests/gateway/test_fills_webhook.py
+++ b/tests/gateway/test_fills_webhook.py
@@ -1,0 +1,84 @@
+import json
+import time
+
+import httpx
+import pytest
+
+from qmtl.gateway.api import create_app, Database
+from qmtl.gateway.event_descriptor import EventDescriptorConfig, sign_event_token
+
+
+class FakeDB(Database):
+    async def insert_strategy(self, strategy_id: str, meta: dict | None) -> None:
+        return None
+
+
+@pytest.fixture
+def app_and_cfg(fake_redis):
+    cfg = EventDescriptorConfig(keys={"k1": "s1"}, active_kid="k1")
+    app = create_app(
+        redis_client=fake_redis,
+        database=FakeDB(),
+        event_config=cfg,
+        enable_background=False,
+    )
+    return app, cfg
+
+
+def _make_token(cfg: EventDescriptorConfig) -> str:
+    claims = {
+        "aud": "controlbus",
+        "exp": int(time.time()) + 60,
+        "world_id": "w1",
+        "strategy_id": "s1",
+    }
+    return sign_event_token(claims, cfg)
+
+
+@pytest.mark.asyncio
+async def test_fills_webhook_accepts_bare_and_cloudevent(app_and_cfg, fake_redis):
+    app, cfg = app_and_cfg
+    token = _make_token(cfg)
+    await fake_redis.delete("trade.fills")
+    bare = {"world_id": "w1", "strategy_id": "s1"}
+    async with httpx.ASGITransport(app=app) as transport:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/fills", headers={"Authorization": f"Bearer {token}"}, json=bare
+            )
+            assert resp.status_code == 202
+            ce = {
+                "specversion": "1.0",
+                "type": "qmtl.trade.fill",
+                "source": "broker/x",
+                "id": "1",
+                "time": "2025-01-01T00:00:00Z",
+                "data": {"world_id": "w1", "strategy_id": "s1"},
+            }
+            resp = await client.post(
+                "/fills", headers={"Authorization": f"Bearer {token}"}, json=ce
+            )
+            assert resp.status_code == 202
+    items = await fake_redis.lrange("trade.fills", 0, -1)
+    assert len(items) == 2
+    # ensure stored data is JSON
+    for raw in items:
+        json.loads(raw)
+
+
+@pytest.mark.asyncio
+async def test_fills_replay_publishes_event(app_and_cfg, fake_redis):
+    app, cfg = app_and_cfg
+    token = _make_token(cfg)
+    await fake_redis.delete("trade.fills")
+    payload = {"from_ts": 1, "to_ts": 2, "world_id": "w1", "strategy_id": "s1"}
+    async with httpx.ASGITransport(app=app) as transport:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/fills/replay", headers={"Authorization": f"Bearer {token}"}, json=payload
+            )
+            assert resp.status_code == 202
+    items = await fake_redis.lrange("trade.fills", 0, -1)
+    assert len(items) == 1
+    event = json.loads(items[0])
+    assert event["data"]["from_ts"] == 1


### PR DESCRIPTION
## Summary
- add `/fills` webhook accepting CloudEvents envelopes and scope JWTs
- support operator `/fills/replay` publishing to `trade.fills`
- document webhook security and replay runbook

## Testing
- `uv run mkdocs build`
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto`

Closes #829

------
https://chatgpt.com/codex/tasks/task_e_68bf0f75f1ec8329bab325735ac42769