### PR TITLE
Unify compute context model and modularize strategy submission

### DIFF
--- a/docs/operations/dagmanager_diff_context_rollout.md
+++ b/docs/operations/dagmanager_diff_context_rollout.md
@@ -10,6 +10,7 @@ deploy sequence.
 - `DiffService.DiffRequest` now accepts optional fields:
   `world_id`, `execution_domain`, `as_of`, `partition`, and
   `dataset_fingerprint`.
+- Gateway, DAG Manager, and the SDK share the canonical compute context model implemented in `qmtl/common/compute_context.py`; ensure all services upgrade in lockstep to retain compatibility.
 - `DiffService` derives a domain-scoped compute key and appends it to each
   `queue_map` partition key as `...#ck=<hash>`. Downstream consumers must strip
   the `#ck=` suffix (if present) before extracting the `node_id` portion.

--- a/qmtl/common/__init__.py
+++ b/qmtl/common/__init__.py
@@ -15,7 +15,8 @@ from .circuit_breaker import AsyncCircuitBreaker
 from .four_dim_cache import FourDimCache
 from .hashutils import hash_bytes
 from .nodeid import compute_node_id
-from .compute_key import ComputeContext, compute_compute_key, DEFAULT_EXECUTION_DOMAIN
+from .compute_key import compute_compute_key
+from .compute_context import ComputeContext, DEFAULT_EXECUTION_DOMAIN
 
 __all__ = [
     "crc32_of_list",

--- a/qmtl/common/compute_context.py
+++ b/qmtl/common/compute_context.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+"""Canonical compute context model shared across QMTL services."""
+
+from dataclasses import dataclass, replace
+import re
+from typing import Any, Mapping
+
+__all__ = [
+    "DEFAULT_EXECUTION_DOMAIN",
+    "ComputeContext",
+    "normalize_context_value",
+    "resolve_execution_domain",
+    "evaluate_safe_mode",
+    "build_strategy_compute_context",
+    "build_worldservice_compute_context",
+    "coerce_compute_context",
+]
+
+DEFAULT_EXECUTION_DOMAIN = "default"
+
+_BACKTEST_TOKENS = {
+    "backtest",
+    "backtesting",
+    "compute",
+    "computeonly",
+    "offline",
+    "sandbox",
+    "sim",
+    "simulation",
+    "simulated",
+    "validate",
+    "validation",
+}
+_DRYRUN_TOKENS = {
+    "dryrun",
+    "dryrunmode",
+    "papermode",
+    "paper",
+    "papertrade",
+    "papertrading",
+    "papertrader",
+}
+_LIVE_TOKENS = {"live", "prod", "production"}
+_SHADOW_TOKENS = {"shadow"}
+
+_WORLD_MODE_TOKENS = {
+    "validate": "backtest",
+    "compute-only": "backtest",
+    "compute_only": "backtest",
+    "paper": "dryrun",
+    "papertrade": "dryrun",
+    "papertrading": "dryrun",
+    "paper_trading": "dryrun",
+    "live": "live",
+    "active": "live",
+    "shadow": "shadow",
+}
+
+
+def normalize_context_value(value: Any | None) -> str | None:
+    """Normalize raw values into stripped strings."""
+
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float)):
+        text = str(value).strip()
+        return text or None
+    return None
+
+
+def _normalize_optional(value: Any | None) -> str | None:
+    normalized = normalize_context_value(value)
+    return normalized
+
+
+def resolve_execution_domain(value: str | None) -> str | None:
+    """Map execution domain aliases to canonical tokens."""
+
+    if value is None:
+        return None
+    lowered = value.lower()
+    segments = re.split(r"[/:]", lowered)
+    for segment in segments:
+        token = re.sub(r"[\s_-]+", "", segment)
+        if token in _BACKTEST_TOKENS:
+            return "backtest"
+        if token in _DRYRUN_TOKENS:
+            return "dryrun"
+        if token in _LIVE_TOKENS:
+            return "live"
+        if token in _SHADOW_TOKENS:
+            return "shadow"
+    return lowered
+
+
+def evaluate_safe_mode(
+    execution_domain: str | None, as_of: str | None
+) -> tuple[str | None, bool, str | None, bool]:
+    """Determine downgrades and safe-mode requirements."""
+
+    downgraded = False
+    downgrade_reason: str | None = None
+    safe_mode = False
+
+    if execution_domain in {"backtest", "dryrun"} and not as_of:
+        downgraded = True
+        downgrade_reason = "missing_as_of"
+        safe_mode = True
+        execution_domain = "backtest"
+
+    return execution_domain, downgraded, downgrade_reason, safe_mode
+
+
+@dataclass(frozen=True)
+class ComputeContext:
+    """Immutable compute context representation."""
+
+    world_id: str = ""
+    execution_domain: str = DEFAULT_EXECUTION_DOMAIN
+    as_of: str | None = None
+    partition: str | None = None
+    dataset_fingerprint: str | None = None
+    downgraded: bool = False
+    downgrade_reason: str | None = None
+    safe_mode: bool = False
+
+    def with_world(self, world_id: str | None) -> "ComputeContext":
+        return replace(self, world_id=_normalize_optional(world_id) or "")
+
+    def with_overrides(
+        self,
+        *,
+        execution_domain: str | None = None,
+        as_of: str | None = None,
+        partition: str | None = None,
+        dataset_fingerprint: str | None = None,
+    ) -> "ComputeContext":
+        domain_value = self.execution_domain
+        if execution_domain is not None:
+            domain_value = resolve_execution_domain(_normalize_optional(execution_domain)) or ""
+
+        as_of_value = self.as_of if as_of is None else _normalize_optional(as_of)
+        partition_value = self.partition if partition is None else _normalize_optional(partition)
+        dataset_value = (
+            self.dataset_fingerprint
+            if dataset_fingerprint is None
+            else _normalize_optional(dataset_fingerprint)
+        )
+
+        final_domain, downgraded, reason, safe_mode = evaluate_safe_mode(
+            domain_value or None,
+            as_of_value,
+        )
+        return replace(
+            self,
+            execution_domain=(final_domain or ""),
+            as_of=as_of_value,
+            partition=partition_value,
+            dataset_fingerprint=dataset_value,
+            downgraded=downgraded,
+            downgrade_reason=reason,
+            safe_mode=safe_mode,
+        )
+
+    def to_dict(self, *, include_flags: bool = True, include_world: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "execution_domain": self.execution_domain or None,
+            "as_of": self.as_of,
+            "partition": self.partition,
+            "dataset_fingerprint": self.dataset_fingerprint,
+        }
+        if include_world:
+            payload["world_id"] = self.world_id or None
+        if include_flags and self.downgraded:
+            payload["downgraded"] = True
+            if self.downgrade_reason:
+                payload["downgrade_reason"] = self.downgrade_reason
+            if self.safe_mode:
+                payload["safe_mode"] = True
+        elif include_flags and self.safe_mode:
+            payload["safe_mode"] = True
+        return payload
+
+    def diff_kwargs(self) -> dict[str, str | None]:
+        return {
+            "execution_domain": self.execution_domain or None,
+            "as_of": self.as_of,
+            "partition": self.partition,
+            "dataset_fingerprint": self.dataset_fingerprint,
+        }
+
+    def metrics_labels(self) -> tuple[str, str, str | None, str | None]:
+        return (
+            self.world_id or "",
+            self.execution_domain or DEFAULT_EXECUTION_DOMAIN,
+            self.as_of,
+            self.partition,
+        )
+
+    def hash_components(self) -> tuple[str, str, str, str]:
+        world = self.world_id or ""
+        domain = self.execution_domain or DEFAULT_EXECUTION_DOMAIN
+        as_of = "" if self.as_of is None else str(self.as_of)
+        partition = "" if self.partition is None else str(self.partition)
+        return world, domain, as_of, partition
+
+
+def _initial_context(
+    *,
+    world_id: Any | None,
+    execution_domain: Any | None,
+    as_of: Any | None,
+    partition: Any | None,
+    dataset_fingerprint: Any | None,
+) -> ComputeContext:
+    world = _normalize_optional(world_id) or ""
+    domain = resolve_execution_domain(_normalize_optional(execution_domain))
+    as_of_norm = _normalize_optional(as_of)
+    partition_norm = _normalize_optional(partition)
+    dataset_norm = _normalize_optional(dataset_fingerprint)
+    final_domain, downgraded, reason, safe_mode = evaluate_safe_mode(
+        domain, as_of_norm
+    )
+    return ComputeContext(
+        world_id=world,
+        execution_domain=(final_domain or ""),
+        as_of=as_of_norm,
+        partition=partition_norm,
+        dataset_fingerprint=dataset_norm,
+        downgraded=downgraded,
+        downgrade_reason=reason,
+        safe_mode=safe_mode,
+    )
+
+
+def build_strategy_compute_context(meta: Mapping[str, Any] | None) -> ComputeContext:
+    """Derive compute context from submission metadata."""
+
+    meta = meta or {}
+    dataset = meta.get("dataset_fingerprint") or meta.get("datasetFingerprint")
+    return _initial_context(
+        world_id=None,
+        execution_domain=meta.get("execution_domain"),
+        as_of=meta.get("as_of"),
+        partition=meta.get("partition"),
+        dataset_fingerprint=dataset,
+    )
+
+
+def _resolve_world_mode(value: Any | None) -> str:
+    if not isinstance(value, str):
+        return "backtest"
+    key = value.strip().lower()
+    return _WORLD_MODE_TOKENS.get(key, "backtest")
+
+
+def build_worldservice_compute_context(
+    world_id: str, payload: Mapping[str, Any]
+) -> ComputeContext:
+    """Derive compute context from a WorldService decision payload."""
+
+    domain = _resolve_world_mode(payload.get("effective_mode"))
+    as_of = payload.get("as_of")
+    partition = payload.get("partition")
+    dataset = payload.get("dataset_fingerprint") or payload.get("datasetFingerprint")
+    context = _initial_context(
+        world_id=world_id,
+        execution_domain=domain,
+        as_of=as_of,
+        partition=partition,
+        dataset_fingerprint=dataset,
+    )
+    return context
+
+
+def coerce_compute_context(payload: Mapping[str, Any] | None) -> ComputeContext:
+    """Coerce a loosely-typed payload into :class:`ComputeContext`."""
+
+    payload = payload or {}
+    dataset = payload.get("dataset_fingerprint") or payload.get("datasetFingerprint")
+    return _initial_context(
+        world_id=payload.get("world_id") or payload.get("world"),
+        execution_domain=payload.get("execution_domain") or payload.get("domain"),
+        as_of=payload.get("as_of"),
+        partition=payload.get("partition"),
+        dataset_fingerprint=dataset,
+    )

