### PR TITLE
feat: add schema version validation for control bus events

### DIFF
--- a/qmtl/common/cloudevents.py
+++ b/qmtl/common/cloudevents.py
@@ -5,6 +5,9 @@ from typing import Any
 from uuid import uuid4
 
 
+EVENT_SCHEMA_VERSION = 1
+
+
 def format_event(
     source: str, event_type: str, data: dict[str, Any], *, correlation_id: str | None = None
 ) -> dict[str, Any]:
@@ -23,4 +26,4 @@ def format_event(
         "correlation_id": correlation_id,
     }
 
-__all__ = ["format_event"]
+__all__ = ["format_event", "EVENT_SCHEMA_VERSION"]

--- a/qmtl/dagmanager/controlbus_producer.py
+++ b/qmtl/dagmanager/controlbus_producer.py
@@ -4,6 +4,8 @@ import contextlib
 import json
 from typing import Any, Iterable
 
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
+
 
 class ControlBusProducer:
     """Publish control events to the internal bus (e.g. Kafka)."""
@@ -38,6 +40,7 @@ class ControlBusProducer:
             "interval": interval,
             "queues": list(queues),
             "match_mode": match_mode,
+            "version": EVENT_SCHEMA_VERSION,
         }
         data = json.dumps(payload).encode()
         key = ",".join(tags).encode()

--- a/qmtl/gateway/controlbus_consumer.py
+++ b/qmtl/gateway/controlbus_consumer.py
@@ -12,6 +12,7 @@ from qmtl.sdk.node import MatchMode
 from .ws import WebSocketHub
 from . import metrics as gw_metrics
 from .controlbus_codec import decode as decode_cb, PROTO_CONTENT_TYPE
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -190,6 +191,11 @@ class ControlBusConsumer:
         gw_metrics.record_controlbus_message(msg.topic, msg.timestamp_ms)
 
         if not self.ws_hub:
+            return
+
+        version = msg.data.get("version")
+        if version != EVENT_SCHEMA_VERSION:
+            logger.warning("Unsupported event version %r", version)
             return
 
         if msg.topic == "activation":

--- a/qmtl/gateway/event_handlers.py
+++ b/qmtl/gateway/event_handlers.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from qmtl.sdk.node import MatchMode
 
