### PR TITLE
Avoid duplicate context application in runner

### DIFF
--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -548,12 +548,6 @@ class Runner:
             partition=partition,
         )
 
-        for n in strategy.nodes:
-            setattr(n, "_schema_enforcement", schema_enforcement)
-            try:
-                n.apply_compute_context(compute_context)
-            except AttributeError:
-                pass
         setattr(strategy, "compute_context", dict(resolved_context))
 
         gateway_context = {

--- a/tests/sdk/test_runner_context.py
+++ b/tests/sdk/test_runner_context.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.sdk.node import StreamInput
+from qmtl.sdk.runner import Runner
+from qmtl.sdk.strategy import Strategy
+from qmtl.sdk.strategy_bootstrapper import BootstrapResult, StrategyBootstrapper
+
+
+class CountingStreamInput(StreamInput):
+    def __init__(self) -> None:
+        super().__init__(interval="60s", period=1)
+        self.apply_calls: int = 0
+        self.seen_contexts: list[object] = []
+
+    def apply_compute_context(self, context) -> None:  # type: ignore[override]
+        self.apply_calls += 1
+        self.seen_contexts.append(context)
+        super().apply_compute_context(context)
+
+
+class CountingStrategy(Strategy):
+    def setup(self) -> None:
+        node = CountingStreamInput()
+        self.add_nodes([node])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("offline", [False, True])
+async def test_runner_applies_context_once(monkeypatch, offline: bool) -> None:
+    before_counts: list[list[int]] = []
+    after_counts: list[list[int]] = []
+    received_offline: list[bool] = []
+
+    async def fake_bootstrap(
+        self,
+        strategy: Strategy,
+        *,
+        context,
+        schema_enforcement: str,
+        offline: bool,
+        **kwargs,
+    ) -> BootstrapResult:
+        received_offline.append(offline)
+        before_counts.append([node.apply_calls for node in strategy.nodes])
+        for node in strategy.nodes:
+            setattr(node, "_schema_enforcement", schema_enforcement)
+            node.apply_compute_context(context)
+        after_counts.append([node.apply_calls for node in strategy.nodes])
+        return BootstrapResult(
+            manager=object(),
+            offline_mode=offline,
+            completed=True,
+            dataset_fingerprint=None,
+            tag_service=object(),
+            dag_meta=None,
+        )
+
+    monkeypatch.setattr(StrategyBootstrapper, "bootstrap", fake_bootstrap, raising=False)
+
+    strategy = await Runner.run_async(
+        CountingStrategy,
+        world_id="world",
+        offline=offline,
+        schema_enforcement="strict",
+    )
+
+    assert before_counts == [[0]]
+    assert after_counts == [[1]]
+    assert received_offline == [offline]
+
+    node = strategy.nodes[0]
+    assert isinstance(node, CountingStreamInput)
+    assert node.apply_calls == 1
+    assert getattr(node, "_schema_enforcement") == "strict"
+    assert len(node.seen_contexts) == 1
+


### PR DESCRIPTION
## Summary
- rely on `StrategyBootstrapper` to apply schema enforcement and compute context inside `Runner.run_async`
- add coverage that ensures compute context is only applied once for live and offline flows

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto


------
https://chatgpt.com/codex/tasks/task_e_68d079a5f3688329a802a73c7309f1e9