### PR TITLE
gateway: metric + warning for legacy NodeID acceptance (Closes #893)

### DIFF
--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -50,6 +50,13 @@ commit_invalid_total = Counter(
     registry=global_registry,
 )
 
+# Legacy NodeID acceptance counter (temporary during migration)
+node_id_legacy_accept_total = Counter(
+    "node_id_legacy_accept_total",
+    "Number of times a legacy world-coupled NodeID was accepted",
+    registry=global_registry,
+)
+
 owner_reassign_total = Counter(
     "owner_reassign_total",
     "Total number of lease owner changes mid-bucket",


### PR DESCRIPTION
Adds prometheus Counter node_id_legacy_accept_total and logs a concise warning when a legacy world-coupled NodeID is accepted during migration. Keeps canonical check unchanged.\n\nCloses #893