### PR TITLE
Implement SDK Feature Artifact Plane

### DIFF
--- a/qmtl/sdk/feature_store/__init__.py
+++ b/qmtl/sdk/feature_store/__init__.py
@@ -1,0 +1,27 @@
+"""Feature Artifact Plane utilities for the SDK.
+
+This package provides the primitives required to persist immutable feature
+artifacts that can be safely reused across execution domains.  The default
+implementation stores artifacts on the local filesystem, but the store is
+pluggable so alternative backends (object storage, RocksDB) can be injected
+without changing strategy code.
+"""
+
+from .types import (
+    FeatureArtifact,
+    FeatureArtifactKey,
+    FeatureDescriptor,
+    FeatureStoreConfig,
+    FeatureStoreContext,
+)
+from .store import FeatureArtifactStore
+
+__all__ = [
+    "FeatureArtifact",
+    "FeatureArtifactKey",
+    "FeatureArtifactStore",
+    "FeatureDescriptor",
+    "FeatureStoreConfig",
+    "FeatureStoreContext",
+]
+

--- a/qmtl/sdk/feature_store/backends.py
+++ b/qmtl/sdk/feature_store/backends.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+"""Storage backends for the Feature Artifact Plane."""
+
+import base64
+import json
+import os
+import pickle
+import re
+import time
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Protocol
+
+try:  # optional dependency
+    import fsspec  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    fsspec = None  # type: ignore
+
+from .types import FeatureArtifact, FeatureArtifactKey
+
+
+class FeatureArtifactBackend(Protocol):
+    """Protocol implemented by artifact storage backends."""
+
+    def list_versions(self, key: FeatureArtifactKey) -> list[int]:
+        ...
+
+    def write(self, artifact: FeatureArtifact) -> FeatureArtifact:
+        ...
+
+    def read(self, key: FeatureArtifactKey, version: int) -> FeatureArtifact | None:
+        ...
+
+    def delete(self, key: FeatureArtifactKey, version: int) -> None:
+        ...
+
+
+def _sanitize(component: str) -> str:
+    component = component.strip()
+    component = component.replace(os.sep, "_")
+    component = re.sub(r"[^A-Za-z0-9_.=-]", "_", component)
+    return component or "_"
+
+
+def _params_hash(key: FeatureArtifactKey) -> str:
+    import hashlib
+
+    return hashlib.blake2b(key.params.encode("utf-8"), digest_size=16).hexdigest()
+
+
+class LocalFileArtifactBackend:
+    """Persist artifacts on the local filesystem."""
+
+    def __init__(self, base_path: str | Path | None = None) -> None:
+        root = Path(base_path or os.getenv("QMTL_FEATURE_STORE_DIR", ".qmtl_feature_store"))
+        root.mkdir(parents=True, exist_ok=True)
+        self._base = root
+
+    # Helpers -----------------------------------------------------------------
+    def _dir(self, key: FeatureArtifactKey) -> Path:
+        parts = [
+            _sanitize(key.factor),
+            f"interval={key.interval}",
+            _sanitize(key.instrument),
+            f"params={_params_hash(key)}",
+            _sanitize(key.dataset_fingerprint),
+            f"ts={int(key.timestamp)}",
+        ]
+        path = self._base.joinpath(*parts)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _path(self, key: FeatureArtifactKey, version: int) -> Path:
+        return self._dir(key) / f"v{version:06d}.json"
+
+    # API ---------------------------------------------------------------------
+    def list_versions(self, key: FeatureArtifactKey) -> list[int]:
+        folder = self._dir(key)
+        versions: list[int] = []
+        for child in folder.glob("v*.json"):
+            try:
+                versions.append(int(child.stem[1:]))
+            except ValueError:
+                continue
+        return sorted(versions)
+
+    def write(self, artifact: FeatureArtifact) -> FeatureArtifact:
+        path = self._path(artifact.key, artifact.version)
+        payload_block: dict[str, Any]
+        encoding = "json"
+        try:
+            json.dumps(artifact.payload)
+            payload_block = {"encoding": "json", "value": artifact.payload}
+        except TypeError:
+            data = base64.b64encode(pickle.dumps(artifact.payload)).decode("ascii")
+            payload_block = {"encoding": "pickle", "value": data}
+            encoding = "pickle"
+        payload = {
+            "key": artifact.key.as_dict(),
+            "meta": {
+                "version": artifact.version,
+                "created_at": artifact.created_at,
+                "execution_domain": artifact.execution_domain,
+                "world_id": artifact.world_id,
+                "encoding": encoding,
+            },
+            "payload": payload_block,
+        }
+        tmp = path.with_suffix(".tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+        tmp.replace(path)
+        return replace(artifact, encoding=encoding)
+
+    def read(self, key: FeatureArtifactKey, version: int) -> FeatureArtifact | None:
+        path = self._path(key, version)
+        if not path.exists():
+            return None
+        with path.open("r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+        payload_block = raw.get("payload", {})
+        encoding = payload_block.get("encoding", "json")
+        if encoding == "pickle":
+            payload = pickle.loads(base64.b64decode(payload_block.get("value", "")))
+        else:
+            payload = payload_block.get("value")
+        meta = raw.get("meta", {})
+        created_at = float(meta.get("created_at", time.time()))
+        return FeatureArtifact(
+            key=key,
+            version=version,
+            payload=payload,
+            created_at=created_at,
+            execution_domain=str(meta.get("execution_domain", "unknown")),
+            world_id=meta.get("world_id"),
+            encoding=str(encoding),
+        )
+
+    def delete(self, key: FeatureArtifactKey, version: int) -> None:
+        path = self._path(key, version)
+        try:
+            path.unlink()
+        except FileNotFoundError:  # pragma: no cover - benign race
+            return
+
+
+class ObjectStoreArtifactBackend(LocalFileArtifactBackend):
+    """Optional backend persisting artifacts via ``fsspec``."""
+
+    def __init__(self, base_url: str, *, cache_dir: str | Path | None = None) -> None:
+        if fsspec is None:  # pragma: no cover - optional dependency guard
+            raise RuntimeError("fsspec is required for ObjectStoreArtifactBackend")
+        self._fs, _, parts = fsspec.get_fs_token_paths(base_url)  # type: ignore[attr-defined]
+        self._base_url = base_url.rstrip("/")
+        cache = cache_dir or os.getenv("QMTL_FEATURE_STORE_CACHE_DIR")
+        super().__init__(cache)
+
+    def _path(self, key: FeatureArtifactKey, version: int) -> Path:
+        # Use local cache directory for atomic writes, then copy to remote
+        return super()._path(key, version)
+
+    def write(self, artifact: FeatureArtifact) -> FeatureArtifact:
+        local = super().write(artifact)
+        rel = local.key  # FeatureArtifactKey
+        path = super()._path(rel, artifact.version)
+        remote = f"{self._base_url}/{path.relative_to(self._base)}"
+        with self._fs.open(remote, "wb") as fh:  # type: ignore[attr-defined]
+            fh.write(path.read_bytes())
+        return local
+
+    def read(self, key: FeatureArtifactKey, version: int) -> FeatureArtifact | None:
+        path = super()._path(key, version)
+        remote = f"{self._base_url}/{path.relative_to(self._base)}"
+        if not path.exists():
+            try:
+                with self._fs.open(remote, "rb") as fh:  # type: ignore[attr-defined]
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    with path.open("wb") as out:
+                        out.write(fh.read())
+            except FileNotFoundError:
+                return None
+        return super().read(key, version)
+
+
+class RocksDbArtifactBackend:
+    """Placeholder backend for RocksDB deployments."""
+
+    def __init__(self, *_, **__):  # pragma: no cover - dependency placeholder
+        raise RuntimeError("python-rocksdb must be installed to use RocksDbArtifactBackend")
+
+
+BACKENDS: dict[str, type[FeatureArtifactBackend]] = {
+    "local": LocalFileArtifactBackend,
+    "object": ObjectStoreArtifactBackend,
+    "rocksdb": RocksDbArtifactBackend,
+}
+
+
+def get_backend(name: str) -> type[FeatureArtifactBackend]:
+    try:
+        return BACKENDS[name]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"unknown feature artifact backend: {name!r}") from exc
+
+
+__all__ = [
+    "FeatureArtifactBackend",
+    "LocalFileArtifactBackend",
+    "ObjectStoreArtifactBackend",
+    "RocksDbArtifactBackend",
+    "get_backend",
+]
+

--- a/qmtl/sdk/feature_store/store.py
+++ b/qmtl/sdk/feature_store/store.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+"""High level orchestration for feature artifact persistence."""
+
+import time
+from typing import Any
+
+from .backends import FeatureArtifactBackend, get_backend
+from .types import (
+    FeatureArtifact,
+    FeatureArtifactKey,
+    FeatureDescriptor,
+    FeatureStoreConfig,
+    FeatureStoreContext,
+)
+from .. import metrics as sdk_metrics
+
+
+class FeatureArtifactStore:
+    """Persist and retrieve immutable feature artifacts."""
+
+    def __init__(
+        self,
+        backend: FeatureArtifactBackend,
+        *,
+        retention_versions: int,
+        retention_seconds: int | None = None,
+    ) -> None:
+        self._backend = backend
+        self._retention_versions = max(int(retention_versions), 1)
+        self._retention_seconds = int(retention_seconds) if retention_seconds else None
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_config(cls, config: FeatureStoreConfig | None = None) -> "FeatureArtifactStore":
+        cfg = config or FeatureStoreConfig.from_env()
+        backend_cls = get_backend(cfg.backend)
+        options = dict(cfg.backend_options or {})
+        if cfg.base_path is not None:
+            if cfg.backend == "object":
+                options.setdefault("cache_dir", cfg.base_path)
+            else:
+                options.setdefault("base_path", cfg.base_path)
+        backend = backend_cls(**options)
+        return cls(
+            backend,
+            retention_versions=cfg.retention_versions,
+            retention_seconds=cfg.retention_seconds,
+        )
+
+    # ------------------------------------------------------------------
+    def write(
+        self,
+        descriptor: FeatureDescriptor,
+        *,
+        interval: int | None,
+        timestamp: int,
+        dataset_fingerprint: str,
+        payload: Any,
+        context: FeatureStoreContext,
+    ) -> FeatureArtifact:
+        key = descriptor.materialise_key(
+            interval=interval,
+            timestamp=timestamp,
+            dataset_fingerprint=dataset_fingerprint,
+        )
+        version = self._next_version(key)
+        artifact = FeatureArtifact(
+            key=key,
+            version=version,
+            payload=payload,
+            created_at=time.time(),
+            execution_domain=context.execution_domain,
+            world_id=context.world_id,
+        )
+        stored = self._backend.write(artifact)
+        sdk_metrics.observe_feature_artifact_write(key.factor, context.execution_domain)
+        self._apply_retention(
+            key,
+            max_versions=descriptor.max_versions,
+            retention_seconds=descriptor.retention_seconds,
+        )
+        return stored
+
+    def read_latest(self, key: FeatureArtifactKey, *, context: FeatureStoreContext) -> FeatureArtifact | None:
+        versions = self._backend.list_versions(key)
+        if not versions:
+            sdk_metrics.observe_feature_artifact_miss(key.factor, context.execution_domain)
+            return None
+        artifact = self._backend.read(key, versions[-1])
+        if artifact is None:
+            sdk_metrics.observe_feature_artifact_miss(key.factor, context.execution_domain)
+            return None
+        sdk_metrics.observe_feature_artifact_hit(key.factor, context.execution_domain)
+        return artifact
+
+    # ------------------------------------------------------------------
+    def _next_version(self, key: FeatureArtifactKey) -> int:
+        versions = self._backend.list_versions(key)
+        return versions[-1] + 1 if versions else 1
+
+    def _apply_retention(
+        self,
+        key: FeatureArtifactKey,
+        *,
+        max_versions: int | None = None,
+        retention_seconds: int | None = None,
+    ) -> None:
+        versions = self._backend.list_versions(key)
+        keep = max_versions if max_versions is not None else self._retention_versions
+        keep = max(int(keep), 1)
+        while len(versions) > keep:
+            oldest = versions.pop(0)
+            self._backend.delete(key, oldest)
+        ttl = retention_seconds if retention_seconds is not None else self._retention_seconds
+        if ttl is None:
+            return
+        cutoff = time.time() - ttl
+        for version in list(versions):
+            artifact = self._backend.read(key, version)
+            if artifact is None:
+                continue
+            if artifact.created_at < cutoff:
+                self._backend.delete(key, version)
+                versions.remove(version)
+
+
+def materialise_key(
+    descriptor: FeatureDescriptor,
+    *,
+    interval: int | None,
+    timestamp: int,
+    dataset_fingerprint: str,
+) -> FeatureArtifactKey:
+    return descriptor.materialise_key(
+        interval=interval,
+        timestamp=timestamp,
+        dataset_fingerprint=dataset_fingerprint,
+    )
+
+
+__all__ = [
+    "FeatureArtifactStore",
+    "materialise_key",
+]
+

--- a/qmtl/sdk/feature_store/types.py
+++ b/qmtl/sdk/feature_store/types.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+"""Dataclasses shared by the Feature Artifact Plane implementation."""
+
+import json
+import os
+from dataclasses import dataclass, field, replace
+from typing import Any, Mapping
+
+
+def _stable_params(params: Mapping[str, Any] | None) -> str:
+    """Return a canonical JSON representation for ``params``."""
+
+    if params is None:
+        return "{}"
+    if not isinstance(params, Mapping):
+        raise TypeError("feature params must be a mapping of string keys")
+    try:
+        return json.dumps(params, sort_keys=True, separators=(",", ":"))
+    except TypeError as exc:  # pragma: no cover - defensive guard
+        raise TypeError("feature params must be JSON serialisable") from exc
+
+
+@dataclass(frozen=True)
+class FeatureDescriptor:
+    """Static description attached to a :class:`qmtl.sdk.node.Node`.
+
+    The descriptor encodes how the node should materialise its feature
+    artifact.  The dataset fingerprint is optional at definition time – it is
+    typically provided by the Runner based on the execution domain.
+    """
+
+    factor: str
+    instrument: str
+    params: Mapping[str, Any] | None = field(default_factory=dict)
+    interval: int | None = None
+    dataset_fingerprint: str | None = None
+    max_versions: int | None = None
+    retention_seconds: int | None = None
+
+    @classmethod
+    def coerce(cls, value: FeatureDescriptor | Mapping[str, Any] | None) -> FeatureDescriptor | None:
+        if value is None:
+            return None
+        if isinstance(value, FeatureDescriptor):
+            return value
+        if not isinstance(value, Mapping):
+            raise TypeError("feature_plane must be a mapping or FeatureDescriptor")
+        data = dict(value)
+        factor = data.get("factor")
+        instrument = data.get("instrument")
+        if not isinstance(factor, str) or not factor:
+            raise ValueError("feature_plane.factor must be a non-empty string")
+        if not isinstance(instrument, str) or not instrument:
+            raise ValueError("feature_plane.instrument must be a non-empty string")
+        params = data.get("params") or {}
+        interval = data.get("interval")
+        dataset_fp = data.get("dataset_fingerprint")
+        max_versions = data.get("max_versions")
+        retention_seconds = data.get("retention_seconds")
+        return cls(
+            factor=factor,
+            instrument=instrument,
+            params=params,
+            interval=int(interval) if interval is not None else None,
+            dataset_fingerprint=str(dataset_fp) if dataset_fp is not None else None,
+            max_versions=int(max_versions) if max_versions is not None else None,
+            retention_seconds=int(retention_seconds)
+            if retention_seconds is not None
+            else None,
+        )
+
+    def with_interval(self, interval: int | None) -> FeatureDescriptor:
+        if interval is None or interval == self.interval:
+            return self
+        return replace(self, interval=int(interval))
+
+    def with_dataset_fingerprint(self, dataset_fingerprint: str | None) -> FeatureDescriptor:
+        if dataset_fingerprint is None:
+            return self
+        return replace(self, dataset_fingerprint=str(dataset_fingerprint))
+
+    def materialise_key(
+        self,
+        *,
+        interval: int | None,
+        timestamp: int,
+        dataset_fingerprint: str,
+    ) -> "FeatureArtifactKey":
+        interval_val = int(interval or self.interval or 0)
+        bucket = timestamp - (timestamp % (interval_val or 1))
+        return FeatureArtifactKey(
+            factor=self.factor,
+            interval=interval_val,
+            params=_stable_params(self.params),
+            instrument=self.instrument,
+            timestamp=bucket,
+            dataset_fingerprint=str(dataset_fingerprint),
+        )
+
+
+@dataclass(frozen=True)
+class FeatureArtifactKey:
+    """Identifier for an immutable feature artifact."""
+
+    factor: str
+    interval: int
+    params: str
+    instrument: str
+    timestamp: int
+    dataset_fingerprint: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "factor": self.factor,
+            "interval": self.interval,
+            "params": self.params,
+            "instrument": self.instrument,
+            "timestamp": self.timestamp,
+            "dataset_fingerprint": self.dataset_fingerprint,
+        }
+
+
+@dataclass(frozen=True)
+class FeatureArtifact:
+    """Concrete persisted artifact payload."""
+
+    key: FeatureArtifactKey
+    version: int
+    payload: Any
+    created_at: float
+    execution_domain: str
+    world_id: str | None = None
+    encoding: str = "json"
+
+
+@dataclass
+class FeatureStoreConfig:
+    """Runtime configuration for the :class:`FeatureArtifactStore`."""
+
+    backend: str = "local"
+    base_path: str | None = None
+    retention_versions: int = 3
+    retention_seconds: int | None = None
+    backend_options: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_env(cls) -> "FeatureStoreConfig":
+        backend = os.getenv("QMTL_FEATURE_STORE_BACKEND", "local").strip() or "local"
+        base_path = os.getenv("QMTL_FEATURE_STORE_DIR")
+        max_versions = os.getenv("QMTL_FEATURE_STORE_MAX_VERSIONS")
+        ttl = os.getenv("QMTL_FEATURE_STORE_TTL_SECONDS")
+        retention_versions = int(max_versions) if max_versions else 3
+        retention_seconds = int(ttl) if ttl else None
+        return cls(
+            backend=backend,
+            base_path=base_path,
+            retention_versions=retention_versions,
+            retention_seconds=retention_seconds,
+        )
+
+
+@dataclass
+class FeatureStoreContext:
+    """Execution-scoped context controlling artifact behaviour."""
+
+    execution_domain: str
+    dataset_fingerprint: str | None = None
+    world_id: str | None = None
+
+    def is_writer(self) -> bool:
+        return self.execution_domain in {"backtest", "dryrun"}
+
+
+__all__ = [
+    "FeatureArtifact",
+    "FeatureArtifactKey",
+    "FeatureDescriptor",
+    "FeatureStoreConfig",
+    "FeatureStoreContext",
+]
+

