### PR TITLE
Propagate shared Node Set resources

### DIFF
--- a/docs/architecture/exchange_node_sets.md
+++ b/docs/architecture/exchange_node_sets.md
@@ -278,6 +278,10 @@ Freeze/Drain Semantics
 - ``world``: snapshots and fills are keyed by ``(world_id, symbol)`` so all
   strategies in the same world draw from a shared portfolio.
 
+Built-in Node Set builders obtain these scopes through a shared helper that
+returns both the activation weight function (soft gating) and the correctly
+scoped :class:`~qmtl.sdk.portfolio.Portfolio` instance keyed by ``world_id``.
+
 When ``portfolio_scope="world"``, ``RiskControlNode`` evaluates leverage and
 concentration across the combined positions of every participating strategy.
 This enables cross‑strategy limits such as capping aggregate symbol exposure

--- a/docs/guides/nodeset_portfolio_scope.md
+++ b/docs/guides/nodeset_portfolio_scope.md
@@ -43,4 +43,4 @@ Notes
 - strategy (default) scopes portfolio snapshots and fills by `(world_id, strategy_id, symbol)`.
 - world scopes by `(world_id, symbol)` so multiple strategies share cash/limits.
 - Prefer using the Node Set as a black box (attach then add); internal nodes are implementation details and may change.
-- In the current scaffold, this option establishes the contract; concrete exchange Node Sets enforce the behavior as they are implemented.
+- Built-in Node Set recipes and the default builder share a per-world `Portfolio` when `portfolio_scope="world"`, so strategies in the same world operate on a common cash/positions view automatically.

--- a/qmtl/nodesets/adapters/ccxt_spot.py
+++ b/qmtl/nodesets/adapters/ccxt_spot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from qmtl.sdk import Node
 from qmtl.nodesets.base import NodeSet
 from qmtl.nodesets.adapter import NodeSetAdapter, NodeSetDescriptor, PortSpec
+from qmtl.nodesets.options import NodeSetOptions
 from qmtl.nodesets.recipes import make_ccxt_spot_nodeset
 
 
@@ -34,7 +35,13 @@ class CcxtSpotAdapter(NodeSetAdapter):
         self.time_in_force = time_in_force
         self.reduce_only = reduce_only
 
-    def build(self, inputs: dict[str, Node], *, world_id: str, options=None) -> NodeSet:
+    def build(
+        self,
+        inputs: dict[str, Node],
+        *,
+        world_id: str,
+        options: NodeSetOptions | None = None,
+    ) -> NodeSet:
         self.validate_inputs(inputs)
         signal = inputs["signal"]
         return make_ccxt_spot_nodeset(
@@ -46,6 +53,7 @@ class CcxtSpotAdapter(NodeSetAdapter):
             secret=self.secret,
             time_in_force=self.time_in_force,
             reduce_only=self.reduce_only,
+            options=options,
             descriptor=self.descriptor,
         )
 

--- a/qmtl/nodesets/resources.py
+++ b/qmtl/nodesets/resources.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+"""Shared execution resources for Node Set builders.
+
+This module centralizes the wiring of activation weighting (soft gating)
+and world-scoped portfolio storage so every Node Set recipe composes the
+same behavior consistently. Recipes and adapters can import the helpers
+here instead of re-implementing the logic locally.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Mapping
+
+from qmtl.sdk.portfolio import Portfolio
+from .options import PortfolioScope
+
+
+_WORLD_PORTFOLIOS: dict[str, Portfolio] = {}
+
+
+@dataclass(frozen=True)
+class ExecutionResources:
+    """Bundle of shared execution resources for a Node Set."""
+
+    portfolio: Portfolio
+    weight_fn: Callable[[Mapping[str, object]], float] | None
+
+
+def _infer_side(order: Mapping[str, object]) -> str:
+    """Infer order side for activation weighting."""
+
+    side = order.get("side")
+    if side:
+        s = str(side).lower()
+        if s in {"buy", "sell", "long", "short"}:
+            return "buy" if s in {"buy", "long"} else "sell"
+    qty = order.get("quantity")
+    if qty is not None:
+        try:
+            return "buy" if float(qty) >= 0 else "sell"
+        except (TypeError, ValueError):
+            pass
+    for key in ("value", "percent", "target_percent"):
+        val = order.get(key)
+        if val is not None:
+            try:
+                return "buy" if float(val) >= 0 else "sell"
+            except (TypeError, ValueError):
+                continue
+    return "buy"
+
+
+def make_activation_weight_fn() -> Callable[[Mapping[str, object]], float]:
+    """Return a weight function backed by Runner's ActivationManager."""
+
+    def _weight(order: Mapping[str, object]) -> float:
+        try:
+            from qmtl.sdk.runner import Runner  # Late import to avoid cycles
+
+            am = Runner._activation_manager
+            if am is None:
+                return 1.0
+            side = _infer_side(order)
+            weight = float(am.weight_for_side(side))
+            if weight < 0.0:
+                return 0.0
+            if weight > 1.0:
+                return 1.0
+            return weight
+        except Exception:
+            return 1.0
+
+    return _weight
+
+
+def get_portfolio_for_scope(world_id: str, scope: PortfolioScope) -> Portfolio:
+    """Return a Portfolio scoped per-world when requested."""
+
+    if scope == "world":
+        return _WORLD_PORTFOLIOS.setdefault(world_id, Portfolio())
+    return Portfolio()
+
+
+def get_execution_resources(
+    world_id: str,
+    *,
+    portfolio_scope: PortfolioScope = "strategy",
+    activation_weighting: bool = True,
+) -> ExecutionResources:
+    """Return shared execution resources for a Node Set."""
+
+    portfolio = get_portfolio_for_scope(world_id, portfolio_scope)
+    weight_fn = make_activation_weight_fn() if activation_weighting else None
+    return ExecutionResources(portfolio=portfolio, weight_fn=weight_fn)
+
+
+def clear_shared_portfolios() -> None:
+    """Reset cached world-scoped portfolio instances (for tests)."""
+
+    _WORLD_PORTFOLIOS.clear()
+
+
+__all__ = [
+    "ExecutionResources",
+    "get_execution_resources",
+    "get_portfolio_for_scope",
+    "make_activation_weight_fn",
+    "clear_shared_portfolios",
+]
+

