### PR TITLE
Schema → Code Generation (lite) for Activation models

### DIFF
--- a/qmtl/reference_models/__init__.py
+++ b/qmtl/reference_models/__init__.py
@@ -1,0 +1,47 @@
+"""Runtime models derived from JSON Schemas.
+
+This module provides minimal pydantic models for commonly used schemas without
+introducing a standalone codegen step. It keeps parity with the reference
+schema files and avoids drift by using aliases where appropriate.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+from typing import Literal, Optional
+
+
+class ActivationEnvelope(BaseModel):
+    world_id: StrictStr
+    strategy_id: StrictStr
+    side: Literal["long", "short"]
+    active: bool
+    weight: StrictFloat
+    freeze: Optional[bool] = None
+    drain: Optional[bool] = None
+    effective_mode: Optional[Literal["compute-only", "paper", "live"]] = None
+    etag: StrictStr
+    run_id: Optional[StrictStr] = None
+    ts: StrictStr
+    state_hash: Optional[StrictStr] = None
+
+
+class ActivationUpdated(BaseModel):
+    type: Literal["ActivationUpdated"] = "ActivationUpdated"
+    version: StrictInt
+    world_id: StrictStr
+    strategy_id: Optional[StrictStr] = None
+    side: Literal["long", "short"]
+    active: bool
+    weight: StrictFloat
+    freeze: Optional[bool] = None
+    drain: Optional[bool] = None
+    effective_mode: Optional[Literal["compute-only", "paper", "live"]] = None
+    etag: StrictStr
+    run_id: Optional[StrictStr] = None
+    ts: StrictStr
+    state_hash: Optional[StrictStr] = None
+
+
+__all__ = ["ActivationEnvelope", "ActivationUpdated"]
+

--- a/tests/test_reference_models.py
+++ b/tests/test_reference_models.py
@@ -1,0 +1,26 @@
+from qmtl.reference_models import ActivationEnvelope, ActivationUpdated
+
+
+def test_activation_models_validate_fields():
+    env = ActivationEnvelope(
+        world_id="w1",
+        strategy_id="s1",
+        side="long",
+        active=True,
+        weight=1.0,
+        etag="e1",
+        ts="2025-01-01T00:00:00Z",
+    )
+    assert env.active and env.weight == 1.0
+
+    evt = ActivationUpdated(
+        version=1,
+        world_id="w1",
+        side="long",
+        active=True,
+        weight=1.0,
+        etag="e1",
+        ts="2025-01-01T00:00:00Z",
+    )
+    assert evt.type == "ActivationUpdated"
+


### PR DESCRIPTION
Summary: Provide runtime pydantic models mirroring ActivationEnvelope and ActivationUpdated schemas to reduce friction without a separate codegen step.\n\n- Adds  with pydantic models.\n- Unit test validates basic required fields.\n\nFixes #831