### PR TITLE
Docs: align execution domain terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added `Node.add_tag()` to attach tags after node creation.
 - Added migration guide for removing legacy Runner/CLI/Gateway surfaces. See [docs/guides/migration_bc_removal.md](docs/guides/migration_bc_removal.md).
 - NodeID now uses BLAKE3 with a `blake3:` prefix and no longer includes `world_id`. Legacy SHA-based IDs remain temporarily supported. See [docs/guides/migration_nodeid_blake3.md](docs/guides/migration_nodeid_blake3.md).
-- Live connectors: added standard `BrokerageClient` and `LiveDataFeed` SDK interfaces with reference implementations (`HttpBrokerageClient`, `CcxtBrokerageClient`, `WebSocketFeed`) and a `FakeBrokerageClient` for demos. See [docs/reference/api/connectors.md](docs/reference/api/connectors.md) and example `qmtl/examples/strategies/paper_live_switch_strategy.py`.
+- Live connectors: added standard `BrokerageClient` and `LiveDataFeed` SDK interfaces with reference implementations (`HttpBrokerageClient`, `CcxtBrokerageClient`, `WebSocketFeed`) and a `FakeBrokerageClient` for demos. See [docs/reference/api/connectors.md](docs/reference/api/connectors.md) and example `qmtl/examples/strategies/dryrun_live_switch_strategy.py`.
 
 ---
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -4,7 +4,7 @@ tags:
   - architecture
   - design
 author: "QMTL Team"
-last_modified: 2025-08-24
+last_modified: 2025-09-22
 ---
 
 {{ nav_links() }}
@@ -124,7 +124,7 @@ sequenceDiagram
 - Domains: `backtest | dryrun | live | shadow`. WorldService treats ExecutionDomain as a 1급 개념 and drives gating and promotions via 2‑Phase Apply (Freeze/Drain → Switch → Unfreeze).
 - NodeID vs ComputeKey: NodeID는 전역·월드무관 식별자다. 실행/캐시 격리를 위해 DAG Manager와 런타임은 `ComputeKey = blake3(NodeHash ⊕ world_id ⊕ execution_domain ⊕ as_of ⊕ partition)`를 사용한다. 교차 컨텍스트 캐시 적중은 정책 위반이며 SLO=0이다.
 - WVG 확장: `WorldNodeRef = (world_id, node_id, execution_domain)`로 도메인별 상태/검증이 분리된다. `WvgEdgeOverride`로 기본 교차‑도메인 경로(예: backtest→live)를 비활성화하고, 프로모션 후 정책으로만 활성화한다.
-- Envelope 매핑: Gateway/SDK는 `DecisionEnvelope.effective_mode`를 ExecutionDomain으로 매핑한다(`validate→backtest(주문 게이트 OFF)`, `compute-only→backtest`, `paper→dryrun`, `live→live`; `shadow`는 운영자 전용).
+- Envelope 매핑: Gateway/SDK는 `DecisionEnvelope.effective_mode`를 ExecutionDomain으로 매핑하고 `execution_domain` 필드로 중계한다(`validate→backtest(주문 게이트 OFF)`, `compute-only→backtest`, `paper→dryrun`, `live→live`; `shadow`는 운영자 전용).
 - Queue 네임스페이스: 프로덕션 배포에서는 `{world_id}.{execution_domain}.<topic>` 프리픽스로 토픽을 분리해야 한다(SHALL). 교차 도메인 구독·발행은 ACL로 금지하며, 운영 환경에서만 예외를 명시적으로 허용한다.
 - WorldNodeRef 독립성: 서로 다른 `execution_domain` 조합은 상태·큐·검증 결과를 공유할 수 없다(SHALL). 공유가 필요한 경우 Feature Artifact Plane(§1.4)처럼 불변 아티팩트만 사용한다.
 - Promotion guard: WVG의 `WvgEdgeOverride`는 기본적으로 backtest→live 경로를 비활성화하며(SHALL), 2‑Phase Apply 완료 후 정책에 따라 명시적으로만 해제한다.

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -2,7 +2,7 @@
 title: "QMTL Gateway — Comprehensive Technical Specification"
 tags: []
 author: "QMTL Team"
-last_modified: 2025-08-21
+last_modified: 2025-09-22
 spec_version: v1.2
 ---
 
@@ -268,7 +268,7 @@ Gateway remains the single public boundary for SDKs. It proxies WorldService end
 
 - Strategy submission and worlds:
   - Clients may include `world_id` (single) **or** `world_ids[]` (multiple). Gateway upserts a **WorldStrategyBinding (WSB)** for each world and ensures the corresponding `WorldNodeRef(root)` exists in the WVG. Execution mode is still determined solely by WorldService decisions.
