### PR TITLE
gateway: require CloudEvents for /fills (remove plain JSON path)

### DIFF
--- a/tests/gateway/test_fills_webhook.py
+++ b/tests/gateway/test_fills_webhook.py
@@ -59,12 +59,19 @@ async def test_fills_webhook_produces_kafka(fake_redis):
     }
     token = sign_event_token(claims, cfg)
     payload = {
-        "order_id": "exch-7890",
-        "symbol": "BTC/USDT",
-        "side": "BUY",
-        "quantity": 1.0,
-        "price": 100.0,
-        "extra": "drop-me",
+        "specversion": "1.0",
+        "id": "evt-1",
+        "type": "trade.fill",
+        "source": "test://fills",
+        "time": "2025-01-01T00:00:00Z",
+        "data": {
+            "order_id": "exch-7890",
+            "symbol": "BTC/USDT",
+            "side": "BUY",
+            "quantity": 1.0,
+            "price": 100.0,
+            "extra": "drop-me",
+        },
     }
     async with httpx.ASGITransport(app=app) as transport:
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
This enforces CloudEvents 1.0 on /fills and removes the plain JSON code path.\n- Returns 400 E_CE_REQUIRED when CE envelope is missing.\n- Forwards CE metadata to Kafka headers.\n- Updates test to emit CE payload.\n