### PR TITLE
Observability — Order Lifecycle Tracing and Metrics

### DIFF
--- a/qmtl/pipeline/execution_nodes.py
+++ b/qmtl/pipeline/execution_nodes.py
@@ -34,6 +34,7 @@ from qmtl.sdk.execution_modeling import (
 )
 from qmtl.sdk.risk_management import RiskManager, PositionInfo
 from qmtl.sdk.timing_controls import TimingController
+from qmtl.sdk import metrics as sdk_metrics
 
 
 class PreTradeGateNode(ProcessingNode):
@@ -251,6 +252,10 @@ class PortfolioNode(ProcessingNode):
         if not data:
             return None
         _, fill = data[-1]
+        try:
+            sdk_metrics.record_fill_ingested()
+        except Exception:
+            pass
         symbol = fill["symbol"]
         qty = float(fill["quantity"])
         price = float(fill.get("fill_price", fill.get("price", 0.0)))

--- a/qmtl/sdk/metrics.py
+++ b/qmtl/sdk/metrics.py
@@ -150,6 +150,64 @@ node_process_duration_ms._vals = {}  # type: ignore[attr-defined]
 node_process_failure_total._vals = {}  # type: ignore[attr-defined]
 
 # ---------------------------------------------------------------------------
+# Order lifecycle metrics (SDK-side)
+if "orders_published_total" in global_registry._names_to_collectors:
+    orders_published_total = global_registry._names_to_collectors[
+        "orders_published_total"
+    ]
+else:
+    orders_published_total = Counter(
+        "orders_published_total",
+        "Total orders published by SDK",
+        ["world_id"],
+        registry=global_registry,
+    )
+
+if "fills_ingested_total" in global_registry._names_to_collectors:
+    fills_ingested_total = global_registry._names_to_collectors[
+        "fills_ingested_total"
+    ]
+else:
+    fills_ingested_total = Counter(
+        "fills_ingested_total",
+        "Total fills ingested by SDK",
+        ["world_id"],
+        registry=global_registry,
+    )
+
+if "orders_rejected_total" in global_registry._names_to_collectors:
+    orders_rejected_total = global_registry._names_to_collectors[
+        "orders_rejected_total"
+    ]
+else:
+    orders_rejected_total = Counter(
+        "orders_rejected_total",
+        "Total pre-trade rejections at SDK",
+        ["world_id", "reason"],
+        registry=global_registry,
+    )
+
+orders_published_total._vals = {}  # type: ignore[attr-defined]
+fills_ingested_total._vals = {}  # type: ignore[attr-defined]
+orders_rejected_total._vals = {}  # type: ignore[attr-defined]
+
+def record_order_published() -> None:
+    w = _WORLD_ID
+    orders_published_total.labels(world_id=w).inc()
+    orders_published_total._vals[w] = orders_published_total._vals.get(w, 0) + 1  # type: ignore[attr-defined]
+
+def record_fill_ingested() -> None:
+    w = _WORLD_ID
+    fills_ingested_total.labels(world_id=w).inc()
+    fills_ingested_total._vals[w] = fills_ingested_total._vals.get(w, 0) + 1  # type: ignore[attr-defined]
+
+def record_order_rejected(reason: str) -> None:
+    w = _WORLD_ID
+    orders_rejected_total.labels(world_id=w, reason=reason).inc()
+    key = (w, reason)
+    orders_rejected_total._vals[key] = orders_rejected_total._vals.get(key, 0) + 1  # type: ignore[attr-defined]
+
+# ---------------------------------------------------------------------------
 # Alpha performance metrics
 if "alpha_sharpe" in global_registry._names_to_collectors:
     alpha_sharpe = global_registry._names_to_collectors["alpha_sharpe"]

--- a/qmtl/transforms/publisher.py
+++ b/qmtl/transforms/publisher.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from qmtl.sdk.node import Node
 from qmtl.sdk.cache_view import CacheView
+from qmtl.sdk import metrics as sdk_metrics
 
 
 def publisher_node(signal: Any) -> Any:
@@ -86,4 +87,8 @@ class TradeOrderPublisherNode(Node):
             order["client_order_id"] = signal["client_order_id"]
         elif "newClientOrderId" in signal:
             order["client_order_id"] = signal["newClientOrderId"]
+        try:
+            sdk_metrics.record_order_published()
+        except Exception:
+            pass
         return order

--- a/tests/test_order_lifecycle_metrics.py
+++ b/tests/test_order_lifecycle_metrics.py
@@ -1,0 +1,21 @@
+from qmtl.sdk import metrics as sdk_metrics
+
+
+def test_order_lifecycle_counters_increment():
+    sdk_metrics.set_world_id("test")
+    # Publishing
+    before = sdk_metrics.orders_published_total._vals.get("test", 0)  # type: ignore[attr-defined]
+    sdk_metrics.record_order_published()
+    after = sdk_metrics.orders_published_total._vals.get("test", 0)  # type: ignore[attr-defined]
+    assert after == before + 1
+
+    # Fill ingest
+    before = sdk_metrics.fills_ingested_total._vals.get("test", 0)  # type: ignore[attr-defined]
+    sdk_metrics.record_fill_ingested()
+    after = sdk_metrics.fills_ingested_total._vals.get("test", 0)  # type: ignore[attr-defined]
+    assert after == before + 1
+
+    # Rejection
+    sdk_metrics.record_order_rejected("backpressure")
+    key = ("test", "backpressure")
+    assert sdk_metrics.orders_rejected_total._vals.get(key, 0) >= 1  # type: ignore[attr-defined]


### PR DESCRIPTION
Summary: Add SDK-level counters for orders published, fills ingested, and pre-trade rejections; wire minimal hooks in publisher and portfolio.\n\n- New metrics: orders_published_total, fills_ingested_total, orders_rejected_total.\n- Unit test covers increment semantics.\n\nFixes #832