### PR TITLE
Refactor runner helper services

### DIFF
--- a/qmtl/sdk/history_warmup_service.py
+++ b/qmtl/sdk/history_warmup_service.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Iterable
+
+from . import snapshot as snap
+from .history_loader import HistoryLoader
+from .strategy import Strategy
+
+logger = logging.getLogger(__name__)
+
+
+class HistoryWarmupService:
+    """Coordinate history hydration, replay and strict validation."""
+
+    def __init__(self, loader: type[HistoryLoader] = HistoryLoader) -> None:
+        self._history_loader = loader
+
+    # ------------------------------------------------------------------
+    # Snapshot helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def hydrate_snapshots(strategy: Strategy) -> int:
+        from .node import StreamInput
+
+        count = 0
+        for node in strategy.nodes:
+            if isinstance(node, StreamInput) and node.interval is not None and node.period:
+                try:
+                    strict = False
+                    try:
+                        strict = getattr(node, "runtime_compat", "loose") == "strict"
+                    except Exception:
+                        strict = False
+                    if snap.hydrate(node, strict_runtime=strict):
+                        count += 1
+                except Exception:
+                    logger.exception("snapshot hydration failed for %s", node.node_id)
+        if count:
+            logger.info("hydrated %d nodes from snapshots", count)
+        return count
+
+    @staticmethod
+    def write_snapshots(strategy: Strategy) -> int:
+        from .node import StreamInput
+
+        count = 0
+        for node in strategy.nodes:
+            if isinstance(node, StreamInput) and node.interval is not None and node.period:
+                try:
+                    path = snap.write_snapshot(node)
+                    if path:
+                        count += 1
+                except Exception:
+                    logger.exception("snapshot write failed for %s", node.node_id)
+        if count:
+            logger.info("wrote %d node snapshots", count)
+        return count
+
+    # ------------------------------------------------------------------
+    async def load_history(
+        self, strategy: Strategy, start: int | None, end: int | None
+    ) -> None:
+        await self._history_loader.load(strategy, start, end)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def missing_ranges(
+        coverage: Iterable[tuple[int, int]],
+        start: int,
+        end: int,
+        interval: int,
+    ) -> list[tuple[int, int]]:
+        ranges = sorted([tuple(r) for r in coverage])
+        merged: list[tuple[int, int]] = []
+        for s, e in ranges:
+            if not merged:
+                merged.append((s, e))
+                continue
+            ls, le = merged[-1]
+            if s <= le + interval:
+                merged[-1] = (ls, max(le, e))
+            else:
+                merged.append((s, e))
+
+        gaps: list[tuple[int, int]] = []
+        cur = start
+        for s, e in merged:
+            if e < start:
+                continue
+            if s > end:
+                break
+            if s > cur:
+                gaps.append((cur, min(s - interval, end)))
+            cur = max(cur, e + interval)
+            if cur > end:
+                break
+        if cur <= end:
+            gaps.append((cur, end))
+        return [g for g in gaps if g[0] <= g[1]]
+
+    async def ensure_node_history(
+        self,
+        node,
+        start: int,
+        end: int,
+        *,
+        stop_on_ready: bool = False,
+        strict: bool = False,
+    ) -> None:
+        if node.interval is None or start is None or end is None:
+            return
+        provider = getattr(node, "history_provider", None)
+        if provider is None:
+            await node.load_history(start, end)
+            return
+        if start is None and end is None:
+            coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
+            if coverage:
+                s = min(c[0] for c in coverage)
+                e = max(c[1] for c in coverage)
+                await node.load_history(s, e)
+                return
+        deadline = time.monotonic() + 60.0
+        while node.pre_warmup:
+            coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
+            missing = self.missing_ranges(coverage, start, end, node.interval)
+            if not missing:
+                await node.load_history(start, end)
+                return
+            for s, e in missing:
+                await provider.fill_missing(
+                    s, e, node_id=node.node_id, interval=node.interval
+                )
+                if stop_on_ready and not node.pre_warmup:
+                    return
+            if time.monotonic() > deadline:
+                logger.warning(
+                    "history warm-up timed out for %s; proceeding with available data",
+                    getattr(node, "node_id", "<unknown>"),
+                )
+                break
+            if stop_on_ready:
+                break
+        if node.pre_warmup:
+            try:
+                coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
+            except Exception:
+                coverage = []
+            if coverage:
+                s = min(c[0] for c in coverage)
+                e = max(c[1] for c in coverage)
+                await node.load_history(s, e)
+            else:
+                await node.load_history(start, end)
+        if strict:
+            try:
+                coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
+            except Exception:
+                coverage = []
+            missing = self.missing_ranges(coverage, start, end, node.interval)
+            if missing or getattr(node, "pre_warmup", False):
+                raise RuntimeError(
+                    f"history gap for {getattr(node, 'node_id', '<unknown>')} in strict mode"
+                )
+
+    async def ensure_history(
+        self,
+        strategy: Strategy,
+        start: int | None = None,
+        end: int | None = None,
+        *,
+        stop_on_ready: bool = False,
+        strict: bool = False,
+    ) -> None:
+        from .node import StreamInput
+        from . import runtime as _runtime
+
+        tasks = []
+        now = (
+            _runtime.FIXED_NOW
+            if _runtime.FIXED_NOW is not None
+            else int(time.time())
+        )
+        for node in strategy.nodes:
+            if not isinstance(node, StreamInput):
+                continue
+            if start is None or end is None:
+                if node.interval is None or node.period is None:
+                    continue
+                rng_end = now - (now % node.interval)
+                rng_start = rng_end - node.interval * node.period + node.interval
+            else:
+                rng_start = start
+                rng_end = end
+            tasks.append(
+                asyncio.create_task(
+                    self.ensure_node_history(
+                        node,
+                        rng_start,
+                        rng_end,
+                        stop_on_ready=stop_on_ready,
+                        strict=strict,
+                    )
+                )
+            )
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    # ------------------------------------------------------------------
+    def collect_history_events(
+        self, strategy: Strategy, start: int | None, end: int | None
+    ) -> list[tuple[int, Any, Any]]:
+        from .node import StreamInput
+
+        events: list[tuple[int, Any, Any]] = []
+        for node in strategy.nodes:
+            if not isinstance(node, StreamInput):
+                continue
+            snapshot = node.cache._snapshot().get(node.node_id, {})
+            items = snapshot.get(node.interval, []) if node.interval is not None else []
+            for ts, payload in items:
+                if start is not None and ts < start:
+                    continue
+                if end is not None and ts > end:
+                    continue
+                events.append((ts, node, payload))
+        events.sort(key=lambda event: event[0])
+        return events
+
+    def replay_history_events(
+        self,
+        strategy: Strategy,
+        events: list[tuple[int, Any, Any]],
+        *,
+        on_missing: str = "skip",
+    ) -> None:
+        for ts, src, payload in events:
+            for node in strategy.nodes:
+                if src in getattr(node, "inputs", []):
+                    from .runner import Runner
+
+                    Runner.feed_queue_data(
+                        node,
+                        src.node_id,
+                        src.interval,
+                        ts,
+                        payload,
+                        on_missing=on_missing,
+                    )
+
+    async def replay_history(
+        self,
+        strategy: Strategy,
+        start: int | None,
+        end: int | None,
+        *,
+        on_missing: str = "skip",
+    ) -> None:
+        from .node import StreamInput
+        from qmtl import Pipeline
+
+        pipeline = Pipeline(strategy.nodes)
+
+        async def collect(node: StreamInput) -> list[tuple[int, StreamInput, Any]]:
+            items = node.cache.get_slice(node.node_id, node.interval, count=node.period)
+            return [
+                (ts, node, payload)
+                for ts, payload in items
+                if (start is None or ts >= start) and (end is None or ts <= end)
+            ]
+
+        tasks = [
+            asyncio.create_task(collect(node))
+            for node in strategy.nodes
+            if isinstance(node, StreamInput) and node.interval is not None
+        ]
+
+        events: list[tuple[int, StreamInput, Any]] = []
+        if tasks:
+            results = await asyncio.gather(*tasks)
+            for result in results:
+                events.extend(result)
+        events.sort(key=lambda event: event[0])
+
+        for ts, node, payload in events:
+            pipeline.feed(node, ts, payload, on_missing=on_missing)
+
+    def replay_events_simple(self, strategy: Strategy) -> None:
+        from .cache_view import CacheView
+        from .node import StreamInput
+
+        events = self.collect_history_events(strategy, None, None)
+        by_ts: dict[int, list[tuple[StreamInput, Any]]] = {}
+        for ts, node, payload in events:
+            by_ts.setdefault(ts, []).append((node, payload))
+
+        for ts in sorted(by_ts):
+            seeds = by_ts[ts]
+            event_values: dict[str, dict[int, list[tuple[int, Any]]]] = {}
+            for src, payload in seeds:
+                event_values.setdefault(src.node_id, {}).setdefault(src.interval, []).append(
+                    (ts, payload)
+                )
+
+            progressed = True
+            done: set[str] = set()
+            while progressed:
+                progressed = False
+                for node in strategy.nodes:
+                    if not getattr(node, "compute_fn", None):
+                        continue
+                    if not getattr(node, "execute", True):
+                        continue
+                    inputs = getattr(node, "inputs", [])
+                    if not inputs:
+                        continue
+                    node_id = getattr(node, "node_id", None)
+                    if node_id is None or node_id in done:
+                        continue
+                    ready = True
+                    iterable = inputs if isinstance(inputs, list) else [inputs]
+                    for upstream in iterable:
+                        if upstream is None:
+                            continue
+                        uid = getattr(upstream, "node_id", None)
+                        interval = getattr(upstream, "interval", None)
+                        if uid is None or interval is None:
+                            continue
+                        if uid not in event_values or interval not in event_values[uid]:
+                            ready = False
+                            break
+                    if not ready:
+                        continue
+                    view = CacheView(event_values)
+                    result = node.compute_fn(view)
+                    from .runner import Runner
+
+                    Runner._postprocess_result(node, result)
+                    n_uid = getattr(node, "node_id", None)
+                    interval = getattr(node, "interval", None)
+                    if n_uid is not None and interval is not None:
+                        event_values.setdefault(n_uid, {}).setdefault(interval, []).append(
+                            (ts, result)
+                        )
+                        done.add(n_uid)
+                        progressed = True
+
+    # ------------------------------------------------------------------
+    async def warmup_strategy(
+        self,
+        strategy: Strategy,
+        *,
+        offline_mode: bool,
+        history_start: Any | None,
+        history_end: Any | None,
+    ) -> None:
+        from .node import StreamInput
+        from . import runtime as _runtime
+
+        self.hydrate_snapshots(strategy)
+
+        has_provider = any(
+            isinstance(node, StreamInput)
+            and getattr(node, "history_provider", None) is not None
+            for node in strategy.nodes
+        )
+
+        strict_mode = bool(_runtime.FAIL_ON_HISTORY_GAP)
+
+        h_start = history_start
+        h_end = history_end
+        if offline_mode and h_start is None and h_end is None and not has_provider:
+            h_start, h_end = 1, 2
+
+        ensure_history = has_provider or (h_start is not None and h_end is not None)
+        if not ensure_history and offline_mode:
+            has_cached = False
+            for node in strategy.nodes:
+                if isinstance(node, StreamInput):
+                    try:
+                        snapshot = node.cache._snapshot()[node.node_id].get(node.interval, [])
+                        if snapshot:
+                            has_cached = True
+                            break
+                    except KeyError:
+                        continue
+            if not has_cached:
+                h_start, h_end = 1, 2
+                ensure_history = True
+
+        if ensure_history:
+            await self.ensure_history(
+                strategy,
+                h_start if isinstance(h_start, int) else None,
+                h_end if isinstance(h_end, int) else None,
+                stop_on_ready=True,
+                strict=strict_mode,
+            )
+
+        if offline_mode:
+            if has_provider:
+                await self.replay_history(strategy, None, None)
+            if strict_mode:
+                await self._enforce_strict_mode(strategy)
+
+    async def _enforce_strict_mode(self, strategy: Strategy) -> None:
+        from .node import StreamInput
+
+        for node in strategy.nodes:
+            if isinstance(node, StreamInput) and getattr(node, "pre_warmup", False):
+                raise RuntimeError("history pre-warmup unresolved in strict mode")
+
+        for node in strategy.nodes:
+            if not isinstance(node, StreamInput):
+                continue
+            provider = getattr(node, "history_provider", None)
+            if provider is None:
+                continue
+            try:
+                snapshot = node.cache._snapshot()[node.node_id].get(node.interval, [])
+                ts_sorted = sorted(ts for ts, _ in snapshot)
+            except KeyError:
+                raise RuntimeError("history missing in strict mode")
+            coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
+            if coverage:
+                s = min(c[0] for c in coverage)
+                e = max(c[1] for c in coverage)
+                if node.interval:
+                    expected = int((e - s) // node.interval) + 1
+                    actual = len([ts for ts in ts_sorted if s <= ts <= e])
+                    if actual < expected:
+                        raise RuntimeError("history gap detected in strict mode")
+            else:
+                for a, b in zip(ts_sorted, ts_sorted[1:]):
+                    if node.interval and (b - a) != node.interval:
+                        raise RuntimeError("history gap detected in strict mode")
+            if coverage:
+                needed = getattr(node, "period", 1) or 1
+                if len(ts_sorted) < needed:
+                    raise RuntimeError("history missing in strict mode")
+
+
+__all__ = ["HistoryWarmupService"]

--- a/qmtl/sdk/strategy_bootstrapper.py
+++ b/qmtl/sdk/strategy_bootstrapper.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from qmtl.common.compute_key import ComputeContext
+from qmtl.dagmanager.topic import build_namespace, topic_namespace_enabled
+
+from .feature_store import FeatureArtifactPlane
+from .gateway_client import GatewayClient
+from .strategy import Strategy
+from .tag_manager_service import TagManagerService
+from . import metrics as sdk_metrics
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BootstrapResult:
+    manager: Any
+    offline_mode: bool
+    completed: bool
+    dataset_fingerprint: str | None
+    tag_service: TagManagerService
+    dag_meta: dict | None
+
+
+class StrategyBootstrapper:
+    """Prepare strategies for execution by wiring context and Gateway state."""
+
+    def __init__(self, gateway_client: GatewayClient | None = None) -> None:
+        self._gateway_client = gateway_client or GatewayClient()
+
+    async def bootstrap(
+        self,
+        strategy: Strategy,
+        *,
+        context: ComputeContext,
+        world_id: str,
+        gateway_url: str | None,
+        meta: Mapping[str, Any] | None,
+        offline: bool,
+        kafka_available: bool,
+        trade_mode: str,
+        schema_enforcement: str,
+        feature_plane: FeatureArtifactPlane | None,
+    ) -> BootstrapResult:
+        # Apply context and schema enforcement on all nodes
+        for node in strategy.nodes:
+            setattr(node, "_schema_enforcement", schema_enforcement)
+            try:
+                node.apply_compute_context(context)
+            except AttributeError:
+                pass
+
+        tag_service = TagManagerService(gateway_url)
+        try:
+            manager = tag_service.init(strategy, world_id=world_id)
+        except TypeError:
+            manager = tag_service.init(strategy)
+
+        sdk_metrics.set_world_id(world_id)
+        logger.info("[RUN] %s world=%s", strategy.__class__.__name__, world_id)
+
+        dag = strategy.serialize()
+        logger.info(
+            "Sending DAG to service: %s", [n["node_id"] for n in dag["nodes"]]
+        )
+
+        dag_meta = dag.setdefault("meta", {}) if isinstance(dag, dict) else {}
+        meta_payload = dict(meta) if isinstance(meta, Mapping) else None
+
+        dataset_fingerprint: str | None = None
+        execution_domain_override: str | None = None
+        if isinstance(meta_payload, dict):
+            raw_domain = meta_payload.get("execution_domain")
+            if isinstance(raw_domain, str) and raw_domain.strip():
+                execution_domain_override = raw_domain.strip()
+            raw_fp = meta_payload.get("dataset_fingerprint") or meta_payload.get(
+                "datasetFingerprint"
+            )
+            if isinstance(raw_fp, str) and raw_fp.strip():
+                dataset_fingerprint = raw_fp.strip()
+
+        if topic_namespace_enabled():
+            effective_domain = execution_domain_override
+            if effective_domain is None:
+                if offline:
+                    effective_domain = "backtest"
+                else:
+                    effective_domain = "live" if trade_mode == "live" else "dryrun"
+            namespace = build_namespace(world_id, effective_domain)
+            if namespace:
+                if isinstance(dag_meta, dict):
+                    dag_meta["topic_namespace"] = {
+                        "world": world_id,
+                        "domain": effective_domain,
+                    }
+                if meta_payload is None:
+                    meta_payload = {}
+                meta_payload.setdefault("execution_domain", effective_domain)
+
+        meta_for_gateway = meta_payload if meta_payload is not None else meta
+
+        queue_map: dict[str, Any] | Any
+        queue_map = {}
+        if gateway_url:
+            queue_map = await self._gateway_client.post_strategy(
+                gateway_url=gateway_url,
+                dag=dag,
+                meta=meta_for_gateway,
+                world_id=world_id,
+            )
+            if isinstance(queue_map, dict) and "error" in queue_map:
+                raise RuntimeError(queue_map["error"])
+
+        tag_service.apply_queue_map(strategy, queue_map or {})
+
+        if not any(getattr(node, "execute", False) for node in strategy.nodes):
+            logger.info("No executable nodes; exiting strategy")
+            strategy.on_finish()
+            offline_mode = offline or not kafka_available or not gateway_url
+            return BootstrapResult(
+                manager=manager,
+                offline_mode=offline_mode,
+                completed=True,
+                dataset_fingerprint=dataset_fingerprint,
+                tag_service=tag_service,
+                dag_meta=dag_meta if isinstance(dag_meta, dict) else None,
+            )
+
+        offline_mode = offline or not kafka_available or not gateway_url
+        await manager.resolve_tags(offline=offline_mode)
+
+        if dataset_fingerprint:
+            if isinstance(dag_meta, dict):
+                dag_meta.setdefault("dataset_fingerprint", dataset_fingerprint)
+            for node in strategy.nodes:
+                try:
+                    node.dataset_fingerprint = dataset_fingerprint
+                except AttributeError:
+                    pass
+
+        if feature_plane is not None:
+            feature_plane.configure(
+                dataset_fingerprint=dataset_fingerprint,
+                execution_domain=context.execution_domain,
+            )
+
+        return BootstrapResult(
+            manager=manager,
+            offline_mode=offline_mode,
+            completed=False,
+            dataset_fingerprint=dataset_fingerprint,
+            tag_service=tag_service,
+            dag_meta=dag_meta if isinstance(dag_meta, dict) else None,
+        )
+
+
+__all__ = ["BootstrapResult", "StrategyBootstrapper"]

--- a/qmtl/sdk/trade_dispatcher.py
+++ b/qmtl/sdk/trade_dispatcher.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from cachetools import TTLCache
+
+from .http import HttpPoster
+
+logger = logging.getLogger(__name__)
+
+if "_trade_execution_service_sentinel" not in globals():
+    _trade_execution_service_sentinel = object()
+
+
+class TradeOrderDispatcher:
+    """Dispatch trade orders to configured sinks with gating and deduplication."""
+
+    def __init__(
+        self,
+        *,
+        http_poster: type[HttpPoster] = HttpPoster,
+        dedup_cache: TTLCache[str, bool] | None = None,
+        activation_manager: Any | None = None,
+        trade_execution_service: Any | None = None,
+        trade_order_http_url: str | None = None,
+        kafka_producer: Any | None = None,
+        trade_order_kafka_topic: str | None = None,
+    ) -> None:
+        self._http_poster = http_poster
+        self._order_dedup = dedup_cache
+        self._activation_manager = activation_manager
+        self._trade_execution_service = (
+            trade_execution_service
+            if trade_execution_service is not None
+            else _trade_execution_service_sentinel
+        )
+        self._trade_order_http_url = trade_order_http_url
+        self._kafka_producer = kafka_producer
+        self._trade_order_kafka_topic = trade_order_kafka_topic
+
+    # ------------------------------------------------------------------
+    # Configuration API (mirrors Runner setters for ease of delegation)
+    # ------------------------------------------------------------------
+    def set_activation_manager(self, manager: Any | None) -> None:
+        self._activation_manager = manager
+
+    def set_trade_execution_service(self, service: Any | None) -> None:
+        self._trade_execution_service = (
+            service if service is not None else _trade_execution_service_sentinel
+        )
+
+    def set_http_url(self, url: str | None) -> None:
+        self._trade_order_http_url = url
+
+    def set_kafka_producer(self, producer: Any | None) -> None:
+        self._kafka_producer = producer
+
+    def set_trade_order_kafka_topic(self, topic: str | None) -> None:
+        self._trade_order_kafka_topic = topic
+
+    def set_dedup_cache(self, cache: TTLCache[str, bool] | None) -> None:
+        self._order_dedup = cache
+
+    # ------------------------------------------------------------------
+    def reset_dedup(self) -> None:
+        cache = self._order_dedup
+        if cache is not None:
+            cache.clear()
+
+    # ------------------------------------------------------------------
+    def dispatch(self, order: Any) -> None:
+        """Dispatch ``order`` to configured sinks with gating and deduplication."""
+
+        # Activation gating
+        side = ""
+        if isinstance(order, dict):
+            side = (order.get("side") or "").lower()
+        am = self._activation_manager
+        if am is not None and side:
+            try:
+                allowed = am.allow_side(side)
+            except Exception:  # pragma: no cover - defensive; activation is user provided
+                allowed = True
+            if not allowed:
+                logger.info("Order gated off by activation: side=%s", side)
+                return
+
+        # Custom trade execution service takes precedence when configured
+        service = self._trade_execution_service
+        if service is not _trade_execution_service_sentinel and service is not None:
+            service.post_order(order)
+            return
+
+        # Validate order payload shape for built-in adapters
+        if not isinstance(order, dict) or not order.get("side"):
+            logger.debug("ignoring non-order payload: %s", order)
+            return
+
+        # Deduplicate orders derived from identical signals
+        cache = self._order_dedup
+        dedup_key = self._dedup_key(order)
+        if cache is not None and dedup_key is not None:
+            if cache.get(dedup_key):
+                logger.info("duplicate order suppressed (idempotent): %s", dedup_key)
+                return
+            cache[dedup_key] = True
+
+        # Submit via HTTP if configured
+        if self._trade_order_http_url is not None:
+            for attempt in range(2):
+                try:
+                    self._http_poster.post(self._trade_order_http_url, json=order)
+                    break
+                except Exception:  # pragma: no cover - network failures are non-deterministic
+                    if attempt == 1:
+                        logger.warning("trade order HTTP submit failed; dropping order")
+
+        # Submit via Kafka if configured
+        if self._kafka_producer is not None and self._trade_order_kafka_topic is not None:
+            self._kafka_producer.send(self._trade_order_kafka_topic, order)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _dedup_key(order: dict) -> str | None:
+        try:
+            qty = order.get("quantity")
+            ts = order.get("timestamp")
+            sym = order.get("symbol") or ""
+            side = order.get("side")
+        except Exception:
+            return None
+        if side is None:
+            return None
+        return f"{side}|{qty}|{ts}|{sym}"
+
+
+__all__ = ["TradeOrderDispatcher"]

--- a/tests/sdk/test_history_warmup_service.py
+++ b/tests/sdk/test_history_warmup_service.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from qmtl.sdk import Strategy, StreamInput
+from qmtl.sdk.history_warmup_service import HistoryWarmupService
+
+
+class SimpleStrategy(Strategy):
+    def setup(self) -> None:
+        node = StreamInput(interval="60s", period=1)
+        self.add_nodes([node])
+
+
+@pytest.mark.asyncio
+async def test_history_service_offline_defaults(monkeypatch):
+    strategy = SimpleStrategy()
+    strategy.setup()
+    service = HistoryWarmupService()
+    service.hydrate_snapshots = lambda s: None  # type: ignore[assignment]
+    recorded: list[tuple[int | None, int | None, bool, bool]] = []
+    replays: list[tuple[int | None, int | None]] = []
+
+    async def fake_ensure(self, strat, start, end, *, stop_on_ready, strict):
+        recorded.append((start, end, stop_on_ready, strict))
+
+    async def fake_replay(self, strat, start, end, *, on_missing="skip"):
+        replays.append((start, end))
+
+    service.ensure_history = types.MethodType(fake_ensure, service)  # type: ignore[assignment]
+    service.replay_history = types.MethodType(fake_replay, service)  # type: ignore[assignment]
+
+    await service.warmup_strategy(
+        strategy,
+        offline_mode=True,
+        history_start=None,
+        history_end=None,
+    )
+
+    assert recorded == [(1, 2, True, False)]
+    assert replays == []  # no provider, so no replay
+
+
+@pytest.mark.asyncio
+async def test_history_service_with_provider_and_strict(monkeypatch):
+    class Provider:
+        async def coverage(self, *, node_id, interval):
+            return [(0, 60)]
+
+        async def fill_missing(self, start, end, *, node_id, interval):
+            return None
+
+    class ProviderStrategy(Strategy):
+        def setup(self) -> None:
+            src = StreamInput(interval="60s", period=1, history_provider=Provider())
+            src.pre_warmup = False
+            self.add_nodes([src])
+
+    strategy = ProviderStrategy()
+    strategy.setup()
+    node = strategy.nodes[0]
+
+    service = HistoryWarmupService()
+    service.hydrate_snapshots = lambda s: None  # type: ignore[assignment]
+    monkeypatch.setattr("qmtl.sdk.runtime.FAIL_ON_HISTORY_GAP", True, raising=False)
+
+    recorded: list[tuple[int | None, int | None, bool, bool]] = []
+    replay_calls: list[tuple[int | None, int | None]] = []
+    strict_calls: list[Strategy] = []
+
+    async def fake_ensure(self, strat, start, end, *, stop_on_ready, strict):
+        recorded.append((start, end, stop_on_ready, strict))
+
+    async def fake_replay(self, strat, start, end, *, on_missing="skip"):
+        replay_calls.append((start, end))
+
+    async def fake_strict(self, strat):
+        strict_calls.append(strat)
+
+    service.ensure_history = types.MethodType(fake_ensure, service)  # type: ignore[assignment]
+    service.replay_history = types.MethodType(fake_replay, service)  # type: ignore[assignment]
+    service._enforce_strict_mode = types.MethodType(fake_strict, service)  # type: ignore[assignment]
+
+    await service.warmup_strategy(
+        strategy,
+        offline_mode=True,
+        history_start=None,
+        history_end=None,
+    )
+
+    assert recorded == [(None, None, True, True)]
+    assert replay_calls == [(None, None)]
+    assert strict_calls == [strategy]

--- a/tests/sdk/test_strategy_bootstrapper.py
+++ b/tests/sdk/test_strategy_bootstrapper.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.common.compute_key import ComputeContext
+from qmtl.sdk import StreamInput, Strategy
+from qmtl.sdk import strategy_bootstrapper as bootstrapper_module
+from qmtl.sdk.strategy_bootstrapper import StrategyBootstrapper
+
+
+class SimpleStrategy(Strategy):
+    def setup(self) -> None:
+        node = StreamInput(interval="60s", period=1)
+        self.add_nodes([node])
+
+
+class NoExecuteStrategy(Strategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.finished = False
+
+    def setup(self) -> None:
+        node = StreamInput(interval="60s", period=1)
+        node.execute = False
+        self.add_nodes([node])
+
+    def on_finish(self) -> None:
+        super().on_finish()
+        self.finished = True
+
+
+class FakeGatewayClient:
+    def __init__(self, response: dict[str, object]) -> None:
+        self.response = response
+        self.calls: list[dict[str, object]] = []
+
+    async def post_strategy(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.response
+
+
+class FakeManager:
+    def __init__(self) -> None:
+        self.offline_flags: list[bool] = []
+
+    async def resolve_tags(self, *, offline: bool) -> None:
+        self.offline_flags.append(offline)
+
+
+class FakeTagService:
+    def __init__(self, gateway_url: str | None) -> None:
+        self.gateway_url = gateway_url
+        self.applied: list[dict[str, object]] = []
+        self.manager = FakeManager()
+
+    def init(self, strategy: Strategy, world_id: str | None = None, strategy_id: str | None = None):
+        return self.manager
+
+    def apply_queue_map(self, strategy: Strategy, queue_map: dict[str, object]) -> None:
+        self.applied.append(queue_map)
+
+
+class DummyPlane:
+    def __init__(self) -> None:
+        self.configured: tuple[str | None, str] | None = None
+
+    def configure(self, *, dataset_fingerprint: str | None, execution_domain: str) -> None:
+        self.configured = (dataset_fingerprint, execution_domain)
+
+
+@pytest.mark.asyncio
+async def test_strategy_bootstrapper_applies_queue_map(monkeypatch):
+    strategy = SimpleStrategy()
+    strategy.setup()
+    client = FakeGatewayClient({strategy.nodes[0].node_id: "queue"})
+    plane = DummyPlane()
+    created_services: list[FakeTagService] = []
+
+    def make_service(url: str | None) -> FakeTagService:
+        svc = FakeTagService(url)
+        created_services.append(svc)
+        return svc
+
+    monkeypatch.setattr(bootstrapper_module, "TagManagerService", make_service)
+
+    context = ComputeContext(world_id="w1", execution_domain="live")
+    result = await StrategyBootstrapper(client).bootstrap(
+        strategy,
+        context=context,
+        world_id="w1",
+        gateway_url="http://gateway",
+        meta={"dataset_fingerprint": "fp-123"},
+        offline=False,
+        kafka_available=True,
+        trade_mode="live",
+        schema_enforcement="strict",
+        feature_plane=plane,
+    )
+
+    assert not result.completed
+    assert result.offline_mode is False
+    assert plane.configured == ("fp-123", context.execution_domain)
+    assert getattr(strategy.nodes[0], "dataset_fingerprint") == "fp-123"
+    assert getattr(strategy.nodes[0], "_schema_enforcement") == "strict"
+    assert client.calls  # gateway invoked
+    service = created_services[-1]
+    assert service.applied == [{strategy.nodes[0].node_id: "queue"}]
+    assert service.manager.offline_flags == [False]
+
+
+@pytest.mark.asyncio
+async def test_strategy_bootstrapper_handles_no_executable_nodes(monkeypatch):
+    strategy = NoExecuteStrategy()
+    strategy.setup()
+    client = FakeGatewayClient({})
+    fake_service = FakeTagService(None)
+    monkeypatch.setattr(bootstrapper_module, "TagManagerService", lambda url: fake_service)
+
+    context = ComputeContext(world_id="w2", execution_domain="backtest")
+    result = await StrategyBootstrapper(client).bootstrap(
+        strategy,
+        context=context,
+        world_id="w2",
+        gateway_url=None,
+        meta=None,
+        offline=True,
+        kafka_available=False,
+        trade_mode="simulate",
+        schema_enforcement="fail",
+        feature_plane=None,
+    )
+
+    assert result.completed is True
+    assert strategy.finished is True
+    assert fake_service.manager.offline_flags == []  # resolve_tags not called when completed

--- a/tests/sdk/test_trade_dispatcher.py
+++ b/tests/sdk/test_trade_dispatcher.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+from cachetools import TTLCache
+
+from qmtl.sdk.trade_dispatcher import TradeOrderDispatcher
+
+
+class RecordingPoster:
+    calls: list[tuple[str, dict]] = []
+
+    @classmethod
+    def post(cls, url: str, json: dict) -> None:
+        cls.calls.append((url, json))
+
+
+class RecordingProducer:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, dict]] = []
+
+    def send(self, topic: str, payload: dict) -> None:
+        self.sent.append((topic, payload))
+
+
+class RecordingService:
+    def __init__(self) -> None:
+        self.orders: list[dict] = []
+
+    def post_order(self, order: dict) -> None:
+        self.orders.append(order)
+
+
+class DenyActivation:
+    def allow_side(self, side: str) -> bool:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def clear_poster_calls() -> None:
+    RecordingPoster.calls.clear()
+    yield
+    RecordingPoster.calls.clear()
+
+
+def test_dispatcher_gates_via_activation_manager() -> None:
+    dispatcher = TradeOrderDispatcher(
+        http_poster=RecordingPoster,
+        dedup_cache=TTLCache(maxsize=10, ttl=60),
+        activation_manager=DenyActivation(),
+        trade_order_http_url="http://endpoint",
+    )
+
+    dispatcher.dispatch({"side": "BUY", "quantity": 1, "timestamp": 0})
+
+    assert RecordingPoster.calls == []
+
+
+def test_dispatcher_deduplicates_orders() -> None:
+    dispatcher = TradeOrderDispatcher(
+        http_poster=RecordingPoster,
+        dedup_cache=TTLCache(maxsize=10, ttl=60),
+        trade_order_http_url="http://endpoint",
+    )
+
+    order = {"side": "SELL", "quantity": 1, "timestamp": 1}
+    dispatcher.dispatch(order)
+    dispatcher.dispatch(order)
+
+    assert len(RecordingPoster.calls) == 1
+
+
+def test_dispatcher_uses_http_and_kafka() -> None:
+    producer = RecordingProducer()
+    dispatcher = TradeOrderDispatcher(
+        http_poster=RecordingPoster,
+        dedup_cache=TTLCache(maxsize=10, ttl=60),
+        trade_order_http_url="http://endpoint",
+        kafka_producer=producer,
+        trade_order_kafka_topic="orders",
+    )
+
+    order = {"side": "BUY", "quantity": 2, "timestamp": 2}
+    dispatcher.dispatch(order)
+
+    assert RecordingPoster.calls == [("http://endpoint", order)]
+    assert producer.sent == [("orders", order)]
+
+
+def test_trade_execution_service_takes_precedence() -> None:
+    service = RecordingService()
+    dispatcher = TradeOrderDispatcher(
+        http_poster=RecordingPoster,
+        dedup_cache=TTLCache(maxsize=10, ttl=60),
+        trade_execution_service=service,
+        trade_order_http_url="http://endpoint",
+    )
+
+    order = {"side": "BUY", "quantity": 3, "timestamp": 3}
+    dispatcher.dispatch(order)
+
+    assert service.orders == [order]
+    assert RecordingPoster.calls == []

--- a/tests/test_runner_postprocess.py
+++ b/tests/test_runner_postprocess.py
@@ -100,10 +100,11 @@ def test_handle_trade_order_http_and_kafka(monkeypatch):
 
     import importlib
     import qmtl.sdk.runner as runner_module
+    from qmtl.sdk import trade_dispatcher as dispatcher_module
 
     runner_module = importlib.reload(runner_module)
-    monkeypatch.setattr(runner_module.HttpPoster, "post", fake_post)
-    assert runner_module.HttpPoster.post is fake_post
+    monkeypatch.setattr(dispatcher_module.HttpPoster, "post", fake_post)
+    assert dispatcher_module.HttpPoster.post is fake_post
 
     runner = runner_module.Runner
     producer = FakeKafkaProducer()

--- a/tests/test_trade_execution_service.py
+++ b/tests/test_trade_execution_service.py
@@ -7,6 +7,7 @@ import importlib
 
 import qmtl.sdk.runner as runner_module
 from qmtl.sdk import TradeExecutionService
+from qmtl.sdk import trade_dispatcher as dispatcher_module
 
 
 class DummyResponse:
@@ -24,7 +25,7 @@ def test_service_retries_on_failure(monkeypatch):
         if calls["count"] == 1:
             raise httpx.HTTPError("boom")
         return DummyResponse()
-    monkeypatch.setattr(runner_module.HttpPoster, "post", fake_post)
+    monkeypatch.setattr(dispatcher_module.HttpPoster, "post", fake_post)
     monkeypatch.setattr(TradeExecutionService, "poll_order_status", lambda self, order: None)
     service = TradeExecutionService("http://broker", max_retries=2)
     service.post_order({"id": 1})
@@ -53,7 +54,7 @@ def test_runner_delegates_to_service(monkeypatch):
         def post_order(self, order):
             self.orders.append(order)
 
-    monkeypatch.setattr(runner_module.HttpPoster, "post", boom)
+    monkeypatch.setattr(dispatcher_module.HttpPoster, "post", boom)
     service = DummyService()
     importlib.reload(runner_module)
     runner_module.Runner.set_trade_execution_service(service)


### PR DESCRIPTION
## Summary
- extract strategy bootstrap, history warmup, and trade dispatch responsibilities from `Runner` into dedicated helper modules
- update `Runner` to delegate to the new helpers and keep legacy proxy methods for history while wiring activation and dispatch settings through the dispatcher
- add unit tests for each new helper and refresh existing runner/trade execution tests to cover the new integration points

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68d0292b35c883299fb888688c87b195