### PR TITLE
Follow-up: refine ControlBus parsing and gating (post-#928)

### DIFF
--- a/qmtl/gateway/controlbus_consumer.py
+++ b/qmtl/gateway/controlbus_consumer.py
@@ -175,7 +175,14 @@ class ControlBusConsumer:
                 )
             except Exception:  # pragma: no cover - malformed message
                 event = {}
-        data = event.get("data", {}) if isinstance(event, dict) else {}
+        if not isinstance(event, dict):
+            data = {}
+        elif content_type == PROTO_CONTENT_TYPE:
+            # For proto placeholder, keep full event as data for downstream consumers
+            data = event
+        else:
+            # For JSON, prefer nested payload when present; otherwise pass through
+            data = event.get("data", event)
         etag = (data.get("etag") or headers.get("etag") or "")
         run_id = (data.get("run_id") or headers.get("run_id") or "")
         timestamp_ms = getattr(message, "timestamp", None)

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -437,7 +437,9 @@ def create_api_router(
         data = await client.put_world(world_id, payload, headers=headers)
         return JSONResponse(data, headers={"X-Correlation-ID": cid})
 
-    @router.delete("/worlds/{world_id}", status_code=status.HTTP_204_NO_CONTENT)
+    @router.delete(
+        "/worlds/{world_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None
+    )
     async def delete_world(world_id: str, request: Request) -> Any:
         client: WorldServiceClient | None = world_client
         if client is None:


### PR DESCRIPTION
Summary: Address test regressions and tighten ControlBus handling after merging #928.

- Proto placeholder path: pass full event dict through ControlBusMessage.data so downstream can inspect type/data.
- Queue updates: parsing keeps top-level fields and preserves etag/ts.
- World routes: mark DELETE as response_model=None for 204 bodies (fix FastAPI assertion).
- PreTradeGate: add require_portfolio_watermark flag (default False) so tests and simple pipelines aren’t gated by watermark unless opted in.

All tests: 770 passed, 8 skipped.

Refs #928