### PR TITLE
문서/예제: 팬-인(다중 업스트림) 패턴 추가

### DIFF
--- a/docs/architecture/execution_nodes.md
+++ b/docs/architecture/execution_nodes.md
@@ -5,3 +5,74 @@ portfolio updates, risk controls and timing gates. These classes bridge
 strategy signals with exchange node sets described in
 [exchange_node_sets.md](exchange_node_sets.md) and rely on helper modules
 under `qmtl/sdk`.
+
+Usage note
+- In typical strategies you should attach a prebuilt Node Set (wrapper) rather than wiring these nodes one by one. The Node Set API provides a convenient, stable surface while allowing internal node composition to evolve.
+
+## Fan‑in (Multi‑Upstream) Pattern
+
+Nodes can subscribe to more than one upstream. This enables “fan‑in” patterns where a downstream node reads several inputs at once (e.g., a price stream and an indicator window) to make a combined decision.
+
+```mermaid
+graph LR
+    price[price stream] --> alpha[alpha]
+    alpha --> hist[alpha_history]
+    price --> combine
+    hist --> combine[combine (fan-in)]
+    combine --> signal[trade_signal]
+    signal --> orders[publish_orders]
+    orders --> router[router]
+    router --> micro[MicroBatch]
+```
+
+Example code (CacheView indexing uses the upstream node and its interval):
+
+```python
+from qmtl.sdk import Node, StreamInput
+from qmtl.transforms import alpha_history_node, TradeSignalGeneratorNode
+from qmtl.pipeline.execution_nodes import RouterNode
+from qmtl.pipeline.micro_batch import MicroBatchNode
+
+price = StreamInput(interval="60s", period=2)
+
+def compute_alpha(view):
+    data = view[price][price.interval]
+    if len(data) < 2:
+        return 0.0
+    prev, last = data[-2][1]["close"], data[-1][1]["close"]
+    return (last - prev) / prev
+
+alpha = Node(input=price, compute_fn=compute_alpha, name="alpha")
+history = alpha_history_node(alpha, window=30)
+
+def alpha_with_trend_gate(view):
+    hist_data = view[history][history.interval]
+    price_data = view[price][price.interval]
+    if not hist_data or not price_data:
+        return None
+    hist_series = hist_data[-1][1]  # list[float]
+    closes = [row[1]["close"] for row in price_data]
+    if len(closes) < 2:
+        return hist_series
+    # Gate positive alpha when price momentum is down
+    trend_up = closes[-1] >= closes[-2]
+    return hist_series if trend_up else [v if v <= 0.0 else 0.0 for v in hist_series]
+
+combined = Node(
+    input=[history, price],  # multi-upstream (fan-in)
+    compute_fn=alpha_with_trend_gate,
+    name="alpha_with_trend_gate",
+    interval=history.interval,
+    period=history.period,
+)
+
+signal = TradeSignalGeneratorNode(combined, long_threshold=0.0, short_threshold=0.0)
+orders = TradeOrderPublisherNode(signal)
+router = RouterNode(orders, route_fn=lambda o: "binance" if str(o.get("symbol","")) .upper().endswith("USDT") else "ibkr")
+micro = MicroBatchNode(router)
+```
+
+Notes
+- `Node(input=[...])`: pass any iterable of upstream nodes to create a fan‑in node.
+- `view[upstream][upstream.interval]`: access the latest window for each upstream within `compute_fn`.
+- Event‑time gating uses the slowest upstream watermark; late data handling follows the node’s `allowed_lateness`/`on_late` policy.


### PR DESCRIPTION
요약
- 예제: order_pipeline_strategy에 fan-in 노드 추가 (history + price)
- 문서: Execution Nodes 문서에 Fan-in 섹션(다이어그램+코드) 추가

동기
- 한 노드가 둘 이상의 업스트림을 가질 수 있음을 예제와 문서에서 명시적으로 드러내기 위함

검증
- uv run mkdocs build 통과
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow' → 760 passed, 8 skipped

영향 범위
- qmtl/examples/strategies/order_pipeline_strategy.py
- docs/architecture/execution_nodes.md

리뷰 포인트
- CacheView 접근 패턴(view[upstream][upstream.interval]) 설명이 충분한지
- 다이어그램/예제의 단순성 유지 여부
