### PR TITLE
feat: emit tagquery upsert events

### DIFF
--- a/qmtl/gateway/event_handlers.py
+++ b/qmtl/gateway/event_handlers.py
@@ -22,6 +22,7 @@ from .models import EventSubscribeRequest, EventSubscribeResponse
 from .ws import WebSocketHub
 from .event_models import (
     QueueUpdateData,
+    TagQueryUpsertData,
     SentinelWeightData,
     ActivationUpdatedData,
     PolicyUpdatedData,
@@ -318,6 +319,7 @@ def create_event_router(
     async def events_schema() -> dict[str, Any]:
         """Return JSON Schemas for WS event payloads."""
         return {
+            "tagquery.upsert": CloudEvent[TagQueryUpsertData].model_json_schema(),
             "queue_update": CloudEvent[QueueUpdateData].model_json_schema(),
             "sentinel_weight": CloudEvent[SentinelWeightData].model_json_schema(),
             "activation_updated": CloudEvent[ActivationUpdatedData].model_json_schema(),

--- a/qmtl/gateway/event_models.py
+++ b/qmtl/gateway/event_models.py
@@ -22,6 +22,12 @@ class QueueUpdateData(BaseModel):
     world_id: Optional[StrictStr] = None
 
 
+class TagQueryUpsertData(BaseModel):
+    tags: List[StrictStr]
+    interval: StrictInt
+    queues: List[QueueRef]
+
+
 class SentinelWeightData(BaseModel):
     sentinel_id: StrictStr
     weight: StrictFloat
@@ -69,6 +75,7 @@ class CloudEvent(BaseModel, Generic[T]):
 __all__ = [
     "QueueRef",
     "QueueUpdateData",
+    "TagQueryUpsertData",
     "SentinelWeightData",
     "ActivationUpdatedData",
     "PolicyUpdatedData",

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -380,6 +380,17 @@ class WebSocketHub:
         )
         await self.broadcast(event, topic="queue")
 
+    async def send_tagquery_upsert(
+        self, tags: list[str], interval: int, queues: list[dict[str, object]]
+    ) -> None:
+        """Broadcast tag query upsert events."""
+        event = format_event(
+            "qmtl.gateway",
+            "tagquery.upsert",
+            {"tags": tags, "interval": interval, "queues": queues},
+        )
+        await self.broadcast(event, topic="queue")
+
     async def send_sentinel_weight(self, sentinel_id: str, weight: float) -> None:
         """Broadcast sentinel weight updates."""
         event = format_event(

--- a/tests/tagquery/test_tagquery_upsert_handler.py
+++ b/tests/tagquery/test_tagquery_upsert_handler.py
@@ -1,0 +1,25 @@
+import pytest
+
+from qmtl.sdk import TagQueryNode, MatchMode
+from qmtl.sdk.tagquery_manager import TagQueryManager
+
+
+@pytest.mark.asyncio
+async def test_tagquery_upsert_initializes_node():
+    node = TagQueryNode(["t"], interval="60s", period=1)
+    mgr = TagQueryManager()
+    mgr.register(node)
+    await mgr.handle_message(
+        {
+            "event": "tagquery.upsert",
+            "data": {
+                "tags": ["t"],
+                "interval": 60,
+                "queues": [{"queue": "q1", "global": False}],
+            },
+        }
+    )
+    assert node.upstreams == ["q1"]
+    assert node.pre_warmup
+    key = (("t",), 60, MatchMode.ANY)
+    assert mgr._last_queue_sets[key] == frozenset(["q1"])


### PR DESCRIPTION
## Summary
- broadcast `tagquery.upsert` events when ControlBus reveals new tag/interval queues
- handle `tagquery.upsert` in TagQueryManager to initialize node buffers
- test TagQueryManager response to `tagquery.upsert`

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout --with pytest-asyncio --with fakeredis -m pytest tests/tagquery tests/gateway/test_controlbus_consumer.py -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run --with pytest-asyncio --with fakeredis --with pytest-xdist -m pytest -W error -n auto tests/tagquery tests/gateway/test_controlbus_consumer.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfc96c3b7c8329a02941a91e5f934b