### PR TITLE
Guard order publishing during gateway freeze

### DIFF
--- a/qmtl/pipeline/execution_nodes.py
+++ b/qmtl/pipeline/execution_nodes.py
@@ -38,6 +38,7 @@ from qmtl.sdk.timing_controls import TimingController
 from qmtl.sdk import metrics as sdk_metrics
 from qmtl.gateway.commit_log import CommitLogWriter
 import asyncio
+from qmtl.transforms.execution_nodes import activation_blocks_order
 
 
 class PreTradeGateNode(ProcessingNode):
@@ -279,6 +280,8 @@ class OrderPublishNode(ProcessingNode):
         if not data:
             return None
         ts, order = data[-1]
+        if activation_blocks_order(order):
+            return order
         self._publish_commit_log(ts, order)
         self._publish_gateway(order)
         try:

--- a/tests/test_activation_manager_freeze_drain.py
+++ b/tests/test_activation_manager_freeze_drain.py
@@ -36,3 +36,33 @@ async def test_drain_blocks_new_orders():
     # Drain blocks new submissions
     await _emit(am, "short", active=True, drain=True)
     assert not am.allow_side("short")
+
+
+@pytest.mark.asyncio
+async def test_freeze_blocks_other_side_immediately():
+    am = ActivationManager()
+
+    await _emit(am, "long", active=True, weight=1.0)
+    await _emit(am, "short", active=True, weight=1.0)
+
+    await _emit(am, "long", active=True, freeze=True)
+
+    assert not am.allow_side("long")
+    assert not am.allow_side("short")
+    assert am.weight_for_side("short") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_releasing_modes_restores_weights():
+    am = ActivationManager()
+
+    await _emit(am, "long", active=True, weight=1.0)
+    await _emit(am, "short", active=True, weight=0.5)
+
+    await _emit(am, "short", active=True, drain=True)
+    assert not am.allow_side("long")
+    assert am.weight_for_side("long") == 0.0
+
+    await _emit(am, "short", active=True, drain=False)
+    assert am.allow_side("long")
+    assert am.weight_for_side("long") == 1.0

--- a/tests/test_execution_nodes.py
+++ b/tests/test_execution_nodes.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import asyncio
 
+import qmtl.sdk.runner as runner_module
 from qmtl.sdk.node import Node
-from qmtl.sdk.runner import Runner
 from qmtl.pipeline.execution_nodes import (
     PreTradeGateNode,
     SizingNode,
@@ -25,6 +26,7 @@ from qmtl.sdk.portfolio import Portfolio
 from qmtl.sdk.execution_modeling import ExecutionFill
 from qmtl.sdk.risk_management import RiskManager
 from qmtl.sdk.timing_controls import TimingController
+from qmtl.sdk.activation_manager import ActivationManager
 
 
 class DummyBrokerage:
@@ -60,7 +62,7 @@ def test_pretrade_gate_allows_when_gating_disabled():
         watermark_gate=WatermarkGate.for_mode("simulate"),
     )
     order = {"symbol": "AAPL", "quantity": 1, "price": 10.0}
-    out = Runner.feed_queue_data(node, src.node_id, 60, 120, order)
+    out = runner_module.Runner.feed_queue_data(node, src.node_id, 60, 120, order)
     assert out == order
 
 
@@ -76,17 +78,17 @@ def test_pretrade_gate_blocks_until_watermark_ready():
         watermark_gate=WatermarkGate.for_mode("live"),
     )
     order = {"symbol": "AAPL", "quantity": 1, "price": 10.0}
-    rejected = Runner.feed_queue_data(node, src.node_id, 60, 180, order.copy())
+    rejected = runner_module.Runner.feed_queue_data(node, src.node_id, 60, 180, order.copy())
     assert rejected == {"rejected": True, "reason": "watermark"}
 
     set_watermark("trade.portfolio", "live-world", 179)