--- a/qmtl/sdk/metrics.py
+++ b/qmtl/sdk/metrics.py
@@ -187,9 +187,48 @@ else:
         registry=global_registry,
     )
 
+if "feature_artifact_write_total" in global_registry._names_to_collectors:
+    feature_artifact_write_total = global_registry._names_to_collectors[
+        "feature_artifact_write_total"
+    ]
+else:
+    feature_artifact_write_total = Counter(
+        "feature_artifact_write_total",
+        "Number of feature artifacts written",
+        ["factor", "execution_domain"],
+        registry=global_registry,
+    )
+
+if "feature_artifact_hit_total" in global_registry._names_to_collectors:
+    feature_artifact_hit_total = global_registry._names_to_collectors[
+        "feature_artifact_hit_total"
+    ]
+else:
+    feature_artifact_hit_total = Counter(
+        "feature_artifact_hit_total",
+        "Feature artifact cache hits",
+        ["factor", "execution_domain"],
+        registry=global_registry,
+    )
+
+if "feature_artifact_miss_total" in global_registry._names_to_collectors:
+    feature_artifact_miss_total = global_registry._names_to_collectors[
+        "feature_artifact_miss_total"
+    ]
+else:
+    feature_artifact_miss_total = Counter(
+        "feature_artifact_miss_total",
+        "Feature artifact cache misses",
+        ["factor", "execution_domain"],
+        registry=global_registry,
+    )
+
 orders_published_total._vals = {}  # type: ignore[attr-defined]
 fills_ingested_total._vals = {}  # type: ignore[attr-defined]
 orders_rejected_total._vals = {}  # type: ignore[attr-defined]
