### PR TITLE
Update WorldService terminology

### DIFF
--- a/docs/world/policy_engine.md
+++ b/docs/world/policy_engine.md
@@ -27,7 +27,7 @@ hysteresis:
 
 ## Applying a Policy
 
-Use the World Service API to apply a policy and evaluate strategies:
+Use the WorldService API to apply a policy and evaluate strategies:
 
 ```bash
 curl -X POST /worlds/alpha/apply \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ nav:
       - Glossary: architecture/glossary.md
       - DAG Manager: architecture/dag-manager.md
       - Gateway: architecture/gateway.md
-      - World Service: architecture/worldservice.md
+      - WorldService: architecture/worldservice.md
       - ControlBus: architecture/controlbus.md
       - Lean Brokerage Model: architecture/lean_brokerage_model.md
       - Exchange Node Sets: architecture/exchange_node_sets.md

--- a/qmtl/examples/README.md
+++ b/qmtl/examples/README.md
@@ -12,7 +12,7 @@ uv pip install -e qmtl[dev]
 
 ## Running
 
-Run strategies against a Gateway-connected world service:
+Run strategies against a Gateway-connected WorldService:
 
 ```bash
 python strategies/my_strategy.py --world-id demo --gateway-url http://localhost:8000

--- a/qmtl/examples/config.example.yml
+++ b/qmtl/examples/config.example.yml
@@ -1,4 +1,4 @@
-# Example configuration for running example strategies via Gateway and World Service
+# Example configuration for running example strategies via Gateway and WorldService
 world_id: "example_world"
 gateway_url: "http://localhost:8000"
 

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -198,7 +198,7 @@ def create_api_router(
     ) -> Response:
         client: WorldServiceClient | None = world_client
         if client is None:
-            raise HTTPException(status_code=503, detail="world service disabled")
+            raise HTTPException(status_code=503, detail="WorldService disabled")
 
         headers, cid = _build_world_headers(request)
         data = await func(client, headers)

--- a/qmtl/gateway/world_client.py
+++ b/qmtl/gateway/world_client.py
@@ -150,7 +150,7 @@ class WorldServiceClient:
         gw_metrics.worlds_breaker_failures.set(0)
 
     async def _wait_for_service(self, timeout: float = 5.0) -> None:
-        """Poll the world service health endpoint until it is ready."""
+        """Poll the WorldService health endpoint until it is ready."""
         deadline = asyncio.get_running_loop().time() + timeout
         health_url = f"{self._base}/health"
         while True:
@@ -163,7 +163,7 @@ class WorldServiceClient:
             except Exception:
                 pass
             if asyncio.get_running_loop().time() > deadline:
-                raise RuntimeError("World service unavailable")
+                raise RuntimeError("WorldService unavailable")
             await asyncio.sleep(0.5)
 
     async def _request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:

--- a/tests/gateway/test_world_proxy.py
+++ b/tests/gateway/test_world_proxy.py
@@ -37,7 +37,7 @@ async def test_world_routes_require_world_client(fake_redis):
             resp = await api_client.get("/worlds")
 
     assert resp.status_code == 503
-    assert resp.json() == {"detail": "world service disabled"}
+    assert resp.json() == {"detail": "WorldService disabled"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace remaining "World Service" references with the canonical "WorldService" name across docs, examples, and site navigation
- update the gateway's disabled-client error response and its test expectation to match the new casing
- align the WorldService client helper docstring and exception text with the product terminology

## Testing
- uv run -m pytest tests/gateway/test_world_proxy.py::test_world_routes_require_world_client

------
https://chatgpt.com/codex/tasks/task_e_68d0c0359c00832994ef9270b2f0261a