### PR TITLE
remove(legacy-nodeid): drop legacy NodeID helper and update tests/docs

### DIFF
--- a/docs/guides/migration_nodeid_blake3.md
+++ b/docs/guides/migration_nodeid_blake3.md
@@ -9,17 +9,17 @@ last_modified: 2025-09-07
 
 # Migration: BLAKE3 NodeID
 
-The NodeID algorithm now uses BLAKE3 with a mandatory `blake3:` prefix and no longer includes `world_id`. Legacy SHA-based IDs are temporarily accepted but deprecated.
+The NodeID algorithm uses BLAKE3 with a mandatory `blake3:` prefix and must not include `world_id`. Legacy SHA-based IDs are no longer accepted and the helper has been removed.
 
 ## Changes
 
-- `compute_node_id` now returns `blake3:<digest>` computed from `(node_type, code_hash, config_hash, schema_hash)` without `world_id`.
-- Legacy IDs can be produced via `compute_legacy_node_id` and are accepted by the Gateway during the deprecation window.
+- `compute_node_id` returns `blake3:<digest>` computed from `(node_type, code_hash, config_hash, schema_hash)` without `world_id`.
+- The legacy helper `compute_legacy_node_id` has been removed; Gateways reject non-canonical IDs.
 
 ## Actions
 
-- Remove `world_id` arguments from `compute_node_id` calls.
-- Update stored NodeIDs to the new `blake3:` form.
-- Plan migration away from `compute_legacy_node_id`; support will be removed in a future release.
+- Ensure all code paths use `compute_node_id` exclusively.
+- Migrate any stored NodeIDs to the canonical `blake3:` form.
+- Remove any references to `compute_legacy_node_id` in your codebase.
 
 {{ nav_links() }}

--- a/qmtl/common/__init__.py
+++ b/qmtl/common/__init__.py
@@ -13,7 +13,7 @@ def crc32_of_list(items: Iterable[str]) -> int:
 from .reconnect import ReconnectingRedis, ReconnectingNeo4j
 from .circuit_breaker import AsyncCircuitBreaker
 from .four_dim_cache import FourDimCache
-from .nodeid import compute_node_id, compute_legacy_node_id
+from .nodeid import compute_node_id
 
 __all__ = [
     "crc32_of_list",
@@ -22,5 +22,4 @@ __all__ = [
     "AsyncCircuitBreaker",
     "FourDimCache",
     "compute_node_id",
-    "compute_legacy_node_id",
 ]

--- a/qmtl/common/nodeid.py
+++ b/qmtl/common/nodeid.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 """Deterministic NodeID helpers."""
-
-import hashlib
 from typing import Iterable
 
 from blake3 import blake3
@@ -35,28 +33,4 @@ def compute_node_id(
     return node_id
 
 
-def compute_legacy_node_id(
-    node_type: str,
-    code_hash: str,
-    config_hash: str,
-    schema_hash: str,
-    world_id: str,
-    existing_ids: Iterable[str] | None = None,
-) -> str:
-    """Return legacy SHA-256/sha3 NodeID that includes ``world_id``.
-
-    This is provided for temporary compatibility while migrating to the
-    canonical BLAKE3 NodeID.
-    """
-    data = f"{world_id}:{node_type}:{code_hash}:{config_hash}:{schema_hash}".encode()
-    try:
-        sha = hashlib.sha256(data).hexdigest()
-    except Exception:  # pragma: no cover - unlikely
-        return hashlib.sha3_256(data).hexdigest()
-
-    if existing_ids and sha in set(existing_ids):
-        sha = hashlib.sha3_256(data).hexdigest()
-    return sha
-
-
-__all__ = ["compute_node_id", "compute_legacy_node_id"]
+__all__ = ["compute_node_id"]

--- a/tests/test_dagmanager.py
+++ b/tests/test_dagmanager.py
@@ -2,7 +2,6 @@ from blake3 import blake3
 import hashlib
 
 from qmtl.dagmanager import compute_node_id
-from qmtl.common import compute_legacy_node_id
 from qmtl.dagmanager.neo4j_init import get_schema_queries
 
 
@@ -20,10 +19,10 @@ def test_compute_node_id_collision():
     assert second.startswith("blake3:")
 
 
-def test_compute_legacy_node_id_sha256():
-    node_id = compute_legacy_node_id("type", "code", "cfg", "schema", "w1")
-    expected = hashlib.sha256(b"w1:type:code:cfg:schema").hexdigest()
-    assert node_id == expected
+def test_no_legacy_nodeid_helper_present():
+    # Legacy helper has been removed; ensure import path no longer exposes it
+    import qmtl.common as common
+    assert not hasattr(common, "compute_legacy_node_id")
 
 
 def test_schema_queries():


### PR DESCRIPTION
This PR completes the removal of the legacy world-coupled NodeID helper.\n\nChanges\n- Remove compute_legacy_node_id from qmtl/common/nodeid.py\n- Stop exporting helper in qmtl/common/__init__.py\n- Update tests/test_dagmanager.py to verify helper is not exposed\n- Update docs/guides/migration_nodeid_blake3.md to mark legacy helper as removed and gateway rejecting non-canonical IDs\n\nThis follows the recent change to reject legacy NodeIDs in Gateway.\n