### PR TITLE
Consolidate node validation into shared module

### DIFF
--- a/docs/reference/node_validation.md
+++ b/docs/reference/node_validation.md
@@ -1,0 +1,48 @@
+# Node Identity Validation
+
+`qmtl.common.node_validation` centralizes the checksum and field checks that
+back Gateway ingestion, CLI tooling, and SDK dry-run paths. The helpers wrap the
+canonical [`compute_node_id`](../architecture/gateway.md) routine so every entry
+point enforces identical contracts.
+
+## API Summary
+
+- `validate_node_identity(nodes, provided_checksum)` returns a
+  `NodeValidationReport` describing the computed CRC32 checksum, any missing
+  fields, and mismatched identifiers.
+- `enforce_node_identity(nodes, provided_checksum)` performs the same
+  validation but raises a `NodeValidationError` when the payload is invalid.
+- `NodeValidationReport.raise_for_issues()` promotes report findings to a
+  `NodeValidationError`, allowing callers to defer the exception until after
+  collecting diagnostics.
+- `REQUIRED_NODE_FIELDS` exposes the tuple of attributes (`node_type`,
+  `code_hash`, `config_hash`, `schema_hash`, `schema_compat_id`) that must be
+  non-empty for deterministic hashing.
+
+The `NodeValidationError.detail` payload mirrors FastAPI responses emitted by
+`NodeIdentityValidator` to preserve backwards compatibility for REST clients.
+
+## Error Codes
+
+| Code | Description |
+| ---- | ----------- |
+| `E_NODE_ID_FIELDS` | One or more required attributes are missing. The error payload contains a `missing_fields` list plus a remediation hint. |
+| `E_CHECKSUM_MISMATCH` | The provided CRC32 checksum does not match the computed value derived from the submitted node identifiers. |
+| `E_NODE_ID_MISMATCH` | At least one node's `node_id` differs from the canonical `compute_node_id` output. The error payload enumerates the mismatched nodes. |
+
+## Usage Example
+
+```python
+from qmtl.common import crc32_of_list, enforce_node_identity
+
+def validate_payload(dag: dict[str, object], checksum: int) -> None:
+    nodes = dag.get("nodes", [])
+    enforce_node_identity(nodes, checksum)
+
+dag = {"nodes": [some_node]}
+checksum = crc32_of_list([node["node_id"] for node in dag["nodes"]])
+validate_payload(dag, checksum)
+```
+
+The Gateway submission pipeline and CLI now share this module, ensuring every
+consumer receives consistent diagnostics and hint text.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - World API: reference/api_world.md
       - Enhanced Validation: reference/enhanced_validation.md
       - Node Schema Validation: reference/node_schema_validation.md
+      - Node Identity Validation: reference/node_validation.md
       - Backtest Validation: reference/backtest_validation.md
       - Report CLI: reference/report_cli.md
       - Lean-like Features: reference/lean_like_features.md

--- a/qmtl/common/__init__.py
+++ b/qmtl/common/__init__.py
@@ -1,15 +1,4 @@
-import zlib
-from typing import Iterable
-
-
-def crc32_of_list(items: Iterable[str]) -> int:
-    """Return CRC32 for an iterable of strings in order."""
-    crc = 0
-    for item in items:
-        crc = zlib.crc32(item.encode(), crc)
-    return crc & 0xFFFFFFFF
-
-
+from .crc import crc32_of_list
 from .reconnect import ReconnectingRedis, ReconnectingNeo4j
 from .circuit_breaker import AsyncCircuitBreaker
 from .four_dim_cache import FourDimCache
@@ -17,6 +6,15 @@ from .hashutils import hash_bytes
 from .nodeid import compute_node_id
 from .compute_key import compute_compute_key
 from .compute_context import ComputeContext, DEFAULT_EXECUTION_DOMAIN, DowngradeReason
+from .node_validation import (
+    MissingNodeField,
+    NodeIdentityMismatch,
+    NodeValidationError,
+    NodeValidationReport,
+    REQUIRED_NODE_FIELDS,
+    enforce_node_identity,
+    validate_node_identity,
+)
 
 __all__ = [
     "crc32_of_list",
@@ -30,4 +28,11 @@ __all__ = [
     "DowngradeReason",
     "compute_compute_key",
     "DEFAULT_EXECUTION_DOMAIN",
+    "MissingNodeField",
+    "NodeIdentityMismatch",
+    "NodeValidationError",
+    "NodeValidationReport",
+    "REQUIRED_NODE_FIELDS",
+    "enforce_node_identity",
+    "validate_node_identity",
 ]

--- a/qmtl/common/crc.py
+++ b/qmtl/common/crc.py
@@ -1,0 +1,18 @@
+"""CRC helpers for deterministic validation routines."""
+
+from __future__ import annotations
+
+import zlib
+from typing import Iterable
+
+
+def crc32_of_list(items: Iterable[str]) -> int:
+    """Return CRC32 for an iterable of strings in order."""
+
+    crc = 0
+    for item in items:
+        crc = zlib.crc32(item.encode(), crc)
+    return crc & 0xFFFFFFFF
+
+
+__all__ = ["crc32_of_list"]

--- a/qmtl/common/node_validation.py
+++ b/qmtl/common/node_validation.py
@@ -1,0 +1,211 @@
+"""Shared helpers for validating canonical node identities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from .crc import crc32_of_list
+from .nodeid import compute_node_id
+
+# Required node attributes that must be present for ``compute_node_id`` to be
+# deterministic. The order here mirrors the legacy validator implementations to
+# preserve error payload compatibility for downstream clients.
+REQUIRED_NODE_FIELDS: tuple[str, ...] = (
+    "node_type",
+    "code_hash",
+    "config_hash",
+    "schema_hash",
+    "schema_compat_id",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MissingNodeField:
+    """Record missing attributes for a node encountered during validation."""
+
+    index: int
+    missing: tuple[str, ...]
+    node_id: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"index": self.index, "missing": list(self.missing)}
+        if self.node_id:
+            payload["node_id"] = self.node_id
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class NodeIdentityMismatch:
+    """Report nodes whose supplied ``node_id`` does not match expectations."""
+
+    index: int
+    node_id: str
+    expected: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "node_id": self.node_id,
+            "expected": self.expected,
+        }
+
+
+class NodeValidationError(Exception):
+    """Exception raised when canonical node validation fails."""
+
+    def __init__(self, detail: dict[str, Any]) -> None:
+        self.detail = detail
+        message = detail.get("message") or detail.get("code") or "node validation error"
+        super().__init__(message)
+
+    @property
+    def code(self) -> str:
+        return str(self.detail.get("code", ""))
+
+    @classmethod
+    def missing_fields(cls, missing: Sequence[MissingNodeField]) -> "NodeValidationError":
+        return cls(
+            {
+                "code": "E_NODE_ID_FIELDS",
+                "message": "node_id validation requires node_type, code_hash, config_hash, schema_hash and schema_compat_id",
+                "missing_fields": [item.to_payload() for item in missing],
+                "hint": "Regenerate the DAG with an updated SDK so each node includes the hashes required by compute_node_id().",
+            }
+        )
+
+    @classmethod
+    def checksum_mismatch(
+        cls, provided: int, computed: int
+    ) -> "NodeValidationError":
+        return cls({"code": "E_CHECKSUM_MISMATCH", "message": "node id checksum mismatch"})
+
+    @classmethod
+    def identity_mismatch(
+        cls, mismatches: Sequence[NodeIdentityMismatch]
+    ) -> "NodeValidationError":
+        return cls(
+            {
+                "code": "E_NODE_ID_MISMATCH",
+                "message": "node_id does not match canonical compute_node_id output",
+                "node_id_mismatch": [item.to_payload() for item in mismatches],
+                "hint": "Ensure legacy world-coupled or pre-BLAKE3 node_ids are regenerated using compute_node_id().",
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NodeValidationReport:
+    """Structured result describing node identity validation findings."""
+
+    provided_checksum: int
+    computed_checksum: int
+    node_ids: tuple[str, ...]
+    missing_fields: tuple[MissingNodeField, ...]
+    mismatches: tuple[NodeIdentityMismatch, ...]
+
+    @property
+    def checksum_valid(self) -> bool:
+        return self.provided_checksum == self.computed_checksum
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.missing_fields and self.checksum_valid and not self.mismatches
+
+    def raise_for_issues(self) -> None:
+        if self.missing_fields:
+            raise NodeValidationError.missing_fields(self.missing_fields)
+        if not self.checksum_valid:
+            raise NodeValidationError.checksum_mismatch(
+                self.provided_checksum, self.computed_checksum
+            )
+        if self.mismatches:
+            raise NodeValidationError.identity_mismatch(self.mismatches)
+
+
+def validate_node_identity(
+    nodes: Iterable[Any],
+    provided_checksum: int,
+    *,
+    required_fields: Sequence[str] = REQUIRED_NODE_FIELDS,
+) -> NodeValidationReport:
+    """Validate nodes using canonical hashing rules.
+
+    Parameters
+    ----------
+    nodes:
+        Iterable of node mappings extracted from a DAG payload.
+    provided_checksum:
+        CRC32 supplied by the client covering node identifiers.
+    required_fields:
+        Node attributes that must be non-empty for ``compute_node_id`` to be
+        deterministic.
+
+    Returns
+    -------
+    NodeValidationReport
+        Structured outcome describing checksum and mismatch findings. Call
+        :meth:`NodeValidationReport.raise_for_issues` to raise a
+        :class:`NodeValidationError` when validation fails.
+    """
+
+    node_ids_for_crc: list[str] = []
+    missing_fields: list[MissingNodeField] = []
+    mismatches: list[NodeIdentityMismatch] = []
+
+    for index, node in enumerate(nodes):
+        if not isinstance(node, Mapping):
+            continue
+
+        node_id = node.get("node_id")
+        if not isinstance(node_id, str) or not node_id:
+            node_ids_for_crc.append(str(node_id or ""))
+            missing_fields.append(MissingNodeField(index=index, missing=("node_id",)))
+            continue
+
+        node_ids_for_crc.append(node_id)
+
+        missing = tuple(field for field in required_fields if not node.get(field))
+        if missing:
+            missing_fields.append(
+                MissingNodeField(index=index, node_id=node_id, missing=missing)
+            )
+            continue
+
+        expected = compute_node_id(node)
+        if node_id != expected:
+            mismatches.append(
+                NodeIdentityMismatch(index=index, node_id=node_id, expected=expected)
+            )
+
+    computed_checksum = crc32_of_list(node_ids_for_crc)
+    return NodeValidationReport(
+        provided_checksum=provided_checksum,
+        computed_checksum=computed_checksum,
+        node_ids=tuple(node_ids_for_crc),
+        missing_fields=tuple(missing_fields),
+        mismatches=tuple(mismatches),
+    )
+
+
+def enforce_node_identity(
+    nodes: Iterable[Any], provided_checksum: int, *, required_fields: Sequence[str] = REQUIRED_NODE_FIELDS
+) -> NodeValidationReport:
+    """Validate nodes and raise :class:`NodeValidationError` on failure."""
+
+    report = validate_node_identity(
+        nodes, provided_checksum, required_fields=required_fields
+    )
+    report.raise_for_issues()
+    return report
+
+
+__all__ = [
+    "MissingNodeField",
+    "NodeIdentityMismatch",
+    "NodeValidationError",
+    "NodeValidationReport",
+    "REQUIRED_NODE_FIELDS",
+    "enforce_node_identity",
+    "validate_node_identity",
+]

--- a/qmtl/gateway/strategy_submission.py
+++ b/qmtl/gateway/strategy_submission.py
@@ -155,69 +155,6 @@ class StrategySubmissionHelper:
         strategy_id = config.strategy_id or "dryrun"
         return strategy_id, False
 
-    def _validate_node_ids(self, dag: dict[str, Any], node_ids_crc32: int) -> None:
-        from qmtl.common import crc32_of_list, compute_node_id
-
-        nodes = dag.get("nodes", [])
-        node_ids_for_crc: list[str] = []
-        missing_fields: list[dict[str, Any]] = []
-        mismatches: list[dict[str, str | int]] = []
-
-        for idx, node in enumerate(nodes):
-            nid = node.get("node_id")
-            if not isinstance(nid, str) or not nid:
-                node_ids_for_crc.append(str(nid or ""))
-                missing_fields.append({"index": idx, "missing": ["node_id"]})
-                continue
-
-            node_ids_for_crc.append(nid)
-            required = {
-                "node_type": node.get("node_type"),
-                "code_hash": node.get("code_hash"),
-                "config_hash": node.get("config_hash"),
-                "schema_hash": node.get("schema_hash"),
-                "schema_compat_id": node.get("schema_compat_id"),
-            }
-            missing = [field for field, value in required.items() if not value]
-            if missing:
-                missing_fields.append(
-                    {"index": idx, "node_id": nid, "missing": missing}
-                )
-                continue
-
-            expected = compute_node_id(node)
-            if nid != expected:
-                mismatches.append({"index": idx, "node_id": nid, "expected": expected})
-
-        crc = crc32_of_list(node_ids_for_crc)
-        if missing_fields:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "code": "E_NODE_ID_FIELDS",
-                    "message": "node_id validation requires node_type, code_hash, config_hash, schema_hash and schema_compat_id",
-                    "missing_fields": missing_fields,
-                    "hint": "Regenerate the DAG with an updated SDK so each node includes the hashes required by compute_node_id().",
-                },
-            )
-
-        if crc != node_ids_crc32:
-            raise HTTPException(
-                status_code=400,
-                detail={"code": "E_CHECKSUM_MISMATCH", "message": "node id checksum mismatch"},
-            )
-
-        if mismatches:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "code": "E_NODE_ID_MISMATCH",
-                    "message": "node_id does not match canonical compute_node_id output",
-                    "node_id_mismatch": mismatches,
-                    "hint": "Ensure legacy world-coupled or pre-BLAKE3 node_ids are regenerated using compute_node_id().",
-                },
-            )
-
     async def _persist_world_bindings(
         self, worlds: list[str], default_world: str | None, strategy_id: str
     ) -> None:

--- a/qmtl/gateway/submission/node_identity.py
+++ b/qmtl/gateway/submission/node_identity.py
@@ -6,71 +6,15 @@ from typing import Any, Iterable
 
 from fastapi import HTTPException
 
-from qmtl.common import crc32_of_list, compute_node_id
+from qmtl.common.node_validation import NodeValidationError, enforce_node_identity
 
 
 class NodeIdentityValidator:
     """Ensure submitted node identities match canonical hashing rules."""
 
     def validate(self, dag: dict[str, Any], node_ids_crc32: int) -> None:
-        nodes = dag.get("nodes", [])
-        node_ids_for_crc: list[str] = []
-        missing_fields: list[dict[str, Any]] = []
-        mismatches: list[dict[str, str | int]] = []
-
-        for idx, node in enumerate(nodes):
-            if not isinstance(node, dict):
-                continue
-            nid = node.get("node_id")
-            if not isinstance(nid, str) or not nid:
-                node_ids_for_crc.append(str(nid or ""))
-                missing_fields.append({"index": idx, "missing": ["node_id"]})
-                continue
-
-            node_ids_for_crc.append(nid)
-            required = {
-                "node_type": node.get("node_type"),
-                "code_hash": node.get("code_hash"),
-                "config_hash": node.get("config_hash"),
-                "schema_hash": node.get("schema_hash"),
-                "schema_compat_id": node.get("schema_compat_id"),
-            }
-            missing = [field for field, value in required.items() if not value]
-            if missing:
-                missing_fields.append(
-                    {"index": idx, "node_id": nid, "missing": missing}
-                )
-                continue
-
-            expected = compute_node_id(node)
-            if nid != expected:
-                mismatches.append({"index": idx, "node_id": nid, "expected": expected})
-
-        crc = crc32_of_list(node_ids_for_crc)
-        if missing_fields:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "code": "E_NODE_ID_FIELDS",
-                    "message": "node_id validation requires node_type, code_hash, config_hash, schema_hash and schema_compat_id",
-                    "missing_fields": missing_fields,
-                    "hint": "Regenerate the DAG with an updated SDK so each node includes the hashes required by compute_node_id().",
-                },
-            )
-
-        if crc != node_ids_crc32:
-            raise HTTPException(
-                status_code=400,
-                detail={"code": "E_CHECKSUM_MISMATCH", "message": "node id checksum mismatch"},
-            )
-
-        if mismatches:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "code": "E_NODE_ID_MISMATCH",
-                    "message": "node_id does not match canonical compute_node_id output",
-                    "node_id_mismatch": mismatches,
-                    "hint": "Ensure legacy world-coupled or pre-BLAKE3 node_ids are regenerated using compute_node_id().",
-                },
-            )
+        nodes: Iterable[Any] = dag.get("nodes", [])
+        try:
+            enforce_node_identity(nodes, node_ids_crc32)
+        except NodeValidationError as exc:  # pragma: no cover - exercised via tests
+            raise HTTPException(status_code=400, detail=exc.detail) from exc

--- a/tests/common/test_node_validation.py
+++ b/tests/common/test_node_validation.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.common import crc32_of_list, enforce_node_identity, validate_node_identity
+from qmtl.common.node_validation import NodeValidationError
+from tests.factories import NodeFactory
+
+
+def test_validate_node_identity_success() -> None:
+    factory = NodeFactory()
+    node = factory.build()
+    checksum = crc32_of_list([node["node_id"]])
+
+    report = validate_node_identity([node], checksum)
+
+    assert report.is_valid
+    assert report.checksum_valid
+    assert report.node_ids == (node["node_id"],)
+    report.raise_for_issues()  # does not raise
+
+
+def test_validate_node_identity_missing_fields() -> None:
+    factory = NodeFactory()
+    node = factory.build(schema_hash="")
+
+    report = validate_node_identity([node], 0)
+
+    assert not report.is_valid
+    assert report.missing_fields
+
+    with pytest.raises(NodeValidationError) as exc:
+        report.raise_for_issues()
+
+    detail = exc.value.detail
+    assert detail["code"] == "E_NODE_ID_FIELDS"
+
+
+def test_enforce_node_identity_checksum_mismatch() -> None:
+    factory = NodeFactory()
+    node = factory.build()
+
+    with pytest.raises(NodeValidationError) as exc:
+        enforce_node_identity([node], 0)
+
+    assert exc.value.code == "E_CHECKSUM_MISMATCH"
+
+
+def test_enforce_node_identity_detects_mismatched_id() -> None:
+    factory = NodeFactory()
+    node = factory.build()
+    node["node_id"] = "not-matching"
+
+    checksum = crc32_of_list([node["node_id"]])
+
+    with pytest.raises(NodeValidationError) as exc:
+        enforce_node_identity([node], checksum)
+
+    assert exc.value.code == "E_NODE_ID_MISMATCH"

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,5 @@
+"""Test data factories shared across suites."""
+
+from .node import NodeFactory, make_node
+
+__all__ = ["NodeFactory", "make_node"]

--- a/tests/factories/node.py
+++ b/tests/factories/node.py
@@ -1,0 +1,49 @@
+"""Factories for constructing canonical DAG nodes in tests."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from qmtl.common import compute_node_id
+
+
+def _default_node_template() -> dict[str, Any]:
+    return {
+        "node_type": "TagQueryNode",
+        "code_hash": "blake3:code",
+        "config_hash": "blake3:config",
+        "schema_hash": "blake3:schema",
+        "schema_compat_id": "schema:v1",
+        "params": {"universe": "us_equities"},
+        "inputs": [],
+    }
+
+
+@dataclass(slots=True)
+class NodeFactory:
+    """Build canonical nodes with deterministic node_id values."""
+
+    template: Mapping[str, Any] = field(default_factory=_default_node_template)
+
+    def build(self, *, assign_id: bool = True, **overrides: Any) -> dict[str, Any]:
+        node: dict[str, Any] = deepcopy(dict(self.template))
+        node.update(overrides)
+        if assign_id and "node_id" not in overrides:
+            node["node_id"] = compute_node_id(node)
+        return node
+
+    def build_without_id(self, **overrides: Any) -> dict[str, Any]:
+        node = self.build(assign_id=False, **overrides)
+        node.pop("node_id", None)
+        return node
+
+
+def make_node(**overrides: Any) -> dict[str, Any]:
+    """Convenience helper returning a node with a computed ``node_id``."""
+
+    return NodeFactory().build(**overrides)
+
+
+__all__ = ["NodeFactory", "make_node"]

--- a/tests/gateway/test_submission_node_identity.py
+++ b/tests/gateway/test_submission_node_identity.py
@@ -2,38 +2,26 @@ from __future__ import annotations
 
 import pytest
 
+from qmtl.common import crc32_of_list
 from qmtl.gateway.submission.node_identity import NodeIdentityValidator
+from tests.factories import NodeFactory
 
 
-def _build_node(**overrides):
-    base = {
-        "node_id": None,
-        "node_type": "TagQueryNode",
-        "code_hash": "code",
-        "config_hash": "config",
-        "schema_hash": "schema",
-        "schema_compat_id": "compat",
-    }
-    base.update(overrides)
-    return base
+@pytest.fixture()
+def node_factory() -> NodeFactory:
+    return NodeFactory()
 
 
-def test_validate_accepts_matching_ids() -> None:
+def test_validate_accepts_matching_ids(node_factory: NodeFactory) -> None:
     validator = NodeIdentityValidator()
-    node = _build_node()
+    node = node_factory.build()
     dag = {"nodes": [node]}
-    from qmtl.common import compute_node_id, crc32_of_list
-
-    node_id = compute_node_id(node)
-    node["node_id"] = node_id
-    validator.validate(dag, crc32_of_list([node_id]))
+    validator.validate(dag, crc32_of_list([node["node_id"]]))
 
 
-def test_validate_missing_fields_raises() -> None:
+def test_validate_missing_fields_raises(node_factory: NodeFactory) -> None:
     validator = NodeIdentityValidator()
-    node = _build_node(schema_hash="")
-    node_id = "abc"
-    node["node_id"] = node_id
+    node = node_factory.build(schema_hash="")
     dag = {"nodes": [node]}
 
     with pytest.raises(Exception) as exc:
@@ -43,14 +31,10 @@ def test_validate_missing_fields_raises() -> None:
     assert detail["code"] == "E_NODE_ID_FIELDS"
 
 
-def test_validate_crc_mismatch_raises() -> None:
+def test_validate_crc_mismatch_raises(node_factory: NodeFactory) -> None:
     validator = NodeIdentityValidator()
-    node = _build_node()
+    node = node_factory.build()
     dag = {"nodes": [node]}
-    from qmtl.common import compute_node_id
-
-    node_id = compute_node_id(node)
-    node["node_id"] = node_id
 
     with pytest.raises(Exception) as exc:
         validator.validate(dag, 0)
@@ -59,12 +43,10 @@ def test_validate_crc_mismatch_raises() -> None:
     assert detail["code"] == "E_CHECKSUM_MISMATCH"
 
 
-def test_validate_detects_mismatch() -> None:
+def test_validate_detects_mismatch(node_factory: NodeFactory) -> None:
     validator = NodeIdentityValidator()
-    node = _build_node(node_id="not-matching")
+    node = node_factory.build(node_id="not-matching")
     dag = {"nodes": [node]}
-    from qmtl.common import crc32_of_list
-
     with pytest.raises(Exception) as exc:
         validator.validate(dag, crc32_of_list(["not-matching"]))
 


### PR DESCRIPTION
## Summary
- add `qmtl.common.node_validation` to centralize node checksum and identity checks and export helpers via `qmtl.common`
- update gateway validation paths and tests to use the shared module along with a reusable node factory
- document the validation contract for external consumers and add focused unit coverage

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto
- uv run mkdocs build

Fixes #1010

------
https://chatgpt.com/codex/tasks/task_e_68d0f75d7fe08329ab51baab55810948