### PR TITLE
docs(guides): add Node Set portfolio scope + test kit; example world-scope strategy

### DIFF
--- a/docs/guides/nodeset_portfolio_scope.md
+++ b/docs/guides/nodeset_portfolio_scope.md
@@ -1,0 +1,56 @@
+# Node Set Portfolio Scope
+
+This guide shows how to configure a Node Set to share portfolio state across strategies within the same world (world scope) or keep it isolated per strategy (strategy scope).
+
+See Exchange Node Sets architecture for the end‑to‑end design: ../architecture/exchange_node_sets.md
+
+## Usage
+
+```python
+from qmtl.nodesets import NodeSetBuilder
+from qmtl.nodesets.options import NodeSetOptions
+from qmtl.sdk import Strategy, StreamInput, Node
+from qmtl.transforms import TradeSignalGeneratorNode
+
+
+class WorldScopeNodeSetStrategy(Strategy):
+    def setup(self) -> None:
+        price = StreamInput(interval="60s", period=2)
+
+        def compute_alpha(view):
+            data = view[price][price.interval]
+            if len(data) < 2:
+                return 0.0
+            prev = data[-2][1]["close"]
+            last = data[-1][1]["close"]
+            return (last - prev) / prev
+
+        alpha = Node(input=price, compute_fn=compute_alpha, name="alpha")
+        signal = TradeSignalGeneratorNode(
+            alpha, long_threshold=0.0, short_threshold=0.0, size=1.0
+        )
+
+        # world scope shares portfolio across strategies in the same world
+        opts = NodeSetOptions(portfolio_scope="world")
+        nodeset = NodeSetBuilder(options=opts).attach(signal, world_id="demo", scope="world")
+
+        # Add the execution chain behind the signal
+        self.add_nodes([
+            price,
+            alpha,
+            signal,
+            nodeset.pretrade,
+            nodeset.sizing,
+            nodeset.execution,
+            nodeset.fills,
+            nodeset.portfolio,
+            nodeset.risk,
+            nodeset.timing,
+        ])
+```
+
+Notes
+- strategy (default) scopes portfolio snapshots and fills by `(world_id, strategy_id, symbol)`.
+- world scopes by `(world_id, symbol)` so multiple strategies share cash/limits.
+- In the current scaffold, this option establishes the contract; concrete exchange Node Sets enforce the behavior as they are implemented.
+

--- a/docs/guides/nodeset_testkit.md
+++ b/docs/guides/nodeset_testkit.md
@@ -1,0 +1,38 @@
+# Node Set Test Kit
+
+Quick recipes for composing a Node Set behind a signal during tests and simulating fills via a fake webhook payload.
+
+See the spec for Exchange Node Sets: ../architecture/exchange_node_sets.md
+
+## Attach a minimal Node Set in tests
+
+```python
+from qmtl.sdk.node import Node
+from qmtl.nodesets.base import NodeSetBuilder
+from qmtl.nodesets.testkit import attach_minimal
+
+
+def test_nodeset_attach_minimal():
+    sig = Node(name="sig", interval=1, period=1)
+    ns = attach_minimal(NodeSetBuilder(), sig, world_id="w1")
+    order = {"symbol": "AAPL", "price": 10.0, "quantity": 1.0}
+    # Each stub in the scaffold passes through the payload
+    assert ns.pretrade is not None and ns.execution is not None
+```
+
+## Create a fake fill webhook event
+
+```python
+from qmtl.nodesets.testkit import fake_fill_webhook
+
+
+def test_fake_fill_webhook_shape():
+    evt = fake_fill_webhook("AAPL", 1.0, 10.0)
+    assert evt["specversion"] == "1.0" and evt["type"] == "trade.fill"
+    assert evt["data"]["symbol"] == "AAPL" and evt["data"]["fill_price"] == 10.0
+```
+
+Notes
+- The test kit emits CloudEvents‑shaped payloads for consistency with Gateway webhook ingestion.
+- Minimal scaffolding uses stub nodes to establish contracts; concrete Node Sets replace them as implementations land.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,8 @@ nav:
       - Python Environment: guides/python_environment.md
       - Testing & Pytest: guides/testing.md
       - HTTPX Usage: guides/httpx_usage.md
+      - Node Set Portfolio Scope: guides/nodeset_portfolio_scope.md
+      - Node Set Test Kit: guides/nodeset_testkit.md
       - CCXT Spot Node Set: guides/ccxt_spot_nodeset.md
       - Router/MicroBatch/Test Kit: guides/router_microbatch_testkit.md
   - Operations:

--- a/qmtl/examples/strategies/world_scope_nodeset_strategy.py
+++ b/qmtl/examples/strategies/world_scope_nodeset_strategy.py
@@ -1,0 +1,50 @@
+"""Example strategy wiring a Node Set with world-scoped portfolio.
+
+This demonstrates how multiple strategies in the same world can share
+portfolio state by setting portfolio_scope="world". The current scaffold
+uses stub nodes to establish the contract.
+"""
+
+from __future__ import annotations
+
+from qmtl.sdk import Strategy, StreamInput, Node
+from qmtl.transforms import TradeSignalGeneratorNode
+from qmtl.nodesets.base import NodeSetBuilder
+from qmtl.nodesets.options import NodeSetOptions
+
+
+class WorldScopeNodeSetStrategy(Strategy):
+    def setup(self) -> None:
+        price = StreamInput(interval="60s", period=2)
+
+        def compute_alpha(view):
+            data = view[price][price.interval]
+            if len(data) < 2:
+                return 0.0
+            prev = data[-2][1]["close"]
+            last = data[-1][1]["close"]
+            return (last - prev) / prev
+
+        alpha = Node(input=price, compute_fn=compute_alpha, name="alpha")
+        signal = TradeSignalGeneratorNode(
+            alpha, long_threshold=0.0, short_threshold=0.0, size=1.0
+        )
+
+        opts = NodeSetOptions(portfolio_scope="world")
+        nodeset = NodeSetBuilder(options=opts).attach(signal, world_id="demo", scope="world")
+
+        self.add_nodes(
+            [
+                price,
+                alpha,
+                signal,
+                nodeset.pretrade,
+                nodeset.sizing,
+                nodeset.execution,
+                nodeset.fills,
+                nodeset.portfolio,
+                nodeset.risk,
+                nodeset.timing,
+            ]
+        )
+


### PR DESCRIPTION
- New guides: nodeset_portfolio_scope.md, nodeset_testkit.md
- Example strategy: qmtl/examples/strategies/world_scope_nodeset_strategy.py
- mkdocs nav updated; docs build passes via uvx

Refs #837, #838
