### PR TITLE
Map WS effective mode to execution domain compute context

### DIFF
--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -106,6 +106,13 @@ worlds_stale_responses_total = Counter(
     registry=global_registry,
 )
 
+worlds_compute_context_downgrade_total = Counter(
+    "worlds_compute_context_downgrade_total",
+    "Total number of decision compute contexts downgraded due to missing fields",
+    ["reason"],
+    registry=global_registry,
+)
+
 # Circuit breaker metrics for WorldService
 worlds_breaker_state = Gauge(
     "worlds_breaker_state",
@@ -466,6 +473,7 @@ def reset_metrics() -> None:
     worlds_cache_hit_ratio._val = 0  # type: ignore[attr-defined]
     worlds_stale_responses_total._value.set(0)  # type: ignore[attr-defined]
     worlds_stale_responses_total._val = 0  # type: ignore[attr-defined]
+    worlds_compute_context_downgrade_total.clear()
     _worlds_samples.clear()
     worlds_breaker_state.set(0)
     worlds_breaker_state._val = 0  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- map WorldService decision envelopes into explicit execution domains and emit compute context metadata, including downgrade signaling when required fields are absent
- record compute-context downgrades in gateway metrics and reset them in the test helper
- exercise the new mapping and downgrade behaviours through gateway world proxy tests

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #949

------
https://chatgpt.com/codex/tasks/task_e_68cfa26fad848329a96a3be2346f29e3