--- a/qmtl/gateway/api.py
+++ b/qmtl/gateway/api.py
@@ -30,6 +30,7 @@ from .world_client import Budget, WorldServiceClient
 from .ws import WebSocketHub
 from .commit_log_consumer import CommitLogConsumer
 from .commit_log import CommitLogWriter
+from .submission import SubmissionPipeline
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -220,6 +221,8 @@ def create_app(
             return Response(status_code=503)
         return await call_next(request)
 
+    submission_pipeline = SubmissionPipeline(dagmanager)
+
     api_router = create_api_router(
         manager,
         redis_conn,
@@ -230,6 +233,7 @@ def create_app(
         world_client_local,
         enforce_live_guard,
         fill_producer,
+        submission_pipeline=submission_pipeline,
     )
     app.include_router(api_router)
     # Expose event endpoints (subscribe/JWKS and WS bridge). Pass world and

--- a/qmtl/gateway/compute_context.py
+++ b/qmtl/gateway/compute_context.py
@@ -1,113 +1,24 @@
 from __future__ import annotations
 
-import re
-from typing import Any, Mapping, Tuple
+"""Gateway-facing helpers for compute context handling.
 
-_BACKTEST_TOKENS = {
-    "backtest",
-    "backtesting",
-    "compute",
-    "computeonly",
-    "offline",
-    "sandbox",
-    "sim",
-    "simulation",
-    "simulated",
-    "validate",
-    "validation",
-}
-_DRYRUN_TOKENS = {
-    "dryrun",
-    "dryrunmode",
-    "papermode",
-    "paper",
-    "papertrade",
-    "papertrading",
-    "papertrader",
-}
-_LIVE_TOKENS = {"live", "prod", "production"}
-_SHADOW_TOKENS = {"shadow"}
+This module now re-exports the canonical compute context utilities housed in
+``qmtl.common.compute_context`` to preserve import stability for gateway
+consumers.
+"""
 
-
-def normalize_context_value(value: Any | None) -> str | None:
-    """Normalize raw meta values to stripped strings."""
-    if value is None:
-        return None
-    if isinstance(value, (str, int, float)):
-        text = str(value).strip()
-        return text or None
-    return None
-
-
-def resolve_execution_domain(value: str | None) -> str | None:
-    """Map execution domain aliases to canonical tokens."""
-    if value is None:
-        return None
-    lowered = value.lower()
-    segments = re.split(r"[/:]", lowered)
-    for segment in segments:
-        token = re.sub(r"[\s_-]+", "", segment)
-        if token in _BACKTEST_TOKENS:
-            return "backtest"
-        if token in _DRYRUN_TOKENS:
-            return "dryrun"
-        if token in _LIVE_TOKENS:
-            return "live"
-        if token in _SHADOW_TOKENS:
-            return "shadow"
-    return lowered
-
-
-def evaluate_safe_mode(
-    execution_domain: str | None, as_of: str | None
-) -> Tuple[str | None, bool, str | None, bool]:
-    """Determine whether the compute context must enter safe mode."""
-
-    downgraded = False
-    downgrade_reason: str | None = None
-    safe_mode = False
-
-    if execution_domain in {"backtest", "dryrun"} and not as_of:
-        downgraded = True
-        downgrade_reason = "missing_as_of"
-        safe_mode = True
-        execution_domain = "backtest"
-
-    return execution_domain, downgraded, downgrade_reason, safe_mode
-
-
-def build_strategy_compute_context(
-    meta: Mapping[str, Any] | None,
-) -> tuple[dict[str, str | None], bool, str | None, bool]:
-    """Return normalized compute context and downgrade flags.
-
-    Produces a context dict with keys: execution_domain, as_of, partition,
-    dataset_fingerprint. Also returns (downgraded, downgrade_reason, safe_mode).
-    """
-
-    meta = meta or {}
-    raw_domain = normalize_context_value(meta.get("execution_domain")) if meta else None
-    execution_domain = resolve_execution_domain(raw_domain)
-    as_of = normalize_context_value(meta.get("as_of") if meta else None)
-    partition = normalize_context_value(meta.get("partition") if meta else None)
-    dataset_fingerprint = normalize_context_value(meta.get("dataset_fingerprint") if meta else None)
-
-    execution_domain, downgraded, downgrade_reason, safe_mode = evaluate_safe_mode(
-        execution_domain, as_of
-    )
-
-    context: dict[str, str | None] = {
-        "execution_domain": execution_domain,
-        "as_of": as_of,
-        "partition": partition,
-        "dataset_fingerprint": dataset_fingerprint,
-    }
-    return context, downgraded, downgrade_reason, safe_mode
-
+from qmtl.common.compute_context import (
+    ComputeContext,
+    build_strategy_compute_context,
+    evaluate_safe_mode,
+    normalize_context_value,
+    resolve_execution_domain,
+)
 
 __all__ = [
+    "ComputeContext",
+    "build_strategy_compute_context",
     "evaluate_safe_mode",
     "normalize_context_value",
     "resolve_execution_domain",
-    "build_strategy_compute_context",
 ]

--- a/qmtl/gateway/routes.py
+++ b/qmtl/gateway/routes.py
@@ -36,6 +36,7 @@ from .strategy_submission import (
     StrategySubmissionConfig,
     StrategySubmissionHelper,
 )
+from .submission import SubmissionPipeline
 from .ws import WebSocketHub
 from .world_client import WorldServiceClient
 
@@ -53,12 +54,16 @@ def create_api_router(
     world_client: Optional[WorldServiceClient],
     enforce_live_guard: bool,
     fill_producer: Any | None = None,
+    submission_pipeline: SubmissionPipeline | None = None,
 
 ) -> APIRouter:
 
     router = APIRouter()
 
-    submission_helper = StrategySubmissionHelper(manager, dagmanager, database_obj)
+    pipeline = submission_pipeline or SubmissionPipeline(dagmanager)
+    submission_helper = StrategySubmissionHelper(
+        manager, dagmanager, database_obj, pipeline=pipeline
+    )
 
     @router.get("/status")
     async def status_endpoint() -> dict[str, Any]:

--- a/qmtl/gateway/submission/__init__.py
+++ b/qmtl/gateway/submission/__init__.py
@@ -1,0 +1,19 @@
+"""Submission pipeline services for Gateway strategy ingestion."""
+
+from .context_service import ComputeContextService
+from .dag_loader import DagLoader, LoadedDag
+from .diff_executor import DiffExecutor
+from .node_identity import NodeIdentityValidator
+from .pipeline import PreparedSubmission, SubmissionPipeline
+from .queue_map_resolver import QueueMapResolver
+
+__all__ = [
+    "ComputeContextService",
+    "DagLoader",
+    "DiffExecutor",
+    "LoadedDag",
+    "NodeIdentityValidator",
+    "PreparedSubmission",
+    "SubmissionPipeline",
+    "QueueMapResolver",
+]

--- a/qmtl/gateway/submission/context_service.py
+++ b/qmtl/gateway/submission/context_service.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Shared compute context helpers for strategy submissions."""
+
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from qmtl.common.compute_context import ComputeContext, build_strategy_compute_context
+
+if TYPE_CHECKING:  # pragma: no cover - typing aid
+    from qmtl.gateway.models import StrategySubmit
+
+
+class ComputeContextService:
+    """Normalize compute context metadata and world identifiers."""
+
+    def build(
+        self, payload: "StrategySubmit"
+    ) -> tuple[ComputeContext, Dict[str, Any], Dict[str, str], List[str]]:
+        worlds = self._unique_worlds(payload)
+        meta = payload.meta if isinstance(payload.meta, dict) else None
+        base_ctx = build_strategy_compute_context(meta)
+        context = base_ctx.with_world(worlds[0]) if worlds else base_ctx
+        context_payload = context.to_dict(include_flags=True)
+        context_mapping = {
+            f"compute_{k}": v
+            for k, v in context_payload.items()
+            if isinstance(v, str) and v
+        }
+        return context, context_payload, context_mapping, worlds
+
+    def _unique_worlds(self, payload: "StrategySubmit") -> List[str]:
+        candidates: list[str] = []
+        if payload.world_id:
+            candidates.append(str(payload.world_id))
+        wid_list = getattr(payload, "world_ids", None)
+        if wid_list:
+            candidates.extend(str(item) for item in wid_list if item)
+        unique: list[str] = []
+        seen: set[str] = set()
+        for value in candidates:
+            normalized = self._normalize(value)
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            unique.append(normalized)
+        return unique
+
+    def _normalize(self, value: Any | None) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            value = value.decode()
+        if isinstance(value, (str, int, float)):
+            text = str(value).strip()
+            return text or None
+        return None

--- a/qmtl/gateway/submission/dag_loader.py
+++ b/qmtl/gateway/submission/dag_loader.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Decode and validate strategy DAG payloads."""
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import HTTPException
+
+
+@dataclass
+class LoadedDag:
+    """Container for decoded DAG structures."""
+
+    dag: dict[str, Any]
+    dag_json: str
+
+
+class DagLoader:
+    """Decode base64-encoded DAG submissions and validate schema."""
+
+    def __init__(self) -> None:
+        pass
+
+    def decode(self, dag_payload: str) -> LoadedDag:
+        """Return parsed DAG from ``dag_payload`` which may be base64 encoded."""
+
+        try:
+            dag_bytes = base64.b64decode(dag_payload)
+            decoded = json.loads(dag_bytes.decode())
+        except Exception:
+            decoded = json.loads(dag_payload)
+        return LoadedDag(dag=decoded, dag_json=dag_payload)
+
+    def validate(self, dag: dict[str, Any]) -> None:
+        from qmtl.dagmanager.schema_validator import validate_dag
+
+        ok, _version, verrors = validate_dag(dag)
+        if not ok:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "E_SCHEMA_INVALID", "errors": verrors},
+            )
+
+    def load(self, dag_payload: str) -> LoadedDag:
+        """Decode and validate ``dag_payload`` returning ``LoadedDag``."""
+
+        loaded = self.decode(dag_payload)
+        self.validate(loaded.dag)
+        return loaded

