### PR TITLE
Refactor Arrow cache backend into modular components

### DIFF
--- a/qmtl/sdk/arrow_cache/__init__.py
+++ b/qmtl/sdk/arrow_cache/__init__.py
@@ -1,0 +1,39 @@
+"""Composable Arrow cache backend."""
+from __future__ import annotations
+
+from .backend import NodeCacheArrow
+from .dependencies import (
+    ARROW_AVAILABLE,
+    ARROW_CACHE_ENABLED,
+    RAY_AVAILABLE,
+    pa,
+    ray,
+)
+from .eviction import (
+    EvictionStrategy,
+    RayEvictionStrategy,
+    ThreadedEvictionStrategy,
+    create_default_eviction_strategy,
+)
+from .instrumentation import CacheInstrumentation, NOOP_INSTRUMENTATION, default_instrumentation
+from .slices import _Slice, _SliceView
+from .view import ArrowCacheView
+
+__all__ = [
+    "NodeCacheArrow",
+    "ArrowCacheView",
+    "_Slice",
+    "_SliceView",
+    "CacheInstrumentation",
+    "NOOP_INSTRUMENTATION",
+    "default_instrumentation",
+    "EvictionStrategy",
+    "ThreadedEvictionStrategy",
+    "RayEvictionStrategy",
+    "create_default_eviction_strategy",
+    "ARROW_AVAILABLE",
+    "RAY_AVAILABLE",
+    "ARROW_CACHE_ENABLED",
+    "pa",
+    "ray",
+]

--- a/qmtl/sdk/arrow_cache/dependencies.py
+++ b/qmtl/sdk/arrow_cache/dependencies.py
@@ -1,0 +1,26 @@
+"""Optional dependency guards for Arrow cache backend."""
+from __future__ import annotations
+
+import os
+
+try:  # pragma: no cover - optional dependency
+    import pyarrow as pa  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pa = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import ray  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    ray = None  # type: ignore
+
+ARROW_AVAILABLE = pa is not None
+RAY_AVAILABLE = ray is not None
+ARROW_CACHE_ENABLED = ARROW_AVAILABLE and os.getenv("QMTL_ARROW_CACHE") == "1"
+
+__all__ = [
+    "pa",
+    "ray",
+    "ARROW_AVAILABLE",
+    "RAY_AVAILABLE",
+    "ARROW_CACHE_ENABLED",
+]

--- a/qmtl/sdk/arrow_cache/eviction.py
+++ b/qmtl/sdk/arrow_cache/eviction.py
@@ -1,0 +1,123 @@
+"""Eviction strategies for the Arrow cache backend."""
+from __future__ import annotations
+
+import threading
+from typing import Protocol
+
+from .dependencies import RAY_AVAILABLE, ray
+
+
+class EvictableCache(Protocol):
+    def evict_expired(self) -> None: ...
+
+
+class EvictionStrategy(Protocol):
+    def start(self, cache: EvictableCache) -> None: ...
+
+    def tick(self) -> None: ...
+
+    def stop(self) -> None: ...
+
+
+class ThreadedEvictionStrategy:
+    """Simple eviction runner backed by a background thread."""
+
+    def __init__(self, interval: int) -> None:
+        self._interval = interval
+        self._cache: EvictableCache | None = None
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self, cache: EvictableCache) -> None:
+        self._cache = cache
+        if self._thread is not None:
+            return
+        thread = threading.Thread(target=self._loop, daemon=True)
+        thread.start()
+        self._thread = thread
+
+    def _loop(self) -> None:
+        while not self._stop_event.is_set():
+            self._stop_event.wait(self._interval)
+            self.tick()
+
+    def tick(self) -> None:
+        cache = self._cache
+        if cache is not None:
+            cache.evict_expired()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=0)
+        self._thread = None
+        self._cache = None
+        self._stop_event = threading.Event()
+
+
+if RAY_AVAILABLE:
+
+    @ray.remote  # type: ignore[misc]
+    class _RayEvictor:
+        def __init__(self, interval: int) -> None:
+            self._interval = interval
+            self._stop_event = threading.Event()
+
+        def start(self, cache: EvictableCache) -> None:
+            while not self._stop_event.is_set():
+                self._stop_event.wait(self._interval)
+                cache.evict_expired()
+
+        def stop(self) -> None:
+            self._stop_event.set()
+else:  # pragma: no cover - optional dependency shim
+
+    class _RayEvictor:  # type: ignore[too-many-ancestors]
+        pass
+
+
+class RayEvictionStrategy:
+    """Eviction strategy backed by a Ray actor."""
+
+    def __init__(self, interval: int) -> None:
+        self._interval = interval
+        self._actor = None
+        self._cache: EvictableCache | None = None
+
+    def start(self, cache: EvictableCache) -> None:
+        if not RAY_AVAILABLE or ray is None:
+            raise RuntimeError("ray is not available")
+        self._cache = cache
+        self._actor = _RayEvictor.options(name=f"evictor_{id(cache)}").remote(self._interval)
+        self._actor.start.remote(cache)
+
+    def tick(self) -> None:
+        cache = self._cache
+        if cache is not None:
+            cache.evict_expired()
+
+    def stop(self) -> None:
+        if self._actor is not None and ray is not None:
+            try:
+                ray.get(self._actor.stop.remote())
+            finally:
+                self._actor = None
+        self._cache = None
+
+
+def create_default_eviction_strategy(interval: int) -> EvictionStrategy:
+    """Return the default eviction strategy for the current runtime."""
+
+    from .. import runtime
+
+    if RAY_AVAILABLE and ray is not None and not runtime.NO_RAY:
+        return RayEvictionStrategy(interval)
+    return ThreadedEvictionStrategy(interval)
+
+
+__all__ = [
+    "EvictionStrategy",
+    "ThreadedEvictionStrategy",
+    "RayEvictionStrategy",
+    "create_default_eviction_strategy",
+]

--- a/qmtl/sdk/arrow_cache/instrumentation.py
+++ b/qmtl/sdk/arrow_cache/instrumentation.py
@@ -1,0 +1,52 @@
+"""Metrics adapters for the Arrow cache backend."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class CacheInstrumentation:
+    """Bundle of callbacks used by :class:`NodeCacheArrow`."""
+
+    observe_cache_read: Callable[[str, int], None]
+    observe_cross_context_cache_hit: Callable[..., None]
+    observe_resident_bytes: Callable[[str, int], None]
+
+
+def _noop_cache_read(_upstream_id: str, _interval: int) -> None:
+    return None
+
+
+def _noop_cross_context(*_args, **_kwargs) -> None:
+    return None
+
+
+def _noop_resident_bytes(_node_id: str, _resident: int) -> None:
+    return None
+
+
+NOOP_INSTRUMENTATION = CacheInstrumentation(
+    observe_cache_read=_noop_cache_read,
+    observe_cross_context_cache_hit=_noop_cross_context,
+    observe_resident_bytes=_noop_resident_bytes,
+)
+
+
+def default_instrumentation() -> CacheInstrumentation:
+    """Return instrumentation backed by ``qmtl.sdk.metrics``."""
+
+    from .. import metrics as sdk_metrics
+
+    return CacheInstrumentation(
+        observe_cache_read=sdk_metrics.observe_cache_read,
+        observe_cross_context_cache_hit=sdk_metrics.observe_cross_context_cache_hit,
+        observe_resident_bytes=sdk_metrics.observe_nodecache_resident_bytes,
+    )
+
+
+__all__ = [
+    "CacheInstrumentation",
+    "NOOP_INSTRUMENTATION",
+    "default_instrumentation",
+]

--- a/qmtl/sdk/arrow_cache/slices.py
+++ b/qmtl/sdk/arrow_cache/slices.py
@@ -1,0 +1,93 @@
+"""Arrow slice primitives used by the cache backend."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from .dependencies import ARROW_AVAILABLE, pa
+
+
+class _Slice:
+    """Fixed-width Arrow-backed circular buffer."""
+
+    def __init__(self, period: int) -> None:
+        self.period = period
+        if not ARROW_AVAILABLE:
+            raise RuntimeError("pyarrow is required for Arrow cache")
+        import pickle
+
+        self._pickle = pickle
+        self.ts = pa.array([], pa.int64())
+        self.vals = pa.array([], pa.binary())
+
+    def append(self, timestamp: int, payload: Any) -> None:
+        self.ts = pa.concat_arrays([self.ts, pa.array([timestamp], pa.int64())])
+        buf = self._pickle.dumps(payload)
+        self.vals = pa.concat_arrays([self.vals, pa.array([buf], pa.binary())])
+        if len(self.ts) > self.period:
+            start = len(self.ts) - self.period
+            self.ts = self.ts.slice(start)
+            self.vals = self.vals.slice(start)
+
+    def latest(self) -> tuple[int, Any] | None:
+        if len(self.ts) == 0:
+            return None
+        idx = len(self.ts) - 1
+        ts = self.ts[idx].as_py()
+        val = self._pickle.loads(self.vals[idx].as_py())
+        return int(ts), val
+
+    def get_list(self) -> list[tuple[int, Any]]:
+        ts = self.ts.to_pylist()
+        vals = [self._pickle.loads(x) for x in self.vals.to_pylist()]
+        return [(int(t), v) for t, v in zip(ts, vals)]
+
+    @property
+    def table(self):
+        return pa.table({"t": self.ts, "v": self.vals})
+
+    def slice_table(self, start: int, end: int):
+        start = max(0, start)
+        end = min(len(self.ts), end)
+        length = max(0, end - start)
+        return pa.table({"t": self.ts.slice(start, length), "v": self.vals.slice(start, length)})
+
+    @property
+    def resident_bytes(self) -> int:
+        return int(self.ts.nbytes) + int(self.vals.nbytes)
+
+
+class _SliceView(Sequence):
+    """Sequence view into a :class:`_Slice`."""
+
+    def __init__(self, sl: _Slice, start: int = 0, end: int | None = None) -> None:
+        self._slice = sl
+        self._start = start
+        self._end = len(sl.ts) if end is None else end
+
+    def __len__(self) -> int:
+        return self._end - self._start
+
+    def __getitem__(self, idx: int | slice):
+        if isinstance(idx, slice):
+            start, stop, step = idx.indices(len(self))
+            if step != 1:
+                return [self[i] for i in range(start, stop, step)]
+            return _SliceView(self._slice, self._start + start, self._start + stop)
+        if idx < 0:
+            idx += len(self)
+        if idx < 0 or idx >= len(self):
+            raise IndexError("index out of range")
+        real = self._start + idx
+        ts = self._slice.ts[real].as_py()
+        val = self._slice._pickle.loads(self._slice.vals[real].as_py())
+        return int(ts), val
+
+    def latest(self) -> tuple[int, Any] | None:
+        return self[-1] if len(self) else None
+
+    def table(self):
+        return self._slice.slice_table(self._start, self._end)
+
+
+__all__ = ["_Slice", "_SliceView"]

--- a/qmtl/sdk/arrow_cache/view.py
+++ b/qmtl/sdk/arrow_cache/view.py
@@ -1,0 +1,92 @@
+"""Read-only views over Arrow-backed cache storage."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from .instrumentation import CacheInstrumentation, NOOP_INSTRUMENTATION
+from .slices import _Slice, _SliceView
+
+
+class ArrowCacheView:
+    """Hierarchical read-only view backed by Arrow ``_Slice`` objects."""
+
+    def __init__(
+        self,
+        data: Dict[str, Dict[int, _Slice]],
+        *,
+        track_access: bool = False,
+        artifact_plane: Any | None = None,
+        metrics: CacheInstrumentation | None = None,
+    ) -> None:
+        self._data = data
+        self._track_access = track_access
+        self._access_log: list[tuple[str, int]] = []
+        self._artifact_plane = artifact_plane
+        self._metrics = metrics or NOOP_INSTRUMENTATION
+
+    def __getitem__(self, key: Any):
+        if hasattr(key, "node_id"):
+            key = getattr(key, "node_id")
+        mp = self._data[key]
+        return _SecondLevelView(
+            mp,
+            str(key),
+            self._track_access,
+            self._access_log,
+            self._metrics,
+        )
+
+    def __getattr__(self, name: str):  # pragma: no cover - convenience
+        if name in self._data:
+            return self.__getitem__(name)
+        raise AttributeError(name)
+
+    def access_log(self) -> list[tuple[str, int]]:
+        return list(self._access_log)
+
+    def feature_artifacts(
+        self,
+        factor: Any,
+        *,
+        instrument: str | None = None,
+        dataset_fingerprint: str | None = None,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> list[tuple[int, Any]]:
+        if self._artifact_plane is None:
+            return []
+        return self._artifact_plane.load_series(
+            factor,
+            instrument=instrument,
+            dataset_fingerprint=dataset_fingerprint,
+            start=start,
+            end=end,
+        )
+
+
+class _SecondLevelView:
+    def __init__(
+        self,
+        data: Dict[int, _Slice],
+        upstream: str,
+        track_access: bool,
+        log: list[tuple[str, int]],
+        metrics: CacheInstrumentation,
+    ) -> None:
+        self._data = data
+        self._upstream = upstream
+        self._track_access = track_access
+        self._log = log
+        self._metrics = metrics
+
+    def __getitem__(self, key: int):
+        if self._track_access:
+            self._log.append((self._upstream, key))
+            self._metrics.observe_cache_read(self._upstream, key)
+        return _SliceView(self._data[key])
+
+    def keys(self) -> Iterable[int]:  # pragma: no cover - convenience
+        return self._data.keys()
+
+
+__all__ = ["ArrowCacheView", "_SecondLevelView"]

--- a/qmtl/sdk/nodes/base.py
+++ b/qmtl/sdk/nodes/base.py
@@ -345,9 +345,12 @@ class Node:
                 partition=self._compute_context.partition,
             )
             self.cache.append(upstream_id, interval, timestamp, payload)
-            sdk_metrics.observe_nodecache_resident_bytes(
-                self.node_id, self.cache.resident_bytes
-            )
+            if hasattr(self.cache, "record_resident_bytes"):
+                self.cache.record_resident_bytes(self.node_id)
+            else:
+                sdk_metrics.observe_nodecache_resident_bytes(
+                    self.node_id, self.cache.resident_bytes
+                )
 
         if self.event_service is not None:
             self.event_service.record(self.node_id, interval, timestamp, payload)

--- a/tests/test_arrow_slices.py
+++ b/tests/test_arrow_slices.py
@@ -1,0 +1,29 @@
+import pytest
+
+from qmtl.sdk.arrow_cache import ARROW_AVAILABLE, _Slice, _SliceView
+
+
+@pytest.mark.skipif(not ARROW_AVAILABLE, reason="pyarrow missing")
+def test_slice_append_and_latest():
+    sl = _Slice(period=3)
+    sl.append(10, {"v": 1})
+    sl.append(20, {"v": 2})
+    sl.append(30, {"v": 3})
+    sl.append(40, {"v": 4})
+
+    assert sl.latest() == (40, {"v": 4})
+    assert [ts for ts, _ in sl.get_list()] == [20, 30, 40]
+
+
+@pytest.mark.skipif(not ARROW_AVAILABLE, reason="pyarrow missing")
+def test_slice_view_behaviour():
+    sl = _Slice(period=4)
+    for i in range(4):
+        sl.append((i + 1) * 10, {"v": i})
+
+    view = _SliceView(sl)
+    assert view[-1] == (40, {"v": 3})
+    assert list(view[-2:]) == [(30, {"v": 2}), (40, {"v": 3})]
+    sub = view[1:3]
+    assert isinstance(sub, _SliceView)
+    assert list(sub) == [(20, {"v": 1}), (30, {"v": 2})]


### PR DESCRIPTION
## Summary
- split the Arrow cache backend into a composable package with dedicated modules for dependency guards, slice storage, view adapters, metrics instrumentation, and eviction strategies
- update `NodeCacheArrow` to consume the modular pieces, provide injectable metrics hooks, and expose a `record_resident_bytes` helper used by nodes
- add focused tests that cover the new instrumentation surface and the Arrow slice primitives

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout --with pytest-asyncio --with fakeredis --with jsonschema -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run --with pytest-asyncio --with fakeredis --with jsonschema --with pytest-xdist -m pytest -W error -n auto

Closes #1030

------
https://chatgpt.com/codex/tasks/task_e_68d109fd024083298bd5e53f3cca1050