### PR TITLE
Refactor strategy submission logic into shared helper

### DIFF
--- a/qmtl/gateway/strategy_submission.py
+++ b/qmtl/gateway/strategy_submission.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from fastapi import HTTPException
+
+from .models import StrategySubmit
+
+
+@dataclass
+class StrategySubmissionConfig:
+    """Behavior flags for the shared strategy submission helper."""
+
+    submit: bool
+    strategy_id: str | None = None
+    diff_timeout: float = 0.1
+    prefer_diff_queue_map: bool = False
+    sentinel_default: str | None = None
+    diff_strategy_id: str | None = None
+    use_crc_sentinel_fallback: bool = False
+
+
+@dataclass
+class StrategySubmissionResult:
+    """Structured result returned by the helper."""
+
+    strategy_id: str
+    queue_map: dict[str, list[dict[str, Any] | Any]]
+    sentinel_id: str
+
+
+class StrategySubmissionHelper:
+    """Normalize DAG processing for ingestion and dry-run endpoints."""
+
+    def __init__(self, manager, dagmanager, database) -> None:
+        self._manager = manager
+        self._dagmanager = dagmanager
+        self._database = database
+
+    async def process(
+        self, payload: StrategySubmit, config: StrategySubmissionConfig
+    ) -> StrategySubmissionResult:
+        dag = self._decode_dag(payload.dag_json)
+        self._validate_dag(dag)
+        self._validate_node_ids(dag, payload.node_ids_crc32)
+
+        worlds = self._extract_worlds(payload)
+        compute_ctx = self._extract_compute_context(payload)
+
+        strategy_id, existed = await self._maybe_submit(payload, config)
+        if existed:
+            raise HTTPException(
+                status_code=409,
+                detail={"code": "E_DUPLICATE", "strategy_id": strategy_id},
+            )
+
+        if config.submit and self._database is not None:
+            await self._persist_world_bindings(worlds, payload.world_id, strategy_id)
+
+        queue_map = {}
+        exec_domain = compute_ctx.get("execution_domain")
+
+        prefer_diff = config.prefer_diff_queue_map
+        diff_strategy_id = config.diff_strategy_id or strategy_id
+        dag_json = json.dumps(dag)
+
+        sentinel_default = (
+            config.sentinel_default
+            if config.sentinel_default is not None
+            else (f"{strategy_id}-sentinel" if strategy_id else "")
+        )
+
+        sentinel_id = sentinel_default
+        diff_queue_map: dict[str, list[dict[str, Any]]] | None = None
+        diff_error = False
+        try:
+            sentinel_id, diff_queue_map = await self._run_diff(
+                strategy_id=diff_strategy_id,
+                dag_json=dag_json,
+                worlds=worlds,
+                fallback_world_id=payload.world_id,
+                compute_ctx=compute_ctx,
+                timeout=config.diff_timeout,
+                prefer_queue_map=prefer_diff,
+            )
+            if not sentinel_id:
+                sentinel_id = sentinel_default
+        except Exception:
+            diff_error = True
+            sentinel_id = sentinel_default
+            diff_queue_map = None
+
+        if prefer_diff and not diff_error and diff_queue_map is not None:
+            queue_map = diff_queue_map
+        else:
+            queue_map = await self._build_queue_map_from_queries(
+                dag, worlds, payload.world_id, exec_domain
+            )
+            if (
+                prefer_diff
+                and diff_error
+                and not sentinel_id
+                and config.use_crc_sentinel_fallback
+            ):
+                sentinel_id = self._crc_sentinel(dag)
+
+        if not prefer_diff and config.use_crc_sentinel_fallback and not sentinel_id:
+            sentinel_id = self._crc_sentinel(dag)
+
+        return StrategySubmissionResult(
+            strategy_id=strategy_id,
+            queue_map=queue_map,
+            sentinel_id=sentinel_id,
+        )
+
+    async def _maybe_submit(
+        self, payload: StrategySubmit, config: StrategySubmissionConfig
+    ) -> tuple[str, bool]:
+        if config.submit:
+            if self._manager is None:
+                raise RuntimeError("StrategyManager is required for submission")
+            return await self._manager.submit(payload)
+        strategy_id = config.strategy_id or "dryrun"
+        return strategy_id, False
+
+    def _decode_dag(self, dag_json: str) -> dict[str, Any]:
+        try:
+            dag_bytes = base64.b64decode(dag_json)
+            return json.loads(dag_bytes.decode())
+        except Exception:
+            return json.loads(dag_json)
+
+    def _validate_dag(self, dag: dict[str, Any]) -> None:
+        from qmtl.dagmanager.schema_validator import validate_dag
+
+        ok, _version, verrors = validate_dag(dag)
+        if not ok:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "E_SCHEMA_INVALID", "errors": verrors},
+            )
+
+    def _extract_worlds(self, payload: StrategySubmit) -> list[str]:
+        worlds: list[str] = []
+        wid_list = getattr(payload, "world_ids", None)
+        if wid_list:
+            worlds = list(dict.fromkeys([w for w in (wid_list or []) if w]))
+        elif payload.world_id:
+            worlds = [payload.world_id]
+        return worlds
+
+    def _extract_compute_context(
+        self, payload: StrategySubmit
+    ) -> dict[str, str | None]:
+        meta = payload.meta if isinstance(payload.meta, dict) else {}
+        return {
+            "execution_domain": self._normalize_context_value(
+                meta.get("execution_domain") if meta else None
+            ),
+            "as_of": self._normalize_context_value(meta.get("as_of") if meta else None),
+            "partition": self._normalize_context_value(
+                meta.get("partition") if meta else None
+            ),
+            "dataset_fingerprint": self._normalize_context_value(
+                meta.get("dataset_fingerprint") if meta else None
+            ),
+        }
+
+    def _normalize_context_value(self, value: object | None) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, (str, int, float)):
+            text = str(value).strip()
+            return text or None
+        return None
+
+    def _validate_node_ids(self, dag: dict[str, Any], node_ids_crc32: int) -> None:
+        from qmtl.common import crc32_of_list, compute_node_id
+
+        nodes = dag.get("nodes", [])
+        node_ids_for_crc: list[str] = []
+        missing_fields: list[dict[str, Any]] = []
+        mismatches: list[dict[str, str | int]] = []
+
+        for idx, node in enumerate(nodes):
+            nid = node.get("node_id")
+            if not isinstance(nid, str) or not nid:
+                node_ids_for_crc.append(str(nid or ""))
+                missing_fields.append({"index": idx, "missing": ["node_id"]})
+                continue
+
+            node_ids_for_crc.append(nid)
+            required = {
+                "node_type": node.get("node_type"),
+                "code_hash": node.get("code_hash"),
+                "config_hash": node.get("config_hash"),
+                "schema_hash": node.get("schema_hash"),
+            }
+            missing = [field for field, value in required.items() if not value]
+            if missing:
+                missing_fields.append(
+                    {"index": idx, "node_id": nid, "missing": missing}
+                )
+                continue
+
+            expected = compute_node_id(
+                str(required["node_type"]),
+                str(required["code_hash"]),
+                str(required["config_hash"]),
+                str(required["schema_hash"]),
+            )
+            if nid != expected:
+                mismatches.append({"index": idx, "node_id": nid, "expected": expected})
+
+        crc = crc32_of_list(node_ids_for_crc)
+        if missing_fields:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "E_NODE_ID_FIELDS",
+                    "message": "node_id validation requires node_type, code_hash, config_hash and schema_hash",
+                    "missing_fields": missing_fields,
+                    "hint": "Regenerate the DAG with an updated SDK so each node includes the hashes required by compute_node_id().",
+                },
+            )
+
+        if crc != node_ids_crc32:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "E_CHECKSUM_MISMATCH", "message": "node id checksum mismatch"},
+            )
+
+        if mismatches:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "E_NODE_ID_MISMATCH",
+                    "message": "node_id does not match canonical compute_node_id output",
+                    "node_id_mismatch": mismatches,
+                    "hint": "Ensure legacy world-coupled or pre-BLAKE3 node_ids are regenerated using compute_node_id().",
+                },
+            )
+
+    async def _persist_world_bindings(
+        self, worlds: list[str], default_world: str | None, strategy_id: str
+    ) -> None:
+        if self._database is None:
+            return
+        targets = worlds or ([default_world] if default_world else [])
+        for world_id in targets:
+            if not world_id:
+                continue
+            try:
+                await self._database.upsert_wsb(world_id, strategy_id)
+            except Exception:
+                pass
+
+    async def _build_queue_map_from_queries(
+        self,
+        dag: dict[str, Any],
+        worlds: list[str],
+        default_world: str | None,
+        execution_domain: str | None,
+    ) -> dict[str, list[dict[str, Any] | Any]]:
+        queue_map: dict[str, list[dict[str, Any] | Any]] = {}
+        queries: list[asyncio.Future] = []
+        query_targets: list[tuple[str, str | None]] = []
+
+        nodes = dag.get("nodes", [])
+        for node in nodes:
+            if node.get("node_type") != "TagQueryNode":
+                continue
+            nid = node.get("node_id")
+            if not isinstance(nid, str) or not nid:
+                continue
+            tags = node.get("tags", [])
+            interval = int(node.get("interval", 0))
+            match_mode = node.get("match_mode", "any")
+            if worlds:
+                for world_id in worlds:
+                    queries.append(
+                        self._dagmanager.get_queues_by_tag(
+                            tags, interval, match_mode, world_id, execution_domain
+                        )
+                    )
+                    query_targets.append((nid, world_id))
+            else:
+                queries.append(
+                    self._dagmanager.get_queues_by_tag(
+                        tags, interval, match_mode, default_world, execution_domain
+                    )
+                )
+                query_targets.append((nid, default_world))
+
+        results: Iterable[Any] = []
+        if queries:
+            results = await asyncio.gather(*queries, return_exceptions=True)
+
+        seen: dict[str, set[str]] = {}
+        for (nid, _world_id), result in zip(query_targets, results):
+            lst = queue_map.setdefault(nid, [])
+            seen.setdefault(nid, set())
+            if isinstance(result, Exception):
+                continue
+            for item in result:
+                queue_name = (
+                    item.get("queue")
+                    if isinstance(item, dict)
+                    else str(item)
+                )
+                if queue_name not in seen[nid]:
+                    lst.append(item)
+                    seen[nid].add(queue_name)
+
+        return queue_map
+
+    async def _run_diff(
+        self,
+        *,
+        strategy_id: str,
+        dag_json: str,
+        worlds: list[str],
+        fallback_world_id: str | None,
+        compute_ctx: dict[str, str | None],
+        timeout: float,
+        prefer_queue_map: bool,
+    ) -> tuple[str | None, dict[str, list[dict[str, Any]]] | None]:
+        diff_kwargs = {
+            "execution_domain": compute_ctx.get("execution_domain"),
+            "as_of": compute_ctx.get("as_of"),
+            "partition": compute_ctx.get("partition"),
+            "dataset_fingerprint": compute_ctx.get("dataset_fingerprint"),
+        }
+
+        async def _invoke(world: str | None):
+            return await self._dagmanager.diff(
+                strategy_id,
+                dag_json,
+                world_id=world,
+                **diff_kwargs,
+            )
+
+        sentinel_id: str | None = None
+        queue_map: dict[str, list[dict[str, Any]]] | None = None
+
+        if prefer_queue_map and len(worlds) > 1:
+            tasks = [
+                _invoke(world_id)
+                for world_id in worlds
+            ]
+            chunks = await asyncio.gather(*tasks, return_exceptions=True)
+            queue_map = {}
+            for chunk in chunks:
+                if isinstance(chunk, Exception) or chunk is None:
+                    continue
+                if not sentinel_id:
+                    sentinel_id = getattr(chunk, "sentinel_id", None)
+                for key, topic in dict(getattr(chunk, "queue_map", {})).items():
+                    node_id = self._node_id_from_partition_key(str(key))
+                    lst = queue_map.setdefault(node_id, [])
+                    if topic not in [d.get("queue") for d in lst]:
+                        lst.append({"queue": topic, "global": False})
+            return sentinel_id, queue_map
+
+        world = worlds[0] if worlds else fallback_world_id
+        if world is None and prefer_queue_map and not worlds:
+            queue_map = {}
+
+        chunk = await asyncio.wait_for(_invoke(world), timeout=timeout)
+        if chunk is None:
+            return sentinel_id, queue_map
+
+        sentinel_id = getattr(chunk, "sentinel_id", None)
+        if prefer_queue_map:
+            queue_map = {}
+            for key, topic in dict(getattr(chunk, "queue_map", {})).items():
+                node_id = self._node_id_from_partition_key(str(key))
+                queue_map.setdefault(node_id, []).append(
+                    {"queue": topic, "global": False}
+                )
+
+        return sentinel_id, queue_map
+
+    def _node_id_from_partition_key(self, identifier: str) -> str:
+        base, _, _ = identifier.partition("#")
+        token = base or identifier
+        if ":" in token:
+            return token.rsplit(":", 2)[0]
+        return token
+
+    def _crc_sentinel(self, dag: dict[str, Any]) -> str:
+        from qmtl.common import crc32_of_list
+
+        crc = crc32_of_list(n.get("node_id", "") for n in dag.get("nodes", []))
+        return f"dryrun:{crc:08x}"

