### PR TITLE
Implement feature artifact plane for SDK

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -137,6 +137,9 @@ sequenceDiagram
 - 공유 원칙: 도메인 간 공유는 Feature Artifact 파일만 읽기 전용으로 허용한다(SHALL). 런타임 캐시(ComputeKey 기반)나 상태는 도메인 간 공유가 금지된다.
 - Retention/Backfill: 아티팩트는 버전 관리되며, 백테스트/리플레이 요구에 맞춰 보존 정책과 백필 경로를 문서화한다(SHOULD). 삭제 전에는 소비자 영향도를 평가한다.
 - ComputeKey 연계: 런타임에서 캐시 히트가 발생하면 `ComputeKey`는 현 도메인의 값만 참조해야 하며, Feature Artifact는 입력 창구로만 사용한다.
+- 구현 상태: SDK Runner는 `qmtl.sdk.feature_store` 계층(FileSystem 기본 어댑터, `QMTL_FEATURE_ARTIFACT_DIR` · `QMTL_FEATURE_ARTIFACT_VERSIONS` 환경변수 지원)을 통해 백테스트/드라이런 도메인에서 자동으로 아티팩트를 기록하고, `CacheView.feature_artifacts()`로 라이브/섀도우 도메인에서 읽기 전용 소비를 보장한다.
+- Dataset Fingerprint: 모든 아티팩트·스냅샷은 `dataset_fingerprint`에 고정된다. Fingerprint가 일치하지 않으면 하이드레이션/조회가 차단되어 프로모션 경로에서 데이터 혼합을 방지한다.
+- CLI/Backfill 워크플로: 로컬 백필 시 `QMTL_FEATURE_ARTIFACT_DIR=/mnt/artifacts`처럼 경로를 고정하고, 필요 시 `QMTL_FEATURE_ARTIFACT_WRITE_DOMAINS`로 쓰기 허용 도메인을 제한하여 리플레이와 검증 파이프라인을 분리한다.
 
 ### 1.5 Clock & Input Guards
 

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -338,6 +338,7 @@ def create_api_router(
             worlds = [payload.world_id]
 
         compute_ctx = _extract_compute_context(payload)
+        exec_domain = compute_ctx.get("execution_domain")
 
         # Preferred path: use diff to compute sentinel and queue mapping
         sentinel_id = ""

--- a/qmtl/sdk/cache_view.py
+++ b/qmtl/sdk/cache_view.py
@@ -21,6 +21,7 @@ class CacheView:
         data: Any,
         *,
         track_access: bool = False,
+        artifact_plane: Any | None = None,
         access_log: list[tuple[str, int]] | None = None,
         path: tuple[Any, ...] = (),
     ) -> None:
@@ -28,6 +29,7 @@ class CacheView:
         self._track_access = track_access
         self._access_log = access_log if access_log is not None else []
         self._path = path
+        self._artifact_plane = artifact_plane
 
     def __getitem__(self, key: Any) -> Any:
         # Use direct attribute access to avoid any accidental recursion
@@ -54,6 +56,7 @@ class CacheView:
                 return CacheView(
                     value,
                     track_access=self._track_access,
+                    artifact_plane=self._artifact_plane,
                     access_log=self._access_log,
                     path=new_path,
                 )
@@ -62,6 +65,7 @@ class CacheView:
                 return CacheView(
                     value,
                     track_access=self._track_access,
+                    artifact_plane=self._artifact_plane,
                     access_log=self._access_log,
                     path=new_path,
                 )
@@ -109,3 +113,25 @@ class CacheView:
     def access_log(self) -> list[tuple[str, int]]:
         """Return list of accessed ``(upstream_id, interval)`` pairs."""
         return list(self._access_log)