--- a/qmtl/gateway/submission/diff_executor.py
+++ b/qmtl/gateway/submission/diff_executor.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Async wrapper for invoking DAG Manager diff operations."""
+
+import asyncio
+from typing import Any, Iterable
+
+
+class DiffExecutor:
+    """Run DAG Manager diffs and normalize sentinel/queue_map results."""
+
+    def __init__(self, dagmanager) -> None:
+        self._dagmanager = dagmanager
+
+    async def run(
+        self,
+        *,
+        strategy_id: str,
+        dag_json: str,
+        worlds: list[str],
+        fallback_world_id: str | None,
+        compute_ctx,
+        timeout: float,
+        prefer_queue_map: bool,
+    ) -> tuple[str | None, dict[str, list[dict[str, Any]]] | None]:
+        diff_kwargs = compute_ctx.diff_kwargs()
+
+        async def _invoke(world: str | None):
+            return await self._dagmanager.diff(
+                strategy_id,
+                dag_json,
+                world_id=world,
+                **diff_kwargs,
+            )
+
+        sentinel_id: str | None = None
+        queue_map: dict[str, list[dict[str, Any]]] | None = None
+
+        if prefer_queue_map and len(worlds) > 1:
+            tasks = [_invoke(world_id) for world_id in worlds]
+            chunks = await asyncio.gather(*tasks, return_exceptions=True)
+            queue_map = {}
+            for chunk in chunks:
+                if isinstance(chunk, Exception) or chunk is None:
+                    continue
+                if not sentinel_id:
+                    sentinel_id = getattr(chunk, "sentinel_id", None)
+                for key, topic in dict(getattr(chunk, "queue_map", {})).items():
+                    node_id = self._node_id_from_partition_key(str(key))
+                    lst = queue_map.setdefault(node_id, [])
+                    if topic not in [d.get("queue") for d in lst]:
+                        lst.append({"queue": topic, "global": False})
+            return sentinel_id, queue_map
+
+        world = worlds[0] if worlds else fallback_world_id
+        if world is None and prefer_queue_map and not worlds:
+            queue_map = {}
+
+        chunk = await asyncio.wait_for(_invoke(world), timeout=timeout)
+        if chunk is None:
+            return sentinel_id, queue_map
+
+        sentinel_id = getattr(chunk, "sentinel_id", None)
+        if prefer_queue_map:
+            queue_map = {}
+            for key, topic in dict(getattr(chunk, "queue_map", {})).items():
+                node_id = self._node_id_from_partition_key(str(key))
+                queue_map.setdefault(node_id, []).append(
+                    {"queue": topic, "global": False}
+                )
+
+        return sentinel_id, queue_map
+
+    def _node_id_from_partition_key(self, identifier: str) -> str:
+        base, _, _ = identifier.partition("#")
+        token = base or identifier
+        if ":" in token:
+            return token.rsplit(":", 2)[0]
+        return token

--- a/qmtl/gateway/submission/node_identity.py
+++ b/qmtl/gateway/submission/node_identity.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Validation for node identifiers in submitted DAGs."""
+
+from typing import Any, Iterable
+
+from fastapi import HTTPException
+
+from qmtl.common import crc32_of_list, compute_node_id
+
+
+class NodeIdentityValidator:
+    """Ensure submitted node identities match canonical hashing rules."""
+
+    def validate(self, dag: dict[str, Any], node_ids_crc32: int) -> None:
+        nodes = dag.get("nodes", [])
+        node_ids_for_crc: list[str] = []
+        missing_fields: list[dict[str, Any]] = []
+        mismatches: list[dict[str, str | int]] = []
+
+        for idx, node in enumerate(nodes):
+            if not isinstance(node, dict):
+                continue
+            nid = node.get("node_id")
+            if not isinstance(nid, str) or not nid:
+                node_ids_for_crc.append(str(nid or ""))
+                missing_fields.append({"index": idx, "missing": ["node_id"]})
+                continue
+
+            node_ids_for_crc.append(nid)
+            required = {
+                "node_type": node.get("node_type"),
+                "code_hash": node.get("code_hash"),
+                "config_hash": node.get("config_hash"),
+                "schema_hash": node.get("schema_hash"),
+                "schema_compat_id": node.get("schema_compat_id"),
+            }
+            missing = [field for field, value in required.items() if not value]
+            if missing:
+                missing_fields.append(
+                    {"index": idx, "node_id": nid, "missing": missing}
+                )
+                continue
+
+            expected = compute_node_id(node)
+            if nid != expected:
+                mismatches.append({"index": idx, "node_id": nid, "expected": expected})
+
+        crc = crc32_of_list(node_ids_for_crc)
+        if missing_fields:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "E_NODE_ID_FIELDS",
+                    "message": "node_id validation requires node_type, code_hash, config_hash, schema_hash and schema_compat_id",
+                    "missing_fields": missing_fields,
+                    "hint": "Regenerate the DAG with an updated SDK so each node includes the hashes required by compute_node_id().",
+                },
+            )
+
+        if crc != node_ids_crc32:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "E_CHECKSUM_MISMATCH", "message": "node id checksum mismatch"},
+            )
+
+        if mismatches:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "E_NODE_ID_MISMATCH",
+                    "message": "node_id does not match canonical compute_node_id output",
+                    "node_id_mismatch": mismatches,
+                    "hint": "Ensure legacy world-coupled or pre-BLAKE3 node_ids are regenerated using compute_node_id().",
+                },
+            )

