### PR TITLE
Centralize BLAKE3 hashing for node IDs

### DIFF
--- a/qmtl/common/nodeid.py
+++ b/qmtl/common/nodeid.py
@@ -6,6 +6,39 @@ from typing import Iterable
 from blake3 import blake3
 
 
+def hash_blake3(data: bytes, existing_ids: Iterable[str] | None = None) -> str:
+    """Return a ``blake3:``-prefixed digest for ``data``.
+
+    Parameters
+    ----------
+    data : bytes
+        Payload to hash.
+    existing_ids : Iterable[str] | None
+        Optional set of already issued identifiers used to avoid collisions.
+        If provided and the computed digest already exists within ``existing_ids``
+        a deterministic suffix is appended to the payload and re-hashed until a
+        unique digest is produced.
+    """
+
+    digest = blake3(data).hexdigest()
+    identifier = f"blake3:{digest}"
+
+    if not existing_ids:
+        return identifier
+
+    seen = set(existing_ids)
+    if identifier not in seen:
+        return identifier
+
+    counter = 1
+    while True:
+        digest = blake3(data + f"|{counter}".encode()).hexdigest()
+        identifier = f"blake3:{digest}"
+        if identifier not in seen:
+            return identifier
+        counter += 1
+
+
 def compute_node_id(
     node_type: str,
     code_hash: str,
@@ -13,24 +46,10 @@ def compute_node_id(
     schema_hash: str,
     existing_ids: Iterable[str] | None = None,
 ) -> str:
-    """Return canonical BLAKE3-based NodeID with ``blake3:`` prefix.
+    """Return canonical BLAKE3-based NodeID with ``blake3:`` prefix."""
 
-    Parameters
-    ----------
-    node_type, code_hash, config_hash, schema_hash : str
-        Components defining the node.
-    existing_ids : Iterable[str] | None
-        Previously generated IDs to detect collisions. If the computed digest
-        already exists in this set, a different digest is produced by hashing
-        a domain-separated payload.
-    """
     data = f"{node_type}:{code_hash}:{config_hash}:{schema_hash}".encode()
-    digest = blake3(data).hexdigest()
-    node_id = f"blake3:{digest}"
-    if existing_ids and node_id in set(existing_ids):
-        digest = blake3(data + b"|1").hexdigest()
-        node_id = f"blake3:{digest}"
-    return node_id
+    return hash_blake3(data, existing_ids=existing_ids)
 
 
-__all__ = ["compute_node_id"]
+__all__ = ["hash_blake3", "compute_node_id"]

--- a/qmtl/common/nodespec.py
+++ b/qmtl/common/nodespec.py
@@ -6,8 +6,9 @@ This follows the spirit of the architecture spec by capturing deterministic
 fields and a sorted dependency list from a DAG node dictionary.
 """
 
-from typing import Any, Iterable
-from blake3 import blake3
+from typing import Any
+
+from .nodeid import hash_blake3
 
 
 def _sorted_deps(node: dict) -> list[str]:
@@ -45,7 +46,7 @@ def serialize_nodespec(node: dict[str, Any]) -> bytes:
 
 def canonical_node_id(node: dict[str, Any]) -> str:
     data = serialize_nodespec(node)
-    return f"blake3:{blake3(data).hexdigest()}"
+    return hash_blake3(data)
 
 
 __all__ = ["serialize_nodespec", "canonical_node_id"]


### PR DESCRIPTION
## Summary
- add a reusable `hash_blake3` helper that encapsulates BLAKE3 hashing and collision handling
- update `compute_node_id` and `canonical_node_id` to rely on the shared helper
- tidy module exports and imports after unifying the hashing implementation

## Testing
- uv run -m pytest tests/gateway/test_nodeid.py tests/test_dagmanager.py

------
https://chatgpt.com/codex/tasks/task_e_68c8874a72048329884bc4c75a54ea07