### PR TITLE
Normalize compute context and canonicalize NodeID

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -200,7 +200,7 @@ The architecture document (§3) defines the deterministic NodeID used across Gat
 Clarifications
 - NodeID MUST NOT include `world_id`. World isolation is enforced at the WVG layer and via world-scoped queue namespaces (e.g., `topic_prefix`), not in the global ID.
 - TagQueryNode canonicalization: do not include the dynamically resolved upstream queue set in `dependencies`. Instead, capture the query spec in `params_canon` (normalized `query_tags` sorted, `match_mode`, and `interval`). Runtime queue discovery and growth are delivered via ControlBus → SDK TagQueryManager; NodeID remains stable across discoveries.
-- Gateway rejects any node submission missing the hash tuple `(node_type, code_hash, config_hash, schema_hash)` with `E_NODE_ID_FIELDS` and returns `E_NODE_ID_MISMATCH` when the provided `node_id` does not equal the canonical `compute_node_id()` output. Both errors include actionable hints so SDK clients can regenerate DAGs with the BLAKE3 contract.
+- Gateway rejects any node submission missing `node_type`, `code_hash`, `config_hash`, `schema_hash`, or `schema_compat_id` with `E_NODE_ID_FIELDS` and returns `E_NODE_ID_MISMATCH` when the provided `node_id` does not equal the canonical `compute_node_id()` output. Both errors include actionable hints so SDK clients can regenerate DAGs with the BLAKE3 contract.
 
 Immediately after ingest, Gateway inserts a `VersionSentinel` node into the DAG so that rollbacks and canary traffic control can be orchestrated without strategy code changes. This behaviour is enabled by default and controlled by the ``insert_sentinel`` configuration field; it may be disabled with the ``--no-sentinel`` CLI flag.
 

--- a/docs/guides/migration_nodeid_blake3.md
+++ b/docs/guides/migration_nodeid_blake3.md
@@ -13,7 +13,9 @@ The NodeID algorithm uses BLAKE3 with a mandatory `blake3:` prefix and must not 
 
 ## Changes
 
-- `compute_node_id` returns `blake3:<digest>` computed from `(node_type, code_hash, config_hash, schema_hash)` without `world_id`.
+- `compute_node_id` returns `blake3:<digest>` computed from the canonical node specification:
+  `(node_type, interval, period, params(canonical JSON), dependencies(sorted), schema_compat_id, code_hash)`.
+  `schema_hash` and `config_hash` remain part of the submitted node payload for validation but are no longer inputs to the digest.
 - The legacy helper `compute_legacy_node_id` has been removed; Gateways reject non-canonical IDs.
 
 ## Actions
@@ -21,6 +23,7 @@ The NodeID algorithm uses BLAKE3 with a mandatory `blake3:` prefix and must not 
 - Ensure all code paths use `compute_node_id` exclusively.
 - Migrate any stored NodeIDs to the canonical `blake3:` form.
 - Remove any references to `compute_legacy_node_id` in your codebase.
-- Update DAG serialization to include `config_hash` alongside `code_hash` and `schema_hash` so Gateway validation can recompute canonical IDs.
+- Update DAG serialization to include `schema_compat_id`, canonical `params` (or `config`) values, and the sorted dependency list so Gateway validation can recompute canonical IDs.
+- Continue to ship `code_hash`, `config_hash`, and `schema_hash` for compatibility checks; Gateway now verifies their presence in addition to `schema_compat_id`.
 
 {{ nav_links() }}

--- a/qmtl/common/nodeid.py
+++ b/qmtl/common/nodeid.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 """Deterministic NodeID helpers."""
-from typing import Iterable
+
+from collections.abc import Iterable, Mapping
+from typing import Any
 
 from blake3 import blake3
+
+from .nodespec import serialize_nodespec
 
 
 def hash_blake3(data: bytes, existing_ids: Iterable[str] | None = None) -> str:
