### PR TITLE
Reliability — Backpressure Guard and Fill DLQ

### DIFF
--- a/qmtl/transforms/fill_dlq.py
+++ b/qmtl/transforms/fill_dlq.py
@@ -1,0 +1,30 @@
+"""Lightweight schema guard for fills routing invalid payloads to DLQ.
+
+This helper is intentionally minimal and does not depend on external schema
+validators. It checks for the presence and basic types of ``symbol``,
+``quantity`` and either ``fill_price``/``price``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def validate_fill_or_dlq(payload: dict) -> dict:
+    try:
+        sym = payload.get("symbol")
+        qty = payload.get("quantity")
+        price = payload.get("fill_price", payload.get("price"))
+        if not isinstance(sym, str):
+            raise ValueError("symbol")
+        if not isinstance(qty, (int, float)):
+            raise ValueError("quantity")
+        if not isinstance(price, (int, float)):
+            raise ValueError("price")
+        return payload
+    except Exception:
+        return {"dlq": True, "payload": payload}
+
+
+__all__ = ["validate_fill_or_dlq"]
+

--- a/tests/test_backpressure_guard.py
+++ b/tests/test_backpressure_guard.py
@@ -1,0 +1,26 @@
+from qmtl.sdk.node import Node
+from qmtl.sdk.runner import Runner
+from qmtl.pipeline.execution_nodes import PreTradeGateNode
+from qmtl.sdk.order_gate import Activation
+from qmtl.brokerage.order import Account
+
+
+def test_pretrade_backpressure_blocks():
+    src = Node(name="src", interval=1, period=1)
+    overloaded = True
+
+    def guard() -> bool:
+        return overloaded
+
+    node = PreTradeGateNode(
+        src,
+        activation_map={"AAPL": Activation(True)},
+        brokerage=type("B", (), {"can_submit_order": lambda *_: True})(),
+        account=Account(),
+        backpressure_guard=guard,
+    )
+    out = Runner.feed_queue_data(
+        node, src.node_id, 1, 0, {"symbol": "AAPL", "quantity": 1, "price": 10.0}
+    )
+    assert out["rejected"] and out["reason"] == "backpressure"
+

--- a/tests/test_fill_dlq.py
+++ b/tests/test_fill_dlq.py
@@ -1,0 +1,13 @@
+from qmtl.transforms.fill_dlq import validate_fill_or_dlq
+
+
+def test_fill_dlq_valid():
+    ok = {"symbol": "AAPL", "quantity": 1.0, "fill_price": 10.0}
+    assert validate_fill_or_dlq(ok) == ok
+
+
+def test_fill_dlq_invalid_routes_to_dlq():
+    bad = {"symbol": 123, "quantity": "x"}
+    out = validate_fill_or_dlq(bad)
+    assert out.get("dlq") is True and out.get("payload") == bad
+


### PR DESCRIPTION
Summary: Add a backpressure guard hook to PreTradeGateNode to deny new orders under overload, plus a lightweight DLQ helper for invalid fills.\n\n-  returns standardized rejection  when overloaded.\n-  routes malformed fill payloads for operator review.\n- Tests included.\n\nFixes #833