### PR TITLE
Refactor Redis queue error handling

### DIFF
--- a/qmtl/gateway/redis_queue.py
+++ b/qmtl/gateway/redis_queue.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Awaitable, Callable, Optional
 
 import logging
 import redis.asyncio as redis
@@ -13,25 +13,27 @@ class RedisTaskQueue:
         self.redis = redis_client
         self.name = name
 
+    async def _safe_redis_call(
+        self, op: Callable[..., Awaitable[Any]], *args: Any
+    ) -> Any | None:
+        try:
+            return await op(*args)
+        except Exception as e:  # pragma: no cover - logging
+            operation_name = getattr(op, "__name__", op.__class__.__name__)
+            logging.error("Redis queue %s %s failed: %s", self.name, operation_name, e)
+            return None
+
     async def push(self, item: str) -> bool:
         """Append ``item`` to the queue.
 
         Returns ``True`` on success, ``False`` otherwise.
         """
-        try:
-            await self.redis.rpush(self.name, item)
-            return True
-        except Exception as e:  # pragma: no cover - logging
-            logging.error("Redis queue %s push failed: %s", self.name, e)
-            return False
+        result = await self._safe_redis_call(self.redis.rpush, self.name, item)
+        return result is not None
 
     async def pop(self) -> Optional[str]:
         """Pop the next item from the queue or ``None`` if empty or on error."""
-        try:
-            data = await self.redis.lpop(self.name)
-        except Exception as e:  # pragma: no cover - logging
-            logging.error("Redis queue %s pop failed: %s", self.name, e)
-            return None
+        data = await self._safe_redis_call(self.redis.lpop, self.name)
         if data is None:
             return None
         return data.decode() if isinstance(data, bytes) else data


### PR DESCRIPTION
## Summary
- add a reusable `_safe_redis_call` helper for Redis queue operations
- update `push` and `pop` to delegate error handling to the helper and keep logging consistent

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68c887384df883299850fd7add9583de