### PR TITLE
Enforce safe-mode handling for missing backtest as_of

### DIFF
--- a/qmtl/gateway/compute_context.py
+++ b/qmtl/gateway/compute_context.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Tuple
+
+_BACKTEST_TOKENS = {
+    "backtest",
+    "backtesting",
+    "compute",
+    "computeonly",
+    "offline",
+    "sandbox",
+    "sim",
+    "simulation",
+    "simulated",
+    "validate",
+    "validation",
+}
+
+_DRYRUN_TOKENS = {
+    "dryrun",
+    "dryrunmode",
+    "papermode",
+    "paper",
+    "papertrade",
+    "papertrading",
+    "papertrader",
+}
+
+_LIVE_TOKENS = {"live", "prod", "production"}
+_SHADOW_TOKENS = {"shadow"}
+
+
+def normalize_context_value(value: Any | None) -> str | None:
+    """Normalize raw meta values to stripped strings."""
+
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float)):
+        text = str(value).strip()
+        return text or None
+    return None
+
+
+def resolve_execution_domain(value: str | None) -> str | None:
+    """Map execution domain aliases to canonical tokens."""
+
+    if value is None:
+        return None
+    lowered = value.lower()
+    segments = re.split(r"[/:]", lowered)
+    for segment in segments:
+        token = re.sub(r"[\s_-]+", "", segment)
+        if token in _BACKTEST_TOKENS:
+            return "backtest"
+        if token in _DRYRUN_TOKENS:
+            return "dryrun"
+        if token in _LIVE_TOKENS:
+            return "live"
+        if token in _SHADOW_TOKENS:
+            return "shadow"
+    return lowered
+
+
+def evaluate_safe_mode(
+    execution_domain: str | None, as_of: str | None
+) -> Tuple[str | None, bool, str | None, bool]:
+    """Determine whether the compute context must enter safe mode."""
+
+    downgraded = False
+    downgrade_reason: str | None = None
+    safe_mode = False
+
+    if execution_domain in {"backtest", "dryrun"} and not as_of:
+        downgraded = True
+        downgrade_reason = "missing_as_of"
+        safe_mode = True
+        execution_domain = "backtest"
+
+    return execution_domain, downgraded, downgrade_reason, safe_mode
+
+
+__all__ = [
+    "evaluate_safe_mode",
+    "normalize_context_value",
+    "resolve_execution_domain",
+]

--- a/qmtl/gateway/models.py
+++ b/qmtl/gateway/models.py
@@ -25,6 +25,9 @@ class StrategyAck(BaseModel):
     queue_map: dict[str, object] = Field(default_factory=dict)
     # Include sentinel identifier for parity with dry-run/diff outputs
     sentinel_id: str | None = None
+    downgraded: bool = False
+    downgrade_reason: str | None = None
+    safe_mode: bool = False
 
 
 class StatusResponse(BaseModel):

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -98,6 +98,9 @@ def create_api_router(
             strategy_id=result.strategy_id,
             queue_map=result.queue_map,
             sentinel_id=result.sentinel_id,
+            downgraded=result.downgraded,
+            downgrade_reason=result.downgrade_reason,
+            safe_mode=result.safe_mode,
         )
         duration_ms = (time.perf_counter() - start) * 1000
         gw_metrics.observe_gateway_latency(duration_ms)
