### PR TITLE
feat: add event schema versioning

### DIFF
--- a/qmtl/dagmanager/controlbus_producer.py
+++ b/qmtl/dagmanager/controlbus_producer.py
@@ -30,7 +30,7 @@ class ControlBusProducer:
             await self._producer.stop()
         self._producer = None
 
-    async def publish_queue_update(self, tags, interval, queues, match_mode: str = "any") -> None:
+    async def publish_queue_update(self, tags, interval, queues, match_mode: str = "any", *, version: int = 1) -> None:
         if self._producer is None:
             return
         payload = {
@@ -38,6 +38,7 @@ class ControlBusProducer:
             "interval": interval,
             "queues": list(queues),
             "match_mode": match_mode,
+            "version": version,
         }
         data = json.dumps(payload).encode()
         key = ",".join(tags).encode()

--- a/qmtl/gateway/controlbus_consumer.py
+++ b/qmtl/gateway/controlbus_consumer.py
@@ -194,6 +194,11 @@ class ControlBusConsumer:
         if not self.ws_hub:
             return
 
+        version = msg.data.get("version")
+        if version != 1:
+            logger.warning("unsupported controlbus message version: %s", version)
+            return
+
         if msg.topic == "activation":
             await self.ws_hub.send_activation_updated(msg.data)
         elif msg.topic == "policy":

--- a/qmtl/gateway/event_handlers.py
+++ b/qmtl/gateway/event_handlers.py
@@ -139,6 +139,7 @@ def create_event_router(
                                     "interval": interval_int,
                                     "queues": queues,
                                     "match_mode": mode.value,
+                                    "version": 1,
                                 },
                             )
                             await websocket.send_text(json.dumps(event))
@@ -147,6 +148,8 @@ def create_event_router(
                     if "activation" in topics_set:
                         try:
                             act_data, _ = await world_client.get_activation(world_id)
+                            if isinstance(act_data, dict):
+                                act_data.setdefault("version", 1)
                             event = format_event(
                                 "qmtl.gateway", "activation_updated", act_data
                             )
@@ -161,6 +164,7 @@ def create_event_router(
                             payload = {"world_id": world_id}
                             if isinstance(hash_data, dict):
                                 payload.update(hash_data)
+                            payload["version"] = 1
                             event = format_event(
                                 "qmtl.gateway", "policy_state_hash", payload
                             )

--- a/qmtl/gateway/event_models.py
+++ b/qmtl/gateway/event_models.py
@@ -20,22 +20,25 @@ class QueueUpdateData(BaseModel):
     queues: List[QueueRef]
     match_mode: Literal["any", "all"] = "any"
     world_id: Optional[StrictStr] = None
+    version: StrictInt
 
 
 class TagQueryUpsertData(BaseModel):
     tags: List[StrictStr]
     interval: StrictInt
     queues: List[QueueRef]
+    version: StrictInt
 
 
 class SentinelWeightData(BaseModel):
     sentinel_id: StrictStr
     weight: StrictFloat
     world_id: Optional[StrictStr] = None
+    version: StrictInt
 
 
 class ActivationUpdatedData(BaseModel):
-    version: Optional[StrictInt] = None
+    version: StrictInt
     world_id: StrictStr
     strategy_id: Optional[StrictStr] = None
     side: Optional[Literal["long", "short"]] = None
@@ -51,7 +54,7 @@ class ActivationUpdatedData(BaseModel):
 
 
 class PolicyUpdatedData(BaseModel):
-    version: Optional[StrictInt] = None
+    version: StrictInt
     world_id: StrictStr
     policy_version: Optional[StrictInt] = None
     state_hash: Optional[StrictStr] = None

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -341,7 +341,7 @@ class WebSocketHub:
         event = format_event(
             "qmtl.gateway",
             "progress",
-            {"strategy_id": strategy_id, "status": status},
+            {"strategy_id": strategy_id, "status": status, "version": 1},
         )
         await self.broadcast(event)
 
@@ -351,7 +351,7 @@ class WebSocketHub:
         event = format_event(
             "qmtl.gateway",
             "queue_map",
-            {"strategy_id": strategy_id, "queue_map": queue_map},
+            {"strategy_id": strategy_id, "queue_map": queue_map, "version": 1},
         )
         await self.broadcast(event)
 
@@ -376,6 +376,7 @@ class WebSocketHub:
                 "queues": queues,
                 "match_mode": match_mode.value,
                 **({"world_id": world_id} if world_id else {}),
+                "version": 1,
             },
         )
         await self.broadcast(event, topic="queue")
@@ -387,7 +388,7 @@ class WebSocketHub:
         event = format_event(
             "qmtl.gateway",
             "tagquery.upsert",
-            {"tags": tags, "interval": interval, "queues": queues},
+            {"tags": tags, "interval": interval, "queues": queues, "version": 1},
         )
         await self.broadcast(event, topic="queue")
 
