### PR TITLE
Include compute context in commit-log message keys

### DIFF
--- a/tests/gateway/test_commit_log_flow.py
+++ b/tests/gateway/test_commit_log_flow.py
@@ -1,5 +1,6 @@
 import pytest
 
+from qmtl.dagmanager.kafka_admin import compute_key
 from qmtl.gateway import metrics
 from qmtl.gateway.commit_log import CommitLogWriter
 from qmtl.gateway.commit_log_consumer import CommitLogConsumer
@@ -63,7 +64,12 @@ async def test_commit_log_end_to_end() -> None:
     writer = CommitLogWriter(producer, "commit-log")
 
     # duplicate record within a batch
-    await writer.publish_bucket(100, 60, [("n1", "h1", {"a": 1}), ("n1", "h1", {"a": 2})])
+    ck = compute_key("n1")
+    await writer.publish_bucket(
+        100,
+        60,
+        [("n1", "h1", {"a": 1}, ck), ("n1", "h1", {"a": 2}, ck)],
+    )
 
     # consumer reads messages produced above
     batch = [_FakeMessage(value) for _, _, value in producer.messages]

--- a/tests/gateway/test_commit_log_headers.py
+++ b/tests/gateway/test_commit_log_headers.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 
+from qmtl.dagmanager.kafka_admin import compute_key
 from qmtl.gateway.commit_log import CommitLogWriter
 
 
@@ -24,7 +25,7 @@ class ProducerWithHeaders:
 async def test_commit_log_writer_attaches_runtime_fingerprint_header():
     p = ProducerWithHeaders()
     w = CommitLogWriter(p, "t")
-    await w.publish_bucket(100, 60, [("n1", "h1", {"x": 1})])
+    await w.publish_bucket(100, 60, [("n1", "h1", {"x": 1}, compute_key("n1"))])
     assert p.committed == 1
     assert p.records and isinstance(p.records[-1][3], list)
     headers = dict((k, v) for k, v in p.records[-1][3] or [])

--- a/tests/gateway/test_commit_log_soak.py
+++ b/tests/gateway/test_commit_log_soak.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 
+from qmtl.dagmanager.kafka_admin import compute_key
 from qmtl.gateway import metrics
 from qmtl.gateway.commit_log import CommitLogWriter
 from qmtl.gateway.commit_log_consumer import CommitLogConsumer
@@ -52,7 +53,12 @@ async def test_commit_log_exactly_once_soak():
     w = CommitLogWriter(p, "t")
     n = 100
     # produce duplicates for the same (node, bucket, input_hash)
-    await w.publish_bucket(100, 60, [("n1", "ih", {"v": i % 3}) for i in range(n)])
+    ck = compute_key("n1")
+    await w.publish_bucket(
+        100,
+        60,
+        [("n1", "ih", {"v": i % 3}, ck) for i in range(n)],
+    )
 
     batch = [_M(v) for (_, _, v, _) in p.buf]
     # consumer

--- a/tests/gateway/test_worker_ownership_metrics.py
+++ b/tests/gateway/test_worker_ownership_metrics.py
@@ -14,7 +14,7 @@ from qmtl.gateway.ownership import OwnershipManager
 from qmtl.gateway.redis_queue import RedisTaskQueue
 from qmtl.gateway.worker import StrategyWorker
 from qmtl.gateway.fsm import StrategyFSM
-from qmtl.dagmanager.kafka_admin import partition_key
+from qmtl.dagmanager.kafka_admin import partition_key, compute_key
 
 
 class FakeConn:
@@ -136,7 +136,11 @@ async def test_two_workers_single_commit_no_duplicates() -> None:
         try:
             start.set()
             await finish.wait()
-            await writer.publish_bucket(100, 60, [("n1", "h1", {"a": 1})])
+            await writer.publish_bucket(
+                100,
+                60,
+                [("n1", "h1", {"a": 1}, compute_key("n1"))],
+            )
             return True
         finally:
             await manager.release(key)


### PR DESCRIPTION
## Summary
- add compute-key aware partition key handling in `CommitLogWriter`
- propagate compute context hints when pipeline nodes publish commit-log data
- update commit-log related tests to exercise salted keys per compute context

## Testing
- uv run -m pytest -W error -n auto tests/gateway/test_commit_log_writer.py tests/gateway/test_commit_log_flow.py tests/gateway/test_commit_log_headers.py tests/gateway/test_commit_log_soak.py tests/gateway/test_worker_ownership_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68cfae20e0a483299d1168ad788778e3