-from ..common.cloudevents import format_event
+from ..common.cloudevents import format_event, EVENT_SCHEMA_VERSION
 from .event_descriptor import (
     EventDescriptorConfig,
     jwks,
@@ -134,6 +134,7 @@ def create_event_router(
                                 "qmtl.gateway",
                                 "queue_update",
                                 {
+                                    "version": EVENT_SCHEMA_VERSION,
                                     "tags": tags_list,
                                     "interval": interval_int,
                                     "queues": queues,
@@ -147,7 +148,9 @@ def create_event_router(
                         try:
                             act_data, _ = await world_client.get_activation(world_id)
                             event = format_event(
-                                "qmtl.gateway", "activation_updated", act_data
+                                "qmtl.gateway",
+                                "activation_updated",
+                                {"version": EVENT_SCHEMA_VERSION, **act_data},
                             )
                             await websocket.send_text(json.dumps(event))
                         except Exception:
@@ -157,7 +160,10 @@ def create_event_router(
                             hash_data = await world_client.get_state_hash(
                                 world_id, "policy"
                             )
-                            payload = {"world_id": world_id}
+                            payload = {
+                                "version": EVENT_SCHEMA_VERSION,
+                                "world_id": world_id,
+                            }
                             if isinstance(hash_data, dict):
                                 payload.update(hash_data)
                             event = format_event(

--- a/qmtl/gateway/event_models.py
+++ b/qmtl/gateway/event_models.py
@@ -8,6 +8,8 @@ from typing import Any, Generic, List, Literal, Optional, TypeVar
 
 from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
 
+from ..common.cloudevents import EVENT_SCHEMA_VERSION
+
 
 class QueueRef(BaseModel):
     queue: StrictStr
@@ -15,6 +17,7 @@ class QueueRef(BaseModel):
 
 
 class QueueUpdateData(BaseModel):
+    version: StrictInt = Field(EVENT_SCHEMA_VERSION)
     tags: List[StrictStr]
     interval: StrictInt
     queues: List[QueueRef]
@@ -23,12 +26,14 @@ class QueueUpdateData(BaseModel):
 
 
 class SentinelWeightData(BaseModel):
+    version: StrictInt = Field(EVENT_SCHEMA_VERSION)
     sentinel_id: StrictStr
     weight: StrictFloat
     world_id: Optional[StrictStr] = None
 
 
 class ActivationUpdatedData(BaseModel):
+    version: StrictInt = Field(EVENT_SCHEMA_VERSION)
     world_id: StrictStr
     strategy_id: Optional[StrictStr] = None
     side: Optional[Literal["long", "short"]] = None
@@ -44,6 +49,7 @@ class ActivationUpdatedData(BaseModel):
 
 
 class PolicyUpdatedData(BaseModel):
+    version: StrictInt = Field(EVENT_SCHEMA_VERSION)
     world_id: StrictStr
     policy_version: Optional[StrictInt] = None
     state_hash: Optional[StrictStr] = None

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -10,7 +10,7 @@ from fastapi import WebSocket
 
 from qmtl.sdk.node import MatchMode
 
-from ..common.cloudevents import format_event
+from ..common.cloudevents import format_event, EVENT_SCHEMA_VERSION
 from . import metrics
 
 
@@ -371,6 +371,7 @@ class WebSocketHub:
             "qmtl.gateway",
             "queue_update",
             {
+                "version": EVENT_SCHEMA_VERSION,
                 "tags": tags,
                 "interval": interval,
                 "queues": queues,
@@ -385,18 +386,26 @@ class WebSocketHub:
         event = format_event(
             "qmtl.gateway",
             "sentinel_weight",
-            {"sentinel_id": sentinel_id, "weight": weight},
+            {
+                "version": EVENT_SCHEMA_VERSION,
+                "sentinel_id": sentinel_id,
+                "weight": weight,
+            },
         )
         await self.broadcast(event, topic="activation")
 
     async def send_activation_updated(self, payload: dict) -> None:
         """Broadcast activation updates."""
-        event = format_event("qmtl.gateway", "activation_updated", payload)
+        event = format_event(
+            "qmtl.gateway", "activation_updated", {"version": EVENT_SCHEMA_VERSION, **payload}
+        )
         await self.broadcast(event, topic="activation")
 
     async def send_policy_updated(self, payload: dict) -> None:
         """Broadcast policy updates."""
-        event = format_event("qmtl.gateway", "policy_updated", payload)
+        event = format_event(
+            "qmtl.gateway", "policy_updated", {"version": EVENT_SCHEMA_VERSION, **payload}
+        )
         await self.broadcast(event, topic="policy")
 
 

--- a/qmtl/sdk/activation_manager.py
+++ b/qmtl/sdk/activation_manager.py
@@ -14,6 +14,7 @@ import httpx
 
 from .ws_client import WebSocketClient
 from . import runtime
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 
 @dataclass
@@ -97,6 +98,8 @@ class ActivationManager:
     async def _on_message(self, data: dict) -> None:
         event = data.get("event") or data.get("type")
         payload = data.get("data", data)
+        if payload.get("version") != EVENT_SCHEMA_VERSION:
+            return
         if event == "activation_updated" or payload.get("type") == "ActivationUpdated":
             side = (payload.get("side") or "").lower()
             active = bool(payload.get("active", False))

--- a/qmtl/sdk/tagquery_manager.py
+++ b/qmtl/sdk/tagquery_manager.py
@@ -14,6 +14,7 @@ from qmtl.common.tagquery import split_tags, normalize_match_mode, normalize_que
 
 from .ws_client import WebSocketClient
 from . import runtime
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .node import TagQueryNode
@@ -152,6 +153,9 @@ class TagQueryManager:
         """Apply WebSocket ``data`` to registered nodes."""
         event = data.get("event") or data.get("type")
         payload = data.get("data", data)
+        version = payload.get("version")
+        if version != EVENT_SCHEMA_VERSION:
+            return
         if event == "queue_update":
             tags = payload.get("tags") or []
             interval = payload.get("interval")

--- a/qmtl/worldservice/controlbus_producer.py
+++ b/qmtl/worldservice/controlbus_producer.py
@@ -4,6 +4,8 @@ import contextlib
 import json
 from typing import Any, Iterable
 
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
+
 
 class ControlBusProducer:
     """Publish policy updates to the internal ControlBus."""
@@ -33,7 +35,11 @@ class ControlBusProducer:
     async def publish_policy_update(self, world_id: str, strategies: Iterable[str]) -> None:
         if self._producer is None:
             return
-        payload = {"world_id": world_id, "strategies": list(strategies)}
+        payload = {
+            "world_id": world_id,
+            "strategies": list(strategies),
+            "version": EVENT_SCHEMA_VERSION,
+        }
         data = json.dumps(payload).encode()
         key = world_id.encode()
         await self._producer.send_and_wait(self.topic, data, key=key)

--- a/tests/e2e/test_world_isolation.py
+++ b/tests/e2e/test_world_isolation.py
@@ -8,6 +8,7 @@ from qmtl.gateway.dagmanager_client import DagManagerClient
 from qmtl.gateway.event_handlers import create_event_router
 from qmtl.gateway.event_descriptor import EventDescriptorConfig, validate_event_token
 from qmtl.sdk.activation_manager import ActivationManager
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 from qmtl.sdk.metrics import node_processed_total, generate_latest, global_registry
 
 
@@ -40,8 +41,18 @@ async def test_world_isolation(monkeypatch):
     # 활성 이벤트가 세계마다 독립적으로 처리된다
     am1 = ActivationManager(world_id="w1", strategy_id="s1")
     am2 = ActivationManager(world_id="w2", strategy_id="s1")
-    await am1._on_message({"event": "activation_updated", "data": {"side": "long", "active": True}})
-    await am2._on_message({"event": "activation_updated", "data": {"side": "long", "active": False}})
+    await am1._on_message(
+        {
+            "event": "activation_updated",
+            "data": {"side": "long", "active": True, "version": EVENT_SCHEMA_VERSION},
+        }
+    )
+    await am2._on_message(
+        {
+            "event": "activation_updated",
+            "data": {"side": "long", "active": False, "version": EVENT_SCHEMA_VERSION},
+        }
+    )
     assert am1.allow_side("long") is True
     assert am2.allow_side("long") is False
     await am1.stop()

--- a/tests/gateway/test_queue_update_ws_execution.py
+++ b/tests/gateway/test_queue_update_ws_execution.py
@@ -5,6 +5,7 @@ from qmtl.gateway.ws import WebSocketHub
 from qmtl.sdk import TagQueryNode, Runner, MatchMode
 from qmtl.sdk.ws_client import WebSocketClient
 from qmtl.sdk.tagquery_manager import TagQueryManager
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 
 class DummyDag:
@@ -18,15 +19,18 @@ class DummyHub(WebSocketHub):
         self.client = client
 
     async def send_queue_update(self, tags, interval, queues, match_mode: MatchMode = MatchMode.ANY):  # type: ignore[override]
-        await self.client._handle({
-            "type": "queue_update",
-            "data": {
-                "tags": tags,
-                "interval": interval,
-                "queues": queues,
-                "match_mode": match_mode.value,
-            },
-        })
+        await self.client._handle(
+            {
+                "type": "queue_update",
+                "data": {
+                    "tags": tags,
+                    "interval": interval,
+                    "queues": queues,
+                    "match_mode": match_mode.value,
+                    "version": EVENT_SCHEMA_VERSION,
+                },
+            }
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_ws.py
+++ b/tests/gateway/test_ws.py
@@ -8,6 +8,7 @@ import pytest
 from qmtl.gateway.ws import WebSocketHub
 from qmtl.gateway import metrics
 from qmtl.dagmanager.kafka_admin import partition_key
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 
 class DummyWS:
@@ -92,7 +93,11 @@ async def test_hub_sends_sentinel_weight():
     await hub.stop()
     msg = json.loads(ws.messages[0])
     assert msg["type"] == "sentinel_weight"
-    assert msg["data"] == {"sentinel_id": "s1", "weight": 0.5}
+    assert msg["data"] == {
+        "sentinel_id": "s1",
+        "weight": 0.5,
+        "version": EVENT_SCHEMA_VERSION,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -6,6 +6,7 @@ import pytest
 from qmtl.sdk import Strategy, TagQueryNode, Runner, MatchMode
 from qmtl.gateway.api import create_app, Database
 from qmtl.gateway.ws import WebSocketHub
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 
 async def wait_for(condition, timeout: float = 1.0) -> None:
@@ -64,15 +65,18 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
             self.client = client
 
         async def send_queue_update(self, tags, interval, queues, match_mode: MatchMode = MatchMode.ANY):  # type: ignore[override]
-            await self.client._handle({
-                "type": "queue_update",
-                "data": {
-                    "tags": tags,
-                    "interval": interval,
-                    "queues": queues,
-                    "match_mode": match_mode.value,
-                },
-            })
+            await self.client._handle(
+                {
+                    "type": "queue_update",
+                    "data": {
+                        "tags": tags,
+                        "interval": interval,
+                        "queues": queues,
+                        "match_mode": match_mode.value,
+                        "version": EVENT_SCHEMA_VERSION,
+                    },
+                }
+            )
 
     client = DummyWS("ws://dummy")
 
@@ -130,6 +134,7 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
                     "interval": 60,
                     "queues": [{"queue": "q1", "global": False}],
                     "match_mode": "any",
+                    "version": EVENT_SCHEMA_VERSION,
                 },
             }
         )

--- a/tests/tagquery/test_update_warmup.py
+++ b/tests/tagquery/test_update_warmup.py
@@ -2,6 +2,7 @@ import pytest
 
 from qmtl.sdk import TagQueryNode, Runner
 from qmtl.sdk.tagquery_manager import TagQueryManager
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 
 @pytest.mark.asyncio
@@ -20,6 +21,7 @@ async def test_update_warmup_and_removal():
                 "interval": 60,
                 "queues": [{"queue": "q1", "global": False}],
                 "match_mode": "any",
+                "version": EVENT_SCHEMA_VERSION,
             },
         }
     )
@@ -45,6 +47,7 @@ async def test_update_warmup_and_removal():
                     {"queue": "q2", "global": False},
                 ],
                 "match_mode": "any",
+                "version": EVENT_SCHEMA_VERSION,
             },
         }
     )
