### PR TITLE
Refactor event topic normalization

### DIFF
--- a/tests/gateway/test_event_handlers_module.py
+++ b/tests/gateway/test_event_handlers_module.py
@@ -5,7 +5,7 @@ import httpx
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from qmtl.gateway.event_handlers import create_event_router
+from qmtl.gateway.event_handlers import create_event_router, normalize_topics
 from qmtl.gateway.event_descriptor import EventDescriptorConfig
 from qmtl.gateway.ws import WebSocketHub
 from qmtl.gateway.api import create_app
@@ -18,6 +18,13 @@ class NoServerHub(WebSocketHub):
     async def stop(self) -> None:  # type: ignore[override]
         async with self._lock:
             self._clients.clear()
+
+
+def test_normalize_topics_aliases() -> None:
+    assert normalize_topics(["queues", "queue", "activation", "unknown"]) == {
+        "queue",
+        "activation",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a reusable `normalize_topics` helper for websocket topic handling
- reuse the helper during websocket connect and refresh flows and cover edge cases with tests

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 tests/gateway/test_event_handlers_module.py
- uv run -m pytest -W error -n auto tests/gateway/test_event_handlers_module.py

------
https://chatgpt.com/codex/tasks/task_e_68c886cb36808329a8b4fb3862affde7