+
+    # ------------------------------------------------------------------
+    def feature_artifacts(
+        self,
+        factor: Any,
+        *,
+        instrument: str | None = None,
+        dataset_fingerprint: str | None = None,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> list[tuple[int, Any]]:
+        """Return immutable feature artifacts for ``factor`` when available."""
+
+        if self._artifact_plane is None:
+            return []
+        return self._artifact_plane.load_series(
+            factor,
+            instrument=instrument,
+            dataset_fingerprint=dataset_fingerprint,
+            start=start,
+            end=end,
+        )

--- a/qmtl/sdk/feature_store/__init__.py
+++ b/qmtl/sdk/feature_store/__init__.py
@@ -1,0 +1,10 @@
+from .base import FeatureArtifactKey, FeatureStoreBackend
+from .filesystem import FileSystemFeatureStore
+from .plane import FeatureArtifactPlane
+
+__all__ = [
+    "FeatureArtifactKey",
+    "FeatureStoreBackend",
+    "FileSystemFeatureStore",
+    "FeatureArtifactPlane",
+]

--- a/qmtl/sdk/feature_store/base.py
+++ b/qmtl/sdk/feature_store/base.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Interfaces and key definitions for the Feature Artifact Plane."""
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Protocol
+
+
+@dataclass(frozen=True)
+class FeatureArtifactKey:
+    """Uniquely identify an immutable feature artifact."""
+
+    factor: str
+    interval: int
+    params: str
+    instrument: str
+    timestamp: int
+    dataset_fingerprint: str
+    version: int = 1
+
+
+class FeatureStoreBackend(Protocol):
+    """Storage backend contract for feature artifacts."""
+
+    def write(self, key: FeatureArtifactKey, payload: Any) -> None:
+        """Persist ``payload`` under ``key``."""
+
+    def load_series(
+        self,
+        *,
+        factor: str,
+        interval: int,
+        params: str,
+        instrument: str,
+        dataset_fingerprint: str,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> list[tuple[int, Any]]:
+        """Return artifacts ordered by timestamp."""
+
+    def list_instruments(
+        self,
+        *,
+        factor: str,
+        params: str,
+        dataset_fingerprint: str,
+    ) -> Iterable[str]:
+        """Return known instruments for the given factor."""
+
+    def count(
+        self,
+        *,
+        factor: str,
+        interval: int,
+        params: str,
+        instrument: str,
+        dataset_fingerprint: str,
+    ) -> int:
+        """Return number of stored artifacts for the selection."""

--- a/qmtl/sdk/feature_store/filesystem.py
+++ b/qmtl/sdk/feature_store/filesystem.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+"""Filesystem-backed Feature Artifact storage."""
+
+import base64
+import json
+import os
+import pickle
+import threading
+from pathlib import Path
+from typing import Any, Iterable
+
+from .base import FeatureArtifactKey, FeatureStoreBackend
+
+
+def _sanitize_component(value: str) -> str:
+    value = value.strip()
+    if not value:
+        return "_"
+    banned = {"/", "\\", ".."}
+    if value in banned:
+        return "_"
+    return "".join(c if c.isalnum() or c in {"-", "_", "."} else "_" for c in value)
+
+
+class FileSystemFeatureStore(FeatureStoreBackend):
+    """Simple JSONL + pickle filesystem implementation."""
+
+    def __init__(self, base_dir: str | os.PathLike[str], *, max_versions: int | None = None) -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.max_versions = max_versions
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    def _artifact_dir(self, key: FeatureArtifactKey) -> Path:
+        parts = [
+            _sanitize_component(key.factor),
+            _sanitize_component(key.dataset_fingerprint),
+            _sanitize_component(key.params),
+            _sanitize_component(key.instrument),
+            str(int(key.interval)),
+        ]
+        path = self.base_dir.joinpath(*parts)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _payload_to_record(self, key: FeatureArtifactKey, payload: Any) -> dict[str, Any]:
+        blob = pickle.dumps(payload)
+        encoded = base64.b64encode(blob).decode()
+        return {
+            "t": int(key.timestamp),
+            "version": int(key.version),
+            "payload": encoded,
+        }
+
+    def _read_records(self, path: Path) -> list[dict[str, Any]]:
+        if not path.exists():
+            return []
+        records: list[dict[str, Any]] = []
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            records.append(obj)
+        return records
+
+    def _write_records(self, path: Path, records: list[dict[str, Any]]) -> None:
+        payload = "\n".join(json.dumps(r, sort_keys=True) for r in records)
+        path.write_text(payload + ("\n" if payload else ""))
+
+    def _enforce_retention(self, path: Path) -> None:
+        if self.max_versions is None:
+            return
+        records = self._read_records(path)
+        if len(records) <= self.max_versions:
+            return
+        ordered = sorted(records, key=lambda r: r.get("t", 0))
+        keep = ordered[-self.max_versions :]
+        self._write_records(path, keep)
+
+    # ------------------------------------------------------------------
+    def write(self, key: FeatureArtifactKey, payload: Any) -> None:
+        target_dir = self._artifact_dir(key)
+        file_path = target_dir / "artifacts.jsonl"
+        record = self._payload_to_record(key, payload)
+        with self._lock:
+            existing = self._read_records(file_path)
+            existing.append(record)
+            existing.sort(key=lambda r: r.get("t", 0))
+            self._write_records(file_path, existing)
+            self._enforce_retention(file_path)
+
+    def load_series(
+        self,
+        *,
+        factor: str,
+        interval: int,
+        params: str,
+        instrument: str,
+        dataset_fingerprint: str,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> list[tuple[int, Any]]:
+        key = FeatureArtifactKey(
+            factor=factor,
+            interval=interval,
+            params=params,
+            instrument=instrument,
+            timestamp=0,
+            dataset_fingerprint=dataset_fingerprint,
+        )
+        file_path = self._artifact_dir(key) / "artifacts.jsonl"
+        records = self._read_records(file_path)
+        results: list[tuple[int, Any]] = []
+        for rec in records:
+            try:
+                ts = int(rec.get("t"))
+            except (TypeError, ValueError):
+                continue
+            if start is not None and ts < start:
+                continue
+            if end is not None and ts > end:
+                continue
+            payload_raw = rec.get("payload")
+            if not isinstance(payload_raw, str):
+                continue
+            try:
+                payload = pickle.loads(base64.b64decode(payload_raw))
+            except Exception:
+                continue
+            results.append((ts, payload))
+        results.sort(key=lambda item: item[0])
+        return results
+
+    def list_instruments(
+        self,
+        *,
+        factor: str,
+        params: str,
+        dataset_fingerprint: str,
+    ) -> Iterable[str]:
+        base = self.base_dir / _sanitize_component(factor) / _sanitize_component(dataset_fingerprint) / _sanitize_component(params)
+        if not base.exists():
+            return []
+        return [p.name for p in base.iterdir() if p.is_dir()]
+
+    def count(
+        self,
+        *,
+        factor: str,
+        interval: int,
+        params: str,
+        instrument: str,
+        dataset_fingerprint: str,
+    ) -> int:
+        key = FeatureArtifactKey(
+            factor=factor,
+            interval=interval,
+            params=params,
+            instrument=instrument,
+            timestamp=0,
+            dataset_fingerprint=dataset_fingerprint,
+        )
+        file_path = self._artifact_dir(key) / "artifacts.jsonl"
+        return len(self._read_records(file_path))

--- a/qmtl/sdk/feature_store/plane.py
+++ b/qmtl/sdk/feature_store/plane.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+"""High level helpers for interacting with feature artifact storage."""
+
+import logging
+import os
+from typing import Any, Iterable, Sequence
+
+from qmtl.common.compute_key import DEFAULT_EXECUTION_DOMAIN
+
+from .base import FeatureArtifactKey, FeatureStoreBackend
+from .filesystem import FileSystemFeatureStore
+
+logger = logging.getLogger(__name__)
+
+
+def _infer_instrument(payload: Any) -> str:
+    if isinstance(payload, dict):
+        for key in ("instrument", "symbol", "ticker"):
+            value = payload.get(key)
+            if value is not None:
+                return str(value)
+    for attr in ("instrument", "symbol", "ticker"):
+        if hasattr(payload, attr):
+            value = getattr(payload, attr)
+            if value is not None:
+                return str(value)
+    return "__default__"
+
+
+class FeatureArtifactPlane:
+    """Facade coordinating artifact writes and reads for the SDK."""
+
+    def __init__(
+        self,
+        backend: FeatureStoreBackend,
+        *,
+        write_domains: Iterable[str] | None = None,
+    ) -> None:
+        self.backend = backend
+        self.write_domains = {d for d in (write_domains or ("backtest", "dryrun"))}
+        self._dataset_fingerprint: str | None = None
+        self._execution_domain: str = DEFAULT_EXECUTION_DOMAIN
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_env(cls) -> FeatureArtifactPlane | None:
+        disabled = str(os.getenv("QMTL_FEATURE_ARTIFACTS", "")).strip().lower() in {
+            "0",
+            "false",
+            "off",
+            "no",
+        }
+        if disabled:
+            return None
+        base = os.getenv("QMTL_FEATURE_ARTIFACT_DIR", ".qmtl_feature_artifacts")
+        max_versions_env = os.getenv("QMTL_FEATURE_ARTIFACT_VERSIONS")
+        max_versions = None
+        if max_versions_env:
+            try:
+                max_versions = int(max_versions_env)
+            except ValueError:
+                logger.warning("invalid QMTL_FEATURE_ARTIFACT_VERSIONS value: %s", max_versions_env)
+        backend = FileSystemFeatureStore(base, max_versions=max_versions)
+        domains_env = os.getenv("QMTL_FEATURE_ARTIFACT_WRITE_DOMAINS")
+        domains: Sequence[str] | None = None
+        if domains_env:
+            domains = [d.strip() for d in domains_env.split(",") if d.strip()]
+        return cls(backend, write_domains=domains)
+
+    # ------------------------------------------------------------------
+    def configure(
+        self,
+        *,
+        dataset_fingerprint: str | None = None,
+        execution_domain: str | None = None,
+    ) -> None:
+        if dataset_fingerprint is not None:
+            self._dataset_fingerprint = dataset_fingerprint
+        if execution_domain is not None:
+            self._execution_domain = execution_domain or DEFAULT_EXECUTION_DOMAIN
+
+    # ------------------------------------------------------------------
+    def _resolve_factor(self, factor: Any) -> tuple[str, int, str]:
+        if hasattr(factor, "node_id"):
+            node = factor
+            factor_id = getattr(node, "node_id")
+            interval = int(getattr(node, "interval", 0) or 0)
+            params = getattr(node, "config_hash", "")
+        else:
+            raise ValueError("factor must be a Node when using artifact helpers")
+        return str(factor_id), interval, str(params)
+
+    def _resolve_dataset_fingerprint(self, factor: Any, override: str | None) -> str | None:
+        if override is not None:
+            return override
+        if hasattr(factor, "dataset_fingerprint"):
+            value = getattr(factor, "dataset_fingerprint")
+            if value:
+                return str(value)
+        return self._dataset_fingerprint
+
+    def load_series(
+        self,
+        factor: Any,
+        *,
+        instrument: str | None = None,
+        dataset_fingerprint: str | None = None,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> list[tuple[int, Any]]:
+        factor_id, interval, params = self._resolve_factor(factor)
+        dataset = self._resolve_dataset_fingerprint(factor, dataset_fingerprint)
+        if dataset is None:
+            return []
+        inst = instrument or "__default__"
+        return self.backend.load_series(
+            factor=factor_id,
+            interval=interval,
+            params=params,
+            instrument=inst,
+            dataset_fingerprint=dataset,
+            start=start,
+            end=end,
+        )
+
+    def list_instruments(
+        self,
+        factor: Any,
+        *,
+        dataset_fingerprint: str | None = None,
+    ) -> Iterable[str]:
+        factor_id, _interval, params = self._resolve_factor(factor)
+        dataset = self._resolve_dataset_fingerprint(factor, dataset_fingerprint)
+        if dataset is None:
+            return []
+        return self.backend.list_instruments(
+            factor=factor_id,
+            params=params,
+            dataset_fingerprint=dataset,
+        )
+
+    def count(
+        self,
+        factor: Any,
+        *,
+        instrument: str | None = None,
+        dataset_fingerprint: str | None = None,
+    ) -> int:
+        factor_id, interval, params = self._resolve_factor(factor)
+        dataset = self._resolve_dataset_fingerprint(factor, dataset_fingerprint)
+        if dataset is None:
+            return 0
+        inst = instrument or "__default__"
+        return self.backend.count(
+            factor=factor_id,
+            interval=interval,
+            params=params,
+            instrument=inst,
+            dataset_fingerprint=dataset,
+        )
+
+    # ------------------------------------------------------------------
+    def record(self, factor: Any, timestamp: int, payload: Any) -> None:
+        if payload is None:
+            return
+        try:
+            node = factor
+            enabled = bool(getattr(node, "enable_feature_artifacts", False))
+        except Exception:
+            enabled = False
+        if not enabled:
+            return
+        dataset = self._resolve_dataset_fingerprint(factor, None)
+        if not dataset:
+            return
+        node_domain = str(getattr(factor, "execution_domain", DEFAULT_EXECUTION_DOMAIN))
+        if self.write_domains and node_domain not in self.write_domains:
+            return
+        factor_id, interval, params = self._resolve_factor(factor)
+        instrument = _infer_instrument(payload)
+        key = FeatureArtifactKey(
+            factor=factor_id,
+            interval=interval,
+            params=params,
+            instrument=instrument,
+            timestamp=int(timestamp),
+            dataset_fingerprint=dataset,
+        )
+        try:
+            self.backend.write(key, payload)
+        except Exception:
+            logger.exception("failed to write feature artifact for factor %s", factor_id)
+

--- a/qmtl/sdk/snapshot.py
+++ b/qmtl/sdk/snapshot.py
@@ -151,6 +151,9 @@ def write_snapshot(node) -> Path | None:
         "created_at": int(time.time()),
         "format": os.getenv("QMTL_SNAPSHOT_FORMAT", "json").lower(),
     }
+    dataset_fp = getattr(node, "dataset_fingerprint", None)
+    if dataset_fp:
+        meta["dataset_fingerprint"] = str(dataset_fp)
     key = _node_key(node)
     fmt = meta["format"]
     # Prefer remote base when configured
@@ -289,6 +292,11 @@ def hydrate(node, *, strict_runtime: bool | None = None) -> bool:
                 continue
             if meta.get("schema_hash") != node.schema_hash:
                 continue
+            expected_df = getattr(node, "dataset_fingerprint", None)
+            if expected_df:
+                snap_df = meta.get("dataset_fingerprint")
+                if snap_df != expected_df:
+                    continue
             # Merge into cache preserving most recent
             for u, mp in data.items():
                 for interval_s, items in mp.items():

--- a/tests/sdk/test_feature_artifact_plane.py
+++ b/tests/sdk/test_feature_artifact_plane.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+import pytest
+
+from qmtl.sdk import Strategy, StreamInput, ProcessingNode
+from qmtl.sdk.runner import Runner
+from qmtl.sdk.feature_store import FeatureArtifactPlane, FileSystemFeatureStore
+
+
+class _ArtifactStrategy(Strategy):
+    def __init__(self, *, multiplier: float) -> None:
+        super().__init__()
+        self.multiplier = multiplier
+        self.src = None
+        self.factor = None
+        self.outputs: list[dict] = []
+
+    def setup(self) -> None:
+        self.src = StreamInput(interval=1, period=1)
+
+        def _compute(view):
+            series = view[self.src][self.src.interval]
+            if not series:
+                return None
+            ts, payload = series[-1]
+            artifacts = view.feature_artifacts(self.factor, instrument=payload["instrument"])
+            if artifacts:
+                value = artifacts[-1][1]
+            else:
+                value = {
+                    "instrument": payload["instrument"],
+                    "value": payload["value"] * self.multiplier,
+                }
+            self.outputs.append(value)
+            return value
+
+        self.factor = ProcessingNode(
+            input=self.src,
+            compute_fn=_compute,
+            name="factor",
+            interval=1,
+            period=1,
+        )
+        self.factor.enable_feature_artifacts = True
+        self.add_nodes([self.src, self.factor])
+
+
+@pytest.fixture
+def artifact_plane(tmp_path: Path):
+    base = tmp_path / "artifacts"
+    plane = FeatureArtifactPlane(FileSystemFeatureStore(base))
+    prev = Runner.feature_artifact_plane()
+    Runner.set_feature_artifact_plane(plane)
+    try:
+        yield plane
+    finally:
+        Runner.set_feature_artifact_plane(prev)
+
+def test_feature_artifacts_written_and_read(artifact_plane):
+    strategy = _ArtifactStrategy(multiplier=2.0)
+    strategy.setup()
+    strategy.factor.dataset_fingerprint = "lake:blake3:test"
+    strategy.factor.execution_domain = "backtest"
+    artifact_plane.configure(dataset_fingerprint="lake:blake3:test", execution_domain="backtest")
+
+    Runner.feed_queue_data(
+        strategy.src,
+        strategy.src.node_id,
+        strategy.src.interval,
+        1,
+        {"instrument": "BTC", "value": 10},
+    )
+    result = Runner.feed_queue_data(
+        strategy.factor,
+        strategy.src.node_id,
+        strategy.src.interval,
+        1,
+        {"instrument": "BTC", "value": 10},
+    )
+    assert result["value"] == 20
+    assert artifact_plane.count(strategy.factor, instrument="BTC") == 1
+    series = artifact_plane.load_series(strategy.factor, instrument="BTC")
+    assert series[-1][1]["value"] == 20
+
+
+def test_runner_reuses_artifacts_across_domains(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("QMTL_FEATURE_ARTIFACT_DIR", str(tmp_path / "plane"))
+    plane = FeatureArtifactPlane.from_env()
+    assert plane is not None
+    previous = Runner.feature_artifact_plane()
+    Runner.set_feature_artifact_plane(plane)
+
+    backtest = _ArtifactStrategy(multiplier=2.0)
+    backtest.setup()
+    backtest.factor.dataset_fingerprint = "lake:blake3:data"
+    backtest.factor.execution_domain = "backtest"
+    plane.configure(dataset_fingerprint="lake:blake3:data", execution_domain="backtest")
+
+    Runner.feed_queue_data(
+        backtest.src,
+        backtest.src.node_id,
+        backtest.src.interval,
+        1,
+        {"instrument": "ETH", "value": 5},
+    )
+    result = Runner.feed_queue_data(
+        backtest.factor,
+        backtest.src.node_id,
+        backtest.src.interval,
+        1,
+        {"instrument": "ETH", "value": 5},
+    )
+    assert result["value"] == 10
+    assert plane.count(backtest.factor, instrument="ETH") == 1
+
+    live = _ArtifactStrategy(multiplier=4.0)
+    live.setup()
+    live.factor.dataset_fingerprint = "lake:blake3:data"
+    live.factor.execution_domain = "live"
+    plane.configure(dataset_fingerprint="lake:blake3:data", execution_domain="live")
+
+    Runner.feed_queue_data(
+        live.src,
+        live.src.node_id,
+        live.src.interval,
+        1,
+        {"instrument": "ETH", "value": 5},
+    )
+    live_result = Runner.feed_queue_data(
+        live.factor,
+        live.src.node_id,
+        live.src.interval,
+        1,
+        {"instrument": "ETH", "value": 5},
+    )
+    assert live_result["value"] == 10
+    assert plane.count(live.factor, instrument="ETH") == 1
+    assert live.factor.cache._active_execution_domain == "live"
+    assert backtest.factor.cache._active_execution_domain == "backtest"
+
+    Runner.set_feature_artifact_plane(previous)

--- a/tests/test_arrow_cache.py
+++ b/tests/test_arrow_cache.py
@@ -116,5 +116,5 @@ def test_arrow_cache_compute_context_switch_records_metric():
     cache.append("u1", 60, 180, {"v": 3})
     assert cache.get_slice("u1", 60, count=2) == [(180, {"v": 3})]
 
-    key = ("node", "w", "live")
+    key = ("node", "w", "live", "__unset__", "__unset__")
     assert sdk_metrics.cross_context_cache_hit_total._vals.get(key) == 1

--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -181,7 +181,7 @@ def test_compute_context_switch_clears_cache_and_records_metric():
     Runner.feed_queue_data(node, "u1", 60, 180, {"v": 3})
     assert node.cache.get_slice("u1", 60, count=2) == [(180, {"v": 3})]
 
-    key = (node.node_id, "w", "live")
+    key = (node.node_id, "w", "live", "__unset__", "__unset__")
     assert sdk_metrics.cross_context_cache_hit_total._vals.get(key) == 1
 
 


### PR DESCRIPTION
## Summary
- add an SDK feature artifact plane with a filesystem backend and environment-driven configuration
- wire Runner and CacheView to record immutable feature artifacts, propagate dataset fingerprints, and tighten snapshot/metric isolation
- expand tests and docs covering artifact reuse and cross-context cache metrics

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #959

------
https://chatgpt.com/codex/tasks/task_e_68d022295fd4832993560894a468cc07