### PR TITLE
SDK Runner: minimal execution surface; docs + tests aligned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ For general contribution and testing policies, see the repository root [AGENTS.m
 
 - Manage the Python environment using **uv**. Install dependencies with
   `uv pip install -e .[dev]` and build distributable wheels via `uv pip wheel .`.
+- When a task needs GitHub access (issues, PRs, metadata), use the `gh` CLI commands instead of manual web actions.
 
 ## Architecture
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -121,11 +121,11 @@ sequenceDiagram
 
 ### 1.3 Execution Domains & Isolation (new)
 
-- Domains: `backtest | dryrun | live | shadow`. WorldService treats ExecutionDomain as a 1급 개념 and drives gating and promotions via 2‑Phase Apply (Freeze/Drain → Switch → Unfreeze).
-- NodeID vs ComputeKey: NodeID는 전역·월드무관 식별자다. 실행/캐시 격리를 위해 DAG Manager와 런타임은 `ComputeKey = blake3(NodeHash ⊕ world_id ⊕ execution_domain ⊕ as_of ⊕ partition)`를 사용한다. 교차 컨텍스트 캐시 적중은 정책 위반이며 SLO=0이다.
+- Domains: `backtest | dryrun | live | shadow`. ExecutionDomain은 WorldService가 소유·결정하는 1급 개념이며, 게이팅과 프로모션은 2‑Phase Apply(Freeze/Drain → Switch → Unfreeze)로 백엔드에서 구동한다. SDK/Runner는 도메인을 “선택”하지 않으며, 오직 월드 결정의 결과를 반영한다.
+- NodeID vs ComputeKey: NodeID는 전역·월드무관 식별자다. 실행/캐시 격리를 위해 DAG Manager와 런타임은 `ComputeKey = blake3(NodeHash ⊕ world_id ⊕ execution_domain ⊕ as_of ⊕ partition)`를 사용한다. 교차 컨텍스트 캐시 적중은 정책 위반이며 SLO=0이다. SDK는 ComputeKey를 “제안”하거나 “주입”하지 않는다 — 런타임/서비스가 WS 결정과 제출 메타를 근거로 도출·검증한다.
 - WVG 확장: `WorldNodeRef = (world_id, node_id, execution_domain)`로 도메인별 상태/검증이 분리된다. `WvgEdgeOverride`로 기본 교차‑도메인 경로(예: backtest→live)를 비활성화하고, 프로모션 후 정책으로만 활성화한다.
-- Envelope 매핑: Gateway/SDK는 `DecisionEnvelope.effective_mode`를 ExecutionDomain으로 매핑하고 `execution_domain` 필드로 중계한다(`validate→backtest(주문 게이트 OFF)`, `compute-only→backtest`, `paper→dryrun`, `live→live`; `shadow`는 운영자 전용).
-- Queue 네임스페이스: 프로덕션 배포에서는 `{world_id}.{execution_domain}.<topic>` 프리픽스로 토픽을 분리해야 한다(SHALL). 교차 도메인 구독·발행은 ACL로 금지하며, 운영 환경에서만 예외를 명시적으로 허용한다.
+- Envelope 매핑: Gateway/SDK는 `DecisionEnvelope.effective_mode`를 ExecutionDomain으로 “표시만” 하여 `execution_domain` 필드로 중계한다. SDK/Runner는 이를 입력으로만 취급하며 도메인을 자의적으로 변경하지 않는다. 매핑은 `validate→backtest(주문 게이트 OFF)`, `compute-only→backtest`, `paper→dryrun`, `live→live`이며, `shadow`는 운영자 전용이다.
+- Queue 네임스페이스: 프로덕션 배포에서는 `{world_id}.{execution_domain}.<topic>` 프리픽스로 토픽을 분리해야 한다(SHALL). 교차 도메인 구독·발행은 ACL로 금지하며, 운영 환경에서만 예외를 명시적으로 허용한다. 기본 도메인 표기는 운영적 네임스페이스 목적의 “live”를 따른다. 단, 실행 모드 기본값은 WS 결정 부재·만료 시 “compute‑only(backtest, 주문 게이트 OFF)”이다.
 - WorldNodeRef 독립성: 서로 다른 `execution_domain` 조합은 상태·큐·검증 결과를 공유할 수 없다(SHALL). 공유가 필요한 경우 Feature Artifact Plane(§1.4)처럼 불변 아티팩트만 사용한다.
 - Promotion guard: WVG의 `WvgEdgeOverride`는 기본적으로 backtest→live 경로를 비활성화하며(SHALL), 2‑Phase Apply 완료 후 정책에 따라 명시적으로만 해제한다.
 
@@ -145,7 +145,7 @@ sequenceDiagram
 
 - 백테스트/드라이런은 VirtualClock을 사용하고(as_of 필수) 라이브는 WallClock을 사용한다(SHALL). 혼용 호출은 빌드/정적 검증 단계에서 실패해야 한다.
 - 모든 백테스트 입력 노드는 `as_of`(dataset commit)를 명시해야 하며(SHALL), Gateway는 누락 시 거부하거나 안전 모드로 강등한다.
-- SDK는 노드/런너 레벨에서 클록 타입을 선언적으로 지정하고, WorldService와 Gateway는 정책/결정 시 이를 검증한다.
+- SDK는 노드/런너 레벨에서 클록 타입을 “주석 수준으로 선언”할 수 있으나, 최종 권한은 백엔드(WS/GW)에 있다. 정책과 결정과 상충할 경우 WS/GW는 요청을 거부하거나 안전 모드(backtest, 주문 게이트 OFF)로 강등한다.
 
 ### 전역-로컬 분리와 불변식 (GSG/WVG)
 

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -42,7 +42,7 @@ Gateway sits at the **operational boundary** between *ephemeral* strategy submis
 
 **Ax‑1** SDK nodes adhere to canonical hashing rules (see Architecture doc §1.1).
 **Ax‑2** Neo4j causal cluster exposes single‑leader consistency; read replicas may lag.
-**Ax‑3** Gateway forwards a compute context `{ world_id, execution_domain, as_of, partition }` to downstream services. DAG Manager uses it to derive a Domain‑Scoped ComputeKey; WorldService uses it to authorize/apply domain policies.
+**Ax‑3** Gateway constructs and forwards a compute context `{ world_id, execution_domain, as_of, partition }` to downstream services. The SDK does not choose this context; Gateway derives it from WorldService decisions (and, where applicable, submission metadata). DAG Manager uses it to derive a Domain‑Scoped ComputeKey; WorldService uses it to authorize/apply domain policies.
 
 ### Non‑Goals
 - Gateway does not compute world policy decisions and is not an SSOT for worlds or queues.
@@ -280,8 +280,8 @@ Gateway remains the single public boundary for SDKs. It proxies WorldService end
 
 - Strategy submission and worlds:
   - Clients may include `world_id` (single) **or** `world_ids[]` (multiple). Gateway upserts a **WorldStrategyBinding (WSB)** for each world and ensures the corresponding `WorldNodeRef(root)` exists in the WVG. Execution mode is still determined solely by WorldService decisions.
-  - Gateway maps `DecisionEnvelope.effective_mode` to an ExecutionDomain for compute/context and writes it to envelopes it relays: `validate → backtest (orders gated OFF by default)`, `compute-only → backtest`, `paper → dryrun`, `live → live`. `shadow` is reserved and must be explicitly requested by operators.
-  - Gateway forwards the compute context `{ world_id, execution_domain, as_of (if backtest), partition }` with diff/ingest requests so DAG Manager derives a Domain‑Scoped ComputeKey and isolates caches per domain.
+  - Gateway maps `DecisionEnvelope.effective_mode` to an ExecutionDomain for compute/context and writes it to envelopes it relays: `validate → backtest (orders gated OFF by default)`, `compute-only → backtest`, `paper → dryrun`, `live → live`. `shadow` is reserved and must be explicitly requested by operators. SDK/Runner treats this mapping as input only.
+  - Gateway forwards a compute context `{ world_id, execution_domain, as_of (if backtest), partition }` with diff/ingest requests so DAG Manager derives a Domain‑Scoped ComputeKey and isolates caches per domain. When a caller does not supply backtest metadata, Gateway either derives the context from WS or omits optional fields; DAG Manager then applies safe defaults and context‑scoped isolation.
   - Backtest/dryrun submissions MUST include `as_of` (dataset commit) and MAY include `dataset_fingerprint`; when absent Gateway rejects or falls back to compute-only mode to avoid mixing datasets.
 
 ### Event Stream Descriptor

--- a/docs/guides/strategy_workflow.md
+++ b/docs/guides/strategy_workflow.md
@@ -182,14 +182,14 @@ wait
 When a test starts background services (e.g., TagQueryManager subscriptions or ActivationManager), prefer the session context manager to ensure everything is cleaned up:
 
 ```python
-async with Runner.session(MyStrategy, world_id="w", gateway_url="http://gw", offline=True) as strategy:
+async with Runner.session(MyStrategy, world_id="w", gateway_url="http://gw") as strategy:
     ...  # assertions
 ```
 
 If you cannot use ``async with`` (e.g., in synchronous tests), fall back to the explicit helpers:
 
 ```python
-strategy = Runner.run(MyStrategy, world_id="w", gateway_url="http://gw", offline=True)
+strategy = Runner.run(MyStrategy, world_id="w", gateway_url="http://gw")
 try:
     ...  # assertions
 finally:

--- a/docs/reference/api_world.md
+++ b/docs/reference/api_world.md
@@ -87,7 +87,9 @@ backwards-compatible (`validate|compute-only|paper|live`). Gateway and
 SDK clients MUST derive `execution_domain` from it using the normative
 mapping: `validate → backtest (orders gated OFF)`, `compute-only →
 backtest`, `paper → dryrun`, `live → live`. `shadow` remains reserved
-for operator-controlled dual runs.
+for operator-controlled dual runs. SDKs treat this mapping as
+read-only annotation for local state/metrics; it MUST NOT override
+backend decisions or change execution behavior client-side.
 Schema: reference/schemas/activation_envelope.schema.json
 
 ### GET /worlds/{id}/{topic}/state_hash

--- a/docs/reference/tagquery.md
+++ b/docs/reference/tagquery.md
@@ -19,7 +19,7 @@ last_modified: 2025-09-07
 
 - Boot sequence: `Runner.run(..., world_id=..., gateway_url=...)` attaches `TagQueryManager`, applies the Gateway `queue_map` to nodes, and calls `resolve_tags()` once before starting live subscriptions.
 - Live updates: After boot, `TagQueryManager.start()` subscribes to `/events/subscribe` and periodically reconciles via `GET /queues/by_tag` to heal divergence.
-- Offline mode: When `offline=True` or Gateway/Kafka are unavailable, `resolve_tags(offline=True)` hydrates queue mappings from a local cache file (`.qmtl_tagmap.json` by default). If no snapshot exists, nodes fall back to an empty queue set and remain compute-only until data is fed.
+- Offline mode: When using `Runner.offline(...)` or when Gateway/Kafka are unavailable, `resolve_tags(offline=True)` hydrates queue mappings from a local cache file (`.qmtl_tagmap.json` by default). If no snapshot exists, nodes fall back to an empty queue set and remain compute-only until data is fed.
 
 ## Caching & Determinism
 
@@ -34,4 +34,3 @@ last_modified: 2025-09-07
 - Test mode: Set `QMTL_TEST_MODE=1` to activate conservative time budgets for CI and local tests.
 
 {{ nav_links() }}
-

--- a/qmtl/sdk/cli.py
+++ b/qmtl/sdk/cli.py
@@ -22,21 +22,11 @@ async def _main(argv: List[str] | None = None) -> int:
     run_p.add_argument("--world-id", required=True)
     run_p.add_argument("--gateway-url", required=True, help="Gateway base URL")
     run_p.add_argument("--no-ray", action="store_true", help="Disable Ray-based features")
-    run_p.add_argument(
-        "--mode",
-        choices=["backtest", "dryrun", "live"],
-        help="Execution mode (backtest/dryrun/live)",
-    )
-    run_p.add_argument(
-        "--clock",
-        choices=["virtual", "wall"],
-        help="Clock discipline to request from Gateway",
-    )
-    run_p.add_argument("--as-of", help="Dataset snapshot timestamp/identifier")
-    run_p.add_argument(
-        "--dataset-fingerprint",
-        help="Immutable dataset fingerprint for non-live runs",
-    )
+    # Deprecated advanced options kept for CLI compatibility; ignored.
+    run_p.add_argument("--mode", choices=["backtest", "dryrun", "live"], help=argparse.SUPPRESS)
+    run_p.add_argument("--clock", choices=["virtual", "wall"], help=argparse.SUPPRESS)
+    run_p.add_argument("--as-of", help=argparse.SUPPRESS)
+    run_p.add_argument("--dataset-fingerprint", help=argparse.SUPPRESS)
 
     off_p = sub.add_parser("offline", help="Run locally without Gateway/WS")
     off_p.add_argument("strategy", help="Import path as module:Class")
@@ -68,10 +58,6 @@ async def _main(argv: List[str] | None = None) -> int:
             strategy_cls,
             world_id=args.world_id,
             gateway_url=args.gateway_url,
-            execution_mode=args.mode,
-            clock=args.clock,
-            as_of=args.as_of,
-            dataset_fingerprint=args.dataset_fingerprint,
             history_start=h_start,
             history_end=h_end,
         )

--- a/tests/runner/test_execution.py
+++ b/tests/runner/test_execution.py
@@ -51,7 +51,7 @@ def test_run_executes_nodes_offline(monkeypatch):
             node = Node(input=src, compute_fn=lambda v: calls.append(v), interval="60s", period=2)
             self.add_nodes([src, node])
 
-    Runner.run(Strat, world_id="w", gateway_url="http://gw", offline=True)
+    Runner.offline(Strat)
     assert len(calls) == 1
 
 

--- a/tests/runner/test_run_pipeline.py
+++ b/tests/runner/test_run_pipeline.py
@@ -57,9 +57,7 @@ def test_run_offline_pipeline(monkeypatch):
     monkeypatch.setattr(Runner, "_kafka_available", True)
     calls, results = [], []
 
-    strat = Runner.run(
-        _make_strategy(calls, results), world_id="w", gateway_url="http://gw", offline=True
-    )
+    strat = Runner.offline(_make_strategy(calls, results))
     src = strat.src
     src.cache.backfill_bulk(src.node_id, 60, [(60, {"v": 1}), (120, {"v": 2})])
     Runner.run_pipeline(strat)

--- a/tests/sdk/test_runner_context.py
+++ b/tests/sdk/test_runner_context.py
@@ -27,8 +27,7 @@ class CountingStrategy(Strategy):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("offline", [False, True])
-async def test_runner_applies_context_once(monkeypatch, offline: bool) -> None:
+async def test_runner_applies_context_once(monkeypatch) -> None:
     before_counts: list[list[int]] = []
     after_counts: list[list[int]] = []
     received_offline: list[bool] = []
@@ -62,17 +61,17 @@ async def test_runner_applies_context_once(monkeypatch, offline: bool) -> None:
     strategy = await Runner.run_async(
         CountingStrategy,
         world_id="world",
-        offline=offline,
+        gateway_url="http://gw",
         schema_enforcement="strict",
     )
 
     assert before_counts == [[0]]
     assert after_counts == [[1]]
-    assert received_offline == [offline]
+    # Runner.run_async uses online path; offline flag passed to bootstrap is False.
+    assert received_offline == [False]
 
     node = strategy.nodes[0]
     assert isinstance(node, CountingStreamInput)
     assert node.apply_calls == 1
     assert getattr(node, "_schema_enforcement") == "strict"
     assert len(node.seen_contexts) == 1
-

--- a/tests/test_runner_postprocess.py
+++ b/tests/test_runner_postprocess.py
@@ -70,9 +70,7 @@ def test_run_hooks_offline(monkeypatch):
         "qmtl.sdk.runner.Runner._handle_trade_order", staticmethod(fake_order)
     )
 
-    strategy = Runner.run(
-        DummyStrategy, world_id="w", gateway_url="http://gw", offline=True
-    )
+    strategy = Runner.offline(DummyStrategy)
     _trigger(strategy)
 
     Runner.set_trade_order_http_url(None)
@@ -159,9 +157,7 @@ def test_run_hooks_live_like(monkeypatch):
         "qmtl.sdk.runner.Runner._handle_trade_order", staticmethod(fake_order)
     )
 
-    strategy = Runner.run(
-        DummyStrategy, world_id="w", gateway_url="http://gw", offline=True
-    )
+    strategy = Runner.offline(DummyStrategy)
     _trigger(strategy)
 
     Runner.set_trade_order_http_url(None)

--- a/tests/test_runner_validation_integration.py
+++ b/tests/test_runner_validation_integration.py
@@ -31,12 +31,7 @@ def test_run_offline_minimal(monkeypatch):
             stream = StreamInput(interval="60s", period=2)
             self.add_nodes([stream])
 
-    strategy = Runner.run(
-        TestStrategy,
-        world_id="w",
-        gateway_url="http://gw",
-        offline=True,
-    )
+    strategy = Runner.offline(TestStrategy)
     assert isinstance(strategy, TestStrategy)
 
 
@@ -69,12 +64,7 @@ def test_run_offline_with_cached_data(monkeypatch):
             stream.cache.append("test_queue", 60, 120, {"close": 10.1})
             self.add_nodes([stream])
 
-    strategy = Runner.run(
-        TestStrategy,
-        world_id="w",
-        gateway_url="http://gw",
-        offline=True,
-    )
+    strategy = Runner.offline(TestStrategy)
     assert isinstance(strategy, TestStrategy)
 
 
@@ -107,10 +97,5 @@ def test_run_offline_with_larger_moves(monkeypatch):
             stream.cache.append("test_queue", 60, 120, {"close": 12.0})  # 20% change
             self.add_nodes([stream])
 
-    strategy = Runner.run(
-        TestStrategy,
-        world_id="w",
-        gateway_url="http://gw",
-        offline=True,
-    )
+    strategy = Runner.offline(TestStrategy)
     assert isinstance(strategy, TestStrategy)

--- a/tests/test_strategy_callbacks.py
+++ b/tests/test_strategy_callbacks.py
@@ -47,7 +47,7 @@ def test_lifecycle_hooks_called(monkeypatch):
         lambda self, strategy, world_id=None: DummyManager(),
     )
 
-    strategy = Runner.run(CallbackStrategy, world_id="w", gateway_url=None, offline=True)
+    strategy = Runner.offline(CallbackStrategy)
     assert strategy.events == ["start", "finish"]
 
 
@@ -58,7 +58,7 @@ def test_on_error_called(monkeypatch):
     monkeypatch.setattr("qmtl.sdk.runner.TagManagerService.init", fail_init)
 
     with pytest.raises(RuntimeError):
-        Runner.run(ErrorStrategy, world_id="w", gateway_url=None, offline=True)
+        Runner.run(ErrorStrategy, world_id="w", gateway_url=None)
 
     assert isinstance(ErrorStrategy.instances[-1].error, RuntimeError)
 


### PR DESCRIPTION
Summary\n- Minimalize Runner API: remove execution-domain/clock/as_of params; backend (WS/GW) decides execution.\n- CLI: ignore deprecated flags; use minimal Runner API.\n- Docs: clarify ownership/mapping; update guides.\n- Tests: refactor to offline() where appropriate; update online mocks.\n\nValidation\n- Tests: 872 passed, 8 skipped (uv run -m pytest -n auto).\n\nMigration\n- Use Runner.run(MyStrategy, world_id=..., gateway_url=...) or Runner.offline(MyStrategy).\n- CLI: qmtl sdk run/offline; legacy flags are ignored.\n