-  - Gateway maps `DecisionEnvelope.effective_mode` to an ExecutionDomain for compute/context: `validate → backtest (orders gated OFF)` unless `shadow` is explicitly requested; `compute-only → backtest`; `paper → dryrun`; `live → live`. `shadow` is reserved and must be explicitly requested by operators.
+  - Gateway maps `DecisionEnvelope.effective_mode` to an ExecutionDomain for compute/context and writes it to envelopes it relays: `validate → backtest (orders gated OFF by default)`, `compute-only → backtest`, `paper → dryrun`, `live → live`. `shadow` is reserved and must be explicitly requested by operators.
   - Gateway forwards the compute context `{ world_id, execution_domain, as_of (if backtest), partition }` with diff/ingest requests so DAG Manager derives a Domain‑Scoped ComputeKey and isolates caches per domain.
   - Backtest/dryrun submissions MUST include `as_of` (dataset commit) and MAY include `dataset_fingerprint`; when absent Gateway rejects or falls back to compute-only mode to avoid mixing datasets.
 

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -2,7 +2,7 @@
 title: "Architecture Glossary"
 tags: [architecture, glossary]
 author: "QMTL Team"
-last_modified: 2025-08-29
+last_modified: 2025-09-22
 ---
 
 {{ nav_links() }}
@@ -11,6 +11,7 @@ last_modified: 2025-08-29
 
 - DecisionEnvelope: World decision result containing `world_id`, `policy_version`, `effective_mode`, `reason`, `as_of`, `ttl`, `etag`.
 - effective_mode: Policy output string in DecisionEnvelope. Values: `validate | compute-only | paper | live`. Consumers MUST map to an ExecutionDomain for compute/routing; see mapping below.
+- execution_domain: Derived field emitted by Gateway/SDK after mapping `effective_mode` (`backtest | dryrun | live | shadow`). Persisted on envelopes relayed to SDKs.
 - ActivationEnvelope: Activation state for a `(world_id, strategy_id, side)` with `active`, `weight`, `etag`, `run_id`, `ts` and optional `state_hash`.
 - ControlBus: Internal control bus (Kafka/Redpanda) carrying versioned control events (ActivationUpdated, QueueUpdated, PolicyUpdated); not a public API.
 - EventStreamDescriptor: Opaque WS descriptor from Gateway (`stream_url`, `token`, `topics`, `expires_at`, optional `fallback_url`, `alt_stream_url`).

--- a/docs/guides/sdk_tutorial.md
+++ b/docs/guides/sdk_tutorial.md
@@ -2,7 +2,7 @@
 title: "SDK 사용 가이드"
 tags: []
 author: "QMTL Team"
-last_modified: 2025-08-24
+last_modified: 2025-09-22
 ---
 
 {{ nav_links() }}
@@ -126,6 +126,14 @@ class WorldStrategy(Strategy):
 # world_id는 노드 등록과 메트릭 레이블에 자동으로 반영됩니다.
 Runner.run(WorldStrategy, world_id="demo_world", gateway_url="http://gw")
 ```
+
+### ExecutionDomain 매핑
+
+- WorldService는 정책 평가 결과를 `effective_mode` (`validate|compute-only|paper|live`)로 전달합니다.
+- Gateway와 SDK는 이 값을 ExecutionDomain으로 매핑해 `execution_domain` 필드를 채웁니다.
+- **매핑 규칙:** `validate → backtest (주문 게이트 OFF)`, `compute-only → backtest`, `paper → dryrun`, `live → live`. `shadow`는 운영자 전용입니다.
+- 실행 예시: [`dryrun_live_switch_strategy.py`]({{ code_url('qmtl/examples/strategies/dryrun_live_switch_strategy.py') }})는 `QMTL_EXECUTION_DOMAIN` 환경 변수로 `dryrun`/`live`를 전환합니다. 레거시 `QMTL_TRADE_MODE` 값 `paper`는 자동으로 `dryrun`으로 변환됩니다.
+- 오프라인 실행(`Runner.offline`)은 기본적으로 `backtest` 도메인과 동일한 게이팅을 적용합니다. WorldService가 `effective_mode="validate"`를 전달하면 SDK는 자동으로 `backtest` ExecutionDomain을 사용해 주문을 차단합니다.
 
 ## CLI 도움말
 

--- a/docs/guides/strategy_workflow.md
+++ b/docs/guides/strategy_workflow.md
@@ -2,7 +2,7 @@
 title: "Strategy Development and Testing Workflow"
 tags: []
 author: "QMTL Team"
-last_modified: 2025-08-21
+last_modified: 2025-09-22
 ---
 
 {{ nav_links() }}
@@ -123,6 +123,13 @@ Use `Runner.offline()` for local testing without dependencies. For integrated ru
 switch to `Runner.run(strategy_cls, world_id=..., gateway_url=...)`. Activation and queue
 updates are delivered via the Gateway's opaque control stream on the `/events/subscribe`
 WebSocket; WS remains the authority for policy and activation.
+
+Execution domains are now surfaced explicitly on envelopes:
+
+- WorldService decisions emit `effective_mode` (`validate|compute-only|paper|live`).
+- Gateway/SDKs derive `execution_domain` (`backtest|dryrun|live|shadow`) using the normative mapping `validate → backtest (orders gated OFF)`, `compute-only → backtest`, `paper → dryrun`, `live → live`.
+- Example: [`dryrun_live_switch_strategy.py`]({{ code_url('qmtl/examples/strategies/dryrun_live_switch_strategy.py') }}) toggles between `dryrun` and `live` by reading `QMTL_EXECUTION_DOMAIN`. Legacy `QMTL_TRADE_MODE=paper` is accepted but coerced to `dryrun` for compatibility.
+- Offline runs mirror the `backtest` domain, so a `validate` decision never publishes orders until promotion completes.
 
 ```bash
 # start with built-in defaults

