### PR TITLE
Add topic namespace plumbing

### DIFF
--- a/qmtl/dagmanager/cli.py
+++ b/qmtl/dagmanager/cli.py
@@ -63,11 +63,19 @@ class _MemQueue(QueueManager):
         version: str,
         *,
         dry_run: bool = False,
+        namespace: object | None = None,
     ) -> str:
-        key = (asset, node_type, code_hash, version, dry_run)
+        key = (asset, node_type, code_hash, version, dry_run, namespace)
         topic = self.topics.get(key)
         if not topic:
-            topic = topic_name(asset, node_type, code_hash, version, dry_run=dry_run)
+            topic = topic_name(
+                asset,
+                node_type,
+                code_hash,
+                version,
+                dry_run=dry_run,
+                namespace=namespace,
+            )
             self.topics[key] = topic
         return topic
 

--- a/qmtl/dagmanager/topic.py
+++ b/qmtl/dagmanager/topic.py
@@ -3,7 +3,91 @@ from __future__ import annotations
 """Utilities for Kafka topic naming and configuration."""
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Mapping
+import os
+
+
+_NAMESPACE_FLAG_ENV = "QMTL_ENABLE_TOPIC_NAMESPACE"
+
+
+def topic_namespace_enabled() -> bool:
+    """Return ``True`` when topic namespace prefixing is enabled."""
+
+    return os.getenv(_NAMESPACE_FLAG_ENV, "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _sanitize_namespace_segment(value: object) -> str:
+    """Return a Kafka-safe namespace segment."""
+
+    if not isinstance(value, str):
+        return ""
+    cleaned: list[str] = []
+    for ch in value.strip():
+        if ch.isalnum():
+            cleaned.append(ch.lower())
+        elif ch in {"-", "_"}:
+            cleaned.append(ch)
+        elif ch == ".":
+            # Dots separate segments; normalise to hyphen inside a segment
+            cleaned.append("-")
+        else:
+            cleaned.append("-")
+    result = "".join(cleaned).strip("-_")
+    return result
+
+
+def _sanitize_namespace(value: object) -> str | None:
+    if isinstance(value, str):
+        parts = [_sanitize_namespace_segment(part) for part in value.split(".")]
+    elif isinstance(value, Mapping):
+        world = value.get("world") or value.get("world_id")
+        domain = value.get("domain") or value.get("execution_domain")
+        parts = [_sanitize_namespace_segment(world), _sanitize_namespace_segment(domain)]
+    else:
+        return None
+    filtered = [part for part in parts if part]
+    if not filtered:
+        return None
+    return ".".join(filtered)
+
+
+def build_namespace(world: object | None, domain: object | None) -> str | None:
+    """Return ``"world.domain"`` namespace when both segments are valid."""
+
+    world_part = _sanitize_namespace_segment(world)
+    domain_part = _sanitize_namespace_segment(domain)
+    if not world_part or not domain_part:
+        return None
+    return f"{world_part}.{domain_part}"
+
+
+def normalize_namespace(namespace: object | None) -> str | None:
+    """Normalise namespace input (string or mapping) to ``world.domain``."""
+
+    if namespace is None:
+        return None
+    if isinstance(namespace, Mapping):
+        return build_namespace(
+            namespace.get("world") or namespace.get("world_id"),
+            namespace.get("domain") or namespace.get("execution_domain"),
+        )
+    return _sanitize_namespace(namespace)
+
+
+def ensure_namespace(topic: str, namespace: object | None) -> str:
+    """Return ``topic`` prefixed with ``namespace`` when provided."""
+
+    normalized = normalize_namespace(namespace)
+    if not normalized:
+        return topic
+    prefix = f"{normalized}."
+    if topic.startswith(prefix):
+        return topic
+    return prefix + topic
 
 
 @dataclass(frozen=True)
@@ -28,6 +112,7 @@ def topic_name(
     *,
     dry_run: bool = False,
     existing: Iterable[str] | None = None,
+    namespace: object | None = None,
 ) -> str:
     """Return unique topic name per spec.
 
@@ -43,13 +128,15 @@ def topic_name(
     # First try by growing the short hash up to the full hash length
     while length <= len(code_hash):
         short_hash = code_hash[:length]
-        name = f"{asset}_{node_type}_{short_hash}_{version}{suffix}"
+        base = f"{asset}_{node_type}_{short_hash}_{version}{suffix}"
+        name = ensure_namespace(base, namespace)
         if name not in taken:
             return name
         length += 2
 
     # Fall back to numeric suffix if all hash-length attempts collide
     base = f"{asset}_{node_type}_{code_hash}_{version}{suffix}"
+    base = ensure_namespace(base, namespace)
     if base not in taken:
         return base
     for n in range(1, 10000):
@@ -68,4 +155,12 @@ def get_config(topic_type: str) -> TopicConfig:
         raise ValueError(f"unknown topic type: {topic_type}")
 
 
-__all__ = ["TopicConfig", "topic_name", "get_config"]
+__all__ = [
+    "TopicConfig",
+    "topic_name",
+    "get_config",
+    "topic_namespace_enabled",
+    "build_namespace",
+    "normalize_namespace",
+    "ensure_namespace",
+]

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -193,28 +193,35 @@ def create_api_router(
         node_ids: list[str] = []
         queries: list[Coroutine[Any, Any, list[str]]] = []
         query_targets: list[tuple[str, str | None]] = []  # (node_id, world_id)
+        exec_domain: str | None = None
+        if isinstance(payload.meta, dict):
+            raw_domain = payload.meta.get("execution_domain")
+            if isinstance(raw_domain, str) and raw_domain.strip():
+                exec_domain = raw_domain.strip()
+
         for node in dag.get("nodes", []):
-            if node.get("node_type") == "TagQueryNode":
-                tags = node.get("tags", [])
-                interval = int(node.get("interval", 0))
-                match_mode = node.get("match_mode", "any")
-                nid = node["node_id"]
-                node_ids.append(nid)
-                if worlds:
-                    for w in worlds:
-                        queries.append(
-                            dagmanager.get_queues_by_tag(
-                                tags, interval, match_mode, w
-                            )
-                        )
-                        query_targets.append((nid, w))
-                else:
+            if node.get("node_type") != "TagQueryNode":
+                continue
+            tags = node.get("tags", [])
+            interval = int(node.get("interval", 0))
+            match_mode = node.get("match_mode", "any")
+            nid = node["node_id"]
+            node_ids.append(nid)
+            if worlds:
+                for w in worlds:
                     queries.append(
                         dagmanager.get_queues_by_tag(
-                            tags, interval, match_mode, payload.world_id
+                            tags, interval, match_mode, w, exec_domain
                         )
                     )
-                    query_targets.append((nid, payload.world_id))
+                    query_targets.append((nid, w))
+            else:
+                queries.append(
+                    dagmanager.get_queues_by_tag(
+                        tags, interval, match_mode, payload.world_id, exec_domain
+                    )
+                )
+                query_targets.append((nid, payload.world_id))
 
         results = []
         if queries:
@@ -344,14 +351,14 @@ def create_api_router(
                         for w in worlds:
                             queries.append(
                                 dagmanager.get_queues_by_tag(
-                                    tags, interval, match_mode, w
+                                    tags, interval, match_mode, w, exec_domain
                                 )
                             )
                             query_targets.append((nid, w))
                     else:
                         queries.append(
                             dagmanager.get_queues_by_tag(
-                                tags, interval, match_mode, payload.world_id
+                                tags, interval, match_mode, payload.world_id, exec_domain
                             )
                         )
                         query_targets.append((nid, payload.world_id))

--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -26,6 +26,7 @@ from .history_loader import HistoryLoader
 from . import runtime, metrics as sdk_metrics
 from .http import HttpPoster
 from . import snapshot as snap
+from qmtl.dagmanager.topic import build_namespace, topic_namespace_enabled
 
 try:  # Optional aiokafka dependency
     from aiokafka import AIOKafkaConsumer  # type: ignore
@@ -599,12 +600,39 @@ class Runner:
             dag = strategy.serialize()
             logger.info("Sending DAG to service: %s", [n["node_id"] for n in dag["nodes"]])
 
+            dag_meta = dag.setdefault("meta", {}) if isinstance(dag, dict) else {}
+            meta_payload = dict(meta) if isinstance(meta, dict) else None
+            execution_domain: str | None = None
+            if isinstance(meta_payload, dict):
+                raw_domain = meta_payload.get("execution_domain")
+                if isinstance(raw_domain, str) and raw_domain.strip():
+                    execution_domain = raw_domain.strip()
+
+            if topic_namespace_enabled():
+                if execution_domain is None:
+                    if offline:
+                        execution_domain = "backtest"
+                    else:
+                        execution_domain = "live" if Runner._trade_mode == "live" else "dryrun"
+                namespace = build_namespace(world_id, execution_domain)
+                if namespace:
+                    if isinstance(dag_meta, dict):
+                        dag_meta["topic_namespace"] = {
+                            "world": world_id,
+                            "domain": execution_domain,
+                        }
+                    if meta_payload is None:
+                        meta_payload = {}
+                    meta_payload.setdefault("execution_domain", execution_domain)
+
+            meta_for_gateway = meta_payload if meta_payload is not None else meta
+
             queue_map = {}
             if gateway_url:
                 queue_map = await Runner._gateway_client.post_strategy(
                     gateway_url=gateway_url,
                     dag=dag,
-                    meta=meta,
+                    meta=meta_for_gateway,
                     world_id=world_id,
                 )
                 if isinstance(queue_map, dict) and "error" in queue_map:

--- a/tests/e2e/test_world_isolation.py
+++ b/tests/e2e/test_world_isolation.py
@@ -31,10 +31,12 @@ async def test_world_isolation(monkeypatch):
         self._tag_stub = StubTagStub()
 
     monkeypatch.setattr(DagManagerClient, "_ensure_channel", fake_ensure)
-    q1 = await client.get_queues_by_tag(["t"], 60, world_id="w1")
-    q2 = await client.get_queues_by_tag(["t"], 60, world_id="w2")
-    assert q1[0]["queue"] == "w/w1/base"
-    assert q2[0]["queue"] == "w/w2/base"
+    monkeypatch.setenv("QMTL_ENABLE_TOPIC_NAMESPACE", "1")
+
+    q1 = await client.get_queues_by_tag(["t"], 60, world_id="w1", execution_domain="dryrun")
+    q2 = await client.get_queues_by_tag(["t"], 60, world_id="w2", execution_domain="dryrun")
+    assert q1[0]["queue"] == "w1.dryrun.base"
+    assert q2[0]["queue"] == "w2.dryrun.base"
     await client.close()
 
     # 활성 이벤트가 세계마다 독립적으로 처리된다

--- a/tests/gateway/test_dry_run_parity.py
+++ b/tests/gateway/test_dry_run_parity.py
@@ -35,7 +35,9 @@ class DummyDagClient:
             ]
         }
 
-    async def get_queues_by_tag(self, tags, interval, match_mode="any", world_id=None):
+    async def get_queues_by_tag(
+        self, tags, interval, match_mode="any", world_id=None, execution_domain=None
+    ):
         # Mirror the diff-produced topics
         return list(self._queues.get(_TAGQUERY_NODE_ID, []))
 

--- a/tests/gateway/test_queue_update_ws_execution.py
+++ b/tests/gateway/test_queue_update_ws_execution.py
@@ -8,7 +8,9 @@ from qmtl.sdk.tagquery_manager import TagQueryManager
 
 
 class DummyDag:
-    async def get_queues_by_tag(self, tags, interval, match_mode="any", world_id=None):
+    async def get_queues_by_tag(
+        self, tags, interval, match_mode="any", world_id=None, execution_domain=None
+    ):
         return []
 
 

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -78,9 +78,9 @@ class DummyDag(DagManagerClient):
         self.called_with = None
 
     async def get_queues_by_tag(
-        self, tags, interval, match_mode="any", world_id=None
+        self, tags, interval, match_mode="any", world_id=None, execution_domain=None
     ):
-        self.called_with = (tags, interval, match_mode, world_id)
+        self.called_with = (tags, interval, match_mode, world_id, execution_domain)
         return [{"queue": "q1", "global": False}, {"queue": "q2", "global": False}]
 
 
@@ -104,7 +104,7 @@ def test_queues_by_tag_route(client):
         {"queue": "q1", "global": False},
         {"queue": "q2", "global": False},
     ]
-    assert dag.called_with == (["t1", "t2"], 60, "any", None)
+    assert dag.called_with == (["t1", "t2"], 60, "any", None, None)
 
 
 def test_queues_by_tag_route_all_mode(client):
@@ -118,7 +118,7 @@ def test_queues_by_tag_route_all_mode(client):
         {"queue": "q1", "global": False},
         {"queue": "q2", "global": False},
     ]
-    assert dag.called_with == (["t1", "t2"], 60, "all", None)
+    assert dag.called_with == (["t1", "t2"], 60, "all", None, None)
 
 
 def test_submit_tag_query_node(client):
@@ -151,7 +151,7 @@ def test_submit_tag_query_node(client):
             {"queue": "q2", "global": False},
         ]
     }
-    assert dag.called_with == (["t1"], 60, "any", None)
+    assert dag.called_with == (["t1"], 60, "any", None, None)
 
 
 def test_multiple_tag_query_nodes_handle_errors(fake_redis):
@@ -161,9 +161,9 @@ def test_multiple_tag_query_nodes_handle_errors(fake_redis):
             self.calls = []
 
         async def get_queues_by_tag(
-            self, tags, interval, match_mode="any", world_id=None
+            self, tags, interval, match_mode="any", world_id=None, execution_domain=None
         ):
-            self.calls.append((tags, interval, match_mode, world_id))
+            self.calls.append((tags, interval, match_mode, world_id, execution_domain))
             if "bad" in tags:
                 raise RuntimeError("boom")
             return [{"queue": f"{tags[0]}_q", "global": False}]

--- a/tests/gateway/test_ws_evt_initial_snapshot.py
+++ b/tests/gateway/test_ws_evt_initial_snapshot.py
@@ -30,7 +30,7 @@ class StubWorldClient:
 
 class StubDagManager:
     async def get_queues_by_tag(
-        self, tags, interval, match_mode="any", world_id=None
+        self, tags, interval, match_mode="any", world_id=None, execution_domain=None
     ):
         return ["q1", "q2"]
 

--- a/tests/tagquery/test_runner_live_updates.py
+++ b/tests/tagquery/test_runner_live_updates.py
@@ -17,7 +17,9 @@ async def wait_for(condition, timeout: float = 1.0) -> None:
 
 
 class DummyDag:
-    async def get_queues_by_tag(self, tags, interval, match_mode="any", world_id=None):
+    async def get_queues_by_tag(
+        self, tags, interval, match_mode="any", world_id=None, execution_domain=None
+    ):
         return []
 
 

--- a/tests/test_diff_service.py
+++ b/tests/test_diff_service.py
@@ -55,9 +55,13 @@ class FakeQueue(QueueManager):
     def __init__(self):
         self.calls = []
 
-    def upsert(self, asset, node_type, code_hash, version, *, dry_run=False):
-        self.calls.append((asset, node_type, code_hash, version, dry_run))
-        return topic_name(asset, node_type, code_hash, version, dry_run=dry_run)
+    def upsert(
+        self, asset, node_type, code_hash, version, *, dry_run=False, namespace=None
+    ):
+        self.calls.append((asset, node_type, code_hash, version, dry_run, namespace))
+        return topic_name(
+            asset, node_type, code_hash, version, dry_run=dry_run, namespace=namespace
+        )
 
 
 class FakeStream(StreamSender):
@@ -171,7 +175,59 @@ def test_hash_compare_and_queue_upsert():
     expected_b = topic_name("asset", "N", "c2", "v1")
     assert chunk.queue_map[partition_key("A", None, None)] == expected_a
     assert chunk.queue_map[partition_key("B", None, None)] == expected_b
-    assert queue.calls == [("asset", "N", "c2", "v1", False)]
+    assert queue.calls == [("asset", "N", "c2", "v1", False, None)]
+
+
+def test_namespace_applied_to_queue_names(monkeypatch):
+    repo = FakeRepo()
+    repo.records["A"] = NodeRecord(
+        "A",
+        "N",
+        "c1",
+        "s1",
+        "id1",
+        None,
+        None,
+        [],
+        None,
+        False,
+        topic_name("asset", "N", "c1", "v1"),
+    )
+    queue = FakeQueue()
+    stream = FakeStream()
+    service = DiffService(repo, queue, stream)
+
+    dag = json.dumps(
+        {
+            "nodes": [
+                {
+                    "node_id": "A",
+                    "node_type": "N",
+                    "code_hash": "c1",
+                    "schema_hash": "s1",
+                },
+                {
+                    "node_id": "B",
+                    "node_type": "N",
+                    "code_hash": "c2",
+                    "schema_hash": "s2",
+                },
+            ],
+            "meta": {
+                "topic_namespace": {"world": "World-1", "domain": "Live"},
+            },
+        }
+    )
+
+    monkeypatch.setenv("QMTL_ENABLE_TOPIC_NAMESPACE", "1")
+
+    chunk = service.diff(DiffRequest(strategy_id="s", dag_json=dag))
+
+    existing_topic = chunk.queue_map[partition_key("A", None, None)]
+    new_topic = chunk.queue_map[partition_key("B", None, None)]
+    assert existing_topic.startswith("world-1.live.")
+    assert new_topic.startswith("world-1.live.")
+    assert queue.calls[-1][5] == "world-1.live"
 
 
 def test_schema_change_buffering_flag():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -38,12 +38,18 @@ class FakeRepo(NodeRepository):
 
 
 class FakeQueue(QueueManager):
-    def upsert(self, asset, node_type, code_hash, version, *, dry_run=False):
-        return topic_name(asset, node_type, code_hash, version, dry_run=dry_run)
+    def upsert(
+        self, asset, node_type, code_hash, version, *, dry_run=False, namespace=None
+    ):
+        return topic_name(
+            asset, node_type, code_hash, version, dry_run=dry_run, namespace=namespace
+        )
 
 
 class FailingQueue(QueueManager):
-    def upsert(self, asset, node_type, code_hash, version, *, dry_run=False):
+    def upsert(
+        self, asset, node_type, code_hash, version, *, dry_run=False, namespace=None
+    ):
         raise RuntimeError("fail")
 
 

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -36,6 +36,17 @@ def test_topic_name_generation():
     )
     assert sim.endswith("_sim")
 
+
+def test_topic_name_with_namespace():
+    name = topic_name(
+        "btc",
+        "Indicator",
+        "abcdef123456",
+        "v1",
+        namespace={"world": "W1", "domain": "Live"},
+    )
+    assert name.startswith("w1.live.")
+
 def test_topic_config_values():
     config = get_config("raw")
     assert config == TopicConfig(partitions=3, replication_factor=3, retention_ms=7 * 24 * 60 * 60 * 1000)

--- a/tests/test_world_scope.py
+++ b/tests/test_world_scope.py
@@ -22,8 +22,10 @@ async def test_world_scoping_topics(monkeypatch):
         self._tag_stub = StubTagStub()
     monkeypatch.setattr(DagManagerClient, "_ensure_channel", fake_ensure)
 
-    q1 = await client.get_queues_by_tag(["t"], 60, world_id="w1")
-    q2 = await client.get_queues_by_tag(["t"], 60, world_id="w2")
-    assert q1[0]["queue"] == "w/w1/base"
-    assert q2[0]["queue"] == "w/w2/base"
+    monkeypatch.setenv("QMTL_ENABLE_TOPIC_NAMESPACE", "1")
+
+    q1 = await client.get_queues_by_tag(["t"], 60, world_id="w1", execution_domain="dryrun")
+    q2 = await client.get_queues_by_tag(["t"], 60, world_id="w2", execution_domain="dryrun")
+    assert q1[0]["queue"] == "w1.dryrun.base"
+    assert q2[0]["queue"] == "w2.dryrun.base"
     await client.close()


### PR DESCRIPTION
## Summary
- add topic namespace utilities and env flag helpers for Kafka topic naming
- propagate namespace metadata through the runner, gateway client, and diff service so queue creation respects world/domain prefixes
- update gateway and DAG manager tests to assert the new `{world}.{domain}.topic` convention

## Testing
- uv run -m pytest tests/dagmanager/test_in_memory_admin.py
- uv run -m pytest -W error -n auto

Fixes #954

------
https://chatgpt.com/codex/tasks/task_e_68cfa2ad8cac8329bb841ee19367a156