+feature_artifact_write_total._vals = {}  # type: ignore[attr-defined]
+feature_artifact_hit_total._vals = {}  # type: ignore[attr-defined]
+feature_artifact_miss_total._vals = {}  # type: ignore[attr-defined]
 
 def record_order_published() -> None:
     w = _WORLD_ID
@@ -206,6 +245,27 @@ def record_order_rejected(reason: str) -> None:
     orders_rejected_total.labels(world_id=w, reason=reason).inc()
     key = (w, reason)
     orders_rejected_total._vals[key] = orders_rejected_total._vals.get(key, 0) + 1  # type: ignore[attr-defined]
+
+
+def observe_feature_artifact_write(factor: str, execution_domain: str) -> None:
+    f = str(factor)
+    d = str(execution_domain)
+    feature_artifact_write_total.labels(factor=f, execution_domain=d).inc()
+    feature_artifact_write_total._vals[(f, d)] = feature_artifact_write_total._vals.get((f, d), 0) + 1  # type: ignore[attr-defined]
+
+
+def observe_feature_artifact_hit(factor: str, execution_domain: str) -> None:
+    f = str(factor)
+    d = str(execution_domain)
+    feature_artifact_hit_total.labels(factor=f, execution_domain=d).inc()
+    feature_artifact_hit_total._vals[(f, d)] = feature_artifact_hit_total._vals.get((f, d), 0) + 1  # type: ignore[attr-defined]
+
+
+def observe_feature_artifact_miss(factor: str, execution_domain: str) -> None:
+    f = str(factor)
+    d = str(execution_domain)
+    feature_artifact_miss_total.labels(factor=f, execution_domain=d).inc()
+    feature_artifact_miss_total._vals[(f, d)] = feature_artifact_miss_total._vals.get((f, d), 0) + 1  # type: ignore[attr-defined]
 
 # ---------------------------------------------------------------------------
 # Alpha performance metrics
