### PR TITLE
worldservice: audit breadcrumbs for lazy migration and domain-scoped EvalKey

### DIFF
--- a/docs/operations/neo4j_migrations.md
+++ b/docs/operations/neo4j_migrations.md
@@ -57,6 +57,7 @@ Use with caution in lower environments; production rollback should follow a cont
 4. **Validation**
    - Sample `MATCH (n:WorldNodeRef) RETURN n.execution_domain, count(*) ORDER BY n.execution_domain;` to ensure the histogram aligns with expectations.
    - Automated coverage: `tests/worldservice/test_worldservice_api.py::test_world_nodes_execution_domains_and_legacy_migration` exercises the lazy conversion path via the public API.
+   - WorldService appends `world_node_bucket_normalized` audit events when legacy payloads are promoted on-demand. Monitor `GET /worlds/{id}/audit` to confirm conversions complete without manual intervention.
 
 ### Rollback
 
@@ -77,6 +78,7 @@ Use with caution in lower environments; production rollback should follow a cont
    - During lookup the service rehashes the context; mismatched keys are dropped and the caller re-runs validation.
    - Tests cover this path via `tests/worldservice/test_validation_cache.py::test_validation_cache_legacy_payloads_are_normalised_and_invalidated`.
    - Canonical execution domain coercion is verified by `tests/worldservice/test_validation_cache.py::test_validation_cache_normalises_execution_domain_on_set` to prevent divergent cache buckets during the rollout.
+   - The audit log records `validation_cache_bucket_normalized` when payloads are rewritten and `validation_cache_invalidated` once stale EvalKeys are purged, providing an operational breadcrumb during rollout.
 3. **Optional proactive purge**
    - `MATCH (v:Validation) REMOVE v.eval_key_without_domain;` if a transitional property exists.
    - To force re-validation immediately, delete the `Validation` nodes: `MATCH (v:Validation) WHERE v.version < $cutover REMOVE v` (adjust predicate to local schema).
@@ -85,4 +87,3 @@ Use with caution in lower environments; production rollback should follow a cont
 
 - Monitor the validation cache miss metrics; a spike is expected during rollout and should converge as caches repopulate.
 - Confirm new entries have the `execution_domain` field present in Neo4j snapshots.
-


### PR DESCRIPTION
Summary: Add audit breadcrumbs in WorldService storage for zero‑downtime migration of WorldNodeRef domain expansion and EvalKey domain scoping. Tests extended; ops doc updated.\n\nDetails:\n- WorldNodeRef: emit world_node_bucket_normalized when promoting legacy single‑domain payloads and when normalising per‑domain buckets.\n- Validation cache: emit validation_cache_bucket_normalized when rewriting buckets; preserve validation_cache_invalidated on context mismatches.\n- Tests assert audit signals and lazy invalidation/normalisation.\n- docs/operations/neo4j_migrations.md documents audit breadcrumbs.\n\nFixes #956