### PR TITLE
docs: replace absolute links in world todo

### DIFF
--- a/docs/world/world_todo.md
+++ b/docs/world/world_todo.md
@@ -1,4 +1,6 @@
-QMTL 전략 상태 관리 아키텍처 설계 초안
+# [Home](../index.md) / [world](index.md) / [world_todo](world_todo.md)
+
+# QMTL 전략 상태 관리 아키텍처 설계 초안
 
 개요 (Overview)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,19 +76,6 @@ nav:
 plugins:
   - search
   - macros
-  - mkdocs-breadcrumbs-plugin:
-      log_level: WARNING
-      exclude_paths:
-        - architecture
-        - architecture/**
-        - archive
-        - archive/**
-        - guides
-        - guides/**
-        - operations
-        - operations/**
-        - reference
-        - reference/**
   - tags
 theme:
   name: material


### PR DESCRIPTION
## Summary
- replace world TODO's absolute breadcrumbs with relative paths
- remove breadcrumbs plugin to avoid injecting absolute URLs in docs

## Testing
- `uv run mkdocs build`
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'`
- `uv run -m pytest -W error -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68bf2e89ff388329aa97fdb74cfeb932