### PR TITLE
Refactor world proxy routes to use shared helper

### DIFF
--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -10,7 +10,7 @@ import hashlib
 import os
 import logging
 from datetime import datetime, timezone, timedelta
-from typing import Any, Optional
+from typing import Any, Optional, Awaitable, Callable
 
 from fastapi import APIRouter, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
@@ -184,170 +184,186 @@ def create_api_router(
         headers["X-Correlation-ID"] = cid
         return headers, cid
 
+    async def _proxy_world_call(
+        request: Request,
+        func: Callable[[WorldServiceClient, dict[str, str]], Awaitable[Any]],
+        *,
+        response_builder: Callable[[Any, dict[str, str]], Response] | None = None,
+    ) -> Response:
+        client: WorldServiceClient | None = world_client
+        if client is None:
+            raise HTTPException(status_code=503, detail="world service disabled")
+
+        headers, cid = _build_world_headers(request)
+        data = await func(client, headers)
+
+        base_headers = {"X-Correlation-ID": cid}
+        builder = response_builder or (
+            lambda payload, hdrs: JSONResponse(payload, headers=dict(hdrs))
+        )
+        return builder(data, dict(base_headers))
+
 
     @router.post("/worlds")
     async def create_world(payload: dict, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.create_world(payload, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.create_world(payload, headers=headers),
+        )
 
     @router.get("/worlds")
     async def list_worlds(request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.list_worlds(headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request, lambda client, headers: client.list_worlds(headers=headers)
+        )
 
     @router.get("/worlds/{world_id}")
     async def get_world(world_id: str, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.get_world(world_id, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.get_world(world_id, headers=headers),
+        )
 
     @router.put("/worlds/{world_id}")
     async def put_world(world_id: str, payload: dict, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.put_world(world_id, payload, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.put_world(
+                world_id, payload, headers=headers
+            ),
+        )
 
     @router.delete(
         "/worlds/{world_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None
     )
     async def delete_world(world_id: str, request: Request) -> Response:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        await client.delete_world(world_id, headers=headers)
-        return Response(status_code=status.HTTP_204_NO_CONTENT, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.delete_world(world_id, headers=headers),
+            response_builder=lambda _data, headers: Response(
+                status_code=status.HTTP_204_NO_CONTENT, headers=headers
+            ),
+        )
 
     @router.post("/worlds/{world_id}/policies")
     async def post_world_policy(world_id: str, payload: dict, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.post_policy(world_id, payload, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.post_policy(
+                world_id, payload, headers=headers
+            ),
+        )
 
     @router.get("/worlds/{world_id}/policies")
     async def get_world_policies(world_id: str, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.get_policies(world_id, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.get_policies(world_id, headers=headers),
+        )
 
     @router.post("/worlds/{world_id}/set-default")
     async def post_world_set_default(world_id: str, payload: dict, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.set_default_policy(world_id, payload, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.set_default_policy(
+                world_id, payload, headers=headers
+            ),
+        )
 
     @router.post("/worlds/{world_id}/bindings")
     async def post_world_bindings(world_id: str, payload: dict, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.post_bindings(world_id, payload, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.post_bindings(
+                world_id, payload, headers=headers
+            ),
+        )
 
     @router.get("/worlds/{world_id}/bindings")
     async def get_world_bindings(world_id: str, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.get_bindings(world_id, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.get_bindings(world_id, headers=headers),
+        )
 
     @router.post("/worlds/{world_id}/decisions")
     async def post_world_decisions(world_id: str, payload: dict, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.post_decisions(world_id, payload, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.post_decisions(
+                world_id, payload, headers=headers
+            ),
+        )
 
     @router.put("/worlds/{world_id}/activation")
     async def put_world_activation(world_id: str, payload: dict, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.put_activation(world_id, payload, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.put_activation(
+                world_id, payload, headers=headers
+            ),
+        )
 
     @router.get("/worlds/{world_id}/audit")
     async def get_world_audit(world_id: str, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.get_audit(world_id, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.get_audit(world_id, headers=headers),
+        )
     @router.get("/worlds/{world_id}/decide")
     async def get_world_decide(world_id: str, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data, stale = await client.get_decide(world_id, headers=headers)
-        resp_headers = {"X-Correlation-ID": cid}
-        if stale:
-            resp_headers["Warning"] = "110 - Response is stale"
-            resp_headers["X-Stale"] = "true"
-        return JSONResponse(data, headers=resp_headers)
+        def _response(result: Any, headers: dict[str, str]) -> Response:
+            data, stale = result
+            resp_headers = dict(headers)
+            if stale:
+                resp_headers["Warning"] = "110 - Response is stale"
+                resp_headers["X-Stale"] = "true"
+            return JSONResponse(data, headers=resp_headers)
+
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.get_decide(world_id, headers=headers),
+            response_builder=_response,
+        )
 
     @router.get("/worlds/{world_id}/activation")
     async def get_world_activation(world_id: str, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
         strategy_id = request.query_params.get("strategy_id", "")
         side = request.query_params.get("side", "")
-        data, stale = await client.get_activation(world_id, strategy_id, side, headers=headers)
-        resp_headers = {"X-Correlation-ID": cid}
-        if stale:
-            resp_headers["Warning"] = "110 - Response is stale"
-            resp_headers["X-Stale"] = "true"
-        return JSONResponse(data, headers=resp_headers)
+
+        def _response(result: Any, headers: dict[str, str]) -> Response:
+            data, stale = result
+            resp_headers = dict(headers)
+            if stale:
+                resp_headers["Warning"] = "110 - Response is stale"
+                resp_headers["X-Stale"] = "true"
+            return JSONResponse(data, headers=resp_headers)
+
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.get_activation(
+                world_id, strategy_id, side, headers=headers
+            ),
+            response_builder=_response,
+        )
 
     @router.get("/worlds/{world_id}/{topic}/state_hash")
     async def get_world_state_hash(world_id: str, topic: str, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.get_state_hash(world_id, topic, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.get_state_hash(
+                world_id, topic, headers=headers
+            ),
+        )
 
     @router.post("/worlds/{world_id}/evaluate")
     async def post_world_evaluate(world_id: str, payload: dict, request: Request) -> Any:
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.post_evaluate(world_id, payload, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.post_evaluate(
+                world_id, payload, headers=headers
+            ),
+        )
 
     @router.post("/worlds/{world_id}/apply")
     async def post_world_apply(world_id: str, payload: dict, request: Request) -> Any:
@@ -356,12 +372,12 @@ def create_api_router(
                 status_code=403,
                 detail={"code": "E_PERMISSION_DENIED", "message": "live trading not allowed"},
             )
-        client: WorldServiceClient | None = world_client
-        if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
-        headers, cid = _build_world_headers(request)
-        data = await client.post_apply(world_id, payload, headers=headers)
-        return JSONResponse(data, headers={"X-Correlation-ID": cid})
+        return await _proxy_world_call(
+            request,
+            lambda client, headers: client.post_apply(
+                world_id, payload, headers=headers
+            ),
+        )
 
     @router.post("/fills", status_code=status.HTTP_202_ACCEPTED)
     async def post_fills(request: Request) -> Response:


### PR DESCRIPTION
## Summary
- add a shared `_proxy_world_call` helper in the gateway routes to centralize world service header construction, client checks, and response handling
- refactor all world-related REST endpoints to reuse the helper while keeping stale-response and no-content behaviors via custom builders
- extend world proxy tests to cover missing world client errors and correlation ID propagation

## Testing
- uv run -m pytest tests/gateway/test_world_proxy.py


------
https://chatgpt.com/codex/tasks/task_e_68d079ac8ed883298a0d378c7db1710f