### PR TITLE
Allow optional match_mode parameter in queues_by_tag endpoint

### DIFF
--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -147,7 +147,7 @@ def create_api_router(
     # ControlBus-driven updates; see qmtl.gateway.ws and event handlers.
     @router.get("/queues/by_tag", response_model=QueuesByTagResponse)
     async def queues_by_tag(
-        tags: str, interval: int, match_mode: str, world_id: str = ""
+        tags: str, interval: int, match_mode: str | None = None, world_id: str = ""
     ) -> QueuesByTagResponse:
         from qmtl.common.tagquery import split_tags, normalize_match_mode
 

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -107,6 +107,20 @@ def test_queues_by_tag_route(client):
     assert dag.called_with == (["t1", "t2"], 60, "any", None, None)
 
 
+def test_queues_by_tag_route_default_match_mode(client):
+    c, dag = client
+    resp = c.get(
+        "/queues/by_tag",
+        params={"tags": "t1,t2", "interval": "60"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["queues"] == [
+        {"queue": "q1", "global": False},
+        {"queue": "q2", "global": False},
+    ]
+    assert dag.called_with == (["t1", "t2"], 60, "any", None, None)
+
+
 def test_queues_by_tag_route_all_mode(client):
     c, dag = client
     resp = c.get(


### PR DESCRIPTION
## Summary
- allow the `/queues/by_tag` route to accept an optional `match_mode` query parameter and rely on existing normalization defaults
- keep the response contract unchanged while continuing to forward the normalized match mode to the DAG client
- add a regression test to confirm the endpoint succeeds and defaults to `"any"` when `match_mode` is omitted

## Testing
- `uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 tests/gateway/test_tag_query.py`
- `uv run -m pytest -W error -n auto tests/gateway/test_tag_query.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0819d96c48329b27058cc2a55524f