### PR TITLE
feat: enrich control bus events with metadata

### DIFF
--- a/qmtl/gateway/event_models.py
+++ b/qmtl/gateway/event_models.py
@@ -57,7 +57,9 @@ class PolicyUpdatedData(BaseModel):
     version: StrictInt
     world_id: StrictStr
     policy_version: Optional[StrictInt] = None
-    state_hash: Optional[StrictStr] = None
+    checksum: Optional[StrictStr] = None
+    status: Optional[StrictStr] = None
+    ts: Optional[StrictStr] = None
 
 
 T = TypeVar("T", bound=BaseModel)

--- a/qmtl/sdk/activation_manager.py
+++ b/qmtl/sdk/activation_manager.py
@@ -30,6 +30,9 @@ class ActivationState:
     long: SideState = field(default_factory=SideState)
     short: SideState = field(default_factory=SideState)
     etag: Optional[str] = None
+    run_id: Optional[str] = None
+    ts: Optional[str] = None
+    state_hash: Optional[str] = None
     effective_mode: Optional[str] = None
     stale: bool = True
 
@@ -106,6 +109,9 @@ class ActivationManager:
             drain = bool(payload.get("drain", False))
             eff_mode = payload.get("effective_mode")
             self.state.etag = payload.get("etag") or self.state.etag
+            self.state.run_id = payload.get("run_id") or self.state.run_id
+            self.state.ts = payload.get("ts") or self.state.ts
+            self.state.state_hash = payload.get("state_hash") or self.state.state_hash
             ver = payload.get("version")
             if ver is not None:
                 try:

--- a/tests/worldservice/test_controlbus_producer.py
+++ b/tests/worldservice/test_controlbus_producer.py
@@ -1,0 +1,60 @@
+import json
+import pytest
+
+from qmtl.worldservice.controlbus_producer import ControlBusProducer
+
+
+class DummyProducer:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, bytes, bytes | None]] = []
+
+    async def send_and_wait(self, topic: str, data: bytes, key: bytes | None = None) -> None:
+        self.sent.append((topic, data, key))
+
+
+@pytest.mark.asyncio
+async def test_publish_policy_update_cloud_event():
+    dummy = DummyProducer()
+    producer = ControlBusProducer(producer=dummy, topic="policy")
+    await producer.publish_policy_update(
+        "w1",
+        policy_version=1,
+        checksum="chk",
+        status="ACTIVE",
+        ts="2024-01-01T00:00:00Z",
+    )
+    topic, data, key = dummy.sent[0]
+    evt = json.loads(data.decode())
+    assert evt["type"] == "policy_updated"
+    assert evt["data"]["world_id"] == "w1"
+    assert evt["data"]["policy_version"] == 1
+    assert evt["data"]["checksum"] == "chk"
+    assert evt["data"]["status"] == "ACTIVE"
+    assert evt["data"]["ts"] == "2024-01-01T00:00:00Z"
+    assert topic == "policy"
+    assert key == b"w1"
+
+
+@pytest.mark.asyncio
+async def test_publish_activation_update_cloud_event():
+    dummy = DummyProducer()
+    producer = ControlBusProducer(producer=dummy, topic="activation")
+    await producer.publish_activation_update(
+        "w1",
+        etag="e1",
+        run_id="r1",
+        ts="2024-01-01T00:00:00Z",
+        state_hash="h1",
+        payload={"side": "long", "active": True},
+    )
+    topic, data, key = dummy.sent[0]
+    evt = json.loads(data.decode())
+    assert evt["type"] == "activation_updated"
+    assert evt["data"]["world_id"] == "w1"
+    assert evt["data"]["etag"] == "e1"
+    assert evt["data"]["run_id"] == "r1"
+    assert evt["data"]["state_hash"] == "h1"
+    assert evt["data"]["side"] == "long"
+    assert evt["data"]["active"] is True
+    assert topic == "activation"
+    assert key == b"w1"


### PR DESCRIPTION
## Summary
- emit CloudEvents for policy and activation updates with extra metadata
- parse CloudEvent payloads and dedupe using new fields in gateway consumer
- store activation metadata in SDK and add coverage for CloudEvent producer

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 tests/worldservice tests/gateway/test_controlbus_consumer.py tests/test_activation_manager_default.py tests/test_activation_manager_freeze_drain.py`
- `uv run -m pytest -W error -n auto tests/worldservice tests/gateway/test_controlbus_consumer.py tests/test_activation_manager_default.py tests/test_activation_manager_freeze_drain.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfd44fda3c8329963cf71223b405d4