### PR TITLE
Node Set Test Kit and Fake Webhook Simulator

### DIFF
--- a/qmtl/nodesets/testkit.py
+++ b/qmtl/nodesets/testkit.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from qmtl.sdk.node import Node
+from .base import NodeSetBuilder, NodeSet
+
+
+def attach_minimal(builder: NodeSetBuilder, signal: Node, world_id: str) -> NodeSet:
+    """Attach the node set behind ``signal`` using default options.
+
+    Returns the composed :class:`NodeSet` for testing.
+    """
+    return builder.attach(signal, world_id=world_id)
+
+
+def make_cloudevent(event_type: str, source: str, data: dict) -> dict:
+    """Make a minimal CloudEvents 1.0 JSON object for tests."""
+    return {
+        "specversion": "1.0",
+        "id": str(uuid.uuid4()),
+        "source": source,
+        "type": event_type,
+        "time": datetime.now(timezone.utc).isoformat(),
+        "datacontenttype": "application/json",
+        "data": data,
+    }
+
+
+def fake_fill_webhook(symbol: str, quantity: float, price: float, **extra) -> dict:
+    """Create a fake fill CloudEvent for webhook simulation in tests."""
+    payload = {"symbol": symbol, "quantity": float(quantity), "fill_price": float(price)}
+    payload.update(extra)
+    return make_cloudevent("trade.fill", "qmtl.testkit", payload)
+
+
+__all__ = ["attach_minimal", "make_cloudevent", "fake_fill_webhook"]
+

--- a/tests/nodesets/test_nodeset_testkit_and_webhook.py
+++ b/tests/nodesets/test_nodeset_testkit_and_webhook.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from qmtl.sdk.node import Node
+from qmtl.sdk.runner import Runner
+from qmtl.nodesets.base import NodeSetBuilder
+from qmtl.nodesets.testkit import attach_minimal, fake_fill_webhook
+
+
+def test_nodeset_testkit_attach():
+    sig = Node(name="sig", interval=1, period=1)
+    ns = attach_minimal(NodeSetBuilder(), sig, world_id="w1")
+    order = {"symbol": "AAPL", "price": 10.0, "quantity": 1.0}
+    out = Runner.feed_queue_data(ns.pretrade, sig.node_id, 1, 0, order)
+    assert out == order
+
+
+def test_fake_fill_webhook_shape():
+    evt = fake_fill_webhook("AAPL", 1.0, 10.0)
+    assert evt["specversion"] == "1.0" and evt["type"] == "trade.fill"
+    assert evt["data"]["symbol"] == "AAPL" and evt["data"]["fill_price"] == 10.0
+


### PR DESCRIPTION
Summary: Add  helpers to attach Node Sets in tests and generate fake fill CloudEvents for webhook simulations.\n\nFixes #830