@@ -396,17 +397,19 @@ class WebSocketHub:
         event = format_event(
             "qmtl.gateway",
             "sentinel_weight",
-            {"sentinel_id": sentinel_id, "weight": weight},
+            {"sentinel_id": sentinel_id, "weight": weight, "version": 1},
         )
         await self.broadcast(event, topic="activation")
 
     async def send_activation_updated(self, payload: dict) -> None:
         """Broadcast activation updates."""
+        payload.setdefault("version", 1)
         event = format_event("qmtl.gateway", "activation_updated", payload)
         await self.broadcast(event, topic="activation")
 
     async def send_policy_updated(self, payload: dict) -> None:
         """Broadcast policy updates."""
+        payload.setdefault("version", 1)
         event = format_event("qmtl.gateway", "policy_updated", payload)
         await self.broadcast(event, topic="policy")
 

--- a/qmtl/sdk/tagquery_manager.py
+++ b/qmtl/sdk/tagquery_manager.py
@@ -152,6 +152,9 @@ class TagQueryManager:
         """Apply WebSocket ``data`` to registered nodes."""
         event = data.get("event") or data.get("type")
         payload = data.get("data", data)
+        ver = payload.get("version")
+        if ver != 1:
+            return
         if event == "tagquery.upsert":
             tags = payload.get("tags") or []
             interval = payload.get("interval")

--- a/qmtl/sdk/ws_client.py
+++ b/qmtl/sdk/ws_client.py
@@ -56,6 +56,11 @@ class WebSocketClient:
     async def _handle(self, data: dict) -> None:
         event = data.get("event") or data.get("type")
         payload = data.get("data", data)
+        if event != "ack":
+            ver = payload.get("version")
+            if ver != 1:
+                logging.warning("unsupported event version: %s for %s", ver, event)
+                return
         if event == "queue_created":
             qid = payload.get("queue_id")
             topic = payload.get("topic")

--- a/qmtl/worldservice/controlbus_producer.py
+++ b/qmtl/worldservice/controlbus_producer.py
@@ -30,22 +30,28 @@ class ControlBusProducer:
             await self._producer.stop()
         self._producer = None
 
-    async def publish_policy_update(self, world_id: str, strategies: Iterable[str], *, version: int | None = None) -> None:
+    async def publish_policy_update(self, world_id: str, strategies: Iterable[str], *, version: int = 1) -> None:
         if self._producer is None:
             return
-        payload: Dict[str, Any] = {"type": "PolicyUpdated", "world_id": world_id, "strategies": list(strategies)}
-        if version is not None:
-            payload["version"] = version
+        payload: Dict[str, Any] = {
+            "type": "PolicyUpdated",
+            "world_id": world_id,
+            "strategies": list(strategies),
+            "version": version,
+        }
         data = json.dumps(payload).encode()
         key = world_id.encode()
         await self._producer.send_and_wait(self.topic, data, key=key)
 
-    async def publish_activation_update(self, world_id: str, payload: Dict[str, Any], *, version: int | None = None) -> None:
+    async def publish_activation_update(self, world_id: str, payload: Dict[str, Any], *, version: int = 1) -> None:
         if self._producer is None:
             return
-        evt: Dict[str, Any] = {"type": "ActivationUpdated", "world_id": world_id, **payload}
-        if version is not None:
-            evt["version"] = version
+        evt: Dict[str, Any] = {
+            "type": "ActivationUpdated",
+            "world_id": world_id,
+            **payload,
+            "version": version,
+        }
         data = json.dumps(evt).encode()
         key = world_id.encode()
         await self._producer.send_and_wait(self.topic, data, key=key)

--- a/tests/gateway/test_queue_update_ws_execution.py
+++ b/tests/gateway/test_queue_update_ws_execution.py
@@ -25,6 +25,7 @@ class DummyHub(WebSocketHub):
                 "interval": interval,
                 "queues": queues,
                 "match_mode": match_mode.value,
+                "version": 1,
             },
         })
 

--- a/tests/gateway/test_ws.py
+++ b/tests/gateway/test_ws.py
@@ -92,7 +92,7 @@ async def test_hub_sends_sentinel_weight():
     await hub.stop()
     msg = json.loads(ws.messages[0])
     assert msg["type"] == "sentinel_weight"
-    assert msg["data"] == {"sentinel_id": "s1", "weight": 0.5}
+    assert msg["data"] == {"sentinel_id": "s1", "weight": 0.5, "version": 1}
 
 
 @pytest.mark.asyncio

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -71,6 +71,7 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
                     "interval": interval,
                     "queues": queues,
                     "match_mode": match_mode.value,
+                    "version": 1,
                 },
             })
 
@@ -130,6 +131,7 @@ async def test_live_auto_subscribes(monkeypatch, fake_redis):
                     "interval": 60,
                     "queues": [{"queue": "q1", "global": False}],
                     "match_mode": "any",