--- a/docs/reference/api/connectors.md
+++ b/docs/reference/api/connectors.md
@@ -2,7 +2,7 @@
 title: "Live & Brokerage Connectors"
 tags: [api]
 author: "QMTL Team"
-last_modified: 2025-09-09
+last_modified: 2025-09-22
 ---
 
 {{ nav_links() }}
@@ -145,14 +145,16 @@ await fake.stop()
 Minimal env configuration for a live run:
 
 ```bash
-export QMTL_TRADE_MODE=live
+export QMTL_EXECUTION_DOMAIN=live
 export QMTL_BROKER_URL=https://broker/api/orders
 export QMTL_TRADE_MAX_RETRIES=3
 export QMTL_TRADE_BACKOFF=0.1
 export QMTL_WS_URL=wss://gateway/ws
+# Optional legacy compatibility (maps "paper" → "dryrun")
+export QMTL_TRADE_MODE=live
 ```
 
-Example strategy: `qmtl/examples/strategies/paper_live_switch_strategy.py` reads these variables to switch between paper and live.
+Example strategy: `qmtl/examples/strategies/dryrun_live_switch_strategy.py` reads these variables to switch between dryrun and live domains.
 
 YAML integration: you can mirror these settings in your project config and load them before constructing clients. The SDK does not enforce a specific YAML schema.
 

--- a/docs/reference/api_world.md
+++ b/docs/reference/api_world.md
@@ -2,7 +2,7 @@
 title: "World API Reference — Proxied via Gateway"
 tags: [reference, api, world]
 author: "QMTL Team"
-last_modified: 2025-08-29
+last_modified: 2025-09-22
 ---
 
 {{ nav_links() }}
@@ -76,11 +76,18 @@ Response (ActivationEnvelope)
   "freeze": false,
   "drain": false,
   "effective_mode": "paper",
+  "execution_domain": "dryrun",
   "etag": "act:crypto_mom_1h:abcd:long:42",
   "run_id": "7a1b4c...",
   "ts": "2025-08-28T09:00:00Z"
 }
 ```
+`effective_mode` carries the WorldService policy string and remains
+backwards-compatible (`validate|compute-only|paper|live`). Gateway and
+SDK clients MUST derive `execution_domain` from it using the normative
+mapping: `validate → backtest (orders gated OFF)`, `compute-only →
+backtest`, `paper → dryrun`, `live → live`. `shadow` remains reserved
+for operator-controlled dual runs.
 Schema: reference/schemas/activation_envelope.schema.json
 
 ### GET /worlds/{id}/{topic}/state_hash

--- a/qmtl/examples/utils/mode_switch_example.py
+++ b/qmtl/examples/utils/mode_switch_example.py
@@ -7,7 +7,7 @@ from qmtl.sdk import Strategy, Node, StreamInput, Runner
 
 
 class ModeSwitchStrategy(Strategy):
-    """Run the same strategy in multiple modes."""
+    """Run the same strategy across multiple execution domains."""
 
     def setup(self) -> None:
         price = StreamInput(interval="60s", period=30)


### PR DESCRIPTION
## Summary
- rename the paper/live switch example to dryrun/live and add execution domain helpers
- document ExecutionDomain mapping across architecture and SDK guides
- refresh connector and world API docs to surface the `execution_domain` field and new env vars

## Testing
- uv run mkdocs build

Closes #957

------
https://chatgpt.com/codex/tasks/task_e_68cfa2b7490083299dcea6f7e184f72b