--- a/qmtl/gateway/submission/pipeline.py
+++ b/qmtl/gateway/submission/pipeline.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""High-level orchestration for the strategy submission pipeline."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, List
+
+from qmtl.common.compute_context import ComputeContext
+
+from .context_service import ComputeContextService
+from .dag_loader import DagLoader
+from .diff_executor import DiffExecutor
+from .node_identity import NodeIdentityValidator
+from .queue_map_resolver import QueueMapResolver
+
+if TYPE_CHECKING:  # pragma: no cover - typing hints only
+    from qmtl.gateway.models import StrategySubmit
+
+
+@dataclass
+class PreparedSubmission:
+    dag: dict[str, Any]
+    compute_context: ComputeContext
+    context_payload: dict[str, Any]
+    context_mapping: dict[str, str]
+    worlds: List[str]
+
+
+class SubmissionPipeline:
+    """Compose submission services to prepare DAGs and downstream calls."""
+
+    def __init__(
+        self,
+        dagmanager,
+        *,
+        dag_loader: DagLoader | None = None,
+        node_validator: NodeIdentityValidator | None = None,
+        context_service: ComputeContextService | None = None,
+        diff_executor: DiffExecutor | None = None,
+        queue_map_resolver: QueueMapResolver | None = None,
+    ) -> None:
+        self._dag_loader = dag_loader or DagLoader()
+        self._node_validator = node_validator or NodeIdentityValidator()
+        self._context_service = context_service or ComputeContextService()
+        self._diff_executor = diff_executor or DiffExecutor(dagmanager)
+        self._queue_map_resolver = queue_map_resolver or QueueMapResolver(dagmanager)
+
+    def prepare(self, payload: "StrategySubmit") -> PreparedSubmission:
+        loaded = self._dag_loader.load(payload.dag_json)
+        dag = loaded.dag
+        self._node_validator.validate(dag, payload.node_ids_crc32)
+        context, context_payload, mapping, worlds = self._context_service.build(payload)
+        return PreparedSubmission(
+            dag=dag,
+            compute_context=context,
+            context_payload=context_payload,
+            context_mapping=mapping,
+            worlds=worlds,
+        )
+
+    async def run_diff(
+        self,
+        *,
+        strategy_id: str,
+        dag_json: str,
+        worlds: list[str],
+        fallback_world_id: str | None,
+        compute_ctx: ComputeContext,
+        timeout: float,
+        prefer_queue_map: bool,
+    ) -> tuple[str | None, dict[str, list[dict[str, Any]]] | None]:
+        return await self._diff_executor.run(
+            strategy_id=strategy_id,
+            dag_json=dag_json,
+            worlds=worlds,
+            fallback_world_id=fallback_world_id,
+            compute_ctx=compute_ctx,
+            timeout=timeout,
+            prefer_queue_map=prefer_queue_map,
+        )
+
+    async def build_queue_map(
+        self,
+        dag: dict[str, Any],
+        worlds: list[str],
+        default_world: str | None,
+        execution_domain: str | None,
+    ) -> dict[str, list[dict[str, Any] | Any]]:
+        return await self._queue_map_resolver.build(
+            dag,
+            worlds,
+            default_world,
+            execution_domain,
+        )

