### PR TITLE
feat: add queue update etag and ts

### DIFF
--- a/qmtl/gateway/event_models.py
+++ b/qmtl/gateway/event_models.py
@@ -21,6 +21,8 @@ class QueueUpdateData(BaseModel):
     match_mode: Literal["any", "all"] = "any"
     world_id: Optional[StrictStr] = None
     version: StrictInt
+    etag: StrictStr
+    ts: StrictStr
 
 
 class TagQueryUpsertData(BaseModel):

--- a/qmtl/gateway/ws.py
+++ b/qmtl/gateway/ws.py
@@ -361,7 +361,10 @@ class WebSocketHub:
         interval: int,
         queues: list[dict[str, object]],
         match_mode: MatchMode = MatchMode.ANY,
+        *,
         world_id: str | None = None,
+        etag: str | None = None,
+        ts: str | None = None,
     ) -> None:
         """Broadcast queue update events.
 
@@ -376,6 +379,8 @@ class WebSocketHub:
                 "queues": queues,
                 "match_mode": match_mode.value,
                 **({"world_id": world_id} if world_id else {}),
+                **({"etag": etag} if etag is not None else {}),
+                **({"ts": ts} if ts is not None else {}),
                 "version": 1,
             },
         )

--- a/tests/gateway/test_controlbus_codec.py
+++ b/tests/gateway/test_controlbus_codec.py
@@ -28,3 +28,24 @@ def test_consumer_parse_kafka_message_proto_path():
     out = c._parse_kafka_message(msg)
     assert out.data == evt
 
+
+def test_consumer_parse_queue_event_etag_ts():
+    c = ControlBusConsumer(brokers=None, topics=["queue"], group="g")
+    evt = {
+        "type": "QueueUpdated",
+        "tags": ["x"],
+        "interval": 60,
+        "queues": [],
+        "match_mode": "any",
+        "version": 1,
+        "etag": "q:x:60:1",
+        "ts": "2020-01-01T00:00:00Z",
+    }
+    payload, headers = encode(evt)
+    msg = _Msg(payload, headers)
+    msg.topic = "queue"
+    out = c._parse_kafka_message(msg)
+    assert out.etag == "q:x:60:1"
+    assert out.data["etag"] == "q:x:60:1"
+    assert out.data["ts"] == "2020-01-01T00:00:00Z"
+

--- a/tests/gateway/test_controlbus_consumer.py
+++ b/tests/gateway/test_controlbus_consumer.py
@@ -34,7 +34,14 @@ class FakeHub:
             self._done.set()
 
     async def send_queue_update(
-        self, tags, interval, queues, match_mode: MatchMode = MatchMode.ANY
+        self,
+        tags,
+        interval,
+        queues,
+        match_mode: MatchMode = MatchMode.ANY,
+        *,
+        etag: str | None = None,
+        ts: str | None = None,
     ) -> None:
         self.events.append(
             (
@@ -44,6 +51,9 @@ class FakeHub:
                     "interval": interval,
                     "queues": queues,
                     "match_mode": match_mode,
+                    "etag": etag,
+                    "ts": ts,
+                    "version": 1,
                 },
             )
         )
@@ -54,7 +64,7 @@ class FakeHub:
         self.events.append(
             (
                 "tagquery.upsert",
-                {"tags": tags, "interval": interval, "queues": queues},
+                {"tags": tags, "interval": interval, "queues": queues, "version": 1},
             )
         )
         if self._done and len(self.events) == 4:
@@ -115,6 +125,8 @@ async def test_consumer_relays_and_deduplicates():
             "queues": [{"queue": "q", "global": False}],
             "match_mode": "any",
             "version": 1,
+            "etag": "e3",
+            "ts": "2020-01-01T00:00:00Z",
         },
         timestamp_ms=ts,
     )
@@ -134,6 +146,9 @@ async def test_consumer_relays_and_deduplicates():
                 "interval": 60,
                 "queues": [{"queue": "q", "global": False}],
                 "match_mode": MatchMode.ANY,
+                "etag": "e3",
+                "ts": "2020-01-01T00:00:00Z",
+                "version": 1,
             },
         ),
         (
@@ -142,6 +157,7 @@ async def test_consumer_relays_and_deduplicates():
                 "tags": ["x"],
                 "interval": 60,
                 "queues": [{"queue": "q", "global": False}],
+                "version": 1,
             },
         ),
     ]

--- a/tests/gateway/test_queue_update_ws_execution.py
+++ b/tests/gateway/test_queue_update_ws_execution.py
@@ -17,17 +17,30 @@ class DummyHub(WebSocketHub):
         super().__init__()
         self.client = client
 
-    async def send_queue_update(self, tags, interval, queues, match_mode: MatchMode = MatchMode.ANY):  # type: ignore[override]
-        await self.client._handle({
-            "type": "queue_update",
-            "data": {
-                "tags": tags,
-                "interval": interval,
-                "queues": queues,
-                "match_mode": match_mode.value,
-                "version": 1,
-            },
-        })
+    async def send_queue_update(
+        self,
+        tags,
+        interval,
+        queues,
+        match_mode: MatchMode = MatchMode.ANY,
+        *,
+        etag: str | None = None,
+        ts: str | None = None,
+    ) -> None:  # type: ignore[override]
+        await self.client._handle(
+            {
+                "type": "queue_update",
+                "data": {
+                    "tags": tags,
+                    "interval": interval,
+                    "queues": queues,
+                    "match_mode": match_mode.value,
+                    "etag": etag,
+                    "ts": ts,
+                    "version": 1,
+                },
+            }
+        )
 
 
 @pytest.mark.asyncio
@@ -46,6 +59,8 @@ async def test_node_unpauses_on_queue_update():
         60,
         [{"queue": "q1", "global": False}],
         MatchMode.ANY,
+        etag="q:t1:60:1",
+        ts="2020-01-01T00:00:00Z",
     )
 
     assert node.execute


### PR DESCRIPTION
## Summary
- include etag and timestamp in queue update events
- propagate etag/ts through control bus consumer and websocket hub
- expand tests for new queue update fields

## Testing
- `uv run -m pytest tests/gateway/test_controlbus_codec.py -q`
- `uv run -m pytest tests/gateway/test_controlbus_consumer.py::test_consumer_relays_and_deduplicates -q`
- `uv run -m pytest tests/gateway/test_queue_update_ws_execution.py -q`
- `uv run -m pytest tests/tagquery/test_runner_live_updates.py -q` *(fails: Status code 204 must not have a response body)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd44ede348329aaaa9b6eb0f96af4