### PR TITLE
feat: enforce compute context isolation

### DIFF
--- a/qmtl/common/__init__.py
+++ b/qmtl/common/__init__.py
@@ -15,6 +15,7 @@ from .circuit_breaker import AsyncCircuitBreaker
 from .four_dim_cache import FourDimCache
 from .hashutils import hash_bytes
 from .nodeid import compute_node_id
+from .compute_key import ComputeContext, compute_compute_key, DEFAULT_EXECUTION_DOMAIN
 
 __all__ = [
     "crc32_of_list",
@@ -24,4 +25,7 @@ __all__ = [
     "FourDimCache",
     "hash_bytes",
     "compute_node_id",
+    "ComputeContext",
+    "compute_compute_key",
+    "DEFAULT_EXECUTION_DOMAIN",
 ]

--- a/qmtl/common/compute_key.py
+++ b/qmtl/common/compute_key.py
@@ -1,0 +1,45 @@
+"""Compute key helpers shared across SDK and services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from blake3 import blake3
+
+__all__ = [
+    "ComputeContext",
+    "DEFAULT_EXECUTION_DOMAIN",
+    "compute_compute_key",
+]
+
+
+DEFAULT_EXECUTION_DOMAIN = "default"
+
+
+@dataclass(frozen=True)
+class ComputeContext:
+    """Describe the execution context for a node compute run."""
+
+    world_id: str = ""
+    execution_domain: str = DEFAULT_EXECUTION_DOMAIN
+    as_of: Any | None = None
+    partition: Any | None = None
+
+    def _canon(self) -> tuple[str, str, str, str]:
+        """Return canonical string parts for hashing."""
+
+        world = str(self.world_id or "")
+        domain = str(self.execution_domain or "")
+        as_of = "" if self.as_of is None else str(self.as_of)
+        partition = "" if self.partition is None else str(self.partition)
+        return world, domain, as_of, partition
+
+
+def compute_compute_key(node_hash: str, context: ComputeContext) -> str:
+    """Return a domain-scoped compute key for ``node_hash`` and ``context``."""
+
+    node_part = str(node_hash or "")
+    payload = "\x1f".join((node_part, *context._canon())).encode()
+    return f"blake3:{blake3(payload).hexdigest()}"
+


### PR DESCRIPTION
## Summary
- add shared ComputeContext helpers to derive compute keys used for cache isolation
- update NodeCache and Arrow cache implementations plus Runner to activate compute keys and reset state when context changes, emitting the new cross_context_cache_hit_total metric
- expand SDK metrics and tests to cover cross-context guard behaviour

## Testing
- pytest tests/test_node_cache.py tests/test_arrow_cache.py

Fixes #945

------
https://chatgpt.com/codex/tasks/task_e_68cfa24f97c48329b7614c8a8d6cd314