--- a/qmtl/gateway/submission/queue_map_resolver.py
+++ b/qmtl/gateway/submission/queue_map_resolver.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Fallback queue-map resolution using TagQuery lookups."""
+
+import asyncio
+from typing import Any, Iterable
+
+
+class QueueMapResolver:
+    """Build queue maps by querying DAG Manager tag endpoints."""
+
+    def __init__(self, dagmanager) -> None:
+        self._dagmanager = dagmanager
+
+    async def build(
+        self,
+        dag: dict[str, Any],
+        worlds: list[str],
+        default_world: str | None,
+        execution_domain: str | None,
+    ) -> dict[str, list[dict[str, Any] | Any]]:
+        queue_map: dict[str, list[dict[str, Any] | Any]] = {}
+        queries: list[asyncio.Future] = []
+        query_targets: list[tuple[str, str | None]] = []
+
+        nodes = dag.get("nodes", [])
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            if node.get("node_type") != "TagQueryNode":
+                continue
+            nid = node.get("node_id")
+            if not isinstance(nid, str) or not nid:
+                continue
+            tags = node.get("tags", [])
+            interval = int(node.get("interval", 0))
+            match_mode = node.get("match_mode", "any")
+            if worlds:
+                for world_id in worlds:
+                    queries.append(
+                        self._dagmanager.get_queues_by_tag(
+                            tags, interval, match_mode, world_id, execution_domain
+                        )
+                    )
+                    query_targets.append((nid, world_id))
+            else:
+                queries.append(
+                    self._dagmanager.get_queues_by_tag(
+                        tags, interval, match_mode, default_world, execution_domain
+                    )
+                )
+                query_targets.append((nid, default_world))
+
+        results: Iterable[Any] = []
+        if queries:
+            results = await asyncio.gather(*queries, return_exceptions=True)
+
+        seen: dict[str, set[str]] = {}
+        for (nid, _world_id), result in zip(query_targets, results):
+            lst = queue_map.setdefault(nid, [])
+            seen.setdefault(nid, set())
+            if isinstance(result, Exception):
+                continue
+            for item in result:
+                queue_name = (
+                    item.get("queue")
+                    if isinstance(item, dict)
+                    else str(item)
+                )
+                if queue_name not in seen[nid]:
+                    lst.append(item)
+                    seen[nid].add(queue_name)
+
+        return queue_map

--- a/tests/gateway/test_strategy_manager_helpers.py
+++ b/tests/gateway/test_strategy_manager_helpers.py
@@ -86,7 +86,7 @@ async def test_publish_submission_noop_without_writer(
 ) -> None:
     payload = _make_payload()
     decoded = strategy_manager._decode_dag(payload)
-    compute_ctx, _, worlds, _, _ = strategy_manager._build_compute_context(payload)
+    _, compute_ctx_payload, _, worlds = strategy_manager._build_compute_context(payload)
 
     await strategy_manager._publish_submission(
         decoded.strategy_id,
@@ -94,7 +94,7 @@ async def test_publish_submission_noop_without_writer(
         decoded.encoded_dag,
         decoded.dag_hash,
         payload,
-        compute_ctx,
+        compute_ctx_payload,
         worlds,
     )
 
@@ -116,7 +116,7 @@ async def test_publish_submission_failure_rolls_back(
     )
 
     strategy_manager.commit_log_writer = _ExplodingWriter()
-    compute_ctx, _, worlds, _, _ = strategy_manager._build_compute_context(payload)
+    _, compute_ctx_payload, _, worlds = strategy_manager._build_compute_context(payload)
 
     with pytest.raises(HTTPException):
         await strategy_manager._publish_submission(
@@ -125,7 +125,7 @@ async def test_publish_submission_failure_rolls_back(
             decoded.encoded_dag,
             decoded.dag_hash,
             payload,
-            compute_ctx,
+            compute_ctx_payload,
             worlds,
         )
 

--- a/tests/gateway/test_strategy_manager_module.py
+++ b/tests/gateway/test_strategy_manager_module.py
@@ -226,11 +226,11 @@ async def test_strategy_manager_missing_as_of_triggers_safe_mode() -> None:
         node_ids_crc32=0,
     )
 
-    context, _, _, downgraded, reason = manager._build_compute_context(payload)
-    assert downgraded is True
-    assert reason == "missing_as_of"
-    assert context["execution_domain"] == "backtest"
-    assert context["safe_mode"] is True
+    context, context_payload, _, _ = manager._build_compute_context(payload)
+    assert context.downgraded is True
+    assert context.downgrade_reason == "missing_as_of"
+    assert context_payload["execution_domain"] == "backtest"
+    assert context_payload["safe_mode"] is True
 
     sid, existed = await manager.submit(payload)
     assert not existed

--- a/tests/gateway/test_submission_context_service.py
+++ b/tests/gateway/test_submission_context_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.gateway.models import StrategySubmit
+from qmtl.gateway.submission.context_service import ComputeContextService
+
+
+def _make_payload(**meta_overrides) -> StrategySubmit:
+    meta = {
+        "execution_domain": "live",
+        "as_of": "2024-01-01T00:00:00Z",
+        "partition": "tenant-a",
+        "dataset_fingerprint": "lake:abc",
+    }
+    meta.update(meta_overrides)
+    return StrategySubmit(
+        dag_json="{}",
+        meta=meta,
+        world_id="world-1",
+        world_ids=["world-1", "world-2"],
+        node_ids_crc32=0,
+    )
+
+
+def test_build_returns_unique_worlds() -> None:
+    service = ComputeContextService()
+    payload = _make_payload()
+
+    context, payload_dict, mapping, worlds = service.build(payload)
+
+    assert context.world_id == "world-1"
+    assert worlds == ["world-1", "world-2"]
+    assert payload_dict["execution_domain"] == "live"
+    assert mapping["compute_execution_domain"] == "live"
+
+
+def test_build_handles_missing_as_of() -> None:
+    service = ComputeContextService()
+    payload = _make_payload(as_of=None, execution_domain="dryrun")
+
+    context, payload_dict, _, _ = service.build(payload)
+
+    assert context.execution_domain == "backtest"
+    assert context.downgraded is True
+    assert payload_dict["safe_mode"] is True
+
+
+def test_build_without_worlds() -> None:
+    service = ComputeContextService()
+    payload = StrategySubmit(
+        dag_json="{}",
+        meta=None,
+        world_id=None,
+        node_ids_crc32=0,
+    )
+
+    context, payload_dict, mapping, worlds = service.build(payload)
+    assert context.world_id == ""
+    assert worlds == []
+    assert mapping == {}
+    assert payload_dict["execution_domain"] in {None, ""}
+

--- a/tests/gateway/test_submission_dag_loader.py
+++ b/tests/gateway/test_submission_dag_loader.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from qmtl.gateway.submission.dag_loader import DagLoader
+
+
+def test_decode_accepts_base64_payload() -> None:
+    dag = {"nodes": [], "meta": {}}
+    encoded = base64.b64encode(json.dumps(dag).encode()).decode()
+
+    loader = DagLoader()
+    loaded = loader.decode(encoded)
+
+    assert loaded.dag == dag
+
+
+def test_load_validates_schema(monkeypatch) -> None:
+    dag = {"nodes": [], "meta": {}}
+    loader = DagLoader()
+
+    calls: list[dict] = []
+
+    def fake_validate(data):  # type: ignore[compatible-type]
+        calls.append(data)
+        return True, "v1", []
+
+    monkeypatch.setattr(
+        "qmtl.dagmanager.schema_validator.validate_dag",
+        fake_validate,
+    )
+
+    loaded = loader.load(json.dumps(dag))
+    assert calls and calls[0] == dag
+    assert loaded.dag == dag
+
+
+def test_load_raises_on_invalid_schema(monkeypatch) -> None:
+    loader = DagLoader()
+
+    def fake_validate(_dag):  # type: ignore[compatible-type]
+        return False, "v1", ["broken"]
+
+    monkeypatch.setattr(
+        "qmtl.dagmanager.schema_validator.validate_dag",
+        fake_validate,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        loader.load("{}")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["code"] == "E_SCHEMA_INVALID"

--- a/tests/gateway/test_submission_node_identity.py
+++ b/tests/gateway/test_submission_node_identity.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.gateway.submission.node_identity import NodeIdentityValidator
+
+
+def _build_node(**overrides):
+    base = {
+        "node_id": None,
+        "node_type": "TagQueryNode",
+        "code_hash": "code",
+        "config_hash": "config",
+        "schema_hash": "schema",
+        "schema_compat_id": "compat",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_validate_accepts_matching_ids() -> None:
+    validator = NodeIdentityValidator()
+    node = _build_node()
+    dag = {"nodes": [node]}
+    from qmtl.common import compute_node_id, crc32_of_list
+
+    node_id = compute_node_id(node)
+    node["node_id"] = node_id
+    validator.validate(dag, crc32_of_list([node_id]))
+
+
+def test_validate_missing_fields_raises() -> None:
+    validator = NodeIdentityValidator()
+    node = _build_node(schema_hash="")
+    node_id = "abc"
+    node["node_id"] = node_id
+    dag = {"nodes": [node]}
+
+    with pytest.raises(Exception) as exc:
+        validator.validate(dag, 0)
+
+    detail = exc.value.detail  # type: ignore[attr-defined]
+    assert detail["code"] == "E_NODE_ID_FIELDS"
+
+
+def test_validate_crc_mismatch_raises() -> None:
+    validator = NodeIdentityValidator()
+    node = _build_node()
+    dag = {"nodes": [node]}
+    from qmtl.common import compute_node_id
+
+    node_id = compute_node_id(node)
+    node["node_id"] = node_id
+
+    with pytest.raises(Exception) as exc:
+        validator.validate(dag, 0)
+
+    detail = exc.value.detail  # type: ignore[attr-defined]
+    assert detail["code"] == "E_CHECKSUM_MISMATCH"
+
+
+def test_validate_detects_mismatch() -> None:
+    validator = NodeIdentityValidator()
+    node = _build_node(node_id="not-matching")
+    dag = {"nodes": [node]}
+    from qmtl.common import crc32_of_list
+
+    with pytest.raises(Exception) as exc:
+        validator.validate(dag, crc32_of_list(["not-matching"]))
+
+    detail = exc.value.detail  # type: ignore[attr-defined]
+    assert detail["code"] == "E_NODE_ID_MISMATCH"

--- a/tests/gateway/test_submission_pipeline.py
+++ b/tests/gateway/test_submission_pipeline.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from qmtl.common.compute_context import ComputeContext
+from qmtl.gateway.submission import PreparedSubmission, SubmissionPipeline
+
+
+class _Loader:
+    def __init__(self) -> None:
+        self.called = False
+
+    def load(self, dag_json: str):  # type: ignore[override]
+        self.called = True
+        class _Loaded:
+            dag = {"nodes": ["n"]}
+        return _Loaded()
+
+
+class _Validator:
+    def __init__(self) -> None:
+        self.calls: list[tuple[dict, int]] = []
+
+    def validate(self, dag, crc):
+        self.calls.append((dag, crc))
+
+
+class _ContextService:
+    def build(self, payload):
+        context = ComputeContext(world_id="w1", execution_domain="live")
+        return context, {"execution_domain": "live"}, {"compute_execution_domain": "live"}, ["w1"]
+
+
+class _DiffExecutor:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def run(self, **kwargs):
+        self.calls.append(kwargs)
+        return "sentinel", {"nid": [{"queue": "q", "global": False}]}
+
+
+class _QueueMapResolver:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def build(self, dag, worlds, default_world, execution_domain):
+        self.calls.append((dag, worlds, default_world, execution_domain))
+        return {"nid": []}
+
+
+class _Payload:
+    dag_json = "{}"
+    node_ids_crc32 = 0
+
+
+@pytest.mark.asyncio
+async def test_pipeline_prepare_and_diff(monkeypatch):
+    loader = _Loader()
+    validator = _Validator()
+    context_service = _ContextService()
+    diff_exec = _DiffExecutor()
+    resolver = _QueueMapResolver()
+
+    pipeline = SubmissionPipeline(
+        dagmanager=None,
+        dag_loader=loader,
+        node_validator=validator,
+        context_service=context_service,
+        diff_executor=diff_exec,
+        queue_map_resolver=resolver,
+    )
+
+    prepared = pipeline.prepare(_Payload())
+    assert isinstance(prepared, PreparedSubmission)
+    assert prepared.dag == {"nodes": ["n"]}
+    assert prepared.compute_context.execution_domain == "live"
+    assert prepared.worlds == ["w1"]
+    assert validator.calls
+
+    sentinel, queue_map = await pipeline.run_diff(
+        strategy_id="sid",
+        dag_json="{}",
+        worlds=["w1"],
+        fallback_world_id=None,
+        compute_ctx=prepared.compute_context,
+        timeout=0.1,
+        prefer_queue_map=False,
+    )
+    assert sentinel == "sentinel"
+    assert queue_map == {"nid": [{"queue": "q", "global": False}]}
+    assert diff_exec.calls
+
+    result = await pipeline.build_queue_map(prepared.dag, ["w1"], "w1", "live")
+    assert result == {"nid": []}
+    assert resolver.calls


### PR DESCRIPTION
## Summary
- add canonical compute context dataclass shared by gateway, dagmanager, and sdk
- refactor strategy submission helper into modular services orchestrated by SubmissionPipeline
- update docs and tests to reflect the new pipeline and compute context contract

## Testing
- uv run -m pytest qmtl/gateway/tests/test_strategy_submission_helper.py tests/gateway/test_submission_pipeline.py tests/gateway/test_strategy_manager_module.py tests/gateway/test_strategy_manager_helpers.py tests/gateway/test_world_proxy.py
- uv run -m pytest -W error -n auto

Closes #1014
Closes #1015