### PR TITLE
Enforce SDK run context guards for clocks and dataset metadata

### DIFF
--- a/qmtl/sdk/gateway_client.py
+++ b/qmtl/sdk/gateway_client.py
@@ -27,6 +27,7 @@ class GatewayClient:
         gateway_url: str,
         dag: dict,
         meta: Optional[dict],
+        context: Optional[dict[str, str]] = None,
         world_id: Optional[str] = None,
     ) -> dict:
         """Submit a strategy DAG to the gateway."""
@@ -38,6 +39,8 @@ class GatewayClient:
         }
         if world_id is not None:
             payload["world_id"] = world_id
+        if context:
+            payload["context"] = context
         headers: dict[str, str] = {}
         inject(headers)
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import pytest
 import pytest_asyncio
 from fakeredis.aioredis import FakeRedis
 
+from qmtl.sdk.runner import Runner
+
 @pytest_asyncio.fixture
 async def fake_redis():
     redis = FakeRedis(decode_responses=True)
@@ -12,3 +14,18 @@ async def fake_redis():
             await redis.aclose(close_connection_pool=True)
         else:
             await redis.close()
+
+
+@pytest.fixture(autouse=True)
+def _default_runner_context():
+    context = {
+        "execution_mode": "backtest",
+        "clock": "virtual",
+        "as_of": "2025-01-01T00:00:00Z",
+        "dataset_fingerprint": "lake:blake3:test",
+    }
+    Runner.set_default_context(context)
+    try:
+        yield context
+    finally:
+        Runner.set_default_context(None)


### PR DESCRIPTION
## Summary
- normalize Runner compute context handling, enforcing clock mode compatibility and dataset metadata fallback
- surface run clock/mode/as_of/dataset options via the SDK CLI and forward context through Gateway submissions
- document the new requirements and cover compute-only fallback plus guard behavior with focused tests

## Testing
- uv run -m pytest tests/test_runner.py::test_runner_missing_dataset_forces_compute_only tests/test_runner.py::test_runner_backtest_enforces_virtual_clock tests/test_runner.py::test_runner_live_enforces_wall_clock

Fixes #960

------
https://chatgpt.com/codex/tasks/task_e_68cfa2c0448c832989fae4336409ef5c