--- a/qmtl/nodesets/stubs.py
+++ b/qmtl/nodesets/stubs.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Callable
+
 from qmtl.sdk.node import ProcessingNode, Node, CacheView
+from qmtl.sdk.portfolio import Portfolio
 
 
 class StubPreTradeGateNode(ProcessingNode):
@@ -32,10 +35,20 @@ class StubSizingNode(ProcessingNode):
     """Pass-through sizing stub.
 
     A real implementation would convert value/percent to absolute quantity.
+    The stub still records shared resources for compatibility with recipes.
     """
 
-    def __init__(self, order: Node, *, name: str | None = None) -> None:
+    def __init__(
+        self,
+        order: Node,
+        *,
+        portfolio: Portfolio | None = None,
+        weight_fn: Callable[[dict], float] | None = None,
+        name: str | None = None,
+    ) -> None:
         self.order = order
+        self.portfolio = portfolio
+        self.weight_fn = weight_fn
         super().__init__(
             order,
             compute_fn=self._compute,
@@ -118,8 +131,15 @@ class StubFillIngestNode(ProcessingNode):
 class StubPortfolioNode(ProcessingNode):
     """Pass-through portfolio stub."""
 
-    def __init__(self, fills: Node, *, name: str | None = None) -> None:
+    def __init__(
+        self,
+        fills: Node,
+        *,
+        portfolio: Portfolio | None = None,
+        name: str | None = None,
+    ) -> None:
         self.fills = fills
+        self.portfolio = portfolio
         super().__init__(
             fills,
             compute_fn=self._compute,

--- a/tests/nodesets/test_nodeset_adapter_descriptor.py
+++ b/tests/nodesets/test_nodeset_adapter_descriptor.py
@@ -1,8 +1,11 @@
 from qmtl.sdk import Node, StreamInput
 from qmtl.nodesets.adapters import CcxtSpotAdapter
+from qmtl.nodesets.options import NodeSetOptions
+from qmtl.nodesets.resources import clear_shared_portfolios
 
 
 def test_ccxt_adapter_populates_ports_and_capabilities_in_describe():
+    clear_shared_portfolios()
     price = StreamInput(interval="60s", period=1)
     signal = Node(input=price, compute_fn=lambda v: {"action": "HOLD"})
 
@@ -23,3 +26,14 @@ def test_ccxt_adapter_populates_ports_and_capabilities_in_describe():
     assert "modes" in caps and "simulate" in caps["modes"]
     assert caps.get("portfolio_scope") == "strategy"
     assert info.get("name") == "ccxt_spot"
+
+
+def test_ccxt_adapter_respects_options():
+    clear_shared_portfolios()
+    price = StreamInput(interval="60s", period=1)
+    signal = Node(input=price, compute_fn=lambda v: {"action": "HOLD"})
+    adapter = CcxtSpotAdapter(exchange_id="binance")
+    options = NodeSetOptions(portfolio_scope="world")
+    ns = adapter.build({"signal": signal}, world_id="w1", options=options)
+    caps = ns.capabilities()
+    assert caps.get("portfolio_scope") == "world"

--- a/tests/test_ccxt_nodeset_attach_exec.py
+++ b/tests/test_ccxt_nodeset_attach_exec.py
@@ -1,8 +1,10 @@
 from qmtl.sdk import Node, StreamInput
 from qmtl.nodesets.recipes import make_ccxt_spot_nodeset
+from qmtl.nodesets.resources import clear_shared_portfolios
 
 
 def test_ccxt_nodeset_exec_carries_symbol_and_defaults():
+    clear_shared_portfolios()
     price = StreamInput(interval="60s", period=1)
 
     def make_signal(view):

--- a/tests/test_ccxt_spot_nodeset.py
+++ b/tests/test_ccxt_spot_nodeset.py
@@ -1,10 +1,14 @@
 import pytest
 
 from qmtl.sdk import Node, StreamInput
+from qmtl.sdk.cache_view import CacheView
+from qmtl.nodesets.options import NodeSetOptions
 from qmtl.nodesets.recipes import make_ccxt_spot_nodeset
+from qmtl.nodesets.resources import clear_shared_portfolios
 
 
 def test_attach_nodeset_simulate():
+    clear_shared_portfolios()
     price = StreamInput(interval="60s", period=1)
     signal = Node(input=price, compute_fn=lambda view: {"action": "BUY", "size": 1, "symbol": "BTC/USDT"})
     ns = make_ccxt_spot_nodeset(signal, "world", exchange_id="binance")
@@ -17,3 +21,36 @@ def test_attach_nodeset_sandbox_requires_credentials():
     signal = Node(input=price, compute_fn=lambda view: {"action": "BUY", "size": 1, "symbol": "BTC/USDT"})
     with pytest.raises(RuntimeError):
         make_ccxt_spot_nodeset(signal, "world", exchange_id="binance", sandbox=True)
+
+
+def test_ccxt_nodeset_applies_activation_weight():
+    clear_shared_portfolios()
+    price = StreamInput(interval=1, period=1)
+    signal = Node(input=price, compute_fn=lambda view: {})
+    ns = make_ccxt_spot_nodeset(signal, "world", exchange_id="binance")
+    nodes = list(ns)
+    sizing = nodes[1]
+    order = {"symbol": "BTC/USDT", "price": 10.0, "value": 100.0, "side": "BUY"}
+    assert sizing.weight_fn is not None
+    sizing.weight_fn = lambda payload: 0.5
+    upstream = sizing.order
+    view = CacheView({upstream.node_id: {upstream.interval: [(0, order)]}})
+    sized = sizing.compute_fn(view)
+    assert sized["quantity"] == pytest.approx(5.0)
+
+
+def test_ccxt_nodeset_world_portfolio_shared():
+    clear_shared_portfolios()
+    price = StreamInput(interval=1, period=1)
+    sig1 = Node(input=price, compute_fn=lambda view: {})
+    sig2 = Node(input=price, compute_fn=lambda view: {})
+    options = NodeSetOptions(portfolio_scope="world")
+    ns1 = make_ccxt_spot_nodeset(sig1, "world", exchange_id="binance", options=options)
+    ns2 = make_ccxt_spot_nodeset(sig2, "world", exchange_id="binance", options=options)
+    sizing1 = list(ns1)[1]
+    sizing2 = list(ns2)[1]
+    portfolio1 = getattr(sizing1, "portfolio", None)
+    portfolio2 = getattr(sizing2, "portfolio", None)
+    assert portfolio1 is not None
+    assert portfolio1 is portfolio2
+    assert getattr(list(ns1)[5], "portfolio", None) is portfolio1


### PR DESCRIPTION
## Summary
- add qmtl/nodesets/resources helpers to share world-scoped portfolios and activation weight functions across Node Set builders
- wire NodeSetBuilder, CCXT recipes/adapters, and stubs to use the shared resources while documenting the new behavior
- extend unit tests to cover world-scope sharing and activation-weight wiring for Node Set builders and CCXT Node Sets

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 *(fails: existing test_market_on_open_and_close_fill_only_at_boundaries raises ValueError)*
- uv run -m pytest -W error -n auto *(fails: existing test_market_on_open_and_close_fill_only_at_boundaries raises ValueError)*
- uv run -m pytest tests/test_ccxt_spot_nodeset.py -q
- uv run -m pytest tests/nodesets/test_nodeset_builder_smoke.py -q
- uv run -m pytest tests/nodesets/test_nodeset_adapter_descriptor.py -q

Fixes #922

------
https://chatgpt.com/codex/tasks/task_e_68cf7719bb088329b4bc536191c97069