### PR TITLE
refactor: add decision and activation envelopes

### DIFF
--- a/qmtl/gateway/event_handlers.py
+++ b/qmtl/gateway/event_handlers.py
@@ -147,13 +147,16 @@ def create_event_router(
                 if world_id and world_client is not None:
                     if "activation" in topics_set:
                         try:
-                            act_data, _ = await world_client.get_activation(world_id)
-                            if isinstance(act_data, dict):
-                                act_data.setdefault("version", 1)
-                            event = format_event(
-                                "qmtl.gateway", "activation_updated", act_data
-                            )
-                            await websocket.send_text(json.dumps(event))
+                            strategy_id = (claims or {}).get("strategy_id") if claims else None
+                            if strategy_id:
+                                for side in ("long", "short"):
+                                    act_data, _ = await world_client.get_activation(world_id, strategy_id, side)
+                                    if isinstance(act_data, dict):
+                                        act_data.setdefault("version", 1)
+                                    event = format_event(
+                                        "qmtl.gateway", "activation_updated", act_data
+                                    )
+                                    await websocket.send_text(json.dumps(event))
                         except Exception:
                             pass
                     if "policy" in topics_set:

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -440,7 +440,7 @@ def create_api_router(
     @router.delete(
         "/worlds/{world_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None
     )
-    async def delete_world(world_id: str, request: Request) -> Any:
+    async def delete_world(world_id: str, request: Request) -> Response:
         client: WorldServiceClient | None = world_client
         if client is None:
             raise HTTPException(status_code=503, detail="world service disabled")
@@ -538,7 +538,9 @@ def create_api_router(
         if client is None:
             raise HTTPException(status_code=503, detail="world service disabled")
         headers, cid = _build_world_headers(request)
-        data, stale = await client.get_activation(world_id, headers=headers)
+        strategy_id = request.query_params.get("strategy_id", "")
+        side = request.query_params.get("side", "")
+        data, stale = await client.get_activation(world_id, strategy_id, side, headers=headers)
         resp_headers = {"X-Correlation-ID": cid}
         if stale:
             resp_headers["Warning"] = "110 - Response is stale"

--- a/qmtl/gateway/world_client.py
+++ b/qmtl/gateway/world_client.py
@@ -178,15 +178,23 @@ class WorldServiceClient:
         return data, False
 
     async def get_activation(
-        self, world_id: str, headers: Optional[Dict[str, str]] = None
+        self,
+        world_id: str,
+        strategy_id: str,
+        side: str,
+        headers: Optional[Dict[str, str]] = None,
     ) -> tuple[Any, bool]:
-        etag, cached = self._activation_cache.get(world_id, (None, None))
+        key = f"{world_id}:{strategy_id}:{side}"
+        etag, cached = self._activation_cache.get(key, (None, None))
         req_headers = dict(headers or {})
         if etag:
             req_headers["If-None-Match"] = etag
         try:
             resp = await self._request(
-                "GET", f"{self._base}/worlds/{world_id}/activation", headers=req_headers
+                "GET",
+                f"{self._base}/worlds/{world_id}/activation",
+                headers=req_headers,
+                params={"strategy_id": strategy_id, "side": side},
             )
         except Exception:
             if cached is not None:
@@ -203,7 +211,7 @@ class WorldServiceClient:
         data = resp.json()
         new_etag = resp.headers.get("ETag")
         if new_etag:
-            self._activation_cache[world_id] = (new_etag, data)
+            self._activation_cache[key] = (new_etag, data)
         return data, False
 
 

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -75,8 +75,9 @@ async def test_activation_etag_cache(fake_redis):
     )
     async with httpx.ASGITransport(app=app) as asgi:
         async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
-            r1 = await api_client.get("/worlds/abc/activation")
-            r2 = await api_client.get("/worlds/abc/activation")
+            params = {"strategy_id": "s", "side": "long"}
+            r1 = await api_client.get("/worlds/abc/activation", params=params)
+            r2 = await api_client.get("/worlds/abc/activation", params=params)
     await client._client.aclose()
     assert r1.json() == {"a": 1}
     assert r2.json() == {"a": 1}
@@ -165,8 +166,9 @@ async def test_activation_stale_on_backend_error(fake_redis):
     )
     async with httpx.ASGITransport(app=app) as asgi:
         async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
-            r1 = await api_client.get("/worlds/abc/activation")
-            r2 = await api_client.get("/worlds/abc/activation")
+            params = {"strategy_id": "s", "side": "long"}
+            r1 = await api_client.get("/worlds/abc/activation", params=params)
+            r2 = await api_client.get("/worlds/abc/activation", params=params)
     await client._client.aclose()
     assert r1.json() == {"a": 1}
     assert r2.json() == {"a": 1}
@@ -195,7 +197,7 @@ async def test_activation_backend_error_no_cache(fake_redis):
     async with httpx.ASGITransport(app=app) as asgi:
         async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
             with pytest.raises(httpx.HTTPStatusError):
-                await api_client.get("/worlds/abc/activation")
+                await api_client.get("/worlds/abc/activation", params={"strategy_id": "s", "side": "long"})
     await client._client.aclose()
     assert metrics.worlds_stale_responses_total._value.get() == 0
 
@@ -326,7 +328,7 @@ async def test_state_hash_probe_divergence(fake_redis):
     async with httpx.ASGITransport(app=app) as asgi:
         async with httpx.AsyncClient(transport=asgi, base_url="http://test") as api_client:
             # initial full snapshot
-            await api_client.get("/worlds/abc/activation")
+            await api_client.get("/worlds/abc/activation", params={"strategy_id": "s", "side": "long"})
             # unchanged hash
             h1 = await api_client.get("/worlds/abc/activation/state_hash")
             assert h1.json() == {"state_hash": "h1"}
@@ -336,7 +338,7 @@ async def test_state_hash_probe_divergence(fake_redis):
             # divergence
             h3 = await api_client.get("/worlds/abc/activation/state_hash")
             assert h3.json() == {"state_hash": "h2"}
-            await api_client.get("/worlds/abc/activation")
+            await api_client.get("/worlds/abc/activation", params={"strategy_id": "s", "side": "long"})
     await client._client.aclose()
     assert calls["snap"] == 2
 

--- a/tests/gateway/test_ws_evt_initial_snapshot.py
+++ b/tests/gateway/test_ws_evt_initial_snapshot.py
@@ -8,12 +8,12 @@ from qmtl.gateway.ws import WebSocketHub
 
 
 class StubWorldClient:
-    async def get_activation(self, world_id, headers=None):
+    async def get_activation(self, world_id, strategy_id, side, headers=None):
         return (
             {
                 "world_id": world_id,
-                "strategy_id": "s1",
-                "side": "long",
+                "strategy_id": strategy_id,
+                "side": side,
                 "active": True,
                 "weight": 1.0,
                 "etag": "e1",
@@ -64,6 +64,7 @@ def test_initial_snapshots_sent_on_connect():
             "/ws/evt?tags=t1,t2&interval=60&match_mode=any",
             headers={"Authorization": f"Bearer {token}"},
         ) as ws:
-            events = [ws.receive_json(), ws.receive_json(), ws.receive_json()]
-    types = {e["type"] for e in events}
-    assert types == {"queue_update", "activation_updated", "policy_state_hash"}
+            events = [ws.receive_json(), ws.receive_json(), ws.receive_json(), ws.receive_json()]
+    types = [e["type"] for e in events]
+    assert types.count("activation_updated") == 2
+    assert set(types) >= {"queue_update", "activation_updated", "policy_state_hash"}

--- a/tests/test_execution_nodes.py
+++ b/tests/test_execution_nodes.py
@@ -14,6 +14,7 @@ from qmtl.pipeline.execution_nodes import (
     TimingGateNode,
 )
 from qmtl.sdk.order_gate import Activation
+from qmtl.sdk.watermark import set_watermark
 from qmtl.brokerage.order import Account
 from qmtl.sdk.portfolio import Portfolio
 from qmtl.sdk.execution_modeling import ExecutionFill
@@ -44,6 +45,7 @@ class DummyExecModel:
 
 def test_pretrade_gate_allows():
     src = Node(name="src", interval=1, period=1)
+    set_watermark("trade.portfolio", "default", 10**9)
     node = PreTradeGateNode(
         src,
         activation_map={"AAPL": Activation(True)},

--- a/tests/worldservice/test_worldservice_api.py
+++ b/tests/worldservice/test_worldservice_api.py
@@ -80,9 +80,18 @@ async def test_world_crud_policy_apply_and_events():
             r = await client.post("/worlds/w1/apply", json=payload)
             assert r.json() == {"active": ["s1"]}
 
+            # Decision envelope
+            d = await client.get("/worlds/w1/decide")
+            assert d.json()["ttl"] == "300s"
+
             # Activation update
-            r = await client.put("/worlds/w1/activation", json={"side": "long", "active": True})
-            assert r.json()["version"] == 1
+            payload_act = {"strategy_id": "s1", "side": "long", "active": True, "weight": 1.0}
+            r = await client.put("/worlds/w1/activation", json=payload_act)
+            assert r.json()["active"] is True
+
+            # Read back activation
+            r = await client.get("/worlds/w1/activation", params={"strategy_id": "s1", "side": "long"})
+            assert r.json()["active"] is True
 
             # Audit log contains entries
             audit = await client.get("/worlds/w1/audit")


### PR DESCRIPTION
## Summary
- replace legacy decision and activation responses with DecisionEnvelope and ActivationEnvelope models
- persist weight, freeze, drain and run metadata in activation storage and propagate through gateway and SDK
- update gateway proxy, activation manager and tests for new activation/decision APIs

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68bfd4522f908329bf8690e4e9335029