### PR TITLE
Enable topic namespaces by default with opt-out

### DIFF
--- a/qmtl/dagmanager/topic.py
+++ b/qmtl/dagmanager/topic.py
@@ -13,11 +13,17 @@ _NAMESPACE_FLAG_ENV = "QMTL_ENABLE_TOPIC_NAMESPACE"
 def topic_namespace_enabled() -> bool:
     """Return ``True`` when topic namespace prefixing is enabled."""
 
-    return os.getenv(_NAMESPACE_FLAG_ENV, "0").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-    }
+    flag = os.getenv(_NAMESPACE_FLAG_ENV)
+    if flag is None:
+        return True
+
+    normalized = flag.strip().lower()
+    if normalized in {"0", "false", "no", "off", "disable", "disabled"}:
+        return False
+
+    # Any other value (including "1", "true", "yes", etc.) keeps the namespace
+    # guard enabled so production deployments honour the required prefixes.
+    return True
 
 
 def _sanitize_namespace_segment(value: object) -> str:

--- a/qmtl/examples/qmtl.yml
+++ b/qmtl/examples/qmtl.yml
@@ -1,3 +1,6 @@
+# Topic namespaces are enabled by default to scope Kafka topics by world and domain.
+# For local experimentation without prefixes, export ``QMTL_ENABLE_TOPIC_NAMESPACE=0``
+# before starting services.
 gateway:
   host: 0.0.0.0
   port: 8000

--- a/tests/e2e/test_domain_transition.py
+++ b/tests/e2e/test_domain_transition.py
@@ -136,7 +136,7 @@ async def test_domain_promotion_flow_respects_freeze_and_isolation(monkeypatch):
                     queues=[SimpleNamespace(**{"queue": "base", "global": False})]
                 )
 
-        monkeypatch.setenv("QMTL_ENABLE_TOPIC_NAMESPACE", "1")
+        monkeypatch.delenv("QMTL_ENABLE_TOPIC_NAMESPACE", raising=False)
         monkeypatch.setattr(
             DagManagerClient,
             "_ensure_channel",

--- a/tests/e2e/test_world_isolation.py
+++ b/tests/e2e/test_world_isolation.py
@@ -31,7 +31,7 @@ async def test_world_isolation(monkeypatch):
         self._tag_stub = StubTagStub()
 
     monkeypatch.setattr(DagManagerClient, "_ensure_channel", fake_ensure)
-    monkeypatch.setenv("QMTL_ENABLE_TOPIC_NAMESPACE", "1")
+    monkeypatch.delenv("QMTL_ENABLE_TOPIC_NAMESPACE", raising=False)
 
     q1 = await client.get_queues_by_tag(["t"], 60, world_id="w1", execution_domain="dryrun")
     q2 = await client.get_queues_by_tag(["t"], 60, world_id="w2", execution_domain="dryrun")

--- a/tests/test_topic_namespace.py
+++ b/tests/test_topic_namespace.py
@@ -1,0 +1,18 @@
+import pytest
+
+from qmtl.dagmanager.topic import topic_namespace_enabled
+
+
+@pytest.mark.parametrize("value", [None, "1", "true", "yes", "ON", "unexpected"])
+def test_namespace_enabled_by_default(monkeypatch, value):
+    if value is None:
+        monkeypatch.delenv("QMTL_ENABLE_TOPIC_NAMESPACE", raising=False)
+    else:
+        monkeypatch.setenv("QMTL_ENABLE_TOPIC_NAMESPACE", value)
+    assert topic_namespace_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "disable", "disabled", " False "])
+def test_namespace_opt_out(monkeypatch, value):
+    monkeypatch.setenv("QMTL_ENABLE_TOPIC_NAMESPACE", value)
+    assert topic_namespace_enabled() is False

--- a/tests/test_world_scope.py
+++ b/tests/test_world_scope.py
@@ -22,7 +22,7 @@ async def test_world_scoping_topics(monkeypatch):
         self._tag_stub = StubTagStub()
     monkeypatch.setattr(DagManagerClient, "_ensure_channel", fake_ensure)
 
-    monkeypatch.setenv("QMTL_ENABLE_TOPIC_NAMESPACE", "1")
+    monkeypatch.delenv("QMTL_ENABLE_TOPIC_NAMESPACE", raising=False)
 
     q1 = await client.get_queues_by_tag(["t"], 60, world_id="w1", execution_domain="dryrun")
     q2 = await client.get_queues_by_tag(["t"], 60, world_id="w2", execution_domain="dryrun")


### PR DESCRIPTION
## Summary
- default `topic_namespace_enabled()` to treat namespacing as on unless the opt-out env var explicitly disables it
- update DagManager-related tests to rely on the new default and add coverage for opt-out handling
- document the env var in the example config for developers who want to disable topic prefixes locally

## Testing
- uv run -m pytest tests/test_topic_namespace.py tests/test_world_scope.py tests/e2e/test_world_isolation.py tests/e2e/test_domain_transition.py

------
https://chatgpt.com/codex/tasks/task_e_68d0909f692483299dc55a0225600082