### PR TITLE
Modularize DAG diff service helpers

### DIFF
--- a/qmtl/dagmanager/models.py
+++ b/qmtl/dagmanager/models.py
@@ -1,0 +1,60 @@
+"""Shared data models for the DAG diff service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+__all__ = [
+    "DiffRequest",
+    "DiffChunk",
+    "NodeInfo",
+    "NodeRecord",
+    "BufferInstruction",
+]
+
+
+@dataclass
+class DiffRequest:
+    strategy_id: str
+    dag_json: str
+    world_id: str | None = None
+    execution_domain: str | None = None
+    as_of: str | None = None
+    partition: str | None = None
+    dataset_fingerprint: str | None = None
+
+
+@dataclass
+class NodeInfo:
+    node_id: str
+    node_type: str
+    code_hash: str
+    schema_hash: str
+    schema_id: str
+    interval: int | None
+    period: int | None
+    tags: list[str]
+    bucket: int | None = None
+    is_global: bool = False
+    compute_key: str | None = field(default=None, init=False)
+
+
+@dataclass
+class NodeRecord(NodeInfo):
+    topic: str = ""
+
+
+@dataclass
+class BufferInstruction(NodeInfo):
+    lag: int = 0
+
+
+@dataclass
+class DiffChunk:
+    queue_map: Dict[str, str]
+    sentinel_id: str
+    version: str
+    buffering_nodes: List[BufferInstruction] = field(default_factory=list)
+    new_nodes: List[NodeInfo] = field(default_factory=list)

--- a/qmtl/dagmanager/node_repository.py
+++ b/qmtl/dagmanager/node_repository.py
@@ -8,7 +8,8 @@ from typing import Iterable, Dict
 
 import networkx as nx
 
-from .diff_service import NodeRepository, NodeRecord
+from .models import NodeRecord
+from .repository import NodeRepository
 
 _GRAPH = nx.DiGraph()
 _GRAPH_PATH: Path | None = None

--- a/qmtl/dagmanager/normalize.py
+++ b/qmtl/dagmanager/normalize.py
@@ -1,0 +1,52 @@
+"""Normalization helpers for DAG diff inputs."""
+
+from __future__ import annotations
+
+
+__all__ = [
+    "normalize_version",
+    "normalize_execution_domain",
+    "stringify",
+]
+
+
+def stringify(value: object) -> str:
+    """Convert ``value`` to a trimmed string.
+
+    ``None`` maps to an empty string to simplify downstream defaulting logic
+    while numeric values preserve their canonical textual representation.
+    """
+
+    if value is None:
+        return ""
+    if isinstance(value, (int, float)):
+        return str(value)
+    return str(value).strip()
+
+
+def normalize_version(raw: object, default: str = "v1") -> str:
+    """Normalize version identifiers used for queue topic suffixes."""
+
+    if isinstance(raw, (int, float)):
+        value = str(raw)
+    elif isinstance(raw, str):
+        value = raw.strip()
+    else:
+        value = ""
+    if not value:
+        return default
+    cleaned = []
+    for ch in value:
+        if ch.isalnum() or ch in {"-", "_", "."}:
+            cleaned.append(ch)
+        else:
+            cleaned.append("-")
+    result = "".join(cleaned).strip("-_.")
+    return result or default
+
+
+def normalize_execution_domain(raw: object) -> str:
+    """Lowercase the execution domain or fall back to ``"live"``."""
+
+    value = stringify(raw)
+    return value.lower() or "live"

--- a/qmtl/dagmanager/repository.py
+++ b/qmtl/dagmanager/repository.py
@@ -1,0 +1,81 @@
+"""Repository interfaces for DAG diff operations."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from qmtl.common import AsyncCircuitBreaker
+
+from .models import NodeRecord
+
+__all__ = ["NodeRepository"]
+
+
+class NodeRepository:
+    """Interface to fetch node metadata and manage buffering state."""
+
+    def get_nodes(
+        self,
+        node_ids: Iterable[str],
+        *,
+        breaker: AsyncCircuitBreaker | None = None,
+    ) -> Dict[str, NodeRecord]:
+        raise NotImplementedError
+
+    def insert_sentinel(
+        self,
+        sentinel_id: str,
+        node_ids: Iterable[str],
+        version: str,
+        *,
+        breaker: AsyncCircuitBreaker | None = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def get_queues_by_tag(
+        self,
+        tags: Iterable[str],
+        interval: int,
+        match_mode: str = "any",
+        *,
+        breaker: AsyncCircuitBreaker | None = None,
+    ) -> list[dict[str, object]]:
+        raise NotImplementedError
+
+    def get_node_by_queue(
+        self,
+        queue: str,
+        *,
+        breaker: AsyncCircuitBreaker | None = None,
+    ) -> NodeRecord | None:
+        raise NotImplementedError
+
+    # buffering -------------------------------------------------------------
+
+    def mark_buffering(
+        self,
+        node_id: str,
+        *,
+        compute_key: str | None = None,
+        timestamp_ms: int | None = None,
+        breaker: AsyncCircuitBreaker | None = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def clear_buffering(
+        self,
+        node_id: str,
+        *,
+        compute_key: str | None = None,
+        breaker: AsyncCircuitBreaker | None = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def get_buffering_nodes(
+        self,
+        older_than_ms: int,
+        *,
+        compute_key: str | None = None,
+        breaker: AsyncCircuitBreaker | None = None,
+    ) -> list[str]:
+        raise NotImplementedError

--- a/tests/dagmanager/test_normalize.py
+++ b/tests/dagmanager/test_normalize.py
@@ -1,0 +1,25 @@
+from qmtl.dagmanager.normalize import (
+    normalize_execution_domain,
+    normalize_version,
+    stringify,
+)
+
+
+def test_stringify_trims_and_handles_none():
+    assert stringify(None) == ""
+    assert stringify("  value  ") == "value"
+    assert stringify(42) == "42"
+
+
+def test_normalize_version_cleans_and_defaults():
+    assert normalize_version(None) == "v1"
+    assert normalize_version("  V2  ") == "V2"
+    assert normalize_version("release candidate!") == "release-candidate"
+    assert normalize_version("--") == "v1"
+    assert normalize_version(3) == "3"
+
+
+def test_normalize_execution_domain_lowercases_and_defaults():
+    assert normalize_execution_domain(None) == "live"
+    assert normalize_execution_domain("Backtest") == "backtest"
+    assert normalize_execution_domain("  PAPER  ") == "paper"


### PR DESCRIPTION
## Summary
- extract DAG diff request/dataclass models into a shared models.py and move the repository interface into repository.py for reuse
- add a normalize.py helper module and update diff_service to import the helpers and models instead of inlining them
- update the in-memory repository imports and cover the normalization helpers with focused tests

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1025

------
https://chatgpt.com/codex/tasks/task_e_68d19796b3b0832990f9e3502e76b240