@@ -398,6 +458,18 @@ def reset_metrics() -> None:
     pretrade_rejections_total._vals = {}  # type: ignore[attr-defined]
     pretrade_rejection_ratio.clear()
     pretrade_rejection_ratio._vals = {}  # type: ignore[attr-defined]
+    orders_published_total.clear()
+    orders_published_total._vals = {}  # type: ignore[attr-defined]
+    fills_ingested_total.clear()
+    fills_ingested_total._vals = {}  # type: ignore[attr-defined]
+    orders_rejected_total.clear()
+    orders_rejected_total._vals = {}  # type: ignore[attr-defined]
+    feature_artifact_write_total.clear()
+    feature_artifact_write_total._vals = {}  # type: ignore[attr-defined]
+    feature_artifact_hit_total.clear()
+    feature_artifact_hit_total._vals = {}  # type: ignore[attr-defined]
+    feature_artifact_miss_total.clear()
+    feature_artifact_miss_total._vals = {}  # type: ignore[attr-defined]
     # Snapshot metrics reset
     try:
         snapshot_write_duration_ms.clear()  # type: ignore[attr-defined]

--- a/tests/sdk/test_feature_artifact_plane.py
+++ b/tests/sdk/test_feature_artifact_plane.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from qmtl.sdk.feature_store import FeatureStoreConfig
+from qmtl.sdk.node import Node, StreamInput
+from qmtl.sdk.runner import Runner
+from qmtl.sdk.strategy import Strategy
+
+
+def _make_strategy(call_log: list[str]):
+    class _Strategy(Strategy):
+        def setup(self) -> None:
+            source = StreamInput(tags=["price"], interval="1m", period=1)
+
+            def compute(cache_view):
+                call_log.append("compute")
+                seq = cache_view[source][source.interval]
+                ts, payload = seq.latest()
+                return {"ts": ts, "value": payload["price"] * 2}
+
+            feature = Node(
+                input=source,
+                compute_fn=compute,
+                interval="1m",
+                period=1,
+                feature_plane={
+                    "factor": "double_price",
+                    "instrument": "BTC-USD",
+                    "params": {"window": 1},
+                },
+            )
+            self.source = source
+            self.feature = feature
+            self.add_nodes([source, feature])
+
+    return _Strategy
+
+
+@pytest.fixture(autouse=True)
+def _reset_feature_store(tmp_path: pathlib.Path):
+    Runner.reset_feature_store()
+    Runner.configure_feature_store(FeatureStoreConfig(base_path=str(tmp_path)))
+    yield
+    Runner.reset_feature_store()
+
+
+def test_feature_artifact_reused_across_domains():
+    dataset_fp = "lake:blake3:test"
+    timestamp = 600
+
+    backtest_calls: list[str] = []
+    BacktestStrategy = _make_strategy(backtest_calls)
+    strategy_back = Runner._prepare(BacktestStrategy)
+    source_back = strategy_back.source
+    feature_back = strategy_back.feature
+
+    with Runner.feature_context(
+        execution_domain="backtest", dataset_fingerprint=dataset_fp, world_id="w"
+    ):
+        result_back = Runner.feed_queue_data(
+            feature_back,
+            source_back.node_id,
+            source_back.interval,
+            timestamp,
+            {"price": 5.0},
+        )
+
+    assert backtest_calls == ["compute"]
+    assert result_back == {"ts": timestamp, "value": 10.0}
+
+    store = Runner.get_feature_store()
+    assert store is not None
+
+    live_calls: list[str] = []
+    LiveStrategy = _make_strategy(live_calls)
+    strategy_live = Runner._prepare(LiveStrategy)
+    source_live = strategy_live.source
+    feature_live = strategy_live.feature
+
+    with Runner.feature_context(
+        execution_domain="live", dataset_fingerprint=dataset_fp, world_id="w"
+    ):
+        result_live = Runner.feed_queue_data(
+            feature_live,
+            source_live.node_id,
+            source_live.interval,
+            timestamp,
+            {"price": 1000.0},
+        )
+
+    # Live domain should reuse the backtest artifact and skip compute
+    assert live_calls == []
+    assert result_live == {"ts": timestamp, "value": 10.0}


### PR DESCRIPTION
## Summary
- add the `qmtl.sdk.feature_store` package with configurable backends, retention hooks, and descriptors keyed on `(factor, interval, params, instrument, t, dataset_fingerprint)`
- teach the runner and cache pipeline to materialize feature artifacts in backtest/dryrun domains and reuse them read-only for live/shadow contexts while tracking metrics
- document the dual-plane workflow, dataset fingerprint pinning, and CLI/backfill usage, and cover reuse with a new SDK test

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout --with pytest-asyncio --with fakeredis --with jsonschema -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run --with pytest-asyncio --with fakeredis --with jsonschema --with pytest-xdist -m pytest -W error -n auto

Fixes #959

------
https://chatgpt.com/codex/tasks/task_e_68cfa2bd6a848329ba2d597a4dff899d