### PR TITLE
Enforce as_of handling for backtest submissions

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -142,10 +142,22 @@ Content‑Encoding: gzip
 Content‑Type: application/json
 {
   "dag_json": "<base64>",
-  "meta": { "user": "quant.alice", "desc": "BTC scalper" },
+  "meta": {
+    "user": "quant.alice",
+    "desc": "BTC scalper",
+    "execution_domain": "backtest",
+    "as_of": "2025-01-01T00:00:00Z",
+    "partition": "tenant-a"
+  },
   "world_ids": ["crypto_mom_1h", "crypto_alt_1h"]  // or legacy single field: "world_id"
 }
 ```
+
+> **Backtests & dry-runs:** When `meta.execution_domain` resolves to `backtest` or
+> `dryrun` (including aliases such as `compute-only`, `paper`, or `sim`), callers
+> MUST include `meta.as_of`. Gateway downgrades missing values to compute-only
+> backtests and records the event via `strategy_compute_context_downgrade_total{
+> reason="missing_as_of"}` to prevent dataset cross-contamination.
 
 **Example Queue Lookup**
 

--- a/qmtl/gateway/metrics.py
+++ b/qmtl/gateway/metrics.py
@@ -113,6 +113,13 @@ worlds_compute_context_downgrade_total = Counter(
     registry=global_registry,
 )
 
+strategy_compute_context_downgrade_total = Counter(
+    "strategy_compute_context_downgrade_total",
+    "Total number of strategy submissions downgraded due to missing fields",
+    ["reason"],
+    registry=global_registry,
+)
+
 # Circuit breaker metrics for WorldService
 worlds_breaker_state = Gauge(
     "worlds_breaker_state",
@@ -474,6 +481,7 @@ def reset_metrics() -> None:
     worlds_stale_responses_total._value.set(0)  # type: ignore[attr-defined]
     worlds_stale_responses_total._val = 0  # type: ignore[attr-defined]
     worlds_compute_context_downgrade_total.clear()
+    strategy_compute_context_downgrade_total.clear()
     _worlds_samples.clear()
     worlds_breaker_state.set(0)
     worlds_breaker_state._val = 0  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- normalize strategy submission execution domains, require `as_of` for backtest/dryrun contexts, and downgrade missing values
- add a strategy submission downgrade metric and reset handling alongside expanded unit coverage
- document the updated `as_of` requirement for clients submitting backtest or dry-run DAGs

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout --with pytest-asyncio --with fakeredis --with jsonschema -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run --with pytest-timeout --with pytest-asyncio --with fakeredis --with jsonschema --with pytest-xdist -m pytest -W error -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68d081a089fc832999c1b071bd57c864