@@ -66,6 +69,7 @@ async def test_update_warmup_and_removal():
                 "interval": 60,
                 "queues": [{"queue": "q2", "global": False}],
                 "match_mode": "any",
+                "version": EVENT_SCHEMA_VERSION,
             },
         }
     )

--- a/tests/test_activation_manager_freeze_drain.py
+++ b/tests/test_activation_manager_freeze_drain.py
@@ -1,9 +1,13 @@
 import pytest
 from qmtl.sdk.activation_manager import ActivationManager
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 
 async def _emit(am: ActivationManager, side: str, **fields) -> None:
-    payload = {"event": "activation_updated", "data": {"side": side, **fields}}
+    payload = {
+        "event": "activation_updated",
+        "data": {"side": side, "version": EVENT_SCHEMA_VERSION, **fields},
+    }
     await am._on_message(payload)  # type: ignore[attr-defined]
 
 

--- a/tests/test_sizing_weight_integration.py
+++ b/tests/test_sizing_weight_integration.py
@@ -5,10 +5,16 @@ from qmtl.sdk.runner import Runner
 from qmtl.pipeline.execution_nodes import SizingNode
 from qmtl.sdk.portfolio import Portfolio
 from qmtl.sdk.activation_manager import ActivationManager
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 
 async def _emit(am: ActivationManager, side: str, **fields) -> None:
