### PR TITLE
Plan world node domain migration and harden validation cache

### DIFF
--- a/docs/operations/neo4j_migrations.md
+++ b/docs/operations/neo4j_migrations.md
@@ -29,3 +29,58 @@ qmtl dagmanager neo4j-rollback \
 
 Use with caution in lower environments; production rollback should follow a controlled migration plan.
 
+## WorldNodeRef Domain Expansion (Backtest/Dryrun/Live Isolation)
+
+### Objective
+
+- Promote `execution_domain` to a first-class component of the `WorldNodeRef` composite key.
+- Allow multiple domain-scoped records per `(world_id, node_id)` without disrupting existing readers.
+
+### Zero-Downtime Approach
+
+1. **Deploy Read/Write Compatible Code**
+   - Ensure Gateway and WorldService nodes are running the release that understands multi-domain buckets. The in-memory `Storage` layer auto-normalises legacy payloads and defaults unknown domains to `live`.
+2. **Add/Update Neo4j Constraints**
+   - `CREATE CONSTRAINT world_node_ref_key IF NOT EXISTS
+     FOR (w:WorldNodeRef)
+     REQUIRE (w.world_id, w.node_id, w.execution_domain) IS UNIQUE;`
+   - Existing single-domain uniques (if any) can remain during the rollout; drop them only after backfill.
+3. **Backfill / Lazy Migration**
+   - _Lazy path_: allow traffic to touch existing nodes. The service converts legacy records (`execution_domain` missing) to the default `live` domain on read.
+   - _Backfill path_: run a Cypher job to clone each `WorldNodeRef` into explicit domain buckets:
+     ```cypher
+     MATCH (n:WorldNodeRef)
+     WHERE n.execution_domain IS NULL OR n.execution_domain = ""
+     SET n.execution_domain = "live";
+     ```
+   - For worlds that require pre-populated `backtest`/`dryrun` buckets, replay the Gateway "world node upsert" task per domain.
+4. **Validation**
+   - Sample `MATCH (n:WorldNodeRef) RETURN n.execution_domain, count(*) ORDER BY n.execution_domain;` to ensure the histogram aligns with expectations.
+
+### Rollback
+
+- Neo4j rollback remains `DROP CONSTRAINT world_node_ref_key IF EXISTS;` followed by restoring the prior snapshot.
+- Because the application tolerates missing `execution_domain`, the rollback is a metadata change; data remains valid.
+
+## EvalKey Recalculation Plan
+
+### Objective
+
+- Extend the validation cache key to include `execution_domain` for strict isolation.
+- Expire legacy entries hashed without the domain component.
+
+### Strategy
+
+1. **Deploy compatible services** that recompute EvalKeys using the new tuple `(node_id, world_id, execution_domain, contract_id, dataset_fingerprint, code_version, resource_policy)`.
+2. **Lazy invalidation**
+   - During lookup the service rehashes the context; mismatched keys are dropped and the caller re-runs validation.
+   - Tests cover this path via `tests/worldservice/test_validation_cache.py::test_validation_cache_legacy_payloads_are_normalised_and_invalidated`.
+3. **Optional proactive purge**
+   - `MATCH (v:Validation) REMOVE v.eval_key_without_domain;` if a transitional property exists.
+   - To force re-validation immediately, delete the `Validation` nodes: `MATCH (v:Validation) WHERE v.version < $cutover REMOVE v` (adjust predicate to local schema).
+
+### Verification
+
+- Monitor the validation cache miss metrics; a spike is expected during rollout and should converge as caches repopulate.
+- Confirm new entries have the `execution_domain` field present in Neo4j snapshots.
+


### PR DESCRIPTION
## Summary
- normalise legacy validation cache payloads so mismatched EvalKeys are lazily purged and the buckets stay type safe
- add regression coverage that exercises the legacy EvalKey migration path
- document the zero-downtime approach for expanding WorldNodeRef domains and recalculating validation EvalKeys

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 *(fails: known NameError in `qmtl/gateway/routes.py::post_strategies_dry_run` when diff fallback references `exec_domain`)*
- uv run -m pytest -W error -n auto *(fails: same NameError plus existing `test_compute_context_switch_clears_cache_and_records_metric` assertion)*
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d02243625c8329be108316407a7dad