### PR TITLE
Refactor Runner dependencies and context handling

### DIFF
--- a/qmtl/nodesets/resources.py
+++ b/qmtl/nodesets/resources.py
@@ -57,7 +57,7 @@ def make_activation_weight_fn() -> Callable[[Mapping[str, object]], float]:
         try:
             from qmtl.sdk.runner import Runner  # Late import to avoid cycles
 
-            am = Runner._activation_manager
+            am = Runner.services().activation_manager
             if am is None:
                 return 1.0
             side = _infer_side(order)

--- a/qmtl/sdk/execution_context.py
+++ b/qmtl/sdk/execution_context.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+"""Helpers for computing execution context dictionaries.
+
+The Runner previously bundled context normalization, merging, and
+resolution logic inside a massive class with substantial state.  This
+module extracts the pure functions so they can be imported and tested in
+isolation without initializing Runner singletons.
+"""
+
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping
+
+from qmtl.common.compute_key import DEFAULT_EXECUTION_DOMAIN
+
+_VALID_MODES = {"backtest", "dryrun", "live"}
+_CLOCKS = {"virtual", "wall"}
+
+
+@dataclass(frozen=True)
+class ExecutionContextResolution:
+    """Result of resolving an execution context."""
+
+    context: dict[str, str]
+    force_offline: bool
+
+
+def normalize_default_context(context: Mapping[str, str] | None) -> dict[str, str] | None:
+    """Normalize a default execution context mapping.
+
+    ``Runner.set_default_context`` historically accepted arbitrary
+    mapping types and coerced keys/values to strings while skipping
+    ``None``.  Moving the logic here keeps the behaviour while enabling
+    deterministic tests.
+    """
+
+    if context is None:
+        return None
+
+    normalized: dict[str, str] = {}
+    for key, value in context.items():
+        if value is None:
+            continue
+        normalized[str(key)] = str(value)
+
+    return normalized or None
+
+
+def _mode_from_domain(domain: str | None) -> str | None:
+    if not domain:
+        return None
+    key = str(domain).strip().lower()
+    if key == DEFAULT_EXECUTION_DOMAIN:
+        return None
+    if key in _VALID_MODES:
+        return key
+    return None
+
+
+def _normalize_mode(value: str | None) -> str:
+    if value is None:
+        raise ValueError("execution_mode must be provided")
+    mode = str(value).strip().lower()
+    if mode not in _VALID_MODES:
+        raise ValueError("execution_mode must be one of 'backtest', 'dryrun', or 'live'")
+    return mode
+
+
+def merge_context(base: MutableMapping[str, str], source: Mapping[str, str] | None) -> None:
+    """Merge ``source`` context values into ``base`` in-place."""
+
+    if not source:
+        return
+    for key, value in source.items():
+        skey = str(key)
+        if value is None:
+            base.pop(skey, None)
+            continue
+        base[skey] = str(value)
+
+
+def resolve_execution_context(
+    default_context: Mapping[str, str] | None,
+    *,
+    context: Mapping[str, str] | None,
+    execution_mode: str | None,
+    execution_domain: str | None,
+    clock: str | None,
+    as_of: object | None,
+    dataset_fingerprint: str | None,
+    offline_requested: bool,
+    gateway_url: str | None,
+    trade_mode: str,
+) -> ExecutionContextResolution:
+    """Resolve execution context inputs into a canonical mapping.
+
+    The return value mirrors ``Runner._resolve_context`` prior to
+    refactoring while living outside the class for ease of testing.
+    """
+
+    merged: dict[str, str] = {}
+    if default_context:
+        merged.update({str(k): str(v) for k, v in default_context.items()})
+
+    merge_context(merged, context)
+
+    mode: str | None = None
+    if execution_mode is not None:
+        mode = _normalize_mode(execution_mode)
+    else:
+        derived = _mode_from_domain(execution_domain)
+        if derived is not None:
+            mode = derived
+    if mode is None:
+        domain_hint = merged.get("execution_domain")
+        if domain_hint:
+            derived = _mode_from_domain(domain_hint)
+            if derived is not None:
+                mode = derived
+    if mode is None:
+        existing = merged.get("execution_mode")
+        if existing:
+            mode = _normalize_mode(existing)
+    if mode is None:
+        if trade_mode == "live" and not offline_requested:
+            mode = "live"
+        elif gateway_url and not offline_requested:
+            mode = "live"
+        else:
+            mode = "backtest"
+
+    merged["execution_mode"] = mode
+    merged["execution_domain"] = mode
+
+    expected_clock = "wall" if mode == "live" else "virtual"
+    if clock is not None:
+        cval = str(clock).strip().lower()
+        if cval not in _CLOCKS:
+            raise ValueError("clock must be one of 'virtual' or 'wall'")
+        if cval != expected_clock:
+            raise ValueError(
+                f"{mode} runs require '{expected_clock}' clock but received '{clock}'"
+            )
+        merged["clock"] = cval
+    else:
+        merged.setdefault("clock", expected_clock)
+
+    if as_of is not None:
+        text = str(as_of).strip()
+        if text:
+            merged["as_of"] = text
+        else:
+            merged.pop("as_of", None)
+    elif "as_of" in merged:
+        text = str(merged["as_of"]).strip()
+        if text:
+            merged["as_of"] = text
+        else:
+            merged.pop("as_of", None)
+
+    if dataset_fingerprint is not None:
+        text = str(dataset_fingerprint).strip()
+        if text:
+            merged["dataset_fingerprint"] = text
+        else:
+            merged.pop("dataset_fingerprint", None)
+    elif "dataset_fingerprint" in merged:
+        text = str(merged["dataset_fingerprint"]).strip()
+        if text:
+            merged["dataset_fingerprint"] = text
+        else:
+            merged.pop("dataset_fingerprint", None)
+
+    force_offline = False
+    if mode != "live":
+        has_as_of = bool(merged.get("as_of"))
+        has_dataset = bool(merged.get("dataset_fingerprint"))
+        if not (has_as_of and has_dataset):
+            if gateway_url and not offline_requested:
+                force_offline = True
+            merged.pop("as_of", None)
+            merged.pop("dataset_fingerprint", None)
+    else:
+        merged.pop("as_of", None)
+        merged.pop("dataset_fingerprint", None)
+
+    return ExecutionContextResolution(context=merged, force_offline=force_offline)
+
+
+__all__ = [
+    "ExecutionContextResolution",
+    "merge_context",
+    "normalize_default_context",
+    "resolve_execution_context",
+]

