### PR TITLE
docs: refresh examples for worldservice gating

### DIFF
--- a/qmtl/examples/README.md
+++ b/qmtl/examples/README.md
@@ -12,7 +12,10 @@ uv pip install -e qmtl[dev]
 
 ## Running
 
-Run strategies against a Gateway-connected WorldService:
+Run strategies against a Gateway-connected WorldService. The Gateway will
+propagate activation envelopes that include the new freeze/drain flags, so
+orders remain gated off until WorldService promotes the world into a runnable
+execution domain:
 
 ```bash
 python strategies/my_strategy.py --world-id demo --gateway-url http://localhost:8000
@@ -23,6 +26,22 @@ For quick offline execution, omit the flags:
 ```bash
 python strategies/my_strategy.py
 ```
+
+### WorldService gating quickstart
+
+Recent releases introduced two-phase apply and per-world gating policies. The
+example project ships with a minimal policy document at
+`worldservice/gating_policy.example.yml` and a helper CLI for driving the
+apply endpoint:
+
+```bash
+python -m qmtl.examples.scripts.worldservice_apply_demo --world-id demo --dry-run
+```
+
+Drop the `--dry-run` flag to post the payload to a locally running
+WorldService instance. The script surfaces the payload in JSON so you can
+inspect the generated `run_id`, metrics map, and parsed gating policy before
+submitting it.
 
 ## Testing
 

--- a/qmtl/examples/docs/README.md
+++ b/qmtl/examples/docs/README.md
@@ -1,4 +1,6 @@
 # Project Documentation
 
-Add project documentation in this directory.
+Add project documentation in this directory. Start with
+[`worldservice_gating.md`](worldservice_gating.md) for a walkthrough of the
+new two-phase apply flow and gating policy schema.
 

--- a/qmtl/examples/docs/worldservice_gating.md
+++ b/qmtl/examples/docs/worldservice_gating.md
@@ -1,0 +1,38 @@
+# WorldService Gating Walkthrough
+
+This guide explains how the example project interacts with the latest
+WorldService gating flow.
+
+## Key concepts
+
+- **Two-phase apply** – Every promotion freezes activation (`freeze=true`,
+  `active=false`), switches the execution domain, and finally unfreezes once
+  the new activation snapshot is acknowledged by Gateway/SDK consumers.
+- **Gating policy document** – Promotion requests must supply a policy defining
+  dataset fingerprints, snapshot isolation, and per-domain edge overrides.
+- **Activation envelopes** – Gateway relays `freeze`/`drain` flags together with
+  weights so strategies can block or scale orders immediately.
+
+## Example assets
+
+- [`worldservice/gating_policy.example.yml`](../worldservice/gating_policy.example.yml)
+  captures the minimal policy accepted by `parse_gating_policy`. It
+  demonstrates how to disable cross-domain edges before promotion and enable
+  them afterwards.
+- [`scripts/worldservice_apply_demo.py`](../scripts/worldservice_apply_demo.py)
+  posts an apply payload containing dummy metrics, a generated `run_id`, and the
+  parsed gating policy body.
+
+## Running the demo
+
+1. Start Gateway and WorldService (for example via `uv run qmtl dev` or the
+   provided Docker compose).
+2. Inspect the payload without side effects:
+   ```bash
+   python -m qmtl.examples.scripts.worldservice_apply_demo --world-id demo --dry-run
+   ```
+3. Drop `--dry-run` to send the request. The script prints the JSON response so
+   you can confirm `phase="completed"` and see which strategies remain active.
+
+The payload produced by the script is ready for manual tweaks—adjust strategy
+metrics or swap in a different gating policy to test promotion guardrails.

--- a/qmtl/examples/scripts/worldservice_apply_demo.py
+++ b/qmtl/examples/scripts/worldservice_apply_demo.py
@@ -1,0 +1,125 @@
+"""Demonstrate a 2-phase apply request with gating policy data.
+
+The script loads the example gating policy, attaches dummy evaluation
+metrics, and posts the payload to a WorldService instance. Use it to
+exercise the new gating hooks locally after spinning up Gateway and
+WorldService with ``uv run qmtl dev`` or docker-compose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Mapping
+
+import httpx
+
+from qmtl.worldservice.policy import parse_gating_policy
+
+
+_DEFAULT_POLICY_PATH = (
+    Path(__file__).resolve().parents[1] / "worldservice" / "gating_policy.example.yml"
+)
+
+
+def _load_gating_policy(path: Path) -> Mapping[str, Any]:
+    """Return the parsed gating policy payload."""
+
+    data = path.read_text(encoding="utf-8")
+    policy = parse_gating_policy(data)
+    return policy.model_dump()
+
+
+def _build_metrics(strategy_ids: list[str]) -> dict[str, dict[str, float]]:
+    """Create placeholder metrics satisfying the apply endpoint."""
+
+    return {
+        sid: {
+            "sharpe": 1.0,
+            "max_drawdown": 0.05,
+            "pnl": 1000.0,
+        }
+        for sid in strategy_ids
+    }
+
+
+def _post_apply(url: str, world_id: str, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Send the apply request and return the JSON response."""
+
+    endpoint = f"{url.rstrip('/')}/worlds/{world_id}/apply"
+    with httpx.Client(timeout=2.0) as client:
+        response = client.post(endpoint, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="WorldService apply demo")
+    parser.add_argument("--world-id", default="demo", help="Target world identifier")
+    parser.add_argument(
+        "--url",
+        default="http://localhost:8080",
+        help="Base URL for the WorldService HTTP API",
+    )
+    parser.add_argument(
+        "--gating-policy",
+        type=Path,
+        default=_DEFAULT_POLICY_PATH,
+        help="Path to the gating policy YAML document",
+    )
+    parser.add_argument(
+        "--strategy",
+        action="append",
+        dest="strategies",
+        default=["example_strategy"],
+        help="Strategy IDs to include in the metrics payload",
+    )
+    parser.add_argument(
+        "--run-id",
+        help="Optional run identifier; generated when omitted",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the payload without posting to WorldService",
+    )
+
+    args = parser.parse_args(argv)
+
+    strategies = list(dict.fromkeys(args.strategies))  # dedupe while preserving order
+    run_id = args.run_id or f"demo-{uuid.uuid4().hex[:8]}"
+
+    try:
+        gating_policy = _load_gating_policy(args.gating_policy)
+    except (OSError, ValueError) as exc:  # pragma: no cover - CLI I/O
+        print(f"Failed to load gating policy: {exc}", file=sys.stderr)
+        return 1
+
+    payload = {
+        "run_id": run_id,
+        "metrics": _build_metrics(strategies),
+        "gating_policy": gating_policy,
+    }
+
+    print("POST /worlds/%s/apply" % args.world_id)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+    if args.dry_run:
+        return 0
+
+    try:
+        body = _post_apply(args.url, args.world_id, payload)
+    except httpx.HTTPError as exc:  # pragma: no cover - network errors
+        print(f"Apply request failed: {exc}", file=sys.stderr)
+        return 2
+
+    print("Response:")
+    print(json.dumps(body, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI execution
+    raise SystemExit(main())

--- a/qmtl/examples/worldservice/gating_policy.example.yml
+++ b/qmtl/examples/worldservice/gating_policy.example.yml
@@ -1,0 +1,15 @@
+# Minimal gating policy compatible with the WorldService parser.
+gating_policy:
+  dataset_fingerprint: "ohlcv:ASOF=2025-09-30T23:59:59Z"
+  share_policy: "feature-artifacts-only"
+  snapshot:
+    strategy_plane: "copy-on-write"
+    feature_plane: "readonly"
+  edges:
+    pre_promotion:
+      disable_edges_to: ["live"]
+    post_promotion:
+      enable_edges_to: ["live"]
+  observability:
+    slo:
+      cross_context_cache_hit: 0


### PR DESCRIPTION
## Summary
- document the new two-phase WorldService gating flow in the example project README and docs
- add a runnable CLI that submits apply payloads with the updated gating policy schema
- ship a minimal gating_policy example used by the helper script

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto


------
https://chatgpt.com/codex/tasks/task_e_68d1a3fe461483298c78bcab17c89289