### PR TITLE
chore: remove backward-compat shims (legacy NodeID, match_mode)

### DIFF
--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -50,12 +50,6 @@ commit_invalid_total = Counter(
     registry=global_registry,
 )
 
-# Legacy NodeID acceptance counter (temporary during migration)
-node_id_legacy_accept_total = Counter(
-    "node_id_legacy_accept_total",
-    "Number of times a legacy world-coupled NodeID was accepted",
-    registry=global_registry,
-)
 
 owner_reassign_total = Counter(
     "owner_reassign_total",


### PR DESCRIPTION
Removes compatibility paths kept during previous work:\n- Gateway no longer accepts legacy world-coupled NodeIDs; only canonical 4-field compute_node_id is allowed.\n- /queues/by_tag requires explicit match_mode parameter (no default).\n- Tests updated accordingly.\n\nRelated to #919.