### PR TITLE
Refactor execution nodes to share pretrade logic

### DIFF
--- a/qmtl/transforms/execution_shared.py
+++ b/qmtl/transforms/execution_shared.py
@@ -22,12 +22,6 @@ def _coerce_float(value: Any) -> float | None:
     return float(value)
 
 
-def _coerce_int(value: Any) -> int | None:
-    if value is None:
-        return None
-    return int(value)
-
-
 def run_pretrade_checks(
     order: Mapping[str, Any],
     *,
@@ -45,7 +39,7 @@ def run_pretrade_checks(
     """
 
     symbol = order["symbol"]
-    quantity = _coerce_int(order["quantity"])
+    quantity = _coerce_float(order["quantity"])
     price = _coerce_float(order.get("price"))
     order_type = order.get("order_type", default_order_type)
     tif = order.get("tif", default_tif)
@@ -57,7 +51,7 @@ def run_pretrade_checks(
         brokerage=brokerage,
         account=account,
         symbol=str(symbol),
-        quantity=quantity if quantity is not None else 0,
+        quantity=quantity if quantity is not None else 0.0,
         price=price if price is not None else 0.0,
         order_type=order_type,
         tif=tif,

--- a/qmtl/transforms/execution_shared.py
+++ b/qmtl/transforms/execution_shared.py
@@ -1,0 +1,125 @@
+"""Shared execution utilities for execution nodes across packages."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Tuple
+
+from qmtl.brokerage import Account, BrokerageModel, OrderType, TimeInForce
+from qmtl.common.pretrade import RejectionReason
+from qmtl.sdk.order_gate import Activation
+from qmtl.sdk.portfolio import (
+    Portfolio,
+    order_percent,
+    order_target_percent,
+    order_value,
+)
+from qmtl.sdk.pretrade import check_pretrade
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+def run_pretrade_checks(
+    order: Mapping[str, Any],
+    *,
+    activation_map: Mapping[str, Activation],
+    brokerage: BrokerageModel,
+    account: Account,
+    default_order_type: OrderType = OrderType.MARKET,
+    default_tif: TimeInForce = TimeInForce.DAY,
+) -> Tuple[bool, dict[str, Any]]:
+    """Return the outcome of the shared pre-trade checks.
+
+    The function copies ``order`` to avoid mutating the caller's payload. When
+    all checks pass the sanitized order dictionary is returned. Otherwise a
+    structured rejection payload is produced.
+    """
+
+    symbol = order["symbol"]
+    quantity = _coerce_int(order["quantity"])
+    price = _coerce_float(order.get("price"))
+    order_type = order.get("order_type", default_order_type)
+    tif = order.get("tif", default_tif)
+    limit_price = _coerce_float(order.get("limit_price"))
+    stop_price = _coerce_float(order.get("stop_price"))
+
+    result = check_pretrade(
+        activation_map=activation_map,
+        brokerage=brokerage,
+        account=account,
+        symbol=str(symbol),
+        quantity=quantity if quantity is not None else 0,
+        price=price if price is not None else 0.0,
+        order_type=order_type,
+        tif=tif,
+        limit_price=limit_price,
+        stop_price=stop_price,
+    )
+
+    if result.allowed:
+        return True, dict(order)
+
+    reason = result.reason.value if getattr(result, "reason", None) else RejectionReason.UNKNOWN.value
+    return False, {"rejected": True, "reason": reason}
+
+
+def apply_sizing(
+    order: Mapping[str, Any],
+    portfolio: Portfolio,
+    *,
+    weight_fn: Callable[[Mapping[str, Any]], float] | None = None,
+) -> dict[str, Any] | None:
+    """Return a sized order dictionary or ``None`` when insufficient data."""
+
+    sized = dict(order)
+    if "quantity" in sized:
+        return sized
+
+    price = _coerce_float(sized.get("price"))
+    if price is None:
+        return None
+
+    symbol = sized.get("symbol")
+    if symbol is None:
+        return None
+
+    qty: float | None = None
+    if "value" in sized:
+        qty = order_value(symbol, _coerce_float(sized["value"]) or 0.0, price)
+    elif "percent" in sized:
+        percent = _coerce_float(sized["percent"])
+        if percent is not None:
+            qty = order_percent(portfolio, symbol, percent, price)
+    elif "target_percent" in sized:
+        target = _coerce_float(sized["target_percent"])
+        if target is not None:
+            qty = order_target_percent(portfolio, symbol, target, price)
+
+    if qty is None:
+        return sized
+
+    if weight_fn is not None:
+        try:
+            weight = float(weight_fn(sized))
+            if weight < 0.0:
+                weight = 0.0
+            elif weight > 1.0:
+                weight = 1.0
+            qty *= weight
+        except Exception:  # pragma: no cover - defensive guard
+            pass
+
+    sized["quantity"] = qty
+    return sized
+
+
+__all__ = ["run_pretrade_checks", "apply_sizing"]

--- a/tests/test_execution_shared.py
+++ b/tests/test_execution_shared.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from qmtl.sdk.cache_view import CacheView
+from qmtl.sdk.node import Node
+from qmtl.sdk.order_gate import Activation
+from qmtl.brokerage import BrokerageModel, CashBuyingPowerModel
+from qmtl.brokerage.fees import PercentFeeModel
+from qmtl.brokerage.fill_models import MarketFillModel
+from qmtl.brokerage.order import Account
+from qmtl.brokerage.slippage import NullSlippageModel
+from qmtl.pipeline.execution_nodes import PreTradeGateNode as PipelinePreTradeGate
+from qmtl.pipeline.execution_nodes import SizingNode as PipelineSizing
+from qmtl.sdk.portfolio import Portfolio
+from qmtl.transforms.execution_nodes import PreTradeGateNode as TransformPreTradeGate
+from qmtl.transforms.execution_nodes import SizingNode as TransformSizing
+
+
+def _make_brokerage() -> BrokerageModel:
+    return BrokerageModel(
+        buying_power_model=CashBuyingPowerModel(),
+        fee_model=PercentFeeModel(),
+        slippage_model=NullSlippageModel(),
+        fill_model=MarketFillModel(),
+    )
+
+
+def _make_view(node: Node, payload) -> CacheView:
+    return CacheView({node.node_id: {node.interval: [(0, payload)]}})
+
+
+def test_pretrade_nodes_allow_consistently():
+    order_node = Node(name="order", interval=1, period=1)
+    activation = {"AAPL": Activation(enabled=True)}
+    brokerage = _make_brokerage()
+    account = Account(cash=10000.0)
+    pipeline_gate = PipelinePreTradeGate(
+        order_node,
+        activation_map=activation,
+        brokerage=brokerage,
+        account=account,
+    )
+    transform_gate = TransformPreTradeGate(
+        order_node,
+        activation_map=activation,
+        brokerage=brokerage,
+        account=account,
+    )
+    payload = {"symbol": "AAPL", "quantity": 5, "price": 100.0}
+    pipeline_out = pipeline_gate._compute(_make_view(order_node, payload))
+    transform_out = transform_gate.compute_fn(_make_view(order_node, payload))
+    assert pipeline_out == transform_out
+
+
+def test_pretrade_nodes_reject_consistently():
+    order_node = Node(name="order", interval=1, period=1)
+    activation = {"AAPL": Activation(enabled=False, reason="disabled")}
+    brokerage = _make_brokerage()
+    account = Account(cash=10000.0)
+    pipeline_gate = PipelinePreTradeGate(
+        order_node,
+        activation_map=activation,
+        brokerage=brokerage,
+        account=account,
+    )
+    transform_gate = TransformPreTradeGate(
+        order_node,
+        activation_map=activation,
+        brokerage=brokerage,
+        account=account,
+    )
+    payload = {"symbol": "AAPL", "quantity": 5, "price": 100.0}
+    pipeline_out = pipeline_gate._compute(_make_view(order_node, payload))
+    transform_out = transform_gate.compute_fn(_make_view(order_node, payload))
+    assert pipeline_out == transform_out
+    assert pipeline_out == {"rejected": True, "reason": "activation_disabled"}
+
+
+def test_sizing_nodes_value_consistently():
+    intent_node = Node(name="intent", interval=1, period=1, config={"role": "intent"})
+    portfolio_node = Node(name="portfolio", interval=1, period=1, config={"role": "portfolio"})
+    portfolio = Portfolio(cash=1000.0)
+    pipeline_sizing = PipelineSizing(intent_node, portfolio=portfolio)
+    transform_sizing = TransformSizing(intent_node, portfolio_node)
+    payload = {"symbol": "AAPL", "price": 100.0, "value": 500.0}
+    pipeline_out = pipeline_sizing._compute(_make_view(intent_node, payload))
+    transform_out = transform_sizing.compute_fn(
+        CacheView({
+            intent_node.node_id: {intent_node.interval: [(0, payload)]},
+            portfolio_node.node_id: {portfolio_node.interval: [(0, portfolio)]},
+        })
+    )
+    assert pipeline_out == transform_out
+    assert pipeline_out["quantity"] == 5
+
+
+def test_sizing_nodes_percent_consistently():
+    intent_node = Node(name="intent", interval=1, period=1, config={"role": "intent"})
+    portfolio_node = Node(name="portfolio", interval=1, period=1, config={"role": "portfolio"})
+    portfolio = Portfolio(cash=1000.0)
+    pipeline_sizing = PipelineSizing(intent_node, portfolio=portfolio)
+    transform_sizing = TransformSizing(intent_node, portfolio_node)
+    payload = {"symbol": "AAPL", "price": 50.0, "percent": 0.1}
+    pipeline_out = pipeline_sizing._compute(_make_view(intent_node, payload))
+    transform_out = transform_sizing.compute_fn(
+        CacheView({
+            intent_node.node_id: {intent_node.interval: [(0, payload)]},
+            portfolio_node.node_id: {portfolio_node.interval: [(0, portfolio)]},
+        })
+    )
+    assert pipeline_out == transform_out
+    assert round(pipeline_out["quantity"], 6) == 2


### PR DESCRIPTION
## Summary
- add a shared `execution_shared` module with pure helpers for pre-trade checks and sizing
- refactor pipeline and transform execution nodes to call the shared helpers while keeping pipeline-specific guards
- add tests that assert pipeline and transform nodes make the same allow, reject, and sizing decisions

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d0c1278e0c83298ef1548633ad7b6c