-    await am._on_message({"event": "activation_updated", "data": {"side": side, **fields}})  # type: ignore
+    await am._on_message(
+        {
+            "event": "activation_updated",
+            "data": {"side": side, "version": EVENT_SCHEMA_VERSION, **fields},
+        }
+    )  # type: ignore
 
 
 def _weight_fn_from_am(am: ActivationManager):

--- a/tests/test_tagquery_manager.py
+++ b/tests/test_tagquery_manager.py
@@ -4,6 +4,7 @@ import pytest
 
 from qmtl.sdk import TagQueryNode, MatchMode
 from qmtl.sdk.tagquery_manager import TagQueryManager
+from qmtl.common.cloudevents import EVENT_SCHEMA_VERSION
 
 
 @pytest.mark.asyncio
@@ -51,6 +52,7 @@ async def test_resolve_and_update(monkeypatch):
                 "interval": 60,
                 "queues": [{"queue": "q2", "global": False}],
                 "match_mode": "any",
+                "version": EVENT_SCHEMA_VERSION,
             },
         }
     )
@@ -64,6 +66,7 @@ async def test_resolve_and_update(monkeypatch):
                 "interval": 60,
                 "queues": [],
                 "match_mode": "any",
+                "version": EVENT_SCHEMA_VERSION,
             },
         }
     )
@@ -123,6 +126,7 @@ async def test_match_mode_routes_updates():
                 "interval": 60,
                 "queues": [{"queue": "q1", "global": False}],
                 "match_mode": "all",
+                "version": EVENT_SCHEMA_VERSION,
             },
         }
     )
@@ -136,6 +140,7 @@ async def test_match_mode_routes_updates():
                 "tags": ["t1"],
                 "interval": 60,
                 "queues": [{"queue": "q2", "global": False}],
+                "version": EVENT_SCHEMA_VERSION,
             },
         }
     )
@@ -198,15 +203,18 @@ async def test_start_uses_event_descriptor(monkeypatch):
 
         async def start(self):
             self.started = True
-            await self.on_message({
-                "event": "queue_update",
-            "data": {
-                "tags": ["t1"],
-                "interval": 60,
-                "queues": [{"queue": "q3", "global": False}],
-                "match_mode": "any",
-            },
-            })
+            await self.on_message(
+                {
+                    "event": "queue_update",
+                    "data": {
+                        "tags": ["t1"],
+                        "interval": 60,
+                        "queues": [{"queue": "q3", "global": False}],
+                        "match_mode": "any",
+                        "version": EVENT_SCHEMA_VERSION,
+                    },
+                }
+            )
 
         async def stop(self):
             self.started = False


### PR DESCRIPTION
## Summary
- add `EVENT_SCHEMA_VERSION` constant and include `version` field in control bus event payloads
- validate event schema version across producers and consumers, including SDK clients
- update tests to cover versioned events

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest --collect-only -q`
- `uv run -m pytest -W error -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68bfc97043e883298656e499e45a4005