+                    "version": 1,
                 },
             }
         )

--- a/tests/tagquery/test_tagquery_upsert_handler.py
+++ b/tests/tagquery/test_tagquery_upsert_handler.py
@@ -16,6 +16,7 @@ async def test_tagquery_upsert_initializes_node():
                 "tags": ["t"],
                 "interval": 60,
                 "queues": [{"queue": "q1", "global": False}],
+                "version": 1,
             },
         }
     )

--- a/tests/tagquery/test_update_warmup.py
+++ b/tests/tagquery/test_update_warmup.py
@@ -20,6 +20,7 @@ async def test_update_warmup_and_removal():
                 "interval": 60,
                 "queues": [{"queue": "q1", "global": False}],
                 "match_mode": "any",
+                "version": 1,
             },
         }
     )
@@ -45,6 +46,7 @@ async def test_update_warmup_and_removal():
                     {"queue": "q2", "global": False},
                 ],
                 "match_mode": "any",
+                "version": 1,
             },
         }
     )
@@ -66,6 +68,7 @@ async def test_update_warmup_and_removal():
                 "interval": 60,
                 "queues": [{"queue": "q2", "global": False}],
                 "match_mode": "any",
+                "version": 1,
             },
         }
     )

--- a/tests/test_completion_monitor.py
+++ b/tests/test_completion_monitor.py
@@ -63,8 +63,8 @@ class DummyBus(ControlBusProducer):
     def __init__(self) -> None:  # pragma: no cover - simple capture
         self.published: list[tuple] = []
 
-    async def publish_queue_update(self, tags, interval, queues, match_mode: str = "any") -> None:  # type: ignore[override]
-        self.published.append((list(tags), interval, list(queues), match_mode))
+    async def publish_queue_update(self, tags, interval, queues, match_mode: str = "any", *, version: int = 1) -> None:  # type: ignore[override]
+        self.published.append((list(tags), interval, list(queues), match_mode, version))
 
 
 @pytest.mark.asyncio
@@ -77,7 +77,8 @@ async def test_completion_emits_event():
     await monitor.check_once()
 
     assert bus.published
-    tags, interval, queues, mode = bus.published[0]
+    tags, interval, queues, mode, version = bus.published[0]
     assert queues == []
     assert tags == ["t1"]
     assert mode == "any"
+    assert version == 1

--- a/tests/test_tagquery_manager.py
+++ b/tests/test_tagquery_manager.py
@@ -51,6 +51,7 @@ async def test_resolve_and_update(monkeypatch):
                 "interval": 60,
                 "queues": [{"queue": "q2", "global": False}],
                 "match_mode": "any",
+                "version": 1,
             },
         }
     )
@@ -64,6 +65,7 @@ async def test_resolve_and_update(monkeypatch):
                 "interval": 60,
                 "queues": [],
                 "match_mode": "any",
+                "version": 1,
             },
         }
     )
@@ -123,6 +125,7 @@ async def test_match_mode_routes_updates():
                 "interval": 60,
                 "queues": [{"queue": "q1", "global": False}],
                 "match_mode": "all",
+                "version": 1,
             },
         }
     )
@@ -136,6 +139,7 @@ async def test_match_mode_routes_updates():
                 "tags": ["t1"],
                 "interval": 60,
                 "queues": [{"queue": "q2", "global": False}],
+                "version": 1,
             },
         }
     )
@@ -205,6 +209,7 @@ async def test_start_uses_event_descriptor(monkeypatch):
                 "interval": 60,
                 "queues": [{"queue": "q3", "global": False}],
                 "match_mode": "any",
+                "version": 1,
             },
             })
 

--- a/tests/worldservice/test_worldservice_api.py
+++ b/tests/worldservice/test_worldservice_api.py
@@ -9,10 +9,10 @@ class DummyBus(ControlBusProducer):
     def __init__(self):
         self.events: list[tuple[str, str, int | None, object]] = []
 
-    async def publish_policy_update(self, world_id: str, strategies: list[str], *, version: int | None = None) -> None:  # type: ignore[override]
+    async def publish_policy_update(self, world_id: str, strategies: list[str], *, version: int = 1) -> None:  # type: ignore[override]
         self.events.append(("policy", world_id, version, list(strategies)))
 
-    async def publish_activation_update(self, world_id: str, payload: dict, *, version: int | None = None) -> None:  # type: ignore[override]
+    async def publish_activation_update(self, world_id: str, payload: dict, *, version: int = 1) -> None:  # type: ignore[override]
         self.events.append(("activation", world_id, version, payload))
 
 


### PR DESCRIPTION
## Summary
- add explicit version field to control bus event models
- include schema version when publishing and forwarding events
- validate event version in consumers and update tests for v1

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68bfcbebf8008329bf936d78f424a8c9