-    rejected_again = Runner.feed_queue_data(
+    rejected_again = runner_module.Runner.feed_queue_data(
         node, src.node_id, 60, 240, {"symbol": "AAPL", "quantity": 1, "price": 10.5}
     )
     assert rejected_again == {"rejected": True, "reason": "watermark"}
 
     set_watermark("trade.portfolio", "live-world", 240)
-    allowed = Runner.feed_queue_data(
+    allowed = runner_module.Runner.feed_queue_data(
         node, src.node_id, 60, 300, {"symbol": "AAPL", "quantity": 1, "price": 10.5}
     )
     assert allowed["symbol"] == "AAPL"
@@ -103,17 +105,17 @@ def test_pretrade_gate_respects_configured_lag():
         account=Account(),
         watermark_gate=WatermarkGate(enabled=True, lag=2),
     )
-    rejected = Runner.feed_queue_data(node, src.node_id, 60, 180, {"symbol": "AAPL", "quantity": 1, "price": 11.0})
+    rejected = runner_module.Runner.feed_queue_data(node, src.node_id, 60, 180, {"symbol": "AAPL", "quantity": 1, "price": 11.0})
     assert rejected == {"rejected": True, "reason": "watermark"}
 
     set_watermark("trade.portfolio", "lag-world", 119)
-    still_blocked = Runner.feed_queue_data(
+    still_blocked = runner_module.Runner.feed_queue_data(
         node, src.node_id, 60, 240, {"symbol": "AAPL", "quantity": 1, "price": 11.5}
     )
     assert still_blocked == {"rejected": True, "reason": "watermark"}
 
     set_watermark("trade.portfolio", "lag-world", 180)
-    allowed = Runner.feed_queue_data(
+    allowed = runner_module.Runner.feed_queue_data(
         node, src.node_id, 60, 300, {"symbol": "AAPL", "quantity": 1, "price": 11.5}
     )
     assert allowed["price"] == 11.5
@@ -141,12 +143,12 @@ def test_pretrade_gate_isolated_per_world():
     )
 
     set_watermark("trade.portfolio", "world-a", 10**9)
-    allowed = Runner.feed_queue_data(
+    allowed = runner_module.Runner.feed_queue_data(
         gate_a, src_a.node_id, 60, 180, {"symbol": "AAPL", "quantity": 1, "price": 12.0}
     )
     assert allowed["price"] == 12.0
 
-    rejected = Runner.feed_queue_data(
+    rejected = runner_module.Runner.feed_queue_data(
         gate_b, src_b.node_id, 60, 180, {"symbol": "AAPL", "quantity": 1, "price": 12.0}
     )
     assert rejected == {"rejected": True, "reason": "watermark"}
@@ -157,7 +159,7 @@ def test_sizing_node_value_to_quantity():
     portfolio = Portfolio(cash=1000)
     node = SizingNode(src, portfolio=portfolio)
     order = {"symbol": "AAPL", "price": 10.0, "value": 100.0}
-    out = Runner.feed_queue_data(node, src.node_id, 1, 0, order)
+    out = runner_module.Runner.feed_queue_data(node, src.node_id, 1, 0, order)
     assert out["quantity"] == 10
 
 
@@ -166,7 +168,7 @@ def test_execution_node_simulates_fill():
     exec_model = DummyExecModel()
     node = ExecutionNode(src, execution_model=exec_model)
     order = {"symbol": "AAPL", "price": 10.0, "quantity": 5.0}
-    out = Runner.feed_queue_data(node, src.node_id, 1, 0, order)
+    out = runner_module.Runner.feed_queue_data(node, src.node_id, 1, 0, order)
     assert out["fill_price"] == 10.0 and out["quantity"] == 5.0
 
 
@@ -175,7 +177,7 @@ def test_portfolio_node_applies_fill():
     portfolio = Portfolio(cash=100.0)
     node = PortfolioNode(src, portfolio=portfolio)
     fill = {"symbol": "AAPL", "quantity": 5.0, "fill_price": 10.0}
-    out = Runner.feed_queue_data(node, src.node_id, 1, 0, fill)
+    out = runner_module.Runner.feed_queue_data(node, src.node_id, 1, 0, fill)
     assert portfolio.cash == 50.0
     assert out["positions"]["AAPL"]["qty"] == 5.0
 
@@ -187,7 +189,7 @@ def test_portfolio_node_updates_custom_watermark_topic():
     portfolio = Portfolio(cash=100.0)
     node = PortfolioNode(src, portfolio=portfolio, watermark_topic="custom.topic")
     fill = {"symbol": "AAPL", "quantity": 1.0, "fill_price": 10.0, "timestamp": 200}
-    Runner.feed_queue_data(node, src.node_id, 1, 0, fill)
+    runner_module.Runner.feed_queue_data(node, src.node_id, 1, 0, fill)
     assert get_watermark("custom.topic", "topic-world") == 200
 
 
@@ -198,9 +200,9 @@ def test_portfolio_node_watermark_ignores_out_of_order_fill():
     portfolio = Portfolio(cash=100.0)
     node = PortfolioNode(src, portfolio=portfolio)
     newest = {"symbol": "AAPL", "quantity": 1.0, "fill_price": 10.0, "timestamp": 220}
-    Runner.feed_queue_data(node, src.node_id, 1, 0, newest)
+    runner_module.Runner.feed_queue_data(node, src.node_id, 1, 0, newest)
     older = {"symbol": "AAPL", "quantity": 1.0, "fill_price": 10.0, "timestamp": 200}
-    Runner.feed_queue_data(node, src.node_id, 1, 0, older)
+    runner_module.Runner.feed_queue_data(node, src.node_id, 1, 0, older)
     assert get_watermark("trade.portfolio", "wm-world") == 220
 
 
@@ -210,7 +212,7 @@ def test_risk_control_node_rejects_large_position():
     risk = RiskManager(max_position_size=50.0)
     node = RiskControlNode(src, portfolio=portfolio, risk_manager=risk)
     order = {"symbol": "AAPL", "price": 10.0, "quantity": 10.0}
-    out = Runner.feed_queue_data(node, src.node_id, 1, 0, order)
+    out = runner_module.Runner.feed_queue_data(node, src.node_id, 1, 0, order)
     assert out["rejected"]
 
 
@@ -220,7 +222,7 @@ def test_timing_gate_node_blocks_closed_market():
     node = TimingGateNode(src, controller=controller)
     order = {"symbol": "AAPL", "price": 10.0, "quantity": 1.0}
     saturday = int(datetime(2024, 1, 6, 15, 0, tzinfo=timezone.utc).timestamp())
-    out = Runner.feed_queue_data(node, src.node_id, 1, saturday, order)
+    out = runner_module.Runner.feed_queue_data(node, src.node_id, 1, saturday, order)
     assert out["rejected"]
 
 
@@ -231,7 +233,122 @@ def test_order_publish_node_calls_publisher():
     def _pub(o):
         calls.append(o)
 
-    node = OrderPublishNode(src, submit_order=_pub)
-    order = {"symbol": "AAPL", "price": 10.0, "quantity": 1.0}
-    out = Runner.feed_queue_data(node, src.node_id, 1, 0, order)
-    assert out == order and calls == [order]
+    prev_am = runner_module.Runner._activation_manager
+    runner_module.Runner.set_activation_manager(None)
+    try:
+        node = OrderPublishNode(src, submit_order=_pub)
+        order = {"symbol": "AAPL", "price": 10.0, "quantity": 1.0}
+        out = runner_module.Runner.feed_queue_data(node, src.node_id, 1, 0, order)
+        assert out == order and calls == [order]
+    finally:
+        runner_module.Runner.set_activation_manager(prev_am)
+
+
+def test_order_publish_node_blocks_during_freeze_and_drain():
+    src = Node(name="src", interval=1, period=1)
+
+    class DummyWriter:
+        def __init__(self) -> None:
+            self.calls: list[tuple[int, int, list[tuple[str, str, dict]]]] = []
+
+        async def publish_bucket(self, ts, interval, entries):
+            self.calls.append((ts, interval, list(entries)))
+
+    class DummySubmit:
+        def __init__(self) -> None:
+            self.orders: list[dict] = []
+
+        def __call__(self, order):
+            self.orders.append(order)
+
+    writer = DummyWriter()
+    submit = DummySubmit()
+    node = OrderPublishNode(src, commit_log_writer=writer, submit_order=submit)
+
+    am = ActivationManager()
+
+    prev_am = runner_module.Runner._activation_manager
+    prev_service = runner_module.Runner._trade_execution_service
+    prev_http = runner_module.Runner._trade_order_http_url
+    prev_topic = runner_module.Runner._trade_order_kafka_topic
+    prev_producer = runner_module.Runner._kafka_producer
+
+    runner_module.Runner.set_trade_execution_service(None)
+    runner_module.Runner.set_trade_order_http_url(None)
+    runner_module.Runner.set_trade_order_kafka_topic(None)
+    runner_module.Runner.set_kafka_producer(None)
+    runner_module.Runner.set_activation_manager(am)
+
+    try:
+        def _feed(ts: int, payload: dict) -> None:
+            runner_module.Runner.feed_queue_data(node, src.node_id, 1, ts, payload.copy())
+
+        asyncio.run(
+            am._on_message({
+                "event": "activation_updated",
+                "data": {"side": "long", "active": True, "weight": 1.0},
+            })
+        )
+        asyncio.run(
+            am._on_message({
+                "event": "activation_updated",
+                "data": {"side": "short", "active": True, "weight": 1.0},
+            })
+        )
+
+        buy = {"symbol": "AAPL", "price": 10.0, "quantity": 1.0, "side": "BUY"}
+        sell = {"symbol": "AAPL", "price": 10.0, "quantity": -1.0, "side": "SELL"}
+
+        _feed(1, buy)
+        assert len(writer.calls) == 1
+        assert len(submit.orders) == 1
+
+        asyncio.run(
+            am._on_message({
+                "event": "activation_updated",
+                "data": {"side": "long", "active": True, "freeze": True},
+            })
+        )
+
+        _feed(2, sell)
+        assert len(writer.calls) == 1
+        assert len(submit.orders) == 1
+
+        asyncio.run(
+            am._on_message({
+                "event": "activation_updated",
+                "data": {"side": "long", "active": True, "freeze": False},
+            })
+        )
+
+        _feed(3, sell)
+        assert len(writer.calls) == 2
+        assert len(submit.orders) == 2
+
+        asyncio.run(
+            am._on_message({
+                "event": "activation_updated",
+                "data": {"side": "short", "active": True, "drain": True},
+            })
+        )
+
+        _feed(4, buy)
+        assert len(writer.calls) == 2
+        assert len(submit.orders) == 2
+
+        asyncio.run(
+            am._on_message({
+                "event": "activation_updated",
+                "data": {"side": "short", "active": True, "drain": False},
+            })
+        )
+
+        _feed(5, buy)
+        assert len(writer.calls) == 3
+        assert len(submit.orders) == 3
+    finally:
+        runner_module.Runner.set_activation_manager(prev_am)
+        runner_module.Runner.set_trade_execution_service(prev_service)
+        runner_module.Runner.set_trade_order_http_url(prev_http)
+        runner_module.Runner.set_trade_order_kafka_topic(prev_topic)
+        runner_module.Runner.set_kafka_producer(prev_producer)


### PR DESCRIPTION
## Summary
- propagate freeze/drain state across both sides in `ActivationManager` so weights and allow checks drop immediately
- gate `OrderPublishNode` via the runner activation state and share a helper for inferring order side
- extend activation freeze/drain tests and add an order publish integration test covering live freeze/drain toggles

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout --with pytest-asyncio --with fakeredis --with jsonschema -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run --with pytest --with pytest-xdist --with pytest-asyncio --with fakeredis --with jsonschema -m pytest -W error -n auto

Fixes #953

------
https://chatgpt.com/codex/tasks/task_e_68cfa2aaf5f88329a899d3b96745ef17