--- a/qmtl/gateway/tests/test_strategy_submission_helper.py
+++ b/qmtl/gateway/tests/test_strategy_submission_helper.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import base64
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from qmtl.common import compute_node_id, crc32_of_list
+from qmtl.gateway.models import StrategySubmit
+from qmtl.gateway.strategy_submission import (
+    StrategySubmissionConfig,
+    StrategySubmissionHelper,
+)
+
+
+class DummyManager:
+    def __init__(self) -> None:
+        self.calls: list[StrategySubmit] = []
+
+    async def submit(self, payload: StrategySubmit) -> tuple[str, bool]:
+        self.calls.append(payload)
+        return "strategy-abc", False
+
+
+class DummyDagManager:
+    def __init__(self) -> None:
+        self.tag_queries: list[tuple] = []
+        self.diff_calls: list[tuple] = []
+        self.raise_diff: bool = False
+        self.diff_result = SimpleNamespace(
+            sentinel_id="diff-sentinel",
+            queue_map={"node123#0": "topic-A"},
+        )
+
+    async def get_queues_by_tag(
+        self, tags, interval, match_mode, world_id, execution_domain
+    ):
+        self.tag_queries.append((tuple(tags), interval, match_mode, world_id, execution_domain))
+        return [{"queue": f"{world_id}:{tags[0]}" if world_id else f"global:{tags[0]}"}]
+
+    async def diff(
+        self,
+        strategy_id,
+        dag_json,
+        world_id=None,
+        execution_domain=None,
+        as_of=None,
+        partition=None,
+        dataset_fingerprint=None,
+    ):
+        self.diff_calls.append((strategy_id, world_id, execution_domain, as_of, partition, dataset_fingerprint))
+        if self.raise_diff:
+            raise TimeoutError("diff timeout")
+        return self.diff_result
+
+
+class DummyDatabase:
+    def __init__(self) -> None:
+        self.bindings: list[tuple[str, str]] = []
+
+    async def upsert_wsb(self, world_id: str, strategy_id: str) -> None:
+        self.bindings.append((world_id, strategy_id))
+
+
+def _build_payload(mismatch: bool = False) -> tuple[StrategySubmit, dict, str]:
+    node_type = "TagQueryNode"
+    code_hash = "code"
+    config_hash = "config"
+    schema_hash = "schema"
+    expected_node_id = compute_node_id(node_type, code_hash, config_hash, schema_hash)
+    node_id = "bad-node" if mismatch else expected_node_id
+    dag = {
+        "nodes": [
+            {
+                "node_id": node_id,
+                "node_type": node_type,
+                "code_hash": code_hash,
+                "config_hash": config_hash,
+                "schema_hash": schema_hash,
+                "tags": ["alpha"],
+                "interval": 5,
+                "match_mode": "any",
+            }
+        ]
+    }
+    dag_json = base64.b64encode(json.dumps(dag).encode()).decode()
+    crc = crc32_of_list([node_id])
+    payload = StrategySubmit(
+        dag_json=dag_json,
+        meta={"execution_domain": " sim "},
+        world_id="world-1",
+        node_ids_crc32=crc,
+    )
+    return payload, dag, expected_node_id
+
+
+@pytest.mark.asyncio
+async def test_process_submission_uses_queries_and_diff_for_strategy():
+    manager = DummyManager()
+    dagmanager = DummyDagManager()
+    database = DummyDatabase()
+    helper = StrategySubmissionHelper(manager, dagmanager, database)
+    payload, _, expected_node_id = _build_payload()
+
+    result = await helper.process(
+        payload,
+        StrategySubmissionConfig(
+            submit=True,
+            diff_timeout=0.1,
+        ),
+    )
+
+    assert result.strategy_id == "strategy-abc"
+    assert result.sentinel_id == "diff-sentinel"
+    assert result.queue_map.keys() == {expected_node_id}
+    queues = result.queue_map[expected_node_id]
+    assert queues and queues[0]["queue"] == "world-1:alpha"
+    assert database.bindings == [("world-1", "strategy-abc")]
+    assert dagmanager.diff_calls, "diff should be invoked for sentinel lookup"
+
+
+@pytest.mark.asyncio
+async def test_process_dry_run_prefers_diff_queue_map():
+    dagmanager = DummyDagManager()
+    helper = StrategySubmissionHelper(DummyManager(), dagmanager, DummyDatabase())
+    payload, _, _ = _build_payload()
+
+    result = await helper.process(
+        payload,
+        StrategySubmissionConfig(
+            submit=False,
+            strategy_id="dryrun",
+            diff_timeout=0.5,
+            prefer_diff_queue_map=True,
+            sentinel_default="",
+            diff_strategy_id="dryrun",
+            use_crc_sentinel_fallback=True,
+        ),
+    )
+
+    assert result.strategy_id == "dryrun"
+    assert result.queue_map == {"node123": [{"queue": "topic-A", "global": False}]}
+    assert not dagmanager.tag_queries, "diff path should avoid tag query lookups"
+    assert result.sentinel_id == "diff-sentinel"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config",
+    [
+        StrategySubmissionConfig(submit=True, diff_timeout=0.1),
+        StrategySubmissionConfig(
+            submit=False,
+            strategy_id="dryrun",
+            diff_timeout=0.5,
+            prefer_diff_queue_map=True,
+            sentinel_default="",
+            diff_strategy_id="dryrun",
+            use_crc_sentinel_fallback=True,
+        ),
+    ],
+    ids=["submit", "dry-run"],
+)
+async def test_shared_validation_path(config: StrategySubmissionConfig) -> None:
+    helper = StrategySubmissionHelper(DummyManager(), DummyDagManager(), DummyDatabase())
+    payload, _, _ = _build_payload(mismatch=True)
+
+    with pytest.raises(HTTPException) as exc:
+        await helper.process(payload, config)
+
+    detail = exc.value.detail
+    assert detail["code"] == "E_NODE_ID_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_diff_failure_falls_back_to_queries_and_crc() -> None:
+    dagmanager = DummyDagManager()
+    dagmanager.raise_diff = True
+    helper = StrategySubmissionHelper(DummyManager(), dagmanager, DummyDatabase())
+    payload, dag, expected_node_id = _build_payload()
+
+    result = await helper.process(
+        payload,
+        StrategySubmissionConfig(
+            submit=False,
+            strategy_id="dryrun",
+            diff_timeout=0.5,
+            prefer_diff_queue_map=True,
+            sentinel_default="",
+            diff_strategy_id="dryrun",
+            use_crc_sentinel_fallback=True,
+        ),
+    )
+
+    assert result.queue_map.keys() == {expected_node_id}
+    assert result.queue_map[expected_node_id][0]["queue"] == "world-1:alpha"
+    expected_crc = crc32_of_list(n.get("node_id", "") for n in dag.get("nodes", []))
+    assert result.sentinel_id == f"dryrun:{expected_crc:08x}"


### PR DESCRIPTION
## Summary
- add a reusable `StrategySubmissionHelper` to centralize DAG decoding, validation, queue mapping, and diff handling for strategy submissions
- update the `/strategies` and `/strategies/dry-run` routes to delegate to the shared helper with flow-specific configuration
- add unit tests that exercise the helper for live submissions and dry runs to ensure common validation and mapping paths

## Testing
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d0294b036c8329a92fcea3c9ef4191