### PR TITLE
Add cross-context cache hit telemetry and alert

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -69,3 +69,11 @@ prometheus:
             severity: warning
           annotations:
             summary: Sentinel traffic skew persists beyond 5s
+        - alert: CrossContextCacheHit
+          expr: increase(cross_context_cache_hit_total[1m]) > 0
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: Cross-context cache hit detected (SLO=0)
+            runbook: docs/operations/monitoring.html#runbook-cross-context-cache-hits-slo-0

--- a/qmtl/dagmanager/metrics.py
+++ b/qmtl/dagmanager/metrics.py
@@ -13,6 +13,9 @@ from qmtl.common.metrics_shared import (
     get_nodecache_resident_bytes,
     observe_nodecache_resident_bytes as _observe_nodecache_resident_bytes,
     clear_nodecache_resident_bytes as _clear_nodecache_resident_bytes,
+    get_cross_context_cache_hit_counter,
+    observe_cross_context_cache_hit as _observe_cross_context_cache_hit,
+    clear_cross_context_cache_hits as _clear_cross_context_cache_hits,
 )
 
 # Metrics defined in documentation
@@ -77,6 +80,8 @@ sentinel_gap_count = Gauge(
 sentinel_gap_count._val = 0  # type: ignore[attr-defined]
 
 nodecache_resident_bytes = get_nodecache_resident_bytes()
+
+cross_context_cache_hit_total = get_cross_context_cache_hit_counter()
 
 orphan_queue_total = Gauge(
     "orphan_queue_total",
@@ -165,6 +170,25 @@ def observe_nodecache_resident_bytes(node_id: str, resident: int) -> None:
     _observe_nodecache_resident_bytes(node_id, resident)
 
 
+def observe_cross_context_cache_hit(
+    node_id: str,
+    world_id: str,
+    execution_domain: str,
+    *,
+    as_of: str | None = None,
+    partition: str | None = None,
+) -> None:
+    """Record a cache hit with mismatched execution context."""
+
+    _observe_cross_context_cache_hit(
+        node_id,
+        world_id,
+        execution_domain,
+        as_of=as_of,
+        partition=partition,
+    )
+
+
 def observe_queue_lag(topic: str, lag_seconds: float, threshold_seconds: float) -> None:
     """Record current lag and configured threshold for ``topic``."""
     queue_lag_seconds.labels(topic=topic).set(lag_seconds)
@@ -236,6 +260,7 @@ def reset_metrics() -> None:
     queue_lag_seconds._vals = {}  # type: ignore[attr-defined]
     queue_lag_threshold_seconds.clear()
     queue_lag_threshold_seconds._vals = {}  # type: ignore[attr-defined]
+    _clear_cross_context_cache_hits()
     if hasattr(dagmanager_active_version_weight, "clear"):
         dagmanager_active_version_weight.clear()
     dagmanager_active_version_weight._vals = {}  # type: ignore[attr-defined]

--- a/tests/sdk/test_node_metrics.py
+++ b/tests/sdk/test_node_metrics.py
@@ -29,3 +29,27 @@ def test_node_metrics_failure():
         Runner.feed_queue_data(node, src.node_id, 60, 60, {"v": 1})
     assert sdk_metrics.node_processed_total._vals[node.node_id] == 1
     assert sdk_metrics.node_process_failure_total._vals[node.node_id] == 1
+
+
+def test_cross_context_cache_hit_counter_normalises_missing_labels():
+    sdk_metrics.reset_metrics()
+    node_id = "node-a"
+    sdk_metrics.observe_cross_context_cache_hit(
+        node_id,
+        world_id="world-a",
+        execution_domain="live",
+        as_of=None,
+        partition=None,
+    )
+    key = ("node-a", "world-a", "live", "__unset__", "__unset__")
+    assert sdk_metrics.cross_context_cache_hit_total._vals[key] == 1  # type: ignore[attr-defined]
+
+    sdk_metrics.observe_cross_context_cache_hit(
+        node_id,
+        world_id="world-a",
+        execution_domain="backtest",
+        as_of="2024-01-01",
+        partition="tenant-1",
+    )
+    key_bt = ("node-a", "world-a", "backtest", "2024-01-01", "tenant-1")
+    assert sdk_metrics.cross_context_cache_hit_total._vals[key_bt] == 1  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- add a shared `cross_context_cache_hit_total` counter that both the SDK and DAG Manager reuse when emitting context violations
- document the SLO=0 policy and runbook for cross-context cache hits alongside a critical alert rule in `alert_rules.yml`

## Testing
- uv run mkdocs build
- uv run -m pytest tests/sdk/test_node_metrics.py

Fixes #955

------
https://chatgpt.com/codex/tasks/task_e_68cfa2af44708329ba841272c19ec512