### PR TITLE
feat(worldservice): add policy retrieval endpoint

### DIFF
--- a/qmtl/worldservice/api.py
+++ b/qmtl/worldservice/api.py
@@ -107,6 +107,13 @@ def create_app(*, bus: ControlBusProducer | None = None, storage: Storage | None
     async def get_policies(world_id: str) -> List[Dict]:
         return await store.list_policies(world_id)
 
+    @app.get('/worlds/{world_id}/policies/{version}')
+    async def get_policy(world_id: str, version: int) -> Dict:
+        policy = await store.get_policy(world_id, version)
+        if not policy:
+            raise HTTPException(status_code=404, detail='policy not found')
+        return policy.model_dump()
+
     @app.post('/worlds/{world_id}/set-default')
     async def post_set_default(world_id: str, payload: PolicyVersionResponse) -> PolicyVersionResponse:
         await store.set_default_policy(world_id, payload.version)

--- a/qmtl/worldservice/storage.py
+++ b/qmtl/worldservice/storage.py
@@ -82,6 +82,12 @@ class Storage:
             return []
         return [{"version": v} for v in sorted(wp.versions.keys())]
 
+    async def get_policy(self, world_id: str, version: int) -> Optional[Policy]:
+        wp = self.policies.get(world_id)
+        if not wp:
+            return None
+        return wp.versions.get(version)
+
     async def set_default_policy(self, world_id: str, version: int) -> None:
         wp = self.policies.setdefault(world_id, WorldPolicies())
         if version not in wp.versions:

--- a/tests/worldservice/test_policies.py
+++ b/tests/worldservice/test_policies.py
@@ -1,0 +1,29 @@
+import httpx
+import pytest
+
+from qmtl.worldservice.api import create_app
+
+
+@pytest.mark.asyncio
+async def test_get_policy_and_missing_version():
+    app = create_app()
+    async with httpx.ASGITransport(app=app) as asgi:
+        async with httpx.AsyncClient(transport=asgi, base_url="http://test") as client:
+            await client.post("/worlds", json={"id": "w1"})
+            await client.post(
+                "/worlds/w1/policies",
+                json={"policy": {"top_k": {"metric": "m", "k": 1}}},
+            )
+
+            r = await client.get("/worlds/w1/policies/1")
+            assert r.status_code == 200
+            assert r.json() == {
+                "thresholds": {},
+                "top_k": {"metric": "m", "k": 1},
+                "correlation": None,
+                "hysteresis": None,
+            }
+
+            r = await client.get("/worlds/w1/policies/2")
+            assert r.status_code == 404
+


### PR DESCRIPTION
## Summary
- support fetching individual policy versions in WorldService
- test policy retrieval including missing version

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1` *(fails: Status code 204 must not have a response body)*
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest tests/worldservice -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto` *(fails: Status code 204 must not have a response body)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd45102e08329af6a4f98bb666114