@@ -40,15 +44,17 @@ def hash_blake3(data: bytes, existing_ids: Iterable[str] | None = None) -> str:
 
 
 def compute_node_id(
-    node_type: str,
-    code_hash: str,
-    config_hash: str,
-    schema_hash: str,
+    node: Mapping[str, Any],
+    *,
     existing_ids: Iterable[str] | None = None,
 ) -> str:
-    """Return canonical BLAKE3-based NodeID with ``blake3:`` prefix."""
+    """Return canonical BLAKE3-based NodeID with ``blake3:`` prefix.
 
-    data = f"{node_type}:{code_hash}:{config_hash}:{schema_hash}".encode()
+    The digest is computed from the canonical serialization of the node as
+    produced by :func:`qmtl.common.nodespec.serialize_nodespec`.
+    """
+
+    data = serialize_nodespec(node)
     return hash_blake3(data, existing_ids=existing_ids)
 
 

--- a/qmtl/common/nodespec.py
+++ b/qmtl/common/nodespec.py
@@ -1,41 +1,81 @@
+"""Utilities for canonical Node specification serialization."""
+
 from __future__ import annotations
 
-"""Canonical NodeSpec serializer and NodeID helper (scaffold).
-
-This follows the spirit of the architecture spec by capturing deterministic
-fields and a sorted dependency list from a DAG node dictionary.
-"""
-
+import json
+from collections.abc import Mapping, Sequence
 from typing import Any
 
-from .nodeid import hash_blake3
+_PARAM_EXCLUDE_KEYS = {
+    "world",
+    "world_id",
+    "world_ids",
+    "execution_world",
+    "execution_domain",
+    "domain",
+    "domains",
+    "as_of",
+    "partition",
+    "dataset_fingerprint",
+}
 
 
-def _sorted_deps(node: dict) -> list[str]:
+def _sorted_deps(node: Mapping[str, Any]) -> list[str]:
     deps = node.get("inputs") or node.get("dependencies") or []
