### PR TITLE
feat: expand worldservice endpoints and storage

### DIFF
--- a/qmtl/gateway/event_models.py
+++ b/qmtl/gateway/event_models.py
@@ -29,6 +29,7 @@ class SentinelWeightData(BaseModel):
 
 
 class ActivationUpdatedData(BaseModel):
+    version: Optional[StrictInt] = None
     world_id: StrictStr
     strategy_id: Optional[StrictStr] = None
     side: Optional[Literal["long", "short"]] = None
@@ -44,6 +45,7 @@ class ActivationUpdatedData(BaseModel):
 
 
 class PolicyUpdatedData(BaseModel):
+    version: Optional[StrictInt] = None
     world_id: StrictStr
     policy_version: Optional[StrictInt] = None
     state_hash: Optional[StrictStr] = None

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -394,6 +394,123 @@ def create_api_router(
         headers["X-Correlation-ID"] = cid
         return headers, cid
 
+
+    @router.post("/worlds")
+    async def create_world(payload: dict, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.create_world(payload, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.get("/worlds")
+    async def list_worlds(request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.list_worlds(headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.get("/worlds/{world_id}")
+    async def get_world(world_id: str, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.get_world(world_id, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.put("/worlds/{world_id}")
+    async def put_world(world_id: str, payload: dict, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.put_world(world_id, payload, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.delete("/worlds/{world_id}", status_code=status.HTTP_204_NO_CONTENT)
+    async def delete_world(world_id: str, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        await client.delete_world(world_id, headers=headers)
+        return Response(status_code=status.HTTP_204_NO_CONTENT, headers={"X-Correlation-ID": cid})
+
+    @router.post("/worlds/{world_id}/policies")
+    async def post_world_policy(world_id: str, payload: dict, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.post_policy(world_id, payload, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.get("/worlds/{world_id}/policies")
+    async def get_world_policies(world_id: str, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.get_policies(world_id, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.post("/worlds/{world_id}/set-default")
+    async def post_world_set_default(world_id: str, payload: dict, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.set_default_policy(world_id, payload, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.post("/worlds/{world_id}/bindings")
+    async def post_world_bindings(world_id: str, payload: dict, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.post_bindings(world_id, payload, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.get("/worlds/{world_id}/bindings")
+    async def get_world_bindings(world_id: str, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.get_bindings(world_id, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.post("/worlds/{world_id}/decisions")
+    async def post_world_decisions(world_id: str, payload: dict, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.post_decisions(world_id, payload, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.put("/worlds/{world_id}/activation")
+    async def put_world_activation(world_id: str, payload: dict, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.put_activation(world_id, payload, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+
+    @router.get("/worlds/{world_id}/audit")
+    async def get_world_audit(world_id: str, request: Request) -> Any:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+        headers, cid = _build_world_headers(request)
+        data = await client.get_audit(world_id, headers=headers)
+        return JSONResponse(data, headers={"X-Correlation-ID": cid})
     @router.get("/worlds/{world_id}/decide")
     async def get_world_decide(world_id: str, request: Request) -> Any:
         client: WorldServiceClient | None = world_client

--- a/qmtl/gateway/world_client.py
+++ b/qmtl/gateway/world_client.py
@@ -206,6 +206,70 @@ class WorldServiceClient:
             self._activation_cache[world_id] = (new_etag, data)
         return data, False
 
+
+    async def list_worlds(self, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("GET", f"{self._base}/worlds", headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def create_world(self, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("POST", f"{self._base}/worlds", headers=headers, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_world(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("GET", f"{self._base}/worlds/{world_id}", headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def put_world(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("PUT", f"{self._base}/worlds/{world_id}", headers=headers, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def delete_world(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> None:
+        resp = await self._request("DELETE", f"{self._base}/worlds/{world_id}", headers=headers)
+        resp.raise_for_status()
+
+    async def post_policy(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("POST", f"{self._base}/worlds/{world_id}/policies", headers=headers, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_policies(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("GET", f"{self._base}/worlds/{world_id}/policies", headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def set_default_policy(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("POST", f"{self._base}/worlds/{world_id}/set-default", headers=headers, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def post_bindings(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("POST", f"{self._base}/worlds/{world_id}/bindings", headers=headers, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_bindings(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("GET", f"{self._base}/worlds/{world_id}/bindings", headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def post_decisions(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("POST", f"{self._base}/worlds/{world_id}/decisions", headers=headers, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def put_activation(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("PUT", f"{self._base}/worlds/{world_id}/activation", headers=headers, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_audit(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
+        resp = await self._request("GET", f"{self._base}/worlds/{world_id}/audit", headers=headers)
+        resp.raise_for_status()
+        return resp.json()
     async def get_state_hash(
         self,
         world_id: str,

--- a/qmtl/sdk/activation_manager.py
+++ b/qmtl/sdk/activation_manager.py
@@ -26,6 +26,7 @@ class SideState:
 
 @dataclass
 class ActivationState:
+    version: int = 0
     long: SideState = field(default_factory=SideState)
     short: SideState = field(default_factory=SideState)
     etag: Optional[str] = None
@@ -105,6 +106,12 @@ class ActivationManager:
             drain = bool(payload.get("drain", False))
             eff_mode = payload.get("effective_mode")
             self.state.etag = payload.get("etag") or self.state.etag
+            ver = payload.get("version")
+            if ver is not None:
+                try:
+                    self.state.version = int(ver)
+                except (TypeError, ValueError):
+                    pass
             if eff_mode:
                 self.state.effective_mode = eff_mode
             self.state.stale = False

--- a/qmtl/worldservice/api.py
+++ b/qmtl/worldservice/api.py
@@ -2,49 +2,172 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
 from pydantic import BaseModel
 
 from .policy_engine import Policy, evaluate_policy
 from .controlbus_producer import ControlBusProducer
+from .storage import Storage
+
+
+class World(BaseModel):
+    id: str
+    name: str | None = None
+
+
+class PolicyRequest(BaseModel):
+    policy: Policy
+
+
+class PolicyVersionResponse(BaseModel):
+    version: int
+
+
+class BindingRequest(BaseModel):
+    strategies: List[str]
+
+
+class ActivationRequest(BaseModel):
+    side: str
+    active: bool
 
 
 class ApplyRequest(BaseModel):
-    policy: Policy
     metrics: Dict[str, Dict[str, float]]
     previous: List[str] | None = None
     correlations: Dict[tuple[str, str], float] | None = None
+    policy: Policy | None = None
 
 
 class ApplyResponse(BaseModel):
     active: List[str]
 
 
-def create_app(*, bus: ControlBusProducer | None = None) -> FastAPI:
-    """Return a FastAPI app exposing policy application APIs."""
+class DecisionsRequest(BaseModel):
+    strategies: List[str]
+
+
+class DecisionsResponse(BaseModel):
+    strategies: List[str]
+
+
+class BindingsResponse(BaseModel):
+    strategies: List[str]
+
+
+class ActivationResponse(BaseModel):
+    version: int
+    state: Dict | None = None
+
+
+def create_app(*, bus: ControlBusProducer | None = None, storage: Storage | None = None) -> FastAPI:
     app = FastAPI()
-    store: Dict[str, ApplyResponse] = {}
-    policies: Dict[str, Policy] = {}
+    store = storage or Storage()
 
-    @app.get("/worlds/{world_id}/apply", response_model=ApplyResponse)
-    async def get_apply(world_id: str) -> ApplyResponse:
-        if world_id not in store:
-            raise HTTPException(status_code=404, detail="world not found")
-        return store[world_id]
+    @app.post('/worlds', status_code=201)
+    async def post_world(payload: World) -> World:
+        await store.create_world(payload.model_dump())
+        return payload
 
-    @app.post("/worlds/{world_id}/apply", response_model=ApplyResponse)
-    async def post_apply(world_id: str, payload: ApplyRequest) -> ApplyResponse:
-        policy = payload.policy
-        policies[world_id] = policy
-        prev = payload.previous or store.get(world_id, ApplyResponse(active=[])).active
-        active = evaluate_policy(payload.metrics, policy, prev, payload.correlations)
-        resp = ApplyResponse(active=active)
-        store[world_id] = resp
+    @app.get('/worlds')
+    async def get_worlds() -> List[Dict]:
+        return await store.list_worlds()
+
+    @app.get('/worlds/{world_id}')
+    async def get_world(world_id: str) -> Dict:
+        w = await store.get_world(world_id)
+        if not w:
+            raise HTTPException(status_code=404, detail='world not found')
+        return w
+
+    @app.put('/worlds/{world_id}')
+    async def put_world(world_id: str, payload: World) -> Dict:
+        await store.update_world(world_id, payload.model_dump())
+        w = await store.get_world(world_id)
+        if not w:
+            raise HTTPException(status_code=404, detail='world not found')
+        return w
+
+    @app.delete('/worlds/{world_id}', status_code=204)
+    async def delete_world(world_id: str) -> Response:
+        await store.delete_world(world_id)
+        return Response(status_code=204)
+
+    @app.post('/worlds/{world_id}/policies', response_model=PolicyVersionResponse)
+    async def post_policy(world_id: str, payload: PolicyRequest) -> PolicyVersionResponse:
+        version = await store.add_policy(world_id, payload.policy)
+        return PolicyVersionResponse(version=version)
+
+    @app.get('/worlds/{world_id}/policies')
+    async def get_policies(world_id: str) -> List[Dict]:
+        return await store.list_policies(world_id)
+
+    @app.post('/worlds/{world_id}/set-default')
+    async def post_set_default(world_id: str, payload: PolicyVersionResponse) -> PolicyVersionResponse:
+        await store.set_default_policy(world_id, payload.version)
+        return payload
+
+    @app.post('/worlds/{world_id}/bindings', response_model=BindingsResponse)
+    async def post_bindings(world_id: str, payload: BindingRequest) -> BindingsResponse:
+        await store.add_bindings(world_id, payload.strategies)
+        strategies = await store.list_bindings(world_id)
+        return BindingsResponse(strategies=strategies)
+
+    @app.get('/worlds/{world_id}/bindings', response_model=BindingsResponse)
+    async def get_bindings(world_id: str) -> BindingsResponse:
+        strategies = await store.list_bindings(world_id)
+        return BindingsResponse(strategies=strategies)
+
+    @app.get('/worlds/{world_id}/decide', response_model=DecisionsResponse)
+    async def get_decide(world_id: str) -> DecisionsResponse:
+        strategies = await store.get_decisions(world_id)
+        return DecisionsResponse(strategies=strategies)
+
+    @app.post('/worlds/{world_id}/decisions', response_model=DecisionsResponse)
+    async def post_decisions(world_id: str, payload: DecisionsRequest) -> DecisionsResponse:
+        await store.set_decisions(world_id, payload.strategies)
+        return DecisionsResponse(strategies=payload.strategies)
+
+    @app.get('/worlds/{world_id}/activation', response_model=ActivationResponse)
+    async def get_activation(world_id: str) -> ActivationResponse:
+        data = await store.get_activation(world_id)
+        return ActivationResponse(version=data['version'], state=data.get('state'))
+
+    @app.put('/worlds/{world_id}/activation', response_model=ActivationResponse)
+    async def put_activation(world_id: str, payload: ActivationRequest) -> ActivationResponse:
+        version = await store.update_activation(world_id, {payload.side: {'active': payload.active}})
         if bus:
-            await bus.publish_policy_update(world_id, active)
-        return resp
+            await bus.publish_activation_update(world_id, {'side': payload.side, 'active': payload.active}, version=version)
+        data = await store.get_activation(world_id)
+        return ActivationResponse(version=version, state=data.get('state'))
+
+    @app.post('/worlds/{world_id}/evaluate', response_model=ApplyResponse)
+    async def post_evaluate(world_id: str, payload: ApplyRequest) -> ApplyResponse:
+        policy = payload.policy or await store.get_default_policy(world_id)
+        if policy is None:
+            raise HTTPException(status_code=404, detail='policy not found')
+        prev = payload.previous or await store.get_decisions(world_id)
+        active = evaluate_policy(payload.metrics, policy, prev, payload.correlations)
+        return ApplyResponse(active=active)
+
+    @app.post('/worlds/{world_id}/apply', response_model=ApplyResponse)
+    async def post_apply(world_id: str, payload: ApplyRequest) -> ApplyResponse:
+        policy = payload.policy or await store.get_default_policy(world_id)
+        if policy is None:
+            raise HTTPException(status_code=404, detail='policy not found')
+        prev = payload.previous or await store.get_decisions(world_id)
+        active = evaluate_policy(payload.metrics, policy, prev, payload.correlations)
+        await store.set_decisions(world_id, active)
+        version = await store.default_policy_version(world_id)
+        if bus:
+            await bus.publish_policy_update(world_id, active, version=version)
+        return ApplyResponse(active=active)
+
+    @app.get('/worlds/{world_id}/audit')
+    async def get_audit(world_id: str) -> List[Dict]:
+        return await store.get_audit(world_id)
 
     return app
 
 
-__all__ = ["ApplyRequest", "ApplyResponse", "create_app"]
+__all__ = ['World', 'PolicyRequest', 'ApplyRequest', 'ApplyResponse', 'create_app']

--- a/qmtl/worldservice/storage.py
+++ b/qmtl/worldservice/storage.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Set
+
+from .policy_engine import Policy
+
+
+@dataclass
+class WorldActivation:
+    """Activation state for a world."""
+
+    version: int = 0
+    state: Dict[str, Dict[str, float | bool]] = field(default_factory=dict)
+
+
+@dataclass
+class WorldPolicies:
+    """Policy versions for a world."""
+
+    versions: Dict[int, Policy] = field(default_factory=dict)
+    default: Optional[int] = None
+
+
+@dataclass
+class WorldAuditLog:
+    """Audit entries for a world."""
+
+    entries: List[Dict] = field(default_factory=list)
+
+
+class Storage:
+    """In-memory storage backing WorldService endpoints.
+
+    This lightweight layer mimics Redis/DB backed models for tests.
+    """
+
+    def __init__(self) -> None:
+        self.worlds: Dict[str, Dict] = {}
+        self.activations: Dict[str, WorldActivation] = {}
+        self.policies: Dict[str, WorldPolicies] = {}
+        self.bindings: Dict[str, Set[str]] = {}
+        self.decisions: Dict[str, List[str]] = {}
+        self.audit: Dict[str, WorldAuditLog] = {}
+
+    async def create_world(self, world: Dict) -> None:
+        self.worlds[world["id"]] = world
+        self.audit.setdefault(world["id"], WorldAuditLog()).entries.append({"event": "world_created", "world": world})
+
+    async def list_worlds(self) -> List[Dict]:
+        return list(self.worlds.values())
+
+    async def get_world(self, world_id: str) -> Optional[Dict]:
+        return self.worlds.get(world_id)
+
+    async def update_world(self, world_id: str, data: Dict) -> None:
+        if world_id not in self.worlds:
+            raise KeyError(world_id)
+        self.worlds[world_id].update(data)
+        self.audit.setdefault(world_id, WorldAuditLog()).entries.append({"event": "world_updated", "world": self.worlds[world_id]})
+
+    async def delete_world(self, world_id: str) -> None:
+        self.worlds.pop(world_id, None)
+        self.activations.pop(world_id, None)
+        self.policies.pop(world_id, None)
+        self.bindings.pop(world_id, None)
+        self.decisions.pop(world_id, None)
+        self.audit.setdefault(world_id, WorldAuditLog()).entries.append({"event": "world_deleted"})
+
+    async def add_policy(self, world_id: str, policy: Policy) -> int:
+        wp = self.policies.setdefault(world_id, WorldPolicies())
+        version = max(wp.versions.keys(), default=0) + 1
+        wp.versions[version] = policy
+        if wp.default is None:
+            wp.default = version
+        self.audit.setdefault(world_id, WorldAuditLog()).entries.append({"event": "policy_added", "version": version})
+        return version
+
+    async def list_policies(self, world_id: str) -> List[Dict]:
+        wp = self.policies.get(world_id)
+        if not wp:
+            return []
+        return [{"version": v} for v in sorted(wp.versions.keys())]
+
+    async def set_default_policy(self, world_id: str, version: int) -> None:
+        wp = self.policies.setdefault(world_id, WorldPolicies())
+        if version not in wp.versions:
+            raise KeyError(version)
+        wp.default = version
+        self.audit.setdefault(world_id, WorldAuditLog()).entries.append({"event": "policy_default_set", "version": version})
+
+    async def get_default_policy(self, world_id: str) -> Optional[Policy]:
+        wp = self.policies.get(world_id)
+        if not wp or wp.default is None:
+            return None
+        return wp.versions.get(wp.default)
+
+    async def default_policy_version(self, world_id: str) -> int:
+        wp = self.policies.get(world_id)
+        if not wp or wp.default is None:
+            return 0
+        return wp.default
+
+    async def add_bindings(self, world_id: str, strategies: Iterable[str]) -> None:
+        b = self.bindings.setdefault(world_id, set())
+        b.update(strategies)
+        self.audit.setdefault(world_id, WorldAuditLog()).entries.append({"event": "bindings_added", "strategies": list(strategies)})
+
+    async def list_bindings(self, world_id: str) -> List[str]:
+        return sorted(self.bindings.get(world_id, set()))
+
+    async def set_decisions(self, world_id: str, strategies: List[str]) -> None:
+        self.decisions[world_id] = list(strategies)
+        self.audit.setdefault(world_id, WorldAuditLog()).entries.append({"event": "decisions_set", "strategies": list(strategies)})
+
+    async def get_decisions(self, world_id: str) -> List[str]:
+        return list(self.decisions.get(world_id, []))
+
+    async def get_activation(self, world_id: str) -> Dict:
+        act = self.activations.get(world_id)
+        if not act:
+            return {"version": 0, "state": {}}
+        return {"version": act.version, **act.state}
+
+    async def update_activation(self, world_id: str, payload: Dict) -> int:
+        act = self.activations.setdefault(world_id, WorldActivation())
+        act.version += 1
+        act.state.update(payload)
+        self.audit.setdefault(world_id, WorldAuditLog()).entries.append({"event": "activation_updated", "version": act.version, **payload})
+        return act.version
+
+    async def get_audit(self, world_id: str) -> List[Dict]:
+        return list(self.audit.get(world_id, WorldAuditLog()).entries)
+
+
+__all__ = [
+    'WorldActivation',
+    'WorldPolicies',
+    'WorldAuditLog',
+    'Storage',
+]

--- a/tests/worldservice/test_worldservice_api.py
+++ b/tests/worldservice/test_worldservice_api.py
@@ -1,30 +1,48 @@
 import httpx
 import pytest
 
-from qmtl.worldservice.api import create_app, ApplyRequest
+from qmtl.worldservice.api import create_app
 from qmtl.worldservice.controlbus_producer import ControlBusProducer
 
 
 class DummyBus(ControlBusProducer):
     def __init__(self):
-        self.published: list[tuple[str, list[str]]] = []
+        self.events: list[tuple[str, str, int | None, object]] = []
 
-    async def publish_policy_update(self, world_id: str, strategies: list[str]) -> None:  # type: ignore[override]
-        self.published.append((world_id, strategies))
+    async def publish_policy_update(self, world_id: str, strategies: list[str], *, version: int | None = None) -> None:  # type: ignore[override]
+        self.events.append(("policy", world_id, version, list(strategies)))
+
+    async def publish_activation_update(self, world_id: str, payload: dict, *, version: int | None = None) -> None:  # type: ignore[override]
+        self.events.append(("activation", world_id, version, payload))
 
 
 @pytest.mark.asyncio
-async def test_apply_endpoint_broadcasts():
+async def test_world_crud_policy_apply_and_events():
     bus = DummyBus()
     app = create_app(bus=bus)
-    payload = ApplyRequest(
-        policy={"top_k": {"metric": "sharpe", "k": 1}},
-        metrics={"s1": {"sharpe": 1.0}, "s2": {"sharpe": 0.5}},
-    )
     async with httpx.ASGITransport(app=app) as asgi:
         async with httpx.AsyncClient(transport=asgi, base_url="http://test") as client:
-            r = await client.post("/worlds/w1/apply", json=payload.model_dump())
+            # Create world
+            await client.post("/worlds", json={"id": "w1", "name": "World"})
+            r = await client.get("/worlds")
+            assert r.json() == [{"id": "w1", "name": "World"}]
+
+            # Add policy and set default
+            await client.post("/worlds/w1/policies", json={"policy": {"top_k": {"metric": "m", "k": 1}}})
+            await client.post("/worlds/w1/set-default", json={"version": 1})
+
+            # Apply metrics
+            payload = {"metrics": {"s1": {"m": 1.0}, "s2": {"m": 0.5}}}
+            r = await client.post("/worlds/w1/apply", json=payload)
             assert r.json() == {"active": ["s1"]}
-            r2 = await client.get("/worlds/w1/apply")
-            assert r2.json() == {"active": ["s1"]}
-    assert bus.published == [("w1", ["s1"])]
+
+            # Activation update
+            r = await client.put("/worlds/w1/activation", json={"side": "long", "active": True})
+            assert r.json()["version"] == 1
+
+            # Audit log contains entries
+            audit = await client.get("/worlds/w1/audit")
+            assert any(e["event"] == "activation_updated" for e in audit.json())
+
+    assert ("policy", "w1", 1, ["s1"]) in bus.events
+    assert ("activation", "w1", 1, {"side": "long", "active": True}) in bus.events


### PR DESCRIPTION
## Summary
- expand worldservice REST API with world CRUD, policy versioning, bindings, decisions, activation control, and audit retrieval
- add in-memory storage layer and ControlBus events with versioned ActivationUpdated/PolicyUpdated
- update gateway proxy, event models, and SDK activation manager for new endpoints/events

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 qmtl/tests/worldservice`
- `uv run -m pytest -W error -n auto qmtl/tests/worldservice`


------
https://chatgpt.com/codex/tasks/task_e_68bfc96ebc948329b6820fe64524688f