### PR TITLE
Add shared node factories for gateway and SDK tests

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -63,3 +63,17 @@ Tips:
 - Run tests in parallel with `pytest-xdist` (`-n auto`) for faster feedback.
 - For suites with shared resources, use `--dist loadscope` or cap workers (e.g., `-n 2`). Mark strictly serial tests and run them separately.
 
+## Shared node factories
+
+Gateway and SDK tests rely on consistent node hashing. Reuse the helpers in
+`tests/factories/node.py` rather than hand-rolling node dictionaries. The
+factories canonicalise parameters, sort dependencies, and compute `node_id`
+values so hash-contract updates only need to change in one place.
+
+```python
+from tests.factories import tag_query_node_payload, node_ids_crc32
+
+node = tag_query_node_payload(tags=["t"], interval=60)
+checksum = node_ids_crc32([node])
+```
+

--- a/tests/common/test_node_factories.py
+++ b/tests/common/test_node_factories.py
@@ -1,0 +1,41 @@
+from tests.factories import (
+    canonical_node_payload,
+    indicator_node_payload,
+    node_ids_crc32,
+    tag_query_node_payload,
+)
+
+
+def test_factory_sorts_dependencies_for_hashing():
+    first = canonical_node_payload(
+        node_type="IndicatorNode",
+        dependencies=["b", "a", "c"],
+        config_hash="cfg-a",
+    )
+    second = canonical_node_payload(
+        node_type="IndicatorNode",
+        dependencies=["c", "b", "a"],
+        config_hash="cfg-a",
+    )
+    assert first["dependencies"] == ["a", "b", "c"]
+    assert first["node_id"] == second["node_id"]
+
+
+def test_factory_canonicalises_params_nested_structures():
+    node = indicator_node_payload(
+        params={"tags": {"b", "a"}, "inner": {"z": 1, "a": 2}},
+        config_hash="cfg-b",
+    )
+    assert node["params"]["tags"] == ["a", "b"]
+    variant = indicator_node_payload(
+        params={"inner": {"a": 2, "z": 1}, "tags": ["a", "b"]},
+        config_hash="cfg-b",
+    )
+    assert node["node_id"] == variant["node_id"]
+
+
+def test_node_ids_crc32_handles_iterables():
+    tag = tag_query_node_payload(tags=["t"], config_hash="cfg-c")
+    indicator = indicator_node_payload(config_hash="cfg-d")
+    checksum = node_ids_crc32([tag, indicator])
+    assert checksum == node_ids_crc32((tag, indicator))

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,17 @@
+"""Shared test factories for QMTL test suite."""
+
+from .node import (
+    canonical_dag,
+    canonical_node_payload,
+    indicator_node_payload,
+    node_ids_crc32,
+    tag_query_node_payload,
+)
+
+__all__ = [
+    "canonical_dag",
+    "canonical_node_payload",
+    "indicator_node_payload",
+    "node_ids_crc32",
+    "tag_query_node_payload",
+]

--- a/tests/factories/node.py
+++ b/tests/factories/node.py
@@ -98,6 +98,8 @@ def canonical_node_payload(
         or payload.get("schema_id", ""),
         "code_hash": payload.get("code_hash", ""),
     }
+    if "inputs" in payload:
+        spec["inputs"] = payload.get("inputs", [])
     if include_node_id:
         payload.setdefault("node_id", compute_node_id(spec))
     return payload