@@ -132,6 +135,9 @@ def create_api_router(
             strategy_id=result.strategy_id,
             queue_map=result.queue_map,
             sentinel_id=result.sentinel_id,
+            downgraded=result.downgraded,
+            downgrade_reason=result.downgrade_reason,
+            safe_mode=result.safe_mode,
         )
 
     @router.get(

--- a/qmtl/gateway/strategy_manager.py
+++ b/qmtl/gateway/strategy_manager.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException
 from opentelemetry import trace
 
 from . import metrics as gw_metrics
+from .compute_context import evaluate_safe_mode, resolve_execution_domain
 from .commit_log import CommitLogWriter
 from .database import Database
 from .degradation import DegradationManager, DegradationLevel
@@ -31,7 +32,12 @@ class StrategyManager:
     insert_sentinel: bool = True
     commit_log_writer: CommitLogWriter | None = None
 
-    async def submit(self, payload: StrategySubmit) -> tuple[str, bool]:
+    async def submit(
+        self,
+        payload: StrategySubmit,
+        *,
+        skip_downgrade_metric: bool = False,
+    ) -> tuple[str, bool]:
         with tracer.start_as_current_span("gateway.submit"):
             try:
                 dag_bytes = base64.b64decode(payload.dag_json)
@@ -61,7 +67,22 @@ class StrategyManager:
                 dag_for_storage.setdefault("nodes", []).append(sentinel)
             encoded_dag = base64.b64encode(json.dumps(dag_for_storage).encode()).decode()
 
-            compute_ctx, context_mapping, world_list = self._build_compute_context(payload)
+            (
+                compute_ctx,
+                context_mapping,
+                world_list,
+                downgraded,
+                downgrade_reason,
+            ) = self._build_compute_context(payload)
+
+            if (
+                downgraded
+                and downgrade_reason
+                and not skip_downgrade_metric
+            ):
+                gw_metrics.strategy_compute_context_downgrade_total.labels(
+                    reason=downgrade_reason
+                ).inc()
 
             # Atomically perform dedupe (SETNX) and initial storage to avoid race duplicates
             lua = """
@@ -209,7 +230,13 @@ class StrategyManager:
 
     def _build_compute_context(
         self, payload: StrategySubmit
-    ) -> tuple[dict[str, str | None], dict[str, str], list[str]]:
+    ) -> tuple[
+        dict[str, str | bool | None],
+        dict[str, str],
+        list[str],
+        bool,
+        str | None,
+    ]:
         world_candidates: list[str] = []
         if payload.world_id:
             world_candidates.append(payload.world_id)
@@ -227,22 +254,41 @@ class StrategyManager:
             if normalised not in seen:
                 seen.add(normalised)
                 unique_worlds.append(normalised)
-        compute_ctx: dict[str, str | None] = {
+        compute_ctx: dict[str, str | bool | None] = {
             "world_id": unique_worlds[0] if unique_worlds else None,
         }
         meta = payload.meta if isinstance(payload.meta, dict) else {}
-        for key in (
-            "execution_domain",
-            "as_of",
-            "partition",
-            "dataset_fingerprint",
-        ):
-            val = self._ctx_value(meta.get(key)) if meta else None
-            if val:
-                compute_ctx[key] = val
+        raw_domain = self._ctx_value(meta.get("execution_domain")) if meta else None
+        execution_domain = (
+            resolve_execution_domain(raw_domain) if raw_domain else None
+        )
+        as_of = self._ctx_value(meta.get("as_of")) if meta else None
+        partition = self._ctx_value(meta.get("partition")) if meta else None
+        dataset_fingerprint = (
+            self._ctx_value(meta.get("dataset_fingerprint")) if meta else None
+        )
+
+        execution_domain, downgraded, downgrade_reason, safe_mode = evaluate_safe_mode(
+            execution_domain, as_of
+        )
+
+        if execution_domain:
+            compute_ctx["execution_domain"] = execution_domain
+        if as_of:
+            compute_ctx["as_of"] = as_of
+        if partition:
+            compute_ctx["partition"] = partition
+        if dataset_fingerprint:
+            compute_ctx["dataset_fingerprint"] = dataset_fingerprint
+        if downgraded:
+            compute_ctx["downgraded"] = True
+            if downgrade_reason:
+                compute_ctx["downgrade_reason"] = downgrade_reason
+            if safe_mode:
+                compute_ctx["safe_mode"] = True
         context_mapping: dict[str, str] = {
             f"compute_{k}": v
             for k, v in compute_ctx.items()
             if isinstance(v, str) and v
         }
-        return compute_ctx, context_mapping, unique_worlds
+        return compute_ctx, context_mapping, unique_worlds, downgraded, downgrade_reason

--- a/tests/gateway/test_strategy_manager_module.py
+++ b/tests/gateway/test_strategy_manager_module.py
@@ -172,3 +172,39 @@ async def test_strategy_manager_rollback_on_commit_log_failure() -> None:
     hash_key = hashlib.sha256(json.dumps(dag, sort_keys=True).encode()).hexdigest()
     assert await redis.get(f"dag_hash:{hash_key}") is None
     assert metrics.lost_requests_total._value.get() == 1
+
+
+@pytest.mark.asyncio
+async def test_strategy_manager_missing_as_of_triggers_safe_mode() -> None:
+    metrics.reset_metrics()
+    redis = InMemoryRedis()
+    db = MemoryDatabase()
+    fsm = StrategyFSM(redis=redis, database=db)
+    manager = StrategyManager(redis=redis, database=db, fsm=fsm, insert_sentinel=False)
+
+    dag = {"nodes": []}
+    dag_json = base64.b64encode(json.dumps(dag).encode()).decode()
+    payload = StrategySubmit(
+        dag_json=dag_json,
+        meta={"execution_domain": "backtest"},
+        node_ids_crc32=0,
+    )
+
+    context, _, _, downgraded, reason = manager._build_compute_context(payload)
+    assert downgraded is True
+    assert reason == "missing_as_of"
+    assert context["execution_domain"] == "backtest"
+    assert context["safe_mode"] is True
+
+    sid, existed = await manager.submit(payload)
+    assert not existed
+    assert sid
+
+    metric_value = (
+        metrics.strategy_compute_context_downgrade_total.labels(reason="missing_as_of")._value.get()
+    )
+    assert metric_value == 1
+    stored_domain = await redis.hget(f"strategy:{sid}", "compute_execution_domain")
+    assert stored_domain == "backtest"
+    stored_reason = await redis.hget(f"strategy:{sid}", "compute_downgrade_reason")
+    assert stored_reason == "missing_as_of"


### PR DESCRIPTION
## Summary
- introduce a shared compute context helper that normalizes execution domains and flags missing `as_of` values
- update strategy submission and manager flows to surface safe-mode metadata, prevent double counting of downgrade metrics, and expose the marker via API responses
- expand gateway unit tests to cover backtest submissions without `as_of` and verify manager downgrade behavior

## Testing
- uv run -m pytest qmtl/gateway/tests/test_strategy_submission_helper.py tests/gateway/test_strategy_manager_module.py

------
https://chatgpt.com/codex/tasks/task_e_68d090a115b483299b269b507ee675ee