-    return sorted([str(d) for d in deps])
+    normalized: list[str] = []
+    for dep in deps:
+        if isinstance(dep, str):
+            normalized.append(dep)
+        elif dep is None:
+            continue
+        else:
+            normalized.append(str(dep))
+    return sorted(normalized)
 
 
-def serialize_nodespec(node: dict[str, Any]) -> bytes:
+def _canonicalize_params(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        canonical: dict[str, Any] = {}
+        for key in sorted(value.keys()):
+            if key in _PARAM_EXCLUDE_KEYS:
+                continue
+            canonical[key] = _canonicalize_params(value[key])
+        return canonical
+    if isinstance(value, set):
+        return sorted(_canonicalize_params(item) for item in value)
+    if isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return [_canonicalize_params(item) for item in value]
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode()
+    return value
+
+
+def _canonical_params_blob(node: Mapping[str, Any]) -> str:
+    params_source = node.get("params")
+    if params_source is None:
+        params_source = node.get("config")
+    canonical = _canonicalize_params(params_source)
+    return json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def serialize_nodespec(node: Mapping[str, Any]) -> bytes:
     node_type = str(node.get("node_type", ""))
     interval = int(node.get("interval") or 0)
     period = int(node.get("period") or 0)
-    params = node.get("params") or node.get("config") or {}
-    # Normalize params: flatten simple key/values and sort by key
-    items = []
-    if isinstance(params, dict):
-        for k in sorted(params.keys()):
-            v = params[k]
-            items.append(f"{k}={v}")
     deps = _sorted_deps(node)
-    schema_compat_id = str(node.get("schema_id", ""))
+    schema_compat_id = str(node.get("schema_compat_id", ""))
+    if not schema_compat_id:
+        schema_compat_id = str(node.get("schema_id", ""))
     code_hash = str(node.get("code_hash", ""))
+    params_blob = _canonical_params_blob(node)
     payload = "|".join(
         [
             node_type,
             str(interval),
             str(period),
-            ";".join(items),
+            params_blob,
             ",".join(deps),
             schema_compat_id,
             code_hash,
@@ -44,10 +84,5 @@ def serialize_nodespec(node: dict[str, Any]) -> bytes:
     return payload.encode()
 
 
-def canonical_node_id(node: dict[str, Any]) -> str:
-    data = serialize_nodespec(node)
-    return hash_blake3(data)
-
-
-__all__ = ["serialize_nodespec", "canonical_node_id"]
+__all__ = ["serialize_nodespec"]
 

--- a/qmtl/common/nodespec.py
+++ b/qmtl/common/nodespec.py
@@ -42,7 +42,13 @@ def _canonicalize_params(value: Any) -> Any:
             canonical[key] = _canonicalize_params(value[key])
         return canonical
     if isinstance(value, set):
-        return sorted(_canonicalize_params(item) for item in value)
+        items = [_canonicalize_params(item) for item in value]
+        def _sort_key(x: Any) -> str:
+            try:
+                return json.dumps(x, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+            except Exception:
+                return str(x)
+        return sorted(items, key=_sort_key)
     if isinstance(value, Sequence) and not isinstance(
         value, (str, bytes, bytearray)
     ):
@@ -85,4 +91,3 @@ def serialize_nodespec(node: Mapping[str, Any]) -> bytes:
 
 
 __all__ = ["serialize_nodespec"]
-

--- a/qmtl/gateway/compute_context.py
+++ b/qmtl/gateway/compute_context.py
@@ -1,0 +1,99 @@
+"""Shared helpers for strategy compute context normalization."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from . import metrics as gw_metrics
+
+_BACKTEST_TOKENS = {
+    "backtest",
+    "backtesting",
+    "compute",
+    "computeonly",
+    "offline",
+    "sandbox",
+    "sim",
+    "simulation",
+    "simulated",
+    "validate",
+    "validation",
+}
+_DRYRUN_TOKENS = {
+    "dryrun",
+    "dryrunmode",
+    "papermode",
+    "paper",
+    "papertrade",
+    "papertrading",
+    "papertrader",
+}
+_LIVE_TOKENS = {"live", "prod", "production"}
+_SHADOW_TOKENS = {"shadow"}
+
+
+def _normalize_value(value: object | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float)):
+        text = str(value).strip()
+        return text or None
+    if isinstance(value, bytes):
+        text = value.decode().strip()
+        return text or None
+    return None
+
+
+def _resolve_execution_domain(value: str | None) -> str | None:
+    if value is None:
+        return None
+    lowered = value.lower()
+    segments = re.split(r"[/:]", lowered)
+    for segment in segments:
+        token = re.sub(r"[\s_-]+", "", segment)
+        if token in _BACKTEST_TOKENS:
+            return "backtest"
+        if token in _DRYRUN_TOKENS:
+            return "dryrun"
+        if token in _LIVE_TOKENS:
+            return "live"
+        if token in _SHADOW_TOKENS:
+            return "shadow"
+    return lowered
+
+
+def build_strategy_compute_context(
+    meta: Mapping[str, Any] | None,
+    *,
+    emit_metrics: bool = True,
+) -> tuple[dict[str, str | None], bool, str | None]:
+    """Return normalized compute context for a strategy submission."""
+
+    meta = meta or {}
+    raw_domain = _normalize_value(meta.get("execution_domain")) if meta else None
+    execution_domain = _resolve_execution_domain(raw_domain)
+    as_of = _normalize_value(meta.get("as_of") if meta else None)
+    partition = _normalize_value(meta.get("partition") if meta else None)
+    dataset_fingerprint = _normalize_value(meta.get("dataset_fingerprint") if meta else None)
+
+    downgraded = False
+    downgrade_reason: str | None = None
+    if execution_domain in {"backtest", "dryrun"} and not as_of:
+        downgraded = True
+        downgrade_reason = "missing_as_of"
+        if emit_metrics:
+            gw_metrics.strategy_compute_context_downgrade_total.labels(reason=downgrade_reason).inc()
+        if execution_domain == "dryrun":
+            execution_domain = "backtest"
+
+    context: dict[str, str | None] = {
+        "execution_domain": execution_domain,
+        "as_of": as_of,
+        "partition": partition,
+        "dataset_fingerprint": dataset_fingerprint,
+    }
+    return context, downgraded, downgrade_reason
+
+
+__all__ = ["build_strategy_compute_context"]

--- a/qmtl/gateway/strategy_submission.py
+++ b/qmtl/gateway/strategy_submission.py
@@ -58,9 +58,8 @@ class StrategySubmissionHelper:
         downgrade_reason = compute_ctx.get("downgrade_reason")
         safe_mode = bool(compute_ctx.get("safe_mode"))
 
-        # Only emit metrics during dry runs (not real submissions).
-        # This avoids recording metrics during actual submissions.
-        if not config.submit and downgraded and downgrade_reason:
+        # Emit a downgrade metric whenever we enter safe mode due to missing context.
+        if downgraded and downgrade_reason:
             gw_metrics.strategy_compute_context_downgrade_total.labels(
                 reason=downgrade_reason
             ).inc()

--- a/qmtl/gateway/tests/test_strategy_submission_helper.py
+++ b/qmtl/gateway/tests/test_strategy_submission_helper.py
@@ -138,7 +138,20 @@ def _build_payload(
     code_hash = "code"
     config_hash = "config"
     schema_hash = "schema"
-    expected_node_id = compute_node_id(node_type, code_hash, config_hash, schema_hash)
+    schema_compat_id = "schema-compat"
+    base_node = {
+        "node_type": node_type,
+        "code_hash": code_hash,
+        "config_hash": config_hash,
+        "schema_hash": schema_hash,
+        "schema_compat_id": schema_compat_id,
+        "params": {"tags": ["alpha"], "match_mode": "any"},
+        "dependencies": [],
+        "tags": ["alpha"],
+        "interval": 5,
+        "match_mode": "any",
+    }
+    expected_node_id = compute_node_id(base_node)
     node_id = "bad-node" if mismatch else expected_node_id
     dag = {
         "nodes": [
@@ -148,6 +161,9 @@ def _build_payload(
                 "code_hash": code_hash,
                 "config_hash": config_hash,
                 "schema_hash": schema_hash,
+                "schema_compat_id": schema_compat_id,
+                "params": {"tags": ["alpha"], "match_mode": "any"},
+                "dependencies": [],
                 "tags": ["alpha"],
                 "interval": 5,
                 "match_mode": "any",

--- a/qmtl/sdk/node.py
+++ b/qmtl/sdk/node.py
@@ -546,6 +546,20 @@ class Node:
         self.execute = True
         self.kafka_topic: str | None = None
         self.enable_feature_artifacts = bool(self.config.get("enable_feature_artifacts", False))
+        compat_id: str | None = None
+        if isinstance(self.schema, dict):
+            compat_id = (
+                self.schema.get("schema_compat_id")
+                or self.schema.get("compat_id")
+                or self.schema.get("compatId")
+            )
+        if compat_id is None and isinstance(self.expected_schema, dict):
+            compat_id = (
+                self.expected_schema.get("schema_compat_id")
+                or self.expected_schema.get("compat_id")
+                or self.expected_schema.get("compatId")
+            )
+        self.schema_compat_id: str = str(compat_id) if compat_id is not None else self.schema_hash
         if arrow_cache.ARROW_AVAILABLE and os.getenv("QMTL_ARROW_CACHE") == "1":
             self.cache = arrow_cache.NodeCacheArrow(period_val or 0)
         else:
@@ -603,12 +617,16 @@ class Node:
 
     @property
     def node_id(self) -> str:
-        return compute_node_id(
-            self.node_type,
-            self.code_hash,
-            self.config_hash,
-            self.schema_hash,
-        )
+        spec = {
+            "node_type": self.node_type,
+            "interval": int(self.interval or 0),
+            "period": int(self.period or 0),
+            "params": self.config,
+            "dependencies": [n.node_id for n in self.inputs],
+            "schema_compat_id": self.schema_compat_id,
+            "code_hash": self.code_hash,
+        }
+        return compute_node_id(spec)
 
     @property
     def node_hash(self) -> str:
@@ -823,6 +841,8 @@ class Node:
             "code_hash": self.code_hash,
             "config_hash": self.config_hash,
             "schema_hash": self.schema_hash,
+            "schema_compat_id": self.schema_compat_id,
+            "params": self.config,
             "pre_warmup": self.pre_warmup,
             "expected_schema": self.expected_schema,
         }

--- a/qmtl/sdk/snapshot.py
+++ b/qmtl/sdk/snapshot.py
@@ -142,6 +142,7 @@ def write_snapshot(node) -> Path | None:
         "interval": node.interval,
         "period": node.period,
         "schema_hash": node.schema_hash,
+        "schema_compat_id": getattr(node, "schema_compat_id", None),
         "runtime_fingerprint": runtime_fingerprint(),
         "state_hash": state_hash,
         "wm_ts": int(min(

--- a/tests/e2e/test_world_isolation.py
+++ b/tests/e2e/test_world_isolation.py
@@ -15,9 +15,19 @@ from qmtl.sdk.metrics import node_processed_total, generate_latest, global_regis
 @pytest.mark.asyncio
 async def test_world_isolation(monkeypatch):
     # 동일 전략 노드가 world에 관계없이 동일한 ID를 갖는다
-    base = ("T", "code", "cfg", "schema")
-    nid1 = compute_node_id(*base)
-    nid2 = compute_node_id(*base)
+    base = {
+        "node_type": "T",
+        "code_hash": "code",
+        "config_hash": "cfg",
+        "schema_hash": "schema",
+        "schema_compat_id": "schema-major",
+        "interval": 15,
+        "period": 5,
+        "params": {"alpha": 1},
+        "dependencies": [],
+    }
+    nid1 = compute_node_id(base)
+    nid2 = compute_node_id(base)
     assert nid1 == nid2
 
     # world별 구독 토픽이 분리된다

--- a/tests/gateway/test_dry_run_parity.py
+++ b/tests/gateway/test_dry_run_parity.py
@@ -10,7 +10,17 @@ from qmtl.dagmanager.kafka_admin import partition_key, compute_key
 from qmtl.proto import dagmanager_pb2
 
 
-_TAGQUERY_NODE_ID = compute_node_id("TagQueryNode", "c", "cfg", "s")
+_TAGQUERY_NODE_ID = compute_node_id(
+    {
+        "node_type": "TagQueryNode",
+        "interval": 60,
+        "period": 0,
+        "params": {"tags": ["t1"], "match_mode": "any"},
+        "dependencies": [],
+        "schema_compat_id": "s-major",
+        "code_hash": "c",
+    }
+)
 
 
 class FakeDB(Database):
@@ -88,6 +98,9 @@ def test_dry_run_matches_submit_queue_map_and_sentinel(fake_redis):
                     "code_hash": "c",
                     "config_hash": "cfg",
                     "schema_hash": "s",
+                    "schema_compat_id": "s-major",
+                    "params": {"tags": ["t1"], "match_mode": "any"},
+                    "dependencies": [],
                     "inputs": [],
                 }
             ]

--- a/tests/gateway/test_strategy_manager_module.py
+++ b/tests/gateway/test_strategy_manager_module.py
@@ -74,7 +74,20 @@ async def test_strategy_manager_writes_commit_log() -> None:
         commit_log_writer=writer,
     )
 
-    dag = {"nodes": [{"node_id": "n1", "node_type": "TypeA", "config_hash": "c", "code_hash": "d", "schema_hash": "s"}]}
+    dag = {
+        "nodes": [
+            {
+                "node_id": "n1",
+                "node_type": "TypeA",
+                "config_hash": "c",
+                "code_hash": "d",
+                "schema_hash": "s",
+                "schema_compat_id": "s-major",
+                "params": {},
+                "dependencies": [],
+            }
+        ]
+    }
     dag_json = base64.b64encode(json.dumps(dag).encode()).decode()
     payload = StrategySubmit(
         dag_json=dag_json,

--- a/tests/integrity/test_checksum.py
+++ b/tests/integrity/test_checksum.py
@@ -37,19 +37,25 @@ def test_checksum_rejects_tampered_ids(client):
         "code_hash": "ch_a",
         "config_hash": "cfg_a",
         "schema_hash": "sch_a",
+        "schema_compat_id": "sch_a_major",
+        "interval": 60,
+        "period": 5,
+        "params": {"window": 5},
+        "dependencies": [],
     }
     node_b = {
         "node_type": "IndicatorNode",
         "code_hash": "ch_b",
         "config_hash": "cfg_b",
         "schema_hash": "sch_b",
+        "schema_compat_id": "sch_b_major",
+        "interval": 60,
+        "period": 5,
+        "params": {"window": 10},
+        "dependencies": ["dep-a"],
     }
-    node_a_id = compute_node_id(
-        node_a["node_type"], node_a["code_hash"], node_a["config_hash"], node_a["schema_hash"]
-    )
-    node_b_id = compute_node_id(
-        node_b["node_type"], node_b["code_hash"], node_b["config_hash"], node_b["schema_hash"]
-    )
+    node_a_id = compute_node_id(node_a)
+    node_b_id = compute_node_id(node_b)
     dag = {
         "nodes": [
             {**node_a, "node_id": node_a_id},

--- a/tests/strategy/test_conflict.py
+++ b/tests/strategy/test_conflict.py
@@ -45,10 +45,13 @@ def test_duplicate_strategy_returns_409(client):
         "code_hash": "ch",
         "config_hash": "cfg",
         "schema_hash": "sh",
+        "schema_compat_id": "sh-major",
+        "interval": 60,
+        "period": 5,
+        "params": {"window": 5},
+        "dependencies": [],
     }
-    node_id = compute_node_id(
-        node["node_type"], node["code_hash"], node["config_hash"], node["schema_hash"]
-    )
+    node_id = compute_node_id(node)
     dag = {"nodes": [{**node, "node_id": node_id}]}
     payload = make_payload(dag)
     first = client.post("/strategies", json=payload.model_dump())

--- a/tests/test_dagmanager.py
+++ b/tests/test_dagmanager.py
@@ -1,5 +1,6 @@
-from blake3 import blake3
 import hashlib
+
+from blake3 import blake3
 
 from qmtl.dagmanager import compute_node_id
 from qmtl.common.nodespec import serialize_nodespec

--- a/tests/test_dagmanager_cli.py
+++ b/tests/test_dagmanager_cli.py
@@ -27,7 +27,19 @@ class DummyRpcError(grpc.RpcError):
         return self._msg
 
 def test_cli_diff_dry_run(tmp_path, capsys):
-    dag = {"nodes": [{"node_id": "n1", "code_hash": "c", "schema_hash": "s"}]}
+    dag = {
+        "nodes": [
+            {
+                "node_id": "n1",
+                "code_hash": "c",
+                "config_hash": "cfg",
+                "schema_hash": "s",
+                "schema_compat_id": "s-major",
+                "params": {},
+                "dependencies": [],
+            }
+        ]
+    }
     path = tmp_path / "dag.json"
     path.write_text(json.dumps(dag))
     main(["diff", "--file", str(path), "--dry_run"])
@@ -183,7 +195,19 @@ def test_cli_queue_stats_grpc_error(monkeypatch, capsys):
 
 
 def test_cli_snapshot_freeze_and_verify(tmp_path, capsys):
-    dag = {"nodes": [{"node_id": "n1", "code_hash": "c", "schema_hash": "s"}]}
+    dag = {
+        "nodes": [
+            {
+                "node_id": "n1",
+                "code_hash": "c",
+                "config_hash": "cfg",
+                "schema_hash": "s",
+                "schema_compat_id": "s-major",
+                "params": {},
+                "dependencies": [],
+            }
+        ]
+    }
     dag_path = tmp_path / "dag.json"
     dag_path.write_text(json.dumps(dag))
     snap_path = tmp_path / "snap.json"

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -102,7 +102,16 @@ async def test_grpc_diff_multiple_chunks():
     server, port = serve(driver, admin, stream, host="127.0.0.1", port=0)
     await server.start()
     nodes = [
-        {"node_id": str(i), "node_type": "N", "code_hash": "c", "schema_hash": "s"}
+        {
+            "node_id": str(i),
+            "node_type": "N",
+            "code_hash": "c",
+            "config_hash": "cfg",
+            "schema_hash": "s",
+            "schema_compat_id": "s-major",
+            "params": {},
+            "dependencies": [],
+        }
         for i in range(120)
     ]
     dag_json = json.dumps({"nodes": nodes})
@@ -322,7 +331,11 @@ async def test_grpc_diff_publishes_controlbus():
                     "node_id": "n1",
                     "node_type": "N",
                     "code_hash": "c",
+                    "config_hash": "cfg",
                     "schema_hash": "s",
+                    "schema_compat_id": "s-major",
+                    "params": {},
+                    "dependencies": [],
                     "interval": 60,
                     "tags": ["x"],
                 }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -94,7 +94,8 @@ class DummyMetrics:
 def _make_dag():
     return (
         '{"nodes": ['
-        '{"node_id": "A", "node_type": "N", "code_hash": "c", "schema_hash": "s"}'
+        '{"node_id": "A", "node_type": "N", "code_hash": "c", "config_hash": "cfg", '
+        '"schema_hash": "s", "schema_compat_id": "s-major", "params": {}, "dependencies": []}'
         ']}'
     )
 

--- a/tests/test_world_scope.py
+++ b/tests/test_world_scope.py
@@ -7,9 +7,19 @@ from qmtl.gateway.dagmanager_client import DagManagerClient
 
 @pytest.mark.asyncio
 async def test_world_scoping_topics(monkeypatch):
-    data = ("T", "code", "cfg", "schema")
-    nid1 = compute_node_id(*data)
-    nid2 = compute_node_id(*data)
+    data = {
+        "node_type": "T",
+        "code_hash": "code",
+        "config_hash": "cfg",
+        "schema_hash": "schema",
+        "schema_compat_id": "schema-major",
+        "interval": 10,
+        "period": 2,
+        "params": {"k": 1},
+        "dependencies": [],
+    }
+    nid1 = compute_node_id(data)
+    nid2 = compute_node_id(data)
     assert nid1 == nid2
 
     client = DagManagerClient("dummy")


### PR DESCRIPTION
## Summary
- add a shared compute-context normalizer and reuse it in strategy submission and commit logging so downgraded dry-runs record the correct execution domain
- update NodeID canonicalization to use schema_compat_id, canonical params, and sorted dependencies, adjusting the SDK node serialization and documentation accordingly
- refresh tests and fixtures to supply canonical node fields that satisfy the stricter validation

## Testing
- `uv run -m pytest -W error -n auto` *(fails at tests/test_arrow_cache.py::test_arrow_cache_view_iteration_benchmark due to Arrow timing variance)*

------
https://chatgpt.com/codex/tasks/task_e_68d090f3872c8329a2a85afbf8c4fa58