### PR TITLE
Add shared hash_bytes helper for worldservice

### DIFF
--- a/qmtl/common/__init__.py
+++ b/qmtl/common/__init__.py
@@ -13,6 +13,7 @@ def crc32_of_list(items: Iterable[str]) -> int:
 from .reconnect import ReconnectingRedis, ReconnectingNeo4j
 from .circuit_breaker import AsyncCircuitBreaker
 from .four_dim_cache import FourDimCache
+from .hashutils import hash_bytes
 from .nodeid import compute_node_id
 
 __all__ = [
@@ -21,5 +22,6 @@ __all__ = [
     "ReconnectingNeo4j",
     "AsyncCircuitBreaker",
     "FourDimCache",
+    "hash_bytes",
     "compute_node_id",
 ]

--- a/qmtl/common/hashutils.py
+++ b/qmtl/common/hashutils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Common hashing utilities with graceful fallbacks."""
+
+from typing import Final
+import hashlib
+
+try:  # pragma: no cover - import guard exercised in fallback tests
+    from blake3 import blake3 as _blake3
+except Exception:  # pragma: no cover - runtime environments may lack blake3
+    _blake3 = None
+
+_BLAKE3_PREFIX: Final[str] = "blake3:"
+_SHA256_PREFIX: Final[str] = "sha256:"
+
+
+def hash_bytes(data: bytes) -> str:
+    """Return a deterministic digest string for the given *data* bytes.
+
+    The function prefers BLAKE3 when available and functional, returning the
+    digest prefixed with ``"blake3:"``. If the BLAKE3 module is unavailable or
+    raises an exception during hashing, it falls back to SHA-256, returning the
+    digest prefixed with ``"sha256:"``.
+    """
+
+    payload = data if isinstance(data, bytes) else bytes(data)
+    if _blake3 is not None:
+        try:
+            return f"{_BLAKE3_PREFIX}{_blake3(payload).hexdigest()}"
+        except Exception:
+            pass
+    return f"{_SHA256_PREFIX}{hashlib.sha256(payload).hexdigest()}"
+
+
+__all__ = ["hash_bytes"]

--- a/tests/common/test_hashutils.py
+++ b/tests/common/test_hashutils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib
+import hashlib
+
+import pytest
+
+from qmtl.common import hash_bytes as exported_hash_bytes
+from qmtl.common.hashutils import hash_bytes
+
+try:  # pragma: no cover - optional dependency in tests
+    from blake3 import blake3 as _blake3
+except Exception:  # pragma: no cover - runtime fallback
+    _blake3 = None
+
+
+@pytest.mark.skipif(_blake3 is None, reason="blake3 module is not available")
+def test_hash_bytes_prefers_blake3() -> None:
+    data = b"hash-me"
+    assert hash_bytes(data) == f"blake3:{_blake3(data).hexdigest()}"
+    # Ensure the helper is also re-exported at package level for convenience.
+    assert exported_hash_bytes(data) == f"blake3:{_blake3(data).hexdigest()}"
+
+
+def test_hash_bytes_falls_back_to_sha256(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.import_module("qmtl.common.hashutils")
+    monkeypatch.setattr(module, "_blake3", None)
+    digest = module.hash_bytes(b"fallback")
+    assert digest == f"sha256:{hashlib.sha256(b'fallback').hexdigest()}"
+
+
+def test_hash_bytes_falls_back_on_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.import_module("qmtl.common.hashutils")
+
+    class BrokenHash:
+        def __call__(self, data: bytes):  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(module, "_blake3", BrokenHash())
+    digest = module.hash_bytes(b"boom")
+    assert digest == f"sha256:{hashlib.sha256(b'boom').hexdigest()}"


### PR DESCRIPTION
## Summary
- add a common `hash_bytes` helper that prefers BLAKE3 and falls back to SHA-256
- refactor the worldservice API to reuse the helper for activation and policy hashing
- re-export the helper from `qmtl.common` and cover the primary and fallback paths with unit tests

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout --with pytest-asyncio --with fakeredis --with jsonschema -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run --with pytest-asyncio --with fakeredis --with jsonschema --with pytest-xdist -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68c88725fe208329af57079cb78f7a38