### PR TITLE
Enforce hard failure on cross-context topic reuse

### DIFF
--- a/qmtl/dagmanager/metrics.py
+++ b/qmtl/dagmanager/metrics.py
@@ -72,6 +72,14 @@ diff_failures_total = Counter(
 
 cross_context_cache_hit_total = get_cross_context_cache_hit_counter()
 
+cross_context_cache_violation_total = Counter(
+    "cross_context_cache_violation_total",
+    "Total number of cross-context cache violations detected during diff",
+    ["node_id", "world_id", "execution_domain"],
+    registry=global_registry,
+)
+cross_context_cache_violation_total._vals = {}  # type: ignore[attr-defined]
+
 sentinel_gap_count = Gauge(
     "sentinel_gap_count",
     "Number of missing sentinel events detected",
@@ -241,6 +249,8 @@ def reset_metrics() -> None:
     queue_lag_threshold_seconds._vals = {}  # type: ignore[attr-defined]
     if hasattr(cross_context_cache_hit_total, "clear"):
         cross_context_cache_hit_total.clear()
+    cross_context_cache_violation_total.clear()
+    cross_context_cache_violation_total._vals = {}  # type: ignore[attr-defined]
     if hasattr(dagmanager_active_version_weight, "clear"):
         dagmanager_active_version_weight.clear()
     dagmanager_active_version_weight._vals = {}  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- add a dedicated exception and metric to guard against cross-context queue reuse during DAG diffs
- persist compute-context snapshots on cached bindings so violations can report the prior domain
- update the queue binding regression test to assert the new failure path and metric

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest tests/dagmanager/test_diff_queue_binding.py -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest tests/dagmanager/test_diff_queue_binding.py -W error -n auto

Refs #1063

------
https://chatgpt.com/codex/tasks/task_e_68d1a7384a2083298a6e46e90e472eec