### PR TITLE
Fix DAG Manager capitalization in CLI docstring

### DIFF
--- a/qmtl/cli/__init__.py
+++ b/qmtl/cli/__init__.py
@@ -7,7 +7,7 @@ subcommand to dedicated modules. Each subcommand implementation lives in
 
 Design note: We avoid ``argparse`` subparsers here so that ``qmtl <cmd> --help``
 is forwarded to the actual subcommand parser (e.g., ``qmtl dagmanager --help``
-prints Dag Manager help, not a placeholder).
+prints DAG Manager help, not a placeholder).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- standardize the CLI module docstring to reference the DAG Manager with consistent capitalization

## Testing
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d0c037d3a08329927a54aa8e55fc31