--- a/tests/factories/node.py
+++ b/tests/factories/node.py
@@ -1,0 +1,196 @@
+"""Factories for canonical node payloads used across tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, Mapping, Sequence
+
+from qmtl.common import compute_node_id, crc32_of_list
+from qmtl.common.nodespec import serialize_nodespec
+
+
+def _normalize_dependencies(deps: Sequence[Any] | None) -> list[str]:
+    if not deps:
+        return []
+    normalized: list[str] = []
+    for dep in deps:
+        if dep in (None, ""):
+            continue
+        if isinstance(dep, str):
+            normalized.append(dep)
+        else:
+            normalized.append(str(dep))
+    return sorted(normalized)
+
+
+def _canonical_params(payload: Mapping[str, Any]) -> Any:
+    params_source = payload.get("params")
+    if params_source is None:
+        params_source = payload.get("config")
+    spec = {
+        "node_type": payload.get("node_type", ""),
+        "interval": int(payload.get("interval") or 0),
+        "period": int(payload.get("period") or 0),
+        "params": params_source,
+        "dependencies": payload.get("dependencies", []),
+        "schema_compat_id": payload.get("schema_compat_id")
+        or payload.get("schema_id")
+        or "",
+        "code_hash": payload.get("code_hash", ""),
+    }
+    params_blob = serialize_nodespec(spec).decode().split("|", 6)[3]
+    if not params_blob or params_blob == "null":
+        return {}
+    canonical = json.loads(params_blob)
+    if canonical is None:
+        return {}
+    return canonical
+
+
+def canonical_node_payload(
+    *,
+    node_type: str,
+    interval: int = 0,
+    period: int = 0,
+    params: Mapping[str, Any] | None = None,
+    config: Mapping[str, Any] | None = None,
+    dependencies: Sequence[Any] | None = None,
+    inputs: Sequence[Any] | None = None,
+    schema_hash: str = "schema",
+    schema_compat_id: str | None = None,
+    code_hash: str = "code",
+    config_hash: str = "cfg",
+    include_node_id: bool = True,
+    extras: Mapping[str, Any] | None = None,
+    **overrides: Any,
+) -> dict[str, Any]:
+    """Build a canonical node payload for gateway and SDK tests."""
+
+    payload: dict[str, Any] = {
+        "node_type": node_type,
+        "interval": interval,
+        "period": period,
+        "params": params if params is not None else {},
+        "dependencies": list(dependencies or []),
+        "schema_hash": schema_hash,
+        "schema_compat_id": (schema_compat_id or f"{schema_hash}-major"),
+        "code_hash": code_hash,
+        "config_hash": config_hash,
+    }
+    if config is not None:
+        payload["config"] = config
+    if inputs is not None:
+        payload["inputs"] = list(inputs)
+    if extras:
+        payload.update(extras)
+    payload.update(overrides)
+    payload["dependencies"] = _normalize_dependencies(payload.get("dependencies"))
+    if "inputs" in payload:
+        payload["inputs"] = _normalize_dependencies(payload.get("inputs"))
+    payload["params"] = _canonical_params(payload)
+    spec = {
+        "node_type": payload["node_type"],
+        "interval": int(payload.get("interval") or 0),
+        "period": int(payload.get("period") or 0),
+        "params": payload.get("params"),
+        "dependencies": payload.get("dependencies", []),
+        "schema_compat_id": payload.get("schema_compat_id")
+        or payload.get("schema_id", ""),
+        "code_hash": payload.get("code_hash", ""),
+    }
+    if include_node_id:
+        payload.setdefault("node_id", compute_node_id(spec))
+    return payload
+
+
+def tag_query_node_payload(
+    *,
+    tags: Sequence[str],
+    match_mode: str = "any",
+    interval: int = 60,
+    period: int = 0,
+    schema_hash: str = "tag-schema",
+    schema_compat_id: str | None = None,
+    code_hash: str = "tag-code",
+    config_hash: str = "cfg",
+    dependencies: Sequence[Any] | None = None,
+    inputs: Sequence[Any] | None = None,
+    params: Mapping[str, Any] | None = None,
+    include_node_id: bool = True,
+    **overrides: Any,
+) -> dict[str, Any]:
+    """Build a canonical TagQuery node payload."""
+
+    tag_list = list(tags)
+    resolved_params = params if params is not None else {"tags": tag_list, "match_mode": match_mode}
+    extras = {"tags": tag_list}
+    return canonical_node_payload(
+        node_type="TagQueryNode",
+        interval=interval,
+        period=period,
+        params=resolved_params,
+        dependencies=dependencies,
+        inputs=inputs,
+        schema_hash=schema_hash,
+        schema_compat_id=schema_compat_id,
+        code_hash=code_hash,
+        config_hash=config_hash,
+        include_node_id=include_node_id,
+        extras=extras,
+        **overrides,
+    )
+
+
+def indicator_node_payload(
+    *,
+    interval: int = 60,
+    period: int = 5,
+    window: int = 5,
+    schema_hash: str = "indicator-schema",
+    schema_compat_id: str | None = None,
+    code_hash: str = "indicator-code",
+    config_hash: str = "cfg",
+    dependencies: Sequence[Any] | None = None,
+    params: Mapping[str, Any] | None = None,
+    include_node_id: bool = True,
+    **overrides: Any,
+) -> dict[str, Any]:
+    """Build a canonical Indicator node payload."""
+
+    resolved_params = params if params is not None else {"window": window}
+    return canonical_node_payload(
+        node_type="IndicatorNode",
+        interval=interval,
+        period=period,
+        params=resolved_params,
+        dependencies=dependencies,
+        schema_hash=schema_hash,
+        schema_compat_id=schema_compat_id,
+        code_hash=code_hash,
+        config_hash=config_hash,
+        include_node_id=include_node_id,
+        **overrides,
+    )
+
+
+def canonical_dag(*nodes: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a canonical DAG wrapper for ``nodes``."""
+
+    return {"nodes": [dict(node) for node in nodes]}
+
+
+def node_ids_crc32(nodes: Iterable[Mapping[str, Any]] | None) -> int:
+    """Compute CRC32 over the node identifiers present in ``nodes``."""
+
+    if not nodes:
+        return 0
+    return crc32_of_list(node.get("node_id") for node in nodes if node.get("node_id"))
+
+
+__all__ = [
+    "canonical_dag",
+    "canonical_node_payload",
+    "indicator_node_payload",
+    "node_ids_crc32",
+    "tag_query_node_payload",
+]

--- a/tests/gateway/test_strategy_manager_module.py
+++ b/tests/gateway/test_strategy_manager_module.py
@@ -15,6 +15,7 @@ from qmtl.gateway.fsm import StrategyFSM
 from qmtl.gateway.models import StrategySubmit
 from qmtl.gateway.redis_client import InMemoryRedis
 from qmtl.gateway.strategy_manager import StrategyManager
