### PR TITLE
Add WorldNodeRef domain migration plan and helpers

### DIFF
--- a/docs/operations/neo4j_migrations.md
+++ b/docs/operations/neo4j_migrations.md
@@ -29,3 +29,68 @@ qmtl dagmanager neo4j-rollback \
 
 Use with caution in lower environments; production rollback should follow a controlled migration plan.
 
+## WorldNodeRef Execution Domain Expansion (online)
+
+The World View Graph (WVG) now scopes `WorldNodeRef` records by
+`execution_domain`. Existing deployments may still hold legacy rows that only
+contain `(world_id, node_id)` and an obsolete `last_eval_key`. Perform the
+following zero-downtime sequence:
+
+1. **Schema** — add the new property and composite key. Example Cypher executed
+   through the usual migration harness:
+
+   ```cypher
+   // allow mixed state while the backfill runs
+   CREATE CONSTRAINT wvg_world_node_ref_domain IF NOT EXISTS
+   FOR (n:WorldNodeRef)
+   REQUIRE (n.world_id, n.node_id, n.execution_domain) IS UNIQUE;
+
+   CALL apoc.util.validatePredicate(
+     n.execution_domain IS NULL,
+     'execution_domain must be populated during domain backfill',
+     [n]
+   )
+   YIELD value
+   RETURN value;
+   ```
+
+2. **Backfill** — stream the legacy rows, convert them to domain-aware
+   dictionaries using `Storage.backfill_world_node_refs`, and write the results
+   back with the preferred driver (Bolt/OGM). The helper performs the
+   EvalKey recalculation to ensure cache isolation:
+
+   ```python
+   import asyncio
+
+   from qmtl.worldservice.storage import Storage
+
+   storage = Storage()
+   storage_loop = asyncio.get_event_loop()
+
+   legacy_rows = fetch_legacy_world_node_refs()  # yields dicts
+   storage_loop.run_until_complete(
+       storage.load_legacy_world_node_refs(legacy_rows, default_domain="live")
+   )
+   upgraded = storage_loop.run_until_complete(storage.backfill_world_node_refs())
+   persist_world_node_refs(upgraded)
+   ```
+
+   The tests in `tests/worldservice/test_worldservice_migrations.py` exercise the
+   conversion logic and EvalKey recomputation.
+
+3. **Lazy guard** — the storage shim keeps a lazy-upgrade path via
+   `Storage.get_world_node_ref` and `Storage.list_world_node_refs`. Any call that
+   touches a legacy row upgrades it on-the-fly, recalculates the EvalKey using
+   the formula `blake3(NodeID || WorldID || ExecutionDomain || ContractID ||
+   DatasetFingerprint || CodeVersion || ResourcePolicy)`, and emits an audit
+   event. This allows the service to stay online while the bulk backfill runs or
+   if stragglers appear later.
+
+4. **Cleanup** — once the migration finishes and monitoring confirms that no
+   lazy upgrades are occurring, drop temporary guards (if any) and enforce the
+   new constraint as mandatory in policy.
+
+Because both the eager backfill and the lazy guard operate under live traffic,
+no maintenance window is required. Monitor the audit log and the
+`world_node_ref_migrated` events to track progress.
+

--- a/qmtl/worldservice/storage.py
+++ b/qmtl/worldservice/storage.py
@@ -237,10 +237,12 @@ class Storage:
         if not legacy_bucket:
             return None
         for legacy in list(legacy_bucket):
-            resolved_domain = self._resolve_domain(legacy, explicit=execution_domain)
+            resolved_domain = self._resolve_domain(legacy)
             if resolved_domain != execution_domain:
                 continue
-            upgraded = self._upgrade_legacy_world_node_ref(legacy, mode="lazy", explicit_domain=execution_domain)
+            upgraded = self._upgrade_legacy_world_node_ref(
+                legacy, mode="lazy", explicit_domain=resolved_domain
+            )
             if upgraded:
                 legacy_bucket.remove(legacy)
                 if not legacy_bucket:

--- a/tests/worldservice/test_worldservice_migrations.py
+++ b/tests/worldservice/test_worldservice_migrations.py
@@ -1,0 +1,89 @@
+import pytest
+
+from qmtl.worldservice.storage import Storage
+
+
+@pytest.mark.asyncio
+async def test_backfill_world_node_refs_recomputes_eval_keys():
+    storage = Storage()
+    legacy = [
+        {
+            "world_id": "w1",
+            "node_id": "blake3:node-1",
+            "status": "valid",
+            "last_eval_key": "blake3:legacy",
+            "annotations": {
+                "contract_id": "contract-1",
+                "dataset_fingerprint": "ohlcv:ASOF=2025-09-30",
+                "code_version": "rev-a",
+                "resource_policy": "baseline",
+            },
+        }
+    ]
+
+    await storage.load_legacy_world_node_refs(legacy, default_domain="dryrun")
+    migrated = await storage.backfill_world_node_refs()
+
+    assert migrated == [
+        {
+            "world_id": "w1",
+            "node_id": "blake3:node-1",
+            "execution_domain": "dryrun",
+            "status": "valid",
+            "last_eval_key": Storage.compute_eval_key(
+                node_id="blake3:node-1",
+                world_id="w1",
+                execution_domain="dryrun",
+                metadata=legacy[0]["annotations"],
+            ),
+            "annotations": legacy[0]["annotations"],
+        }
+    ]
+
+    audit = await storage.get_audit("w1")
+    assert any(event["event"] == "world_node_ref_migrated" and event["mode"] == "backfill" for event in audit)
+
+
+@pytest.mark.asyncio
+async def test_lazy_world_node_ref_upgrade_on_access():
+    storage = Storage()
+
+    def resolver(record):
+        annotations = record.get("annotations") or {}
+        return annotations.get("domain_hint", "live")
+
+    legacy = [
+        {
+            "world_id": "w2",
+            "node_id": "blake3:node-2",
+            "status": "validating",
+            "annotations": {
+                "domain_hint": "shadow",
+                "contract_id": "contract-2",
+                "dataset_fingerprint": "ohlcv:ASOF=2025-09-15",
+                "code_version": "rev-b",
+                "resource_policy": "restricted",
+            },
+        }
+    ]
+
+    await storage.load_legacy_world_node_refs(legacy, domain_resolver=resolver)
+
+    # Lazy upgrade when fetching a specific domain
+    record = await storage.get_world_node_ref("w2", "blake3:node-2", "shadow")
+    assert record is not None
+    assert record["execution_domain"] == "shadow"
+    expected_eval_key = Storage.compute_eval_key(
+        node_id="blake3:node-2",
+        world_id="w2",
+        execution_domain="shadow",
+        metadata=legacy[0]["annotations"],
+    )
+    assert record["last_eval_key"] == expected_eval_key
+
+    audit = await storage.get_audit("w2")
+    assert any(event["event"] == "world_node_ref_migrated" and event["mode"] == "lazy" for event in audit)
+
+    # Listing should return the upgraded entry without duplicating it
+    listing = await storage.list_world_node_refs("w2")
+    assert listing == [record]


### PR DESCRIPTION
## Summary
- add WorldNodeRef migration helpers in the WorldService storage shim to support execution-domain expansion and EvalKey recalculation
- document the zero-downtime backfill and lazy-upgrade plan for Neo4j WorldNodeRef data
- cover the migration helpers with targeted tests for eager backfill and lazy access flows

## Testing
- uv run -m pytest tests/worldservice/test_worldservice_migrations.py -W error -n auto

Closes #956

------
https://chatgpt.com/codex/tasks/task_e_68cfa2b1454483299352f201ae7c6fd2