### PR TITLE
Refactor strategy submission flow

### DIFF
--- a/qmtl/gateway/strategy_persistence.py
+++ b/qmtl/gateway/strategy_persistence.py
@@ -55,9 +55,14 @@ class StrategyStorage:
             if isinstance(existing, bytes):
                 existing = existing.decode()
             return [existing or "", 1]
-        await self._redis.set(
+        inserted = await self._redis.set(
             f"dag_hash:{dag_hash}", strategy_id, nx=True
         )
+        if not inserted:
+            existing = await self._redis.get(f"dag_hash:{dag_hash}")
+            if isinstance(existing, bytes):
+                existing = existing.decode()
+            return [existing or "", 1]
         await self._redis.hset(
             f"strategy:{strategy_id}", mapping={"dag": encoded_dag, "hash": dag_hash}
         )

--- a/qmtl/gateway/strategy_persistence.py
+++ b/qmtl/gateway/strategy_persistence.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any
+
+import redis.asyncio as redis
+
+from .degradation import DegradationLevel, DegradationManager
+
+
+class StrategyStorage:
+    """Persist strategy submissions and enforce deduplication."""
+
+    _LUA_DEDUPE = """
+    local hash = KEYS[1]
+    local sid = ARGV[1]
+    local dag = ARGV[2]
+    local hashkey = 'dag_hash:' .. hash
+    if redis.call('SETNX', hashkey, sid) == 0 then
+        local existing = redis.call('GET', hashkey)
+        return {existing or '', 1}
+    end
+    redis.call('HSET', 'strategy:' .. sid, 'dag', dag, 'hash', hash)
+    return {sid, 0}
+    """
+
+    def __init__(self, redis_client: redis.Redis):
+        self._redis = redis_client
+
+    async def save_unique(
+        self, strategy_id: str, dag_hash: str, encoded_dag: str
+    ) -> tuple[str, bool]:
+        try:
+            res = await self._redis.eval(
+                self._LUA_DEDUPE, 1, dag_hash, strategy_id, encoded_dag
+            )
+        except Exception:
+            res = await self._fallback_dedupe(strategy_id, dag_hash, encoded_dag)
+
+        return self._parse_dedupe_result(res)
+
+    async def rollback(self, strategy_id: str, dag_hash: str) -> None:
+        try:
+            if hasattr(self._redis, "delete"):
+                await self._redis.delete(f"dag_hash:{dag_hash}")
+                await self._redis.delete(f"strategy:{strategy_id}")
+        except Exception:
+            # best-effort cleanup; failures are intentionally ignored
+            pass
+
+    async def _fallback_dedupe(
+        self, strategy_id: str, dag_hash: str, encoded_dag: str
+    ) -> list[Any]:
+        existing = await self._redis.get(f"dag_hash:{dag_hash}")
+        if existing is not None:
+            if isinstance(existing, bytes):
+                existing = existing.decode()
+            return [existing or "", 1]
+        await self._redis.set(
+            f"dag_hash:{dag_hash}", strategy_id, nx=True
+        )
+        await self._redis.hset(
+            f"strategy:{strategy_id}", mapping={"dag": encoded_dag, "hash": dag_hash}
+        )
+        return [strategy_id, 0]
+
+    def _parse_dedupe_result(self, result: Any) -> tuple[str, bool]:
+        if (
+            isinstance(result, (list, tuple))
+            and len(result) >= 2
+            and int(result[1]) == 1
+        ):
+            existing_id = result[0]
+            if isinstance(existing_id, bytes):
+                existing_id = existing_id.decode()
+            return str(existing_id), True
+        if isinstance(result, (list, tuple)) and result:
+            value = result[0]
+            if isinstance(value, bytes):
+                value = value.decode()
+            return str(value), False
+        if isinstance(result, bytes):
+            return result.decode(), False
+        return str(result), False
+
+
+class StrategyQueue:
+    """Enqueue strategies for downstream processing."""
+
+    def __init__(self, redis_client: redis.Redis):
+        self._redis = redis_client
+
+    async def enqueue(
+        self, strategy_id: str, degradation: DegradationManager | None = None
+    ) -> None:
+        if (
+            degradation
+            and degradation.level == DegradationLevel.PARTIAL
+            and not degradation.dag_ok
+        ):
+            degradation.local_queue.append(strategy_id)
+            return
+        await self._redis.rpush("strategy_queue", strategy_id)
+
+
+__all__ = ["StrategyQueue", "StrategyStorage"]

--- a/tests/gateway/test_strategy_manager_helpers.py
+++ b/tests/gateway/test_strategy_manager_helpers.py
@@ -1,0 +1,157 @@
+import base64
+import json
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from qmtl.gateway import metrics
+from qmtl.gateway.database import MemoryDatabase
+from qmtl.gateway.degradation import DegradationLevel
+from qmtl.gateway.fsm import StrategyFSM
+from qmtl.gateway.models import StrategySubmit
+from qmtl.gateway.redis_client import InMemoryRedis
+from qmtl.gateway.strategy_manager import StrategyManager
+
+
+@pytest.fixture
+def strategy_manager() -> StrategyManager:
+    redis = InMemoryRedis()
+    db = MemoryDatabase()
+    fsm = StrategyFSM(redis=redis, database=db)
+    return StrategyManager(redis=redis, database=db, fsm=fsm, insert_sentinel=True)
+
+
+def _make_payload(meta: dict | None = None) -> StrategySubmit:
+    dag = {"nodes": [{"node_id": "n1", "node_type": "X"}]}
+    dag_json = base64.b64encode(json.dumps(dag).encode()).decode()
+    return StrategySubmit(dag_json=dag_json, meta=meta or {}, node_ids_crc32=0)
+
+
+def test_decode_dag_adds_sentinel(strategy_manager: StrategyManager) -> None:
+    payload = _make_payload({"version": " 1.2.3 "})
+
+    decoded = strategy_manager._decode_dag(payload)
+
+    assert decoded.strategy_id
+    assert decoded.dag_for_storage is not decoded.dag
+    sentinel = decoded.dag_for_storage["nodes"][-1]
+    assert sentinel["node_type"] == "VersionSentinel"
+    assert sentinel["node_id"].endswith("-sentinel")
+    assert sentinel["version"] == "1.2.3"
+    round_tripped = json.loads(base64.b64decode(decoded.encoded_dag).decode())
+    assert round_tripped == decoded.dag_for_storage
+
+
+def test_decode_dag_accepts_plain_json(strategy_manager: StrategyManager) -> None:
+    dag = {"nodes": []}
+    payload = StrategySubmit(
+        dag_json=json.dumps(dag),
+        meta={},
+        node_ids_crc32=0,
+    )
+
+    decoded = strategy_manager._decode_dag(payload)
+
+    assert decoded.dag == dag
+    assert json.loads(base64.b64decode(decoded.encoded_dag).decode())["nodes"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_unique_strategy_detects_duplicates(
+    strategy_manager: StrategyManager,
+) -> None:
+    payload = _make_payload()
+    decoded = strategy_manager._decode_dag(payload)
+
+    first_id, existed = await strategy_manager._ensure_unique_strategy(
+        decoded.strategy_id, decoded.dag_hash, decoded.encoded_dag
+    )
+
+    assert not existed
+    assert first_id == decoded.strategy_id
+
+    duplicate_id, existed = await strategy_manager._ensure_unique_strategy(
+        str(uuid.uuid4()), decoded.dag_hash, decoded.encoded_dag
+    )
+
+    assert existed is True
+    assert duplicate_id == first_id
+
+
+@pytest.mark.asyncio
+async def test_publish_submission_noop_without_writer(
+    strategy_manager: StrategyManager,
+) -> None:
+    payload = _make_payload()
+    decoded = strategy_manager._decode_dag(payload)
+    compute_ctx, _, worlds, _, _ = strategy_manager._build_compute_context(payload)
+
+    await strategy_manager._publish_submission(
+        decoded.strategy_id,
+        decoded.dag_for_storage,
+        decoded.encoded_dag,
+        decoded.dag_hash,
+        payload,
+        compute_ctx,
+        worlds,
+    )
+
+
+class _ExplodingWriter:
+    async def publish_submission(self, strategy_id: str, record: dict) -> None:  # pragma: no cover - signature docs
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_publish_submission_failure_rolls_back(
+    strategy_manager: StrategyManager,
+) -> None:
+    metrics.reset_metrics()
+    payload = _make_payload()
+    decoded = strategy_manager._decode_dag(payload)
+    await strategy_manager._ensure_unique_strategy(
+        decoded.strategy_id, decoded.dag_hash, decoded.encoded_dag
+    )
+
+    strategy_manager.commit_log_writer = _ExplodingWriter()
+    compute_ctx, _, worlds, _, _ = strategy_manager._build_compute_context(payload)
+
+    with pytest.raises(HTTPException):
+        await strategy_manager._publish_submission(
+            decoded.strategy_id,
+            decoded.dag_for_storage,
+            decoded.encoded_dag,
+            decoded.dag_hash,
+            payload,
+            compute_ctx,
+            worlds,
+        )
+
+    assert await strategy_manager.redis.get(f"dag_hash:{decoded.dag_hash}") is None
+    assert metrics.lost_requests_total._value.get() == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueue_strategy_respects_degradation(
+    strategy_manager: StrategyManager,
+) -> None:
+    payload = _make_payload()
+    decoded = strategy_manager._decode_dag(payload)
+
+    degrade = SimpleNamespace(
+        level=DegradationLevel.PARTIAL,
+        dag_ok=False,
+        local_queue=[],
+    )
+    strategy_manager.degrade = degrade
+
+    await strategy_manager._enqueue_strategy(decoded.strategy_id)
+    assert degrade.local_queue == [decoded.strategy_id]
+
+    degrade.level = DegradationLevel.NORMAL
+    degrade.dag_ok = True
+    await strategy_manager._enqueue_strategy(decoded.strategy_id)
+    queued = await strategy_manager.redis.lpop("strategy_queue")
+    assert queued == decoded.strategy_id


### PR DESCRIPTION
## Summary
- split `StrategyManager.submit` into composable helpers for DAG decoding, dedupe, commit-log publication, and enqueueing
- extract Redis persistence and queue handling into dedicated `StrategyStorage` and `StrategyQueue` collaborators
- add focused unit coverage for the new helpers and extend the submission integration tests to cover dedupe behaviour

## Testing
- uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d0c12adcac83299f1940cd8c23959d