### PR TITLE
Micro-batching for Order Publish and Fill Ingest

### DIFF
--- a/docs/architecture/exchange_node_sets.md
+++ b/docs/architecture/exchange_node_sets.md
@@ -70,6 +70,11 @@ Tip
   - Soft Gating: optionally applies an activation weight (`0..1`) via a `weight_fn` callback; Node Sets pass a function backed by SDK `ActivationManager.weight_for_side(…)` using the intent’s inferred side.
   - Backed by: `qmtl/sdk/portfolio.py`, `qmtl/sdk/activation_manager.py`
 
+- MicroBatchNode
+  - Purpose: reduce per-item overhead by emitting a list of payloads for the latest bucket.
+  - Usage: place after order publish (or fill ingest) to micro-batch downstream handling.
+  - Backed by: `qmtl/pipeline/micro_batch.py`
+
 - ExecutionNode
   - Inputs: Sized order, Market data (OHLCV/quotes), Brokerage profile
   - Outputs: Execution fills (simulate/paper) or OrderPayload (live)

--- a/qmtl/pipeline/micro_batch.py
+++ b/qmtl/pipeline/micro_batch.py
@@ -1,0 +1,48 @@
+"""Micro-batching helpers for order publish and fill ingest.
+
+These nodes aggregate all items in the latest time bucket from an upstream
+``Node`` and emit them as a list to reduce per-item overhead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from qmtl.sdk.node import ProcessingNode, Node
+from qmtl.sdk.cache_view import CacheView
+
+
+class MicroBatchNode(ProcessingNode):
+    """Aggregate upstream payloads for the latest timestamp into a list."""
+
+    def __init__(self, upstream: Node, *, name: str | None = None) -> None:
+        self.upstream = upstream
+        super().__init__(
+            upstream,
+            compute_fn=self._compute,
+            name=name or f"{upstream.name}_mbatch",
+            interval=upstream.interval,
+            period=upstream.period or 1,
+        )
+
+    def _compute(self, view: CacheView) -> list[Any] | None:
+        data = view[self.upstream][self.upstream.interval]
+        # Convert CacheView leaf to a plain list via slicing
+        seq = data[:] if data else []
+        if not seq:
+            return None
+        # Identify distinct timestamps (ordered as in seq)
+        timestamps = [ts for ts, _ in seq]
+        distinct = []
+        for ts in timestamps:
+            if not distinct or distinct[-1] != ts:
+                distinct.append(ts)
+        # Flush the latest complete bucket: the second-to-last distinct ts
+        if len(distinct) < 2:
+            return None
+        flush_ts = distinct[-2]
+        batch: list[Any] = [payload for ts, payload in seq if ts == flush_ts]
+        return batch
+
+
+__all__ = ["MicroBatchNode"]

--- a/tests/test_micro_batch.py
+++ b/tests/test_micro_batch.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.runner import Runner
+from qmtl.pipeline.micro_batch import MicroBatchNode
+
+
+def test_micro_batch_aggregates_same_timestamp():
+    src = Node(name="src", interval=1, period=4)
+    mb = MicroBatchNode(src)
+    # Feed three payloads in the same bucket (t=0), and one in next bucket
+    # No flush until the next bucket arrives
+    out = Runner.feed_queue_data(mb, src.node_id, 1, 0, {"id": 1})
+    assert out is None
+    out = Runner.feed_queue_data(mb, src.node_id, 1, 0, {"id": 2})
+    assert out is None
+    out = Runner.feed_queue_data(mb, src.node_id, 1, 0, {"id": 3})
+    assert out is None
+    # New bucket t=1 flushes batch for t=0
+    out = Runner.feed_queue_data(mb, src.node_id, 1, 1, {"id": 4})
+    assert out == [{"id": 1}, {"id": 2}, {"id": 3}]
+    # Next bucket t=2 flushes t=1 batch
+    out = Runner.feed_queue_data(mb, src.node_id, 1, 2, {"id": 5})
+    assert out == [{"id": 4}]


### PR DESCRIPTION
Summary: Add MicroBatchNode to aggregate latest-bucket payloads for orders/fills, reducing per-item overhead.\n\n- Emits the latest complete bucket (flushes previous bucket on advance) to respect DAG watermarking.\n- Mirrors upstream period and interval.\n- Docs updated under Exchange Node Sets; tests verify aggregation semantics.\n\nFixes #835