### PR TITLE
docs(gateway): clarify /queues/by_tag default match_mode=any (Closes #902)

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -129,7 +129,8 @@ paths:
                         queue: { type: string }
                         global: { type: boolean }
 ```
-Clients must specify ``match_mode`` to control tag matching behavior.
+Clients SHOULD specify ``match_mode`` to control tag matching behavior. When
+omitted, Gateway defaults to ``any`` for backward compatibility.
 
 **Example Request (compressed 32 KiB DAG JSON omitted)**
 


### PR DESCRIPTION
This updates the API excerpt to state that match_mode defaults to 'any' when omitted, aligning code (qmtl/gateway/routes.py) with docs.\n\nCloses #902