+from tests.factories import canonical_node_payload
 
 
 @pytest.mark.asyncio
@@ -98,20 +99,18 @@ async def test_strategy_manager_writes_commit_log() -> None:
         commit_log_writer=writer,
     )
 
-    dag = {
-        "nodes": [
-            {
-                "node_id": "n1",
-                "node_type": "TypeA",
-                "config_hash": "c",
-                "code_hash": "d",
-                "schema_hash": "s",
-                "schema_compat_id": "s-major",
-                "params": {},
-                "dependencies": [],
-            }
-        ]
-    }
+    node = canonical_node_payload(
+        node_type="TypeA",
+        config_hash="c",
+        code_hash="d",
+        schema_hash="s",
+        schema_compat_id="s-major",
+        params={},
+        dependencies=[],
+        include_node_id=False,
+    )
+    node["node_id"] = "n1"
+    dag = {"nodes": [node]}
     dag_json = base64.b64encode(json.dumps(dag).encode()).decode()
     payload = StrategySubmit(
         dag_json=dag_json,

--- a/tests/gateway/test_submission_node_identity.py
+++ b/tests/gateway/test_submission_node_identity.py
@@ -3,37 +3,33 @@ from __future__ import annotations
 import pytest
 
 from qmtl.gateway.submission.node_identity import NodeIdentityValidator
-
-
-def _build_node(**overrides):
-    base = {
-        "node_id": None,
-        "node_type": "TagQueryNode",
-        "code_hash": "code",
-        "config_hash": "config",
-        "schema_hash": "schema",
-        "schema_compat_id": "compat",
-    }
-    base.update(overrides)
-    return base
+from tests.factories import node_ids_crc32, tag_query_node_payload
 
 
 def test_validate_accepts_matching_ids() -> None:
     validator = NodeIdentityValidator()
-    node = _build_node()
+    node = tag_query_node_payload(
+        tags=["t"],
+        code_hash="code",
+        config_hash="config",
+        schema_hash="schema",
+        schema_compat_id="compat",
+    )
     dag = {"nodes": [node]}
-    from qmtl.common import compute_node_id, crc32_of_list
-
-    node_id = compute_node_id(node)
-    node["node_id"] = node_id
-    validator.validate(dag, crc32_of_list([node_id]))
+    validator.validate(dag, node_ids_crc32([node]))
 
 
 def test_validate_missing_fields_raises() -> None:
     validator = NodeIdentityValidator()
-    node = _build_node(schema_hash="")
-    node_id = "abc"
-    node["node_id"] = node_id
+    node = tag_query_node_payload(
+        tags=["t"],
+        code_hash="code",
+        config_hash="config",
+        schema_hash="",
+        schema_compat_id="",
+        include_node_id=False,
+    )
+    node["node_id"] = "abc"
     dag = {"nodes": [node]}
 
     with pytest.raises(Exception) as exc:
@@ -45,12 +41,14 @@ def test_validate_missing_fields_raises() -> None:
 
 def test_validate_crc_mismatch_raises() -> None:
     validator = NodeIdentityValidator()
-    node = _build_node()
+    node = tag_query_node_payload(
+        tags=["t"],
+        code_hash="code",
+        config_hash="config",
+        schema_hash="schema",
+        schema_compat_id="compat",
+    )
     dag = {"nodes": [node]}
-    from qmtl.common import compute_node_id
-
-    node_id = compute_node_id(node)
-    node["node_id"] = node_id
 
     with pytest.raises(Exception) as exc:
         validator.validate(dag, 0)
@@ -61,12 +59,17 @@ def test_validate_crc_mismatch_raises() -> None:
 
 def test_validate_detects_mismatch() -> None:
     validator = NodeIdentityValidator()
-    node = _build_node(node_id="not-matching")
+    node = tag_query_node_payload(
+        tags=["t"],
+        code_hash="code",
+        config_hash="config",
+        schema_hash="schema",
+        schema_compat_id="compat",
+        node_id="not-matching",
+    )
     dag = {"nodes": [node]}
-    from qmtl.common import crc32_of_list
-
     with pytest.raises(Exception) as exc:
-        validator.validate(dag, crc32_of_list(["not-matching"]))
+        validator.validate(dag, node_ids_crc32([node]))
 
     detail = exc.value.detail  # type: ignore[attr-defined]
     assert detail["code"] == "E_NODE_ID_MISMATCH"


### PR DESCRIPTION
## Summary
- add `tests.factories.node` helpers that canonicalise params, dependencies, and node ids for common node shapes
- refactor gateway and SDK-adjacent tests to build DAG payloads via the shared factories and add coverage for the helpers
- document the new factory module in the contributor testing guide

## Testing
- uv run -m pytest tests/common/test_node_factories.py tests/gateway/test_submission_node_identity.py tests/gateway/test_dry_run_parity.py tests/gateway/test_tag_query.py tests/integrity/test_checksum.py tests/strategy/test_conflict.py

Fixes #1009

------
https://chatgpt.com/codex/tasks/task_e_68d0f777b6f08329a4f2bc429060f362