### PR TITLE
gateway: NodeSpec canonical ID + metric (Closes #892)

### DIFF
--- a/qmtl/common/nodespec.py
+++ b/qmtl/common/nodespec.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Canonical NodeSpec serializer and NodeID helper (scaffold).
+
+This follows the spirit of the architecture spec by capturing deterministic
+fields and a sorted dependency list from a DAG node dictionary.
+"""
+
+from typing import Any, Iterable
+from blake3 import blake3
+
+
+def _sorted_deps(node: dict) -> list[str]:
+    deps = node.get("inputs") or node.get("dependencies") or []
+    return sorted([str(d) for d in deps])
+
+
+def serialize_nodespec(node: dict[str, Any]) -> bytes:
+    node_type = str(node.get("node_type", ""))
+    interval = int(node.get("interval") or 0)
+    period = int(node.get("period") or 0)
+    params = node.get("params") or node.get("config") or {}
+    # Normalize params: flatten simple key/values and sort by key
+    items = []
+    if isinstance(params, dict):
+        for k in sorted(params.keys()):
+            v = params[k]
+            items.append(f"{k}={v}")
+    deps = _sorted_deps(node)
+    schema_compat_id = str(node.get("schema_id", ""))
+    code_hash = str(node.get("code_hash", ""))
+    payload = "|".join(
+        [
+            node_type,
+            str(interval),
+            str(period),
+            ";".join(items),
+            ",".join(deps),
+            schema_compat_id,
+            code_hash,
+        ]
+    )
+    return payload.encode()
+
+
+def canonical_node_id(node: dict[str, Any]) -> str:
+    data = serialize_nodespec(node)
+    return f"blake3:{blake3(data).hexdigest()}"
+
+
+__all__ = ["serialize_nodespec", "canonical_node_id"]
+

--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -63,6 +63,13 @@ owner_reassign_total = Counter(
     registry=global_registry,
 )
 
+# Canonical NodeID mismatch (scaffold metric during migration)
+nodeid_canon_mismatch_total = Counter(
+    "nodeid_canon_mismatch_total",
+    "Number of nodes where canonical NodeID (spec) differs from 4-field ID",
+    registry=global_registry,
+)
+
 dagclient_breaker_state = Gauge(
     "dagclient_breaker_state",
     "DAG Manager circuit breaker state (1=open, 0=closed)",

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -128,6 +128,15 @@ def create_api_router(
                 *required, payload.world_id or ""
             )
             nid = node.get("node_id")
+            # Compute canonical NodeID from NodeSpec for comparison (non-enforcing)
+            try:
+                from qmtl.common.nodespec import canonical_node_id as _canon_id
+
+                canon = _canon_id(node)
+                if isinstance(nid, str) and nid in {expected, legacy} and nid != canon:
+                    gw_metrics.nodeid_canon_mismatch_total.inc()
+            except Exception:
+                pass
             if nid not in {expected, legacy}:
                 mismatches.append(
                     {"index": idx, "node_id": node.get("node_id", ""), "expected": expected}


### PR DESCRIPTION
Adds qmtl/common/nodespec.py (serializer + canonical_node_id) and records a metric when the canonical NodeID differs from the current 4-field/legacy IDs. This scaffolds the migration while maintaining compatibility.\n\nCloses #892