### PR TITLE
Activation Weight Propagation: sizing integration

### DIFF
--- a/docs/architecture/exchange_node_sets.md
+++ b/docs/architecture/exchange_node_sets.md
@@ -67,7 +67,8 @@ Tip
 - [SizingNode](../../qmtl/transforms/execution_nodes.py#L80)
   - Inputs: Order intent, Portfolio snapshot (t−1)
   - Output: Sized order (quantity) using helpers (value/percent/target_percent)
-  - Backed by: `qmtl/sdk/portfolio.py`
+  - Soft Gating: optionally applies an activation weight (`0..1`) via a `weight_fn` callback; Node Sets pass a function backed by SDK `ActivationManager.weight_for_side(…)` using the intent’s inferred side.
+  - Backed by: `qmtl/sdk/portfolio.py`, `qmtl/sdk/activation_manager.py`
 
 - ExecutionNode
   - Inputs: Sized order, Market data (OHLCV/quotes), Brokerage profile

--- a/tests/test_sizing_weight_integration.py
+++ b/tests/test_sizing_weight_integration.py
@@ -1,0 +1,49 @@
+import pytest
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.runner import Runner
+from qmtl.pipeline.execution_nodes import SizingNode
+from qmtl.sdk.portfolio import Portfolio
+from qmtl.sdk.activation_manager import ActivationManager
+
+
+async def _emit(am: ActivationManager, side: str, **fields) -> None:
+    await am._on_message({"event": "activation_updated", "data": {"side": side, **fields}})  # type: ignore
+
+
+def _weight_fn_from_am(am: ActivationManager):
+    def fn(order: dict) -> float:
+        side = order.get("side")
+        if not side:
+            qty = order.get("quantity") or order.get("value") or order.get("percent") or 0.0
+            side = "BUY" if float(qty) >= 0 else "SELL"
+        s = str(side).upper()
+        return am.weight_for_side("long" if s == "BUY" else "short")
+
+    return fn
+
+
+@pytest.mark.asyncio
+async def test_sizing_applies_weight_long():
+    src = Node(name="src", interval=1, period=1)
+    portfolio = Portfolio(cash=1000)
+    am = ActivationManager()
+    await _emit(am, "long", active=True, weight=0.5)
+    assert am.weight_for_side("long") == 0.5
+    node = SizingNode(src, portfolio=portfolio, weight_fn=_weight_fn_from_am(am))
+    order = {"symbol": "AAPL", "price": 10.0, "value": 100.0, "side": "BUY"}
+    out = Runner.feed_queue_data(node, src.node_id, 1, 0, order)
+    assert out["quantity"] == 5.0
+
+
+@pytest.mark.asyncio
+async def test_sizing_applies_weight_short():
+    src = Node(name="src", interval=1, period=1)
+    portfolio = Portfolio(cash=1000)
+    am = ActivationManager()
+    await _emit(am, "short", active=True, weight=0.2)
+    node = SizingNode(src, portfolio=portfolio, weight_fn=_weight_fn_from_am(am))
+    order = {"symbol": "AAPL", "price": 10.0, "percent": -0.1, "side": "SELL"}
+    out = Runner.feed_queue_data(node, src.node_id, 1, 0, order)
+    assert out["quantity"] == -2.0
+


### PR DESCRIPTION
Summary: Apply WS activation weights during sizing (soft gating).\n\n- SizingNode supports an optional weight_fn; Node Sets can pass a function backed by SDK ActivationManager to scale quantities by [0..1].\n- SDK ActivationManager adds weight_for_side(), clamping and honoring freeze/drain semantics.\n- Tests cover long/short scaling; docs updated under Exchange Node Sets.\n\nFixes #836