--- a/qmtl/sdk/optional_services.py
+++ b/qmtl/sdk/optional_services.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Adapters for optional runtime integrations used by Runner."""
+
+from typing import Any, Callable
+
+from . import runtime
+
+
+class RayExecutor:
+    """Execute compute functions via Ray when available."""
+
+    def __init__(self, *, disabled: bool | None = None) -> None:
+        self._disabled = bool(disabled) if disabled is not None else False
+        try:  # Optional Ray dependency
+            import ray  # type: ignore
+        except Exception:  # pragma: no cover - Ray not installed
+            self._ray: Any | None = None
+        else:  # pragma: no cover - exercised when Ray is installed
+            self._ray = ray
+
+    @property
+    def available(self) -> bool:
+        return not (self._disabled or runtime.NO_RAY) and self._ray is not None
+
+    def execute(self, fn: Callable[[Any], Any], cache_view: Any) -> Any | None:
+        """Execute ``fn`` with ``cache_view``.
+
+        Returns the function result when executed locally.  When Ray is
+        available the computation is dispatched to the cluster and ``None``
+        is returned to mirror the historical Runner behaviour.
+        """
+
+        if not self.available:
+            return fn(cache_view)
+
+        ray = self._ray
+        assert ray is not None  # mypy appeasement
+        if not ray.is_initialized():  # type: ignore[attr-defined]
+            ray.init(ignore_reinit_error=True)  # type: ignore[attr-defined]
+        ray.remote(fn).remote(cache_view)  # type: ignore[attr-defined]
+        return None
+
+    def set_disabled(self, disabled: bool) -> None:
+        self._disabled = bool(disabled)
+
+
+class KafkaConsumerFactory:
+    """Factory for creating Kafka consumers when aiokafka is installed."""
+
+    def __init__(self) -> None:
+        try:  # Optional aiokafka dependency
+            from aiokafka import AIOKafkaConsumer  # type: ignore
+        except Exception:  # pragma: no cover - aiokafka not installed
+            self._consumer_cls: Any | None = None
+        else:  # pragma: no cover - exercised when aiokafka is installed
+            self._consumer_cls = AIOKafkaConsumer
+
+    @property
+    def available(self) -> bool:
+        return self._consumer_cls is not None
+
+    def create_consumer(self, topic: str, *, bootstrap_servers: str) -> Any:
+        if self._consumer_cls is None:
+            raise RuntimeError("aiokafka not available")
+        return self._consumer_cls(  # type: ignore[call-arg]
+            topic,
+            bootstrap_servers=bootstrap_servers,
+            enable_auto_commit=True,
+        )
+
+
+__all__ = ["KafkaConsumerFactory", "RayExecutor"]

--- a/qmtl/sdk/services.py
+++ b/qmtl/sdk/services.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+"""Service container used by :mod:`qmtl.sdk.runner`."""
+
+from typing import Any, Callable
+
+from cachetools import TTLCache
+
+from .activation_manager import ActivationManager
+from .feature_store import FeatureArtifactPlane
+from .gateway_client import GatewayClient
+from .history_warmup_service import HistoryWarmupService
+from .optional_services import KafkaConsumerFactory, RayExecutor
+from .trade_dispatcher import TradeOrderDispatcher
+
+ActivationManagerFactory = Callable[..., ActivationManager]
+
+
+def _default_activation_manager_factory(
+    *, gateway_url: str, world_id: str, strategy_id: str | None = None
+) -> ActivationManager:
+    return ActivationManager(gateway_url, world_id=world_id, strategy_id=strategy_id)
+
+
+class RunnerServices:
+    """Bundle of collaborators required by Runner orchestration."""
+
+    def __init__(
+        self,
+        *,
+        gateway_client: GatewayClient | None = None,
+        history_service: HistoryWarmupService | None = None,
+        feature_plane: FeatureArtifactPlane | None = None,
+        ray_executor: RayExecutor | None = None,
+        kafka_factory: KafkaConsumerFactory | None = None,
+        activation_manager_factory: ActivationManagerFactory | None = None,
+        activation_manager: ActivationManager | None = None,
+        trade_dispatcher: TradeOrderDispatcher | None = None,
+        dedup_cache: TTLCache[str, bool] | None = None,
+        trade_execution_service: Any | None = None,
+        trade_order_http_url: str | None = None,
+        kafka_producer: Any | None = None,
+        trade_order_kafka_topic: str | None = None,
+    ) -> None:
+        self.gateway_client = gateway_client or GatewayClient()
+        self.history_service = history_service or HistoryWarmupService()
+        self.feature_plane = feature_plane or FeatureArtifactPlane.from_env()
+        self.ray_executor = ray_executor or RayExecutor()
+        self.kafka_factory = kafka_factory or KafkaConsumerFactory()
+        self._activation_manager_factory = (
+            activation_manager_factory or _default_activation_manager_factory
+        )
+        self._activation_manager = activation_manager
+        self._dedup_cache = dedup_cache or TTLCache(maxsize=10000, ttl=600)
+        self._trade_dispatcher = trade_dispatcher or TradeOrderDispatcher(
+            dedup_cache=self._dedup_cache,
+            activation_manager=activation_manager,
+            trade_execution_service=trade_execution_service,
+            trade_order_http_url=trade_order_http_url,
+            kafka_producer=kafka_producer,
+            trade_order_kafka_topic=trade_order_kafka_topic,
+        )
+        self._trade_execution_service = trade_execution_service
+        self._trade_order_http_url = trade_order_http_url
+        self._kafka_producer = kafka_producer
+        self._trade_order_kafka_topic = trade_order_kafka_topic
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def default(cls) -> "RunnerServices":
+        return cls()
+
+    # ------------------------------------------------------------------
+    @property
+    def trade_dispatcher(self) -> TradeOrderDispatcher:
+        return self._trade_dispatcher
+
+    @property
+    def activation_manager(self) -> ActivationManager | None:
+        return self._activation_manager
+
+    @property
+    def dedup_cache(self) -> TTLCache[str, bool] | None:
+        return self._dedup_cache
+
+    @property
+    def trade_execution_service(self) -> Any | None:
+        return self._trade_execution_service
+
+    @property
+    def trade_order_http_url(self) -> str | None:
+        return self._trade_order_http_url
+
+    @property
+    def kafka_producer(self) -> Any | None:
+        return self._kafka_producer
+
+    @property
+    def trade_order_kafka_topic(self) -> str | None:
+        return self._trade_order_kafka_topic
+
+    # ------------------------------------------------------------------
+    def set_gateway_client(self, client: GatewayClient) -> None:
+        self.gateway_client = client
+
+    def set_activation_manager(self, manager: ActivationManager | None) -> None:
+        self._activation_manager = manager
+        self._trade_dispatcher.set_activation_manager(manager)
+
+    def ensure_activation_manager(
+        self, *, gateway_url: str, world_id: str
+    ) -> ActivationManager:
+        manager = self._activation_manager
+        if manager is None:
+            manager = self._activation_manager_factory(
+                gateway_url=gateway_url, world_id=world_id, strategy_id=None
+            )
+            self.set_activation_manager(manager)
+        return manager
+
+    def set_feature_plane(self, plane: FeatureArtifactPlane | None) -> None:
+        self.feature_plane = plane
+
+    # ------------------------------------------------------------------
+    def set_trade_execution_service(self, service: Any | None) -> None:
+        self._trade_execution_service = service
+        self._trade_dispatcher.set_trade_execution_service(service)
+
+    def set_kafka_producer(self, producer: Any | None) -> None:
+        self._kafka_producer = producer
+        self._trade_dispatcher.set_kafka_producer(producer)
+
+    def set_trade_order_http_url(self, url: str | None) -> None:
+        self._trade_order_http_url = url
+        self._trade_dispatcher.set_http_url(url)
+
+    def set_trade_order_kafka_topic(self, topic: str | None) -> None:
+        self._trade_order_kafka_topic = topic
+        self._trade_dispatcher.set_trade_order_kafka_topic(topic)
+
+    # ------------------------------------------------------------------
+    def reset_trade_order_dedup(self) -> None:
+        cache = self._dedup_cache
+        if cache is not None:
+            cache.clear()
+        self._trade_dispatcher.reset_dedup()
+
+
+__all__ = ["RunnerServices"]

--- a/qmtl/transforms/execution_nodes.py
+++ b/qmtl/transforms/execution_nodes.py
@@ -139,7 +139,7 @@ def activation_blocks_order(order: Mapping[str, Any]) -> bool:
     except Exception:
         return False
 
-    am = Runner._activation_manager
+    am = Runner.services().activation_manager
     if am is None:
         return False
 

--- a/tests/e2e/test_domain_transition.py
+++ b/tests/e2e/test_domain_transition.py
@@ -106,7 +106,9 @@ async def test_domain_promotion_flow_respects_freeze_and_isolation(monkeypatch):
         assert am.state.effective_mode == "validate"
 
         sdk_metrics.reset_metrics()
-        monkeypatch.setattr(Runner, "_ray_available", False)
+        monkeypatch.setattr(
+            Runner.services().ray_executor, "execute", lambda fn, view: fn(view)
+        )
         stream = StreamInput(interval="60s", period=1)
         node = ProcessingNode(
             input=stream,

--- a/tests/runner/test_kafka_consumers.py
+++ b/tests/runner/test_kafka_consumers.py
@@ -25,7 +25,7 @@ async def test_single_node_consumption(monkeypatch):
 
     stop_event = asyncio.Event()
 
-    async def fake_consume(n, *, bootstrap_servers, stop_event):
+    async def fake_consume(n, *, consumer_factory, bootstrap_servers, stop_event):
         Runner.feed_queue_data(n, n.kafka_topic, 60, 60, {"v": 1})
         Runner.feed_queue_data(n, n.kafka_topic, 60, 120, {"v": 2})
         stop_event.set()
@@ -62,7 +62,7 @@ async def test_multi_node_consumption(monkeypatch):
     stop_event = asyncio.Event()
     counter = {"c": 0}
 
-    async def fake_consume(n, *, bootstrap_servers, stop_event):
+    async def fake_consume(n, *, consumer_factory, bootstrap_servers, stop_event):
         Runner.feed_queue_data(n, n.kafka_topic, 60, 60, {"v": 1})
         Runner.feed_queue_data(n, n.kafka_topic, 60, 120, {"v": 2})
         counter["c"] += 1

--- a/tests/test_execution_nodes.py
+++ b/tests/test_execution_nodes.py
@@ -233,7 +233,8 @@ def test_order_publish_node_calls_publisher():
     def _pub(o):
         calls.append(o)
 
-    prev_am = runner_module.Runner._activation_manager
+    services = runner_module.Runner.services()
+    prev_am = services.activation_manager
     runner_module.Runner.set_activation_manager(None)
     try:
         node = OrderPublishNode(src, submit_order=_pub)
@@ -267,11 +268,12 @@ def test_order_publish_node_blocks_during_freeze_and_drain():
 
     am = ActivationManager()
 
-    prev_am = runner_module.Runner._activation_manager
-    prev_service = runner_module.Runner._trade_execution_service
-    prev_http = runner_module.Runner._trade_order_http_url
-    prev_topic = runner_module.Runner._trade_order_kafka_topic
-    prev_producer = runner_module.Runner._kafka_producer
+    services = runner_module.Runner.services()
+    prev_am = services.activation_manager
+    prev_service = services.trade_execution_service
+    prev_http = services.trade_order_http_url
+    prev_topic = services.trade_order_kafka_topic
+    prev_producer = services.kafka_producer
 
     runner_module.Runner.set_trade_execution_service(None)
     runner_module.Runner.set_trade_order_http_url(None)

--- a/tests/test_node_cache.py
+++ b/tests/test_node_cache.py
@@ -47,7 +47,8 @@ def test_cache_warmup_and_compute():
 
 
 def test_node_feed_does_not_execute(monkeypatch):
-    monkeypatch.setattr(Runner, "_ray_available", False)
+    ray_executor = Runner.services().ray_executor
+    monkeypatch.setattr(ray_executor, "execute", lambda fn, view: fn(view))
 
     calls = []
 

--- a/tests/test_order_idempotency.py
+++ b/tests/test_order_idempotency.py
@@ -17,6 +17,7 @@ def test_order_idempotency_suppresses_duplicates(monkeypatch):
     # Reload runner to get a clean class state
     runner = importlib.reload(runner_module).Runner
     runner.reset_trade_order_dedup()
+    runner.set_activation_manager(None)
 
     # Set Kafka producer and topic target
     producer = FakeKafkaProducer()

--- a/tests/test_runner_postprocess.py
+++ b/tests/test_runner_postprocess.py
@@ -55,7 +55,8 @@ def test_run_hooks_offline(monkeypatch):
             pass
 
     monkeypatch.setattr(
-        "qmtl.sdk.runner.Runner._gateway_client.post_strategy",
+        Runner.services().gateway_client,
+        "post_strategy",
         fake_gateway,
     )
     monkeypatch.setattr(
@@ -139,7 +140,8 @@ def test_run_hooks_live_like(monkeypatch):
             pass
 
     monkeypatch.setattr(
-        "qmtl.sdk.runner.Runner._gateway_client.post_strategy",
+        Runner.services().gateway_client,
+        "post_strategy",
         fake_gateway,
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- add `RunnerServices` and optional adapters so Runner wiring relies on injected collaborators instead of module-level singletons
- extract execution-context helpers into a standalone `execution_context` module and delegate Runner logic to it
- update Runner, supporting modules, and tests to use the new service container and adapters

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1022

------
https://chatgpt.com/codex/tasks/task_e_68d109f2b1ec8329a379f8267ed7892f