### PR TITLE
Refactor history warmup responsibilities

### DIFF
--- a/qmtl/sdk/history_coverage.py
+++ b/qmtl/sdk/history_coverage.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class CoverageRange:
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class WarmupWindow:
+    start: int
+    end: int
+    interval: int
+
+
+def merge_coverage(coverage: Iterable[tuple[int, int]], interval: int) -> list[CoverageRange]:
+    ranges = sorted((int(s), int(e)) for s, e in coverage)
+    merged: list[CoverageRange] = []
+    for start, end in ranges:
+        if not merged:
+            merged.append(CoverageRange(start, end))
+            continue
+        last = merged[-1]
+        if start <= last.end + interval:
+            merged[-1] = CoverageRange(last.start, max(last.end, end))
+        else:
+            merged.append(CoverageRange(start, end))
+    return merged
+
+
+def compute_missing_ranges(
+    coverage: Iterable[tuple[int, int]] | None,
+    window: WarmupWindow,
+) -> list[CoverageRange]:
+    if window.start is None or window.end is None:
+        return []
+    merged = merge_coverage(coverage or [], window.interval)
+    gaps: list[CoverageRange] = []
+    cursor = window.start
+    for rng in merged:
+        if rng.end < window.start:
+            continue
+        if rng.start > window.end:
+            break
+        if rng.start > cursor:
+            gaps.append(
+                CoverageRange(cursor, min(rng.start - window.interval, window.end))
+            )
+        cursor = max(cursor, rng.end + window.interval)
+        if cursor > window.end:
+            break
+    if cursor <= window.end:
+        gaps.append(CoverageRange(cursor, window.end))
+    return [gap for gap in gaps if gap.start <= gap.end]
+
+
+def coverage_bounds(coverage: Iterable[tuple[int, int]] | None) -> CoverageRange | None:
+    if not coverage:
+        return None
+    starts, ends = zip(*coverage)
+    return CoverageRange(min(int(s) for s in starts), max(int(e) for e in ends))
+
+
+def ensure_strict_history(
+    timestamps: Sequence[int],
+    interval: int | None,
+    required_points: int | None,
+    coverage: Iterable[tuple[int, int]] | None,
+) -> None:
+    required = (required_points or 1) if required_points is not None else 1
+    if not timestamps:
+        raise RuntimeError("history missing in strict mode")
+
+    if coverage:
+        bounds = coverage_bounds(coverage)
+        if bounds and interval:
+            expected = int((bounds.end - bounds.start) // interval) + 1
+            actual = sum(1 for ts in timestamps if bounds.start <= ts <= bounds.end)
+            if actual < expected:
+                raise RuntimeError("history gap detected in strict mode")
+    elif interval:
+        for a, b in zip(timestamps, timestamps[1:]):
+            if (b - a) != interval:
+                raise RuntimeError("history gap detected in strict mode")
+
+    if len(timestamps) < required:
+        raise RuntimeError("history missing in strict mode")
+
+
+__all__ = [
+    "CoverageRange",
+    "WarmupWindow",
+    "merge_coverage",
+    "compute_missing_ranges",
+    "coverage_bounds",
+    "ensure_strict_history",
+]

--- a/qmtl/sdk/history_snapshot.py
+++ b/qmtl/sdk/history_snapshot.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from . import snapshot as snap
+from .strategy import Strategy
+
+logger = logging.getLogger(__name__)
+
+
+def _iter_stream_nodes(strategy: Strategy) -> Iterable[object]:
+    from .node import StreamInput
+
+    for node in strategy.nodes:
+        if isinstance(node, StreamInput) and node.interval is not None and node.period:
+            yield node
+
+
+def hydrate_strategy_snapshots(strategy: Strategy) -> int:
+    """Hydrate eligible stream nodes from persisted snapshots.
+
+    Returns the number of nodes hydrated.
+    """
+
+    count = 0
+    for node in _iter_stream_nodes(strategy):
+        try:
+            strict = False
+            try:
+                strict = getattr(node, "runtime_compat", "loose") == "strict"
+            except Exception:
+                strict = False
+            if snap.hydrate(node, strict_runtime=strict):
+                count += 1
+        except Exception:  # pragma: no cover - defensive against user nodes
+            logger.exception("snapshot hydration failed for %s", getattr(node, "node_id", "<unknown>"))
+    if count:
+        logger.info("hydrated %d nodes from snapshots", count)
+    return count
+
+
+def write_strategy_snapshots(strategy: Strategy) -> int:
+    """Write snapshots for eligible stream nodes.
+
+    Returns the number of snapshot files written.
+    """
+
+    count = 0
+    for node in _iter_stream_nodes(strategy):
+        try:
+            path = snap.write_snapshot(node)
+            if path:
+                count += 1
+        except Exception:  # pragma: no cover - defensive against user nodes
+            logger.exception("snapshot write failed for %s", getattr(node, "node_id", "<unknown>"))
+    if count:
+        logger.info("wrote %d node snapshots", count)
+    return count
+
+
+__all__ = ["hydrate_strategy_snapshots", "write_strategy_snapshots"]

--- a/qmtl/sdk/history_warmup_polling.py
+++ b/qmtl/sdk/history_warmup_polling.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Iterable, Protocol
+
+from .history_coverage import CoverageRange, WarmupWindow, compute_missing_ranges
+
+
+class HistoryProviderProtocol(Protocol):
+    async def coverage(self, *, node_id: str, interval: int) -> Iterable[tuple[int, int]]: ...
+
+    async def fill_missing(
+        self,
+        start: int,
+        end: int,
+        *,
+        node_id: str,
+        interval: int,
+    ) -> None: ...
+
+
+@dataclass(frozen=True)
+class WarmupRequest:
+    node_id: str
+    interval: int
+    window: WarmupWindow
+    stop_on_ready: bool = False
+    timeout: float = 60.0
+
+
+@dataclass(frozen=True)
+class WarmupResult:
+    coverage: list[tuple[int, int]]
+    missing: list[CoverageRange]
+    timed_out: bool
+
+
+class HistoryWarmupPoller:
+    """Polling state machine coordinating history provider backfills."""
+
+    def __init__(
+        self,
+        provider: HistoryProviderProtocol,
+        *,
+        time_source: Callable[[], float] | None = None,
+    ) -> None:
+        self._provider = provider
+        self._time_source = time_source or time.monotonic
+
+    async def poll(
+        self,
+        request: WarmupRequest,
+        *,
+        is_ready: Callable[[], bool],
+    ) -> WarmupResult:
+        deadline = self._time_source() + request.timeout
+        coverage_list = list(
+            await self._provider.coverage(node_id=request.node_id, interval=request.interval)
+        )
+        missing = compute_missing_ranges(coverage_list, request.window)
+        timed_out = False
+
+        while not is_ready() and missing:
+            for gap in missing:
+                await self._provider.fill_missing(
+                    gap.start,
+                    gap.end,
+                    node_id=request.node_id,
+                    interval=request.interval,
+                )
+                if request.stop_on_ready and is_ready():
+                    break
+            if request.stop_on_ready:
+                break
+            if self._time_source() > deadline:
+                timed_out = True
+                break
+            coverage_list = list(
+                await self._provider.coverage(
+                    node_id=request.node_id, interval=request.interval
+                )
+            )
+            missing = compute_missing_ranges(coverage_list, request.window)
+
+        return WarmupResult(coverage=coverage_list, missing=missing, timed_out=timed_out)
+
+
+__all__ = ["HistoryWarmupPoller", "WarmupRequest", "WarmupResult", "HistoryProviderProtocol"]

--- a/qmtl/sdk/history_warmup_service.py
+++ b/qmtl/sdk/history_warmup_service.py
@@ -3,13 +3,58 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Any, Iterable
+from dataclasses import dataclass
+from typing import Any
 
-from . import snapshot as snap
+from .history_coverage import (
+    WarmupWindow,
+    compute_missing_ranges,
+    coverage_bounds,
+    ensure_strict_history,
+)
 from .history_loader import HistoryLoader
+from .history_snapshot import hydrate_strategy_snapshots, write_strategy_snapshots
+from .history_warmup_polling import HistoryWarmupPoller, WarmupRequest
 from .strategy import Strategy
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NodeWarmupPlan:
+    node_id: str
+    interval: int
+    window: WarmupWindow
+    provider: Any | None
+    stop_on_ready: bool
+    strict: bool
+    timeout: float = 60.0
+
+    @classmethod
+    def build(
+        cls,
+        node: Any,
+        start: int | None,
+        end: int | None,
+        *,
+        stop_on_ready: bool,
+        strict: bool,
+        timeout: float = 60.0,
+    ) -> NodeWarmupPlan | None:
+        interval = getattr(node, "interval", None)
+        if interval is None or start is None or end is None:
+            return None
+        node_id = getattr(node, "node_id", "<unknown>")
+        provider = getattr(node, "history_provider", None)
+        return cls(
+            node_id=node_id,
+            interval=interval,
+            window=WarmupWindow(start=start, end=end, interval=interval),
+            provider=provider,
+            stop_on_ready=stop_on_ready,
+            strict=strict,
+            timeout=timeout,
+        )
 
 
 class HistoryWarmupService:
@@ -23,41 +68,11 @@ class HistoryWarmupService:
     # ------------------------------------------------------------------
     @staticmethod
     def hydrate_snapshots(strategy: Strategy) -> int:
-        from .node import StreamInput
-
-        count = 0
-        for node in strategy.nodes:
-            if isinstance(node, StreamInput) and node.interval is not None and node.period:
-                try:
-                    strict = False
-                    try:
-                        strict = getattr(node, "runtime_compat", "loose") == "strict"
-                    except Exception:
-                        strict = False
-                    if snap.hydrate(node, strict_runtime=strict):
-                        count += 1
-                except Exception:
-                    logger.exception("snapshot hydration failed for %s", node.node_id)
-        if count:
-            logger.info("hydrated %d nodes from snapshots", count)
-        return count
+        return hydrate_strategy_snapshots(strategy)
 
     @staticmethod
     def write_snapshots(strategy: Strategy) -> int:
-        from .node import StreamInput
-
-        count = 0
-        for node in strategy.nodes:
-            if isinstance(node, StreamInput) and node.interval is not None and node.period:
-                try:
-                    path = snap.write_snapshot(node)
-                    if path:
-                        count += 1
-                except Exception:
-                    logger.exception("snapshot write failed for %s", node.node_id)
-        if count:
-            logger.info("wrote %d node snapshots", count)
-        return count
+        return write_strategy_snapshots(strategy)
 
     # ------------------------------------------------------------------
     async def load_history(
@@ -68,38 +83,66 @@ class HistoryWarmupService:
     # ------------------------------------------------------------------
     @staticmethod
     def missing_ranges(
-        coverage: Iterable[tuple[int, int]],
+        coverage: Any,
         start: int,
         end: int,
         interval: int,
     ) -> list[tuple[int, int]]:
-        ranges = sorted([tuple(r) for r in coverage])
-        merged: list[tuple[int, int]] = []
-        for s, e in ranges:
-            if not merged:
-                merged.append((s, e))
-                continue
-            ls, le = merged[-1]
-            if s <= le + interval:
-                merged[-1] = (ls, max(le, e))
-            else:
-                merged.append((s, e))
+        window = WarmupWindow(start=start, end=end, interval=interval)
+        gaps = compute_missing_ranges(coverage, window)
+        return [(gap.start, gap.end) for gap in gaps]
 
-        gaps: list[tuple[int, int]] = []
-        cur = start
-        for s, e in merged:
-            if e < start:
-                continue
-            if s > end:
-                break
-            if s > cur:
-                gaps.append((cur, min(s - interval, end)))
-            cur = max(cur, e + interval)
-            if cur > end:
-                break
-        if cur <= end:
-            gaps.append((cur, end))
-        return [g for g in gaps if g[0] <= g[1]]
+    async def _ensure_node_with_plan(self, node: Any, plan: NodeWarmupPlan) -> None:
+        if plan.provider is None:
+            await node.load_history(plan.window.start, plan.window.end)
+            return
+
+        poller = HistoryWarmupPoller(plan.provider)
+        result = await poller.poll(
+            WarmupRequest(
+                node_id=plan.node_id,
+                interval=plan.interval,
+                window=plan.window,
+                stop_on_ready=plan.stop_on_ready,
+                timeout=plan.timeout,
+            ),
+            is_ready=lambda: not getattr(node, "pre_warmup", False),
+        )
+
+        if result.timed_out:
+            logger.warning(
+                "history warm-up timed out for %s; proceeding with available data",
+                plan.node_id,
+            )
+
+        coverage = result.coverage
+        if getattr(node, "pre_warmup", False):
+            if not coverage:
+                coverage = list(
+                    await plan.provider.coverage(
+                        node_id=plan.node_id, interval=plan.interval
+                    )
+                )
+            bounds = coverage_bounds(coverage)
+            if bounds:
+                await node.load_history(bounds.start, bounds.end)
+            else:
+                await node.load_history(plan.window.start, plan.window.end)
+        else:
+            await node.load_history(plan.window.start, plan.window.end)
+            if not coverage:
+                coverage = list(
+                    await plan.provider.coverage(
+                        node_id=plan.node_id, interval=plan.interval
+                    )
+                )
+
+        if plan.strict:
+            gaps = compute_missing_ranges(coverage, plan.window)
+            if gaps or getattr(node, "pre_warmup", False):
+                raise RuntimeError(
+                    f"history gap for {plan.node_id} in strict mode"
+                )
 
     async def ensure_node_history(
         self,
@@ -110,61 +153,16 @@ class HistoryWarmupService:
         stop_on_ready: bool = False,
         strict: bool = False,
     ) -> None:
-        if node.interval is None or start is None or end is None:
+        plan = NodeWarmupPlan.build(
+            node,
+            start,
+            end,
+            stop_on_ready=stop_on_ready,
+            strict=strict,
+        )
+        if plan is None:
             return
-        provider = getattr(node, "history_provider", None)
-        if provider is None:
-            await node.load_history(start, end)
-            return
-        if start is None and end is None:
-            coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
-            if coverage:
-                s = min(c[0] for c in coverage)
-                e = max(c[1] for c in coverage)
-                await node.load_history(s, e)
-                return
-        deadline = time.monotonic() + 60.0
-        while node.pre_warmup:
-            coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
-            missing = self.missing_ranges(coverage, start, end, node.interval)
-            if not missing:
-                await node.load_history(start, end)
-                return
-            for s, e in missing:
-                await provider.fill_missing(
-                    s, e, node_id=node.node_id, interval=node.interval
-                )
-                if stop_on_ready and not node.pre_warmup:
-                    return
-            if time.monotonic() > deadline:
-                logger.warning(
-                    "history warm-up timed out for %s; proceeding with available data",
-                    getattr(node, "node_id", "<unknown>"),
-                )
-                break
-            if stop_on_ready:
-                break
-        if node.pre_warmup:
-            try:
-                coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
-            except Exception:
-                coverage = []
-            if coverage:
-                s = min(c[0] for c in coverage)
-                e = max(c[1] for c in coverage)
-                await node.load_history(s, e)
-            else:
-                await node.load_history(start, end)
-        if strict:
-            try:
-                coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
-            except Exception:
-                coverage = []
-            missing = self.missing_ranges(coverage, start, end, node.interval)
-            if missing or getattr(node, "pre_warmup", False):
-                raise RuntimeError(
-                    f"history gap for {getattr(node, 'node_id', '<unknown>')} in strict mode"
-                )
+        await self._ensure_node_with_plan(node, plan)
 
     async def ensure_history(
         self,
@@ -195,16 +193,17 @@ class HistoryWarmupService:
             else:
                 rng_start = start
                 rng_end = end
+            plan = NodeWarmupPlan.build(
+                node,
+                rng_start,
+                rng_end,
+                stop_on_ready=stop_on_ready,
+                strict=strict,
+            )
+            if plan is None:
+                continue
             tasks.append(
-                asyncio.create_task(
-                    self.ensure_node_history(
-                        node,
-                        rng_start,
-                        rng_end,
-                        stop_on_ready=stop_on_ready,
-                        strict=strict,
-                    )
-                )
+                asyncio.create_task(self._ensure_node_with_plan(node, plan))
             )
         if tasks:
             await asyncio.gather(*tasks)
@@ -422,25 +421,15 @@ class HistoryWarmupService:
             try:
                 snapshot = node.cache._snapshot()[node.node_id].get(node.interval, [])
                 ts_sorted = sorted(ts for ts, _ in snapshot)
-            except KeyError:
-                raise RuntimeError("history missing in strict mode")
+            except KeyError as exc:
+                raise RuntimeError("history missing in strict mode") from exc
             coverage = await provider.coverage(node_id=node.node_id, interval=node.interval)
-            if coverage:
-                s = min(c[0] for c in coverage)
-                e = max(c[1] for c in coverage)
-                if node.interval:
-                    expected = int((e - s) // node.interval) + 1
-                    actual = len([ts for ts in ts_sorted if s <= ts <= e])
-                    if actual < expected:
-                        raise RuntimeError("history gap detected in strict mode")
-            else:
-                for a, b in zip(ts_sorted, ts_sorted[1:]):
-                    if node.interval and (b - a) != node.interval:
-                        raise RuntimeError("history gap detected in strict mode")
-            if coverage:
-                needed = getattr(node, "period", 1) or 1
-                if len(ts_sorted) < needed:
-                    raise RuntimeError("history missing in strict mode")
+            ensure_strict_history(
+                ts_sorted,
+                getattr(node, "interval", None),
+                getattr(node, "period", 1) or 1,
+                coverage,
+            )
 
 
 __all__ = ["HistoryWarmupService"]

--- a/tests/sdk/test_history_components.py
+++ b/tests/sdk/test_history_components.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.sdk.history_coverage import (
+    WarmupWindow,
+    compute_missing_ranges,
+    ensure_strict_history,
+)
+from qmtl.sdk.history_warmup_polling import HistoryWarmupPoller, WarmupRequest
+
+
+class DummyProvider:
+    def __init__(self, coverages: list[list[tuple[int, int]]]) -> None:
+        self._coverages = coverages
+        self.fill_calls: list[tuple[int, int]] = []
+
+    async def coverage(self, *, node_id: str, interval: int) -> list[tuple[int, int]]:
+        if self._coverages:
+            return self._coverages.pop(0)
+        return []
+
+    async def fill_missing(
+        self,
+        start: int,
+        end: int,
+        *,
+        node_id: str,
+        interval: int,
+    ) -> None:
+        self.fill_calls.append((start, end))
+
+
+class AdvancingTime:
+    def __init__(self, values: list[float]) -> None:
+        self._values = values
+        self._index = 0
+
+    def __call__(self) -> float:
+        value = self._values[min(self._index, len(self._values) - 1)]
+        self._index += 1
+        return value
+
+
+@pytest.mark.asyncio
+async def test_poller_times_out_when_deadline_exceeded() -> None:
+    provider = DummyProvider(coverages=[[], []])
+    time_source = AdvancingTime([0.0, 61.0])
+    poller = HistoryWarmupPoller(provider, time_source=time_source)
+    window = WarmupWindow(start=0, end=10, interval=10)
+    request = WarmupRequest(
+        node_id="n1",
+        interval=10,
+        window=window,
+        timeout=60.0,
+    )
+
+    result = await poller.poll(request, is_ready=lambda: False)
+
+    assert result.timed_out is True
+    assert provider.fill_calls == [(0, 10)]
+    assert [(gap.start, gap.end) for gap in result.missing] == [(0, 10)]
+
+
+def test_missing_ranges_identify_gaps() -> None:
+    window = WarmupWindow(start=0, end=50, interval=10)
+    coverage = [(0, 10), (40, 50)]
+
+    gaps = compute_missing_ranges(coverage, window)
+
+    assert [(gap.start, gap.end) for gap in gaps] == [(20, 30)]
+
+
+def test_strict_history_detects_missing_points() -> None:
+    timestamps = [0, 10, 30, 40]
+    coverage = [(0, 40)]
+
+    with pytest.raises(RuntimeError):
+        ensure_strict_history(timestamps, interval=10, required_points=5, coverage=coverage)


### PR DESCRIPTION
## Summary
- extract snapshot hydration/writing helpers into a standalone module and add pure coverage utilities
- introduce a polling controller plus warmup plan dataclass to slim down `HistoryWarmupService`
- add focused tests for gap detection, strict validation, and timeout behaviour

## Testing
- uv run -m pytest tests/sdk/test_history_components.py

Closes #1033

------
https://chatgpt.com/codex/tasks/task_e_68d10a09fa088329a3c6db80ee6458bf