### PR TITLE
Refactor world service apply orchestration

### DIFF
--- a/qmtl/worldservice/activation.py
+++ b/qmtl/worldservice/activation.py
@@ -1,0 +1,169 @@
+"""Activation event orchestration for apply flows."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Sequence
+
+from qmtl.common.hashutils import hash_bytes
+
+from .controlbus_producer import ControlBusProducer
+from .run_state import ApplyRunState
+from .storage import Storage
+
+
+class ActivationEventPublisher:
+    """Publish activation mutations to storage and the control bus."""
+
+    def __init__(self, store: Storage, bus: ControlBusProducer | None) -> None:
+        self.store = store
+        self.bus = bus
+
+    async def upsert_activation(
+        self, world_id: str, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        version, data = await self.store.update_activation(
+            world_id, payload
+        )
+        if self.bus:
+            full_state = await self.store.get_activation(world_id)
+            state_payload = json.dumps(full_state, sort_keys=True).encode()
+            state_hash = hash_bytes(state_payload)
+            await self.bus.publish_activation_update(
+                world_id,
+                etag=data.get("etag", str(version)),
+                run_id=str(data.get("run_id") or ""),
+                ts=str(data.get("ts")),
+                state_hash=state_hash,
+                payload={
+                    key: val
+                    for key, val in payload.items()
+                    if key not in {"etag", "run_id", "ts"} and val is not None
+                },
+                version=version,
+            )
+        return data
+
+    async def update_activation_state(
+        self,
+        world_id: str,
+        payload: Dict[str, Any],
+        *,
+        phase: str | None = None,
+        requires_ack: bool = False,
+        sequence: int | None = None,
+    ) -> Dict[str, Any]:
+        version, data = await self.store.update_activation(world_id, payload)
+        if self.bus:
+            full_state = await self.store.get_activation(world_id)
+            state_payload = json.dumps(full_state, sort_keys=True).encode()
+            state_hash = hash_bytes(state_payload)
+            event_payload = {
+                key: val
+                for key, val in {
+                    **data,
+                    "strategy_id": payload["strategy_id"],
+                    "side": payload["side"],
+                    "phase": phase,
+                }.items()
+                if key not in {"etag", "run_id", "ts"} and val is not None
+            }
+            await self.bus.publish_activation_update(
+                world_id,
+                etag=data.get("etag", str(version)),
+                run_id=str(data.get("run_id") or ""),
+                ts=str(data.get("ts")),
+                state_hash=state_hash,
+                payload=event_payload,
+                version=version,
+                requires_ack=requires_ack,
+                sequence=sequence,
+            )
+        return data
+
+    async def freeze_world(
+        self,
+        world_id: str,
+        run_id: str,
+        snapshot: Dict[str, Any],
+        run_state: ApplyRunState,
+    ) -> None:
+        state = snapshot.get("state", {})
+        if not state:
+            return
+        for strategy_id, sides in state.items():
+            for side, entry in sides.items():
+                payload = {
+                    "strategy_id": strategy_id,
+                    "side": side,
+                    "active": False,
+                    "weight": entry.get("weight", 0.0),
+                    "freeze": True,
+                    "drain": True,
+                    "effective_mode": entry.get("effective_mode"),
+                    "run_id": run_id,
+                }
+                sequence = run_state.next_sequence()
+                await self.update_activation_state(
+                    world_id,
+                    payload,
+                    phase="freeze",
+                    requires_ack=True,
+                    sequence=sequence,
+                )
+
+    async def unfreeze_world(
+        self,
+        world_id: str,
+        run_id: str,
+        snapshot: Dict[str, Any],
+        run_state: ApplyRunState,
+        target_active: Sequence[str],
+    ) -> None:
+        state = snapshot.get("state", {})
+        active_set = set(target_active)
+        seen: set[tuple[str, str]] = set()
+        for strategy_id, sides in state.items():
+            for side, entry in sides.items():
+                seen.add((strategy_id, side))
+                active_flag = strategy_id in active_set
+                payload = {
+                    "strategy_id": strategy_id,
+                    "side": side,
+                    "active": active_flag,
+                    "weight": entry.get("weight", 1.0 if active_flag else 0.0),
+                    "freeze": False,
+                    "drain": False,
+                    "effective_mode": entry.get("effective_mode"),
+                    "run_id": run_id,
+                }
+                sequence = run_state.next_sequence()
+                await self.update_activation_state(
+                    world_id,
+                    payload,
+                    phase="unfreeze",
+                    requires_ack=True,
+                    sequence=sequence,
+                )
+
+        for strategy_id in active_set:
+            if all(strategy_id != sid for sid, _ in seen):
+                sequence = run_state.next_sequence()
+                await self.update_activation_state(
+                    world_id,
+                    {
+                        "strategy_id": strategy_id,
+                        "side": "long",
+                        "active": True,
+                        "weight": 1.0,
+                        "freeze": False,
+                        "drain": False,
+                        "run_id": run_id,
+                    },
+                    phase="unfreeze",
+                    requires_ack=True,
+                    sequence=sequence,
+                )
+
+
+__all__ = ["ActivationEventPublisher"]

--- a/qmtl/worldservice/apply_flow.py
+++ b/qmtl/worldservice/apply_flow.py
@@ -1,0 +1,267 @@
+"""Apply flow orchestration primitives."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from fastapi import HTTPException
+
+from qmtl.common.hashutils import hash_bytes
+
+from .activation import ActivationEventPublisher
+from .controlbus_producer import ControlBusProducer
+from .decision import DecisionEvaluator
+from .edge_overrides import EdgeOverrideManager, EdgeOverridePlan
+from .policy import GatingPolicy
+from .run_state import ApplyRunRegistry, ApplyRunState, ApplyStage
+from .schemas import ApplyAck, ApplyRequest
+from .storage import Storage
+
+
+@dataclass(slots=True)
+class ApplyContext:
+    world_id: str
+    payload: ApplyRequest
+    gating: GatingPolicy | None
+    plan: EdgeOverridePlan
+    target_active: List[str]
+    snapshot_full: Dict[str, Any]
+    snapshot_view: Dict[str, Any]
+    previous_decisions: List[str]
+
+
+class ApplyCoordinator:
+    """Coordinate the multi-stage apply lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        store: Storage,
+        bus: ControlBusProducer | None,
+        evaluator: DecisionEvaluator,
+        activation: ActivationEventPublisher,
+        runs: ApplyRunRegistry,
+    ) -> None:
+        self.store = store
+        self.bus = bus
+        self._evaluator = evaluator
+        self._activation = activation
+        self._runs = runs
+
+    async def apply(
+        self,
+        world_id: str,
+        payload: ApplyRequest,
+        gating: GatingPolicy | None,
+    ) -> ApplyAck:
+        existing = self._runs.get(world_id)
+        if existing:
+            ack = self._ack_for_existing(world_id, existing, payload.run_id)
+            if ack:
+                return ack
+
+        plan = self._plan_for(gating)
+        context = await self._build_context(world_id, payload, gating, plan)
+        state = self._runs.start(world_id, payload.run_id, context.target_active)
+        await self._record_requested(context, state)
+
+        edge_manager = EdgeOverrideManager(self.store, world_id)
+        try:
+            if plan.pre_disable:
+                await edge_manager.apply_pre_promotion(plan.pre_disable, payload.run_id)
+
+            await self._enter_freeze(context, state)
+            await self._switch_decisions(context, state)
+            await self._notify_policy_update(context)
+            await self._exit_freeze(context, state)
+
+            if plan.post_enable:
+                await edge_manager.apply_post_promotion(plan.post_enable, payload.run_id)
+
+            state.mark(ApplyStage.COMPLETED, completed=True)
+            await self.store.record_apply_stage(
+                context.world_id,
+                context.payload.run_id,
+                ApplyStage.COMPLETED.value,
+            )
+            return ApplyAck(
+                run_id=payload.run_id,
+                active=list(context.target_active),
+                phase=ApplyStage.COMPLETED.value,
+            )
+        except HTTPException:
+            await edge_manager.restore()
+            raise
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            await edge_manager.restore()
+            await self._handle_failure(context, state, exc)
+
+    def _ack_for_existing(
+        self, world_id: str, state: ApplyRunState, incoming_run_id: str
+    ) -> ApplyAck | None:
+        if not state.completed:
+            if state.run_id == incoming_run_id:
+                if state.stage is ApplyStage.ROLLED_BACK:
+                    return ApplyAck(
+                        ok=False,
+                        run_id=state.run_id,
+                        active=list(state.active),
+                        phase=state.stage.value,
+                    )
+                return ApplyAck(
+                    run_id=state.run_id,
+                    active=list(state.active),
+                    phase=state.stage.value,
+                )
+            if state.stage is ApplyStage.ROLLED_BACK:
+                self._runs.remove(world_id)
+            else:
+                raise HTTPException(status_code=409, detail="apply in progress")
+        elif state.run_id == incoming_run_id:
+            return ApplyAck(
+                run_id=state.run_id,
+                active=list(state.active),
+                phase=ApplyStage.COMPLETED.value,
+            )
+        return None
+
+    def _plan_for(self, gating: GatingPolicy | None) -> EdgeOverridePlan:
+        try:
+            return EdgeOverrideManager.plan_for(gating)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    async def _build_context(
+        self,
+        world_id: str,
+        payload: ApplyRequest,
+        gating: GatingPolicy | None,
+        plan: EdgeOverridePlan,
+    ) -> ApplyContext:
+        target_active = await self._evaluator.determine_active(world_id, payload)
+        previous_decisions = list(await self.store.get_decisions(world_id))
+        snapshot_full = await self.store.snapshot_activation(world_id)
+        snapshot_view = {
+            "state": {
+                sid: {side: dict(entry) for side, entry in sides.items()}
+                for sid, sides in snapshot_full.state.items()
+            }
+        }
+        return ApplyContext(
+            world_id=world_id,
+            payload=payload,
+            gating=gating,
+            plan=plan,
+            target_active=list(target_active),
+            snapshot_full=snapshot_full,
+            snapshot_view=snapshot_view,
+            previous_decisions=previous_decisions,
+        )
+
+    async def _record_requested(
+        self, context: ApplyContext, state: ApplyRunState
+    ) -> None:
+        state.mark(ApplyStage.REQUESTED, completed=False, active=context.target_active)
+        await self.store.record_apply_stage(
+            context.world_id,
+            context.payload.run_id,
+            ApplyStage.REQUESTED.value,
+            plan=context.payload.plan.model_dump() if context.payload.plan else None,
+            active=list(context.target_active),
+            gating_policy=(
+                context.gating.model_dump() if isinstance(context.gating, GatingPolicy) else None
+            ),
+        )
+
+    async def _enter_freeze(self, context: ApplyContext, state: ApplyRunState) -> None:
+        state.mark(ApplyStage.FREEZE)
+        await self._activation.freeze_world(
+            context.world_id,
+            context.payload.run_id,
+            context.snapshot_view,
+            state,
+        )
+        await self.store.record_apply_stage(
+            context.world_id,
+            context.payload.run_id,
+            ApplyStage.FREEZE.value,
+        )
+
+    async def _switch_decisions(self, context: ApplyContext, state: ApplyRunState) -> None:
+        await self.store.set_decisions(context.world_id, list(context.target_active))
+        state.mark(ApplyStage.SWITCH)
+        await self.store.record_apply_stage(
+            context.world_id,
+            context.payload.run_id,
+            ApplyStage.SWITCH.value,
+            active=list(context.target_active),
+        )
+
+    async def _notify_policy_update(self, context: ApplyContext) -> None:
+        if not self.bus:
+            return
+        version = await self.store.default_policy_version(context.world_id)
+        sorted_active = sorted(context.target_active)
+        digest_payload = json.dumps(sorted_active).encode()
+        checksum = hash_bytes(digest_payload)
+        ts = datetime.now(timezone.utc).isoformat()
+        await self.bus.publish_policy_update(
+            context.world_id,
+            policy_version=version,
+            checksum=checksum,
+            status="ACTIVE",
+            ts=ts,
+            version=version,
+        )
+
+    async def _exit_freeze(self, context: ApplyContext, state: ApplyRunState) -> None:
+        state.mark(ApplyStage.UNFREEZE)
+        await self._activation.unfreeze_world(
+            context.world_id,
+            context.payload.run_id,
+            context.snapshot_view,
+            state,
+            context.target_active,
+        )
+        await self.store.record_apply_stage(
+            context.world_id,
+            context.payload.run_id,
+            ApplyStage.UNFREEZE.value,
+        )
+
+    async def _handle_failure(
+        self, context: ApplyContext, state: ApplyRunState, exc: Exception
+    ) -> None:
+        await self.store.restore_activation(context.world_id, context.snapshot_full)
+        await self.store.set_decisions(context.world_id, list(context.previous_decisions))
+        await self.store.record_apply_stage(
+            context.world_id,
+            context.payload.run_id,
+            ApplyStage.ROLLED_BACK.value,
+            error=str(exc),
+            active=list(context.previous_decisions),
+        )
+        restored = await self.store.snapshot_activation(context.world_id)
+        restored_view = {
+            "state": {
+                sid: {side: dict(entry) for side, entry in sides.items()}
+                for sid, sides in restored.state.items()
+            }
+        }
+        await self._activation.freeze_world(
+            context.world_id,
+            context.payload.run_id,
+            restored_view,
+            state,
+        )
+        state.mark(
+            ApplyStage.ROLLED_BACK,
+            completed=False,
+            active=context.previous_decisions,
+        )
+        raise HTTPException(status_code=500, detail="apply failed") from exc
+
+__all__ = ["ApplyCoordinator", "ApplyContext"]

--- a/qmtl/worldservice/decision.py
+++ b/qmtl/worldservice/decision.py
@@ -1,0 +1,114 @@
+"""Decision evaluation helpers for world service flows."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from fastapi import HTTPException
+
+from qmtl.transforms.linearity_metrics import (
+    equity_linearity_metrics,
+    equity_linearity_metrics_v2,
+)
+
+from .policy_engine import evaluate_policy
+from .schemas import ApplyRequest, EvaluateRequest, StrategySeries
+from .storage import Storage
+
+
+def augment_metrics_with_linearity(
+    metrics: Dict[str, Dict[str, float]],
+    series: Dict[str, StrategySeries] | None,
+) -> Dict[str, Dict[str, float]]:
+    if not series:
+        return metrics
+
+    out: Dict[str, Dict[str, float]] = {k: dict(v) for k, v in (metrics or {}).items()}
+
+    equities: Dict[str, List[float]] = {}
+    for sid, s in series.items():
+        eq: List[float] | None
+        if s.equity:
+            eq = list(s.equity)
+        elif s.pnl:
+            eq = list(s.pnl)
+        elif s.returns:
+            cumulative = 0.0
+            eq = []
+            for value in s.returns:
+                cumulative += float(value)
+                eq.append(cumulative)
+        else:
+            eq = None
+        if eq and len(eq) >= 2:
+            equities[sid] = eq
+            m1 = equity_linearity_metrics(eq)
+            m2 = equity_linearity_metrics_v2(eq)
+            slot = out.setdefault(sid, {})
+            slot.update(
+                {
+                    "el_v1_score": m1["score"],
+                    "el_v1_r2_up": m1["r2_up"],
+                    "el_v1_straightness": m1["straightness_ratio"],
+                    "el_v1_monotonicity": m1["monotonicity"],
+                    "el_v1_new_high_frac": m1["new_high_frac"],
+                    "el_v1_net_gain": m1["net_gain"],
+                    "el_v2_score": m2["score"],
+                    "el_v2_tvr": m2["tvr"],
+                    "el_v2_tuw": m2["tuw"],
+                    "el_v2_r2_up": m2["r2_up"],
+                    "el_v2_spearman_rho": m2["spearman_rho"],
+                    "el_v2_t_slope": m2["t_slope"],
+                    "el_v2_t_slope_sig": m2["t_slope_sig"],
+                    "el_v2_mdd_norm": m2["mdd_norm"],
+                    "el_v2_net_gain": m2["net_gain"],
+                }
+            )
+
+    if equities:
+        minlen = min(len(v) for v in equities.values())
+        if minlen >= 2:
+            portfolio = [sum(v[i] for v in equities.values()) for i in range(minlen)]
+            p1 = equity_linearity_metrics(portfolio)
+            p2 = equity_linearity_metrics_v2(portfolio)
+            for sid in equities.keys():
+                slot = out.setdefault(sid, {})
+                slot.update(
+                    {
+                        "portfolio_el_v1_score": p1["score"],
+                        "portfolio_el_v2_score": p2["score"],
+                        "portfolio_el_v2_tvr": p2["tvr"],
+                        "portfolio_el_v2_tuw": p2["tuw"],
+                        "portfolio_el_v2_mdd_norm": p2["mdd_norm"],
+                    }
+                )
+
+    return out
+
+
+class DecisionEvaluator:
+    """Augment metric payloads and evaluate gating policies."""
+
+    def __init__(self, store: Storage) -> None:
+        self.store = store
+
+    async def determine_active(
+        self, world_id: str, payload: ApplyRequest | EvaluateRequest
+    ) -> List[str]:
+        if isinstance(payload, ApplyRequest) and payload.plan:
+            prev = payload.previous or await self.store.get_decisions(world_id)
+            activate = set(payload.plan.activate)
+            deactivate = set(payload.plan.deactivate)
+            return sorted((set(prev) - deactivate) | activate)
+
+        policy = payload.policy or await self.store.get_default_policy(world_id)
+        if policy is None:
+            raise HTTPException(status_code=404, detail="policy not found")
+        prev = payload.previous or await self.store.get_decisions(world_id)
+        metrics = augment_metrics_with_linearity(
+            payload.metrics or {}, getattr(payload, "series", None)
+        )
+        return evaluate_policy(metrics, policy, prev, payload.correlations)
+
+
+__all__ = ["DecisionEvaluator", "augment_metrics_with_linearity"]

--- a/qmtl/worldservice/edge_overrides.py
+++ b/qmtl/worldservice/edge_overrides.py
@@ -1,0 +1,117 @@
+"""Edge override management for apply gating scenarios."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Tuple
+
+from .policy import GatingPolicy
+from .storage import EXECUTION_DOMAINS, Storage
+
+
+@dataclass(slots=True)
+class EdgeOverridePlan:
+    """Normalized instructions derived from a gating policy."""
+
+    pre_disable: List[str] = field(default_factory=list)
+    post_enable: List[str] = field(default_factory=list)
+
+
+class EdgeOverrideManager:
+    """Manage edge overrides while recording previous state for restoration."""
+
+    def __init__(self, store: Storage, world_id: str) -> None:
+        self.store = store
+        self.world_id = world_id
+        self._restore: Dict[Tuple[str, str], Dict[str, Any] | None] = {}
+
+    @staticmethod
+    def plan_for(gating: GatingPolicy | None) -> EdgeOverridePlan:
+        if not isinstance(gating, GatingPolicy):
+            return EdgeOverridePlan()
+        return EdgeOverridePlan(
+            pre_disable=EdgeOverrideManager._coerce_edge_targets(
+                gating.edges.pre_promotion.disable_edges_to
+            ),
+            post_enable=EdgeOverrideManager._coerce_edge_targets(
+                gating.edges.post_promotion.enable_edges_to
+            ),
+        )
+
+    async def apply_pre_promotion(self, domains: Iterable[str], run_id: str) -> None:
+        for domain in domains:
+            await self._set_edge_override(
+                domain,
+                active=False,
+                reason=f"pre_promotion_disable:{run_id}",
+            )
+
+    async def apply_post_promotion(self, domains: Iterable[str], run_id: str) -> None:
+        for domain in domains:
+            await self._set_edge_override(
+                domain,
+                active=True,
+                reason=f"post_promotion_enable:{run_id}",
+            )
+
+    async def restore(self) -> None:
+        if not self._restore:
+            return
+        for (src_node_id, dst_node_id), previous in self._restore.items():
+            if previous is None:
+                await self.store.delete_edge_override(
+                    self.world_id, src_node_id, dst_node_id
+                )
+            else:
+                await self.store.upsert_edge_override(
+                    self.world_id,
+                    src_node_id,
+                    dst_node_id,
+                    active=bool(previous.get("active", False)),
+                    reason=previous.get("reason"),
+                )
+
+    async def _set_edge_override(
+        self,
+        domain: str,
+        *,
+        active: bool,
+        reason: str | None,
+    ) -> None:
+        src_node_id = "domain:backtest"
+        dst_node_id = f"domain:{domain}"
+        key = (src_node_id, dst_node_id)
+        if key not in self._restore:
+            self._restore[key] = await self.store.get_edge_override(
+                self.world_id, src_node_id, dst_node_id
+            )
+        await self.store.upsert_edge_override(
+            self.world_id,
+            src_node_id,
+            dst_node_id,
+            active=active,
+            reason=reason,
+        )
+
+    @staticmethod
+    def _coerce_edge_targets(value: Any) -> List[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            candidates: Iterable[str] = [value]
+        else:
+            candidates = list(value)
+        normalized = {EdgeOverrideManager._normalize_edge_domain(item) for item in candidates}
+        return sorted(normalized)
+
+    @staticmethod
+    def _normalize_edge_domain(candidate: str) -> str:
+        domain = str(candidate).strip().lower()
+        if not domain:
+            raise ValueError("edge override domain cannot be empty")
+        if domain not in EXECUTION_DOMAINS:
+            raise ValueError(f"unknown execution domain for edge override: {candidate}")
+        return domain
+
+
+__all__ = ["EdgeOverrideManager", "EdgeOverridePlan"]

--- a/qmtl/worldservice/run_state.py
+++ b/qmtl/worldservice/run_state.py
@@ -1,0 +1,88 @@
+"""State tracking helpers for world service apply flows."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, MutableMapping, Sequence
+
+
+class ApplyStage(str, Enum):
+    """Well-defined phases for the world apply state machine."""
+
+    REQUESTED = "requested"
+    FREEZE = "freeze"
+    SWITCH = "switch"
+    UNFREEZE = "unfreeze"
+    COMPLETED = "completed"
+    ROLLED_BACK = "rolled_back"
+
+
+@dataclass(slots=True)
+class ApplyRunState:
+    """In-memory representation of the progress of an apply invocation."""
+
+    run_id: str
+    active: list[str] = field(default_factory=list)
+    stage: ApplyStage = ApplyStage.REQUESTED
+    completed: bool = False
+    sequence: int = 0
+
+    def mark(
+        self,
+        stage: ApplyStage,
+        *,
+        completed: bool | None = None,
+        active: Sequence[str] | None = None,
+    ) -> None:
+        """Update the current stage metadata for the run."""
+
+        if active is not None:
+            self.active = list(active)
+        self.stage = stage
+        if completed is not None:
+            self.completed = completed
+
+    def next_sequence(self) -> int:
+        """Advance the activation event sequence counter."""
+
+        self.sequence += 1
+        return self.sequence
+
+
+class ApplyRunRegistry:
+    """Track active apply runs and provide per-world synchronization locks."""
+
+    def __init__(self) -> None:
+        self._runs: Dict[str, ApplyRunState] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+
+    def get(self, world_id: str) -> ApplyRunState | None:
+        return self._runs.get(world_id)
+
+    def start(self, world_id: str, run_id: str, active: Sequence[str]) -> ApplyRunState:
+        state = ApplyRunState(run_id=run_id, active=list(active))
+        self._runs[world_id] = state
+        return state
+
+    def remove(self, world_id: str) -> None:
+        self._runs.pop(world_id, None)
+
+    def lock_for(self, world_id: str) -> asyncio.Lock:
+        lock = self._locks.get(world_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[world_id] = lock
+        return lock
+
+    @property
+    def runs(self) -> MutableMapping[str, ApplyRunState]:
+        return self._runs
+
+    @property
+    def locks(self) -> MutableMapping[str, asyncio.Lock]:
+        return self._locks
+
+
+__all__ = ["ApplyRunRegistry", "ApplyRunState", "ApplyStage"]

--- a/qmtl/worldservice/services.py
+++ b/qmtl/worldservice/services.py
@@ -1,21 +1,15 @@
+"""Public service façade orchestrating world operations."""
+
 from __future__ import annotations
 
-import asyncio
-import json
-from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Sequence
+from typing import Dict
 
-from fastapi import HTTPException
-
-from qmtl.common.hashutils import hash_bytes
-from qmtl.transforms.linearity_metrics import (
-    equity_linearity_metrics,
-    equity_linearity_metrics_v2,
-)
-
+from .activation import ActivationEventPublisher
+from .apply_flow import ApplyCoordinator
 from .controlbus_producer import ControlBusProducer
+from .decision import DecisionEvaluator, augment_metrics_with_linearity
 from .policy import GatingPolicy
-from .policy_engine import evaluate_policy
+from .run_state import ApplyRunRegistry, ApplyRunState, ApplyStage
 from .schemas import (
     ActivationEnvelope,
     ActivationRequest,
@@ -25,20 +19,41 @@ from .schemas import (
     EvaluateRequest,
     StrategySeries,
 )
-from .storage import EXECUTION_DOMAINS, Storage
+from .storage import Storage
 
 
 class WorldService:
     """Business logic helpers for the world service FastAPI application."""
 
     def __init__(self, store: Storage, bus: ControlBusProducer | None = None) -> None:
-        self.store = store
         self.bus = bus
-        self.apply_locks: Dict[str, asyncio.Lock] = {}
-        self.apply_runs: Dict[str, Dict[str, Any]] = {}
+        self._runs = ApplyRunRegistry()
+        self.apply_runs = self._runs.runs
+        self.apply_locks = self._runs.locks
+        self._activation = ActivationEventPublisher(store, bus)
+        self._evaluator = DecisionEvaluator(store)
+        self._coordinator = ApplyCoordinator(
+            store=store,
+            bus=bus,
+            evaluator=self._evaluator,
+            activation=self._activation,
+            runs=self._runs,
+        )
+        self.store = store
+
+    @property
+    def store(self) -> Storage:
+        return self._store
+
+    @store.setter
+    def store(self, value: Storage) -> None:
+        self._store = value
+        self._activation.store = value
+        self._evaluator.store = value
+        self._coordinator.store = value
 
     async def evaluate(self, world_id: str, payload: EvaluateRequest) -> ApplyResponse:
-        active = await self._determine_active(world_id, payload)
+        active = await self._evaluator.determine_active(world_id, payload)
         return ApplyResponse(active=active)
 
     async def apply(
@@ -47,213 +62,14 @@ class WorldService:
         payload: ApplyRequest,
         gating: GatingPolicy | None,
     ) -> ApplyAck:
-        pre_disable: List[str] = []
-        post_enable: List[str] = []
-        if isinstance(gating, GatingPolicy):
-            try:
-                pre_disable = self._coerce_edge_targets(gating.edges.pre_promotion.disable_edges_to)
-                post_enable = self._coerce_edge_targets(gating.edges.post_promotion.enable_edges_to)
-            except ValueError as exc:
-                raise HTTPException(status_code=422, detail=str(exc)) from exc
-
-        lock = self._lock_for(world_id)
+        lock = self._runs.lock_for(world_id)
         async with lock:
-            state = self.apply_runs.get(world_id)
-            if state:
-                if not state.get("completed", False):
-                    stage = state.get("stage")
-                    if state.get("run_id") == payload.run_id:
-                        if stage == "rolled_back":
-                            return ApplyAck(
-                                ok=False,
-                                run_id=payload.run_id,
-                                active=list(state.get("active", [])),
-                                phase=stage,
-                            )
-                        return ApplyAck(
-                            run_id=payload.run_id,
-                            active=list(state.get("active", [])),
-                            phase=stage,
-                        )
-                    if stage == "rolled_back":
-                        self.apply_runs.pop(world_id, None)
-                        state = None
-                    else:
-                        raise HTTPException(status_code=409, detail="apply in progress")
-                elif state.get("run_id") == payload.run_id:
-                    return ApplyAck(
-                        run_id=payload.run_id,
-                        active=list(state.get("active", [])),
-                        phase="completed",
-                    )
-
-            target_active = await self._determine_active(world_id, payload)
-            previous_decisions = list(await self.store.get_decisions(world_id))
-            snapshot_full = await self.store.snapshot_activation(world_id)
-            snapshot_view = {
-                "state": {
-                    sid: {side: dict(entry) for side, entry in sides.items()}
-                    for sid, sides in snapshot_full.state.items()
-                }
-            }
-            run_state: Dict[str, Any] = {
-                "run_id": payload.run_id,
-                "stage": "requested",
-                "completed": False,
-                "sequence": 0,
-                "active": list(target_active),
-            }
-            self.apply_runs[world_id] = run_state
-
-            await self.store.record_apply_stage(
-                world_id,
-                payload.run_id,
-                "requested",
-                plan=payload.plan.model_dump() if payload.plan else None,
-                active=list(target_active),
-                gating_policy=gating.model_dump() if isinstance(gating, GatingPolicy) else None,
-            )
-
-            edge_restore: Dict[tuple[str, str], Dict[str, Any] | None] = {}
-
-            async def _set_edge_override(domain: str, *, active: bool, reason: str | None) -> None:
-                src_node_id = "domain:backtest"
-                dst_node_id = f"domain:{domain}"
-                key = (src_node_id, dst_node_id)
-                if key not in edge_restore:
-                    edge_restore[key] = await self.store.get_edge_override(world_id, src_node_id, dst_node_id)
-                await self.store.upsert_edge_override(
-                    world_id,
-                    src_node_id,
-                    dst_node_id,
-                    active=active,
-                    reason=reason,
-                )
-
-            async def _restore_edge_overrides() -> None:
-                if not edge_restore:
-                    return
-                for (src_node_id, dst_node_id), previous in edge_restore.items():
-                    if previous is None:
-                        await self.store.delete_edge_override(world_id, src_node_id, dst_node_id)
-                    else:
-                        await self.store.upsert_edge_override(
-                            world_id,
-                            src_node_id,
-                            dst_node_id,
-                            active=bool(previous.get("active", False)),
-                            reason=previous.get("reason"),
-                        )
-
-            try:
-                if isinstance(gating, GatingPolicy):
-                    for domain in pre_disable:
-                        await _set_edge_override(
-                            domain,
-                            active=False,
-                            reason=f"pre_promotion_disable:{payload.run_id}",
-                        )
-
-                await self._freeze_world(world_id, payload.run_id, snapshot_view, run_state)
-                run_state["stage"] = "freeze"
-                await self.store.record_apply_stage(world_id, payload.run_id, "freeze")
-
-                await self.store.set_decisions(world_id, list(target_active))
-                run_state["stage"] = "switch"
-                await self.store.record_apply_stage(
-                    world_id,
-                    payload.run_id,
-                    "switch",
-                    active=list(target_active),
-                )
-
-                version = await self.store.default_policy_version(world_id)
-                if self.bus:
-                    sorted_active = sorted(target_active)
-                    digest_payload = json.dumps(sorted_active).encode()
-                    checksum = hash_bytes(digest_payload)
-                    ts = datetime.now(timezone.utc).isoformat()
-                    await self.bus.publish_policy_update(
-                        world_id,
-                        policy_version=version,
-                        checksum=checksum,
-                        status="ACTIVE",
-                        ts=ts,
-                        version=version,
-                    )
-
-                await self._unfreeze_world(world_id, payload.run_id, snapshot_view, run_state, target_active)
-                run_state["stage"] = "unfreeze"
-                await self.store.record_apply_stage(world_id, payload.run_id, "unfreeze")
-
-                if isinstance(gating, GatingPolicy):
-                    for domain in post_enable:
-                        await _set_edge_override(
-                            domain,
-                            active=True,
-                            reason=f"post_promotion_enable:{payload.run_id}",
-                        )
-
-                run_state["completed"] = True
-                run_state["stage"] = "completed"
-                await self.store.record_apply_stage(world_id, payload.run_id, "completed")
-                return ApplyAck(run_id=payload.run_id, active=list(target_active), phase="completed")
-            except HTTPException:
-                await _restore_edge_overrides()
-                raise
-            except Exception as exc:  # pragma: no cover - defensive fallback
-                await self.store.restore_activation(world_id, snapshot_full)
-                await self.store.set_decisions(world_id, list(previous_decisions))
-                await self.store.record_apply_stage(
-                    world_id,
-                    payload.run_id,
-                    "rolled_back",
-                    error=str(exc),
-                    active=list(previous_decisions),
-                )
-                restored = await self.store.snapshot_activation(world_id)
-                await self._freeze_world(
-                    world_id,
-                    payload.run_id,
-                    {
-                        "state": {
-                            sid: {side: dict(entry) for side, entry in sides.items()}
-                            for sid, sides in restored.state.items()
-                        }
-                    },
-                    run_state,
-                )
-                run_state["active"] = list(previous_decisions)
-                run_state["stage"] = "rolled_back"
-                run_state["completed"] = False
-                await _restore_edge_overrides()
-                raise HTTPException(status_code=500, detail="apply failed") from exc
+            return await self._coordinator.apply(world_id, payload, gating)
 
     async def upsert_activation(self, world_id: str, payload: ActivationRequest) -> ActivationEnvelope:
-        version, data = await self.store.update_activation(
+        data = await self._activation.upsert_activation(
             world_id, payload.model_dump(exclude_unset=True)
         )
-        if self.bus:
-            full_state = await self.store.get_activation(world_id)
-            state_payload = json.dumps(full_state, sort_keys=True).encode()
-            state_hash = hash_bytes(state_payload)
-            await self.bus.publish_activation_update(
-                world_id,
-                etag=data.get("etag", str(version)),
-                run_id=str(data.get("run_id") or ""),
-                ts=str(data.get("ts")),
-                state_hash=state_hash,
-                payload={
-                    key: val
-                    for key, val in {
-                        **data,
-                        "strategy_id": payload.strategy_id,
-                        "side": payload.side,
-                    }.items()
-                    if key not in {"etag", "run_id", "ts"} and val is not None
-                },
-                version=version,
-            )
         return ActivationEnvelope(
             world_id=world_id,
             strategy_id=payload.strategy_id,
@@ -266,239 +82,12 @@ class WorldService:
         metrics: Dict[str, Dict[str, float]],
         series: Dict[str, StrategySeries] | None,
     ) -> Dict[str, Dict[str, float]]:
-        if not series:
-            return metrics
-        out: Dict[str, Dict[str, float]] = {k: dict(v) for k, v in (metrics or {}).items()}
-
-        equities: Dict[str, List[float]] = {}
-        for sid, s in series.items():
-            eq: List[float] | None
-            if s.equity:
-                eq = list(s.equity)
-            elif s.pnl:
-                eq = list(s.pnl)
-            elif s.returns:
-                cumulative = 0.0
-                eq = []
-                for value in s.returns:
-                    cumulative += float(value)
-                    eq.append(cumulative)
-            else:
-                eq = None
-            if eq and len(eq) >= 2:
-                equities[sid] = eq
-                m1 = equity_linearity_metrics(eq)
-                m2 = equity_linearity_metrics_v2(eq)
-                slot = out.setdefault(sid, {})
-                slot.update(
-                    {
-                        "el_v1_score": m1["score"],
-                        "el_v1_r2_up": m1["r2_up"],
-                        "el_v1_straightness": m1["straightness_ratio"],
-                        "el_v1_monotonicity": m1["monotonicity"],
-                        "el_v1_new_high_frac": m1["new_high_frac"],
-                        "el_v1_net_gain": m1["net_gain"],
-                        "el_v2_score": m2["score"],
-                        "el_v2_tvr": m2["tvr"],
-                        "el_v2_tuw": m2["tuw"],
-                        "el_v2_r2_up": m2["r2_up"],
-                        "el_v2_spearman_rho": m2["spearman_rho"],
-                        "el_v2_t_slope": m2["t_slope"],
-                        "el_v2_t_slope_sig": m2["t_slope_sig"],
-                        "el_v2_mdd_norm": m2["mdd_norm"],
-                        "el_v2_net_gain": m2["net_gain"],
-                    }
-                )
-
-        if equities:
-            minlen = min(len(v) for v in equities.values())
-            if minlen >= 2:
-                portfolio = [sum(v[i] for v in equities.values()) for i in range(minlen)]
-                p1 = equity_linearity_metrics(portfolio)
-                p2 = equity_linearity_metrics_v2(portfolio)
-                for sid in equities.keys():
-                    slot = out.setdefault(sid, {})
-                    slot.update(
-                        {
-                            "portfolio_el_v1_score": p1["score"],
-                            "portfolio_el_v2_score": p2["score"],
-                            "portfolio_el_v2_tvr": p2["tvr"],
-                            "portfolio_el_v2_tuw": p2["tuw"],
-                            "portfolio_el_v2_mdd_norm": p2["mdd_norm"],
-                        }
-                    )
-
-        return out
-
-    def _lock_for(self, world_id: str) -> asyncio.Lock:
-        lock = self.apply_locks.get(world_id)
-        if lock is None:
-            lock = asyncio.Lock()
-            self.apply_locks[world_id] = lock
-        return lock
-
-    def _next_sequence(self, state: Dict[str, Any]) -> int:
-        state["sequence"] = int(state.get("sequence", 0)) + 1
-        return state["sequence"]
-
-    def _coerce_edge_targets(self, value: Any) -> List[str]:
-        if value is None:
-            return []
-        if isinstance(value, str):
-            candidates: Iterable[str] = [value]
-        else:
-            candidates = list(value)
-        normalized = {self._normalize_edge_domain(item) for item in candidates}
-        return sorted(normalized)
-
-    def _normalize_edge_domain(self, candidate: str) -> str:
-        domain = str(candidate).strip().lower()
-        if not domain:
-            raise ValueError("edge override domain cannot be empty")
-        if domain not in EXECUTION_DOMAINS:
-            raise ValueError(f"unknown execution domain for edge override: {candidate}")
-        return domain
-
-    async def _determine_active(
-        self,
-        world_id: str,
-        payload: ApplyRequest | EvaluateRequest,
-    ) -> List[str]:
-        if isinstance(payload, ApplyRequest) and payload.plan:
-            prev = payload.previous or await self.store.get_decisions(world_id)
-            activate = set(payload.plan.activate)
-            deactivate = set(payload.plan.deactivate)
-            return sorted((set(prev) - deactivate) | activate)
-
-        policy = payload.policy or await self.store.get_default_policy(world_id)
-        if policy is None:
-            raise HTTPException(status_code=404, detail="policy not found")
-        prev = payload.previous or await self.store.get_decisions(world_id)
-        metrics = self.augment_metrics_with_linearity(
-            payload.metrics or {}, getattr(payload, "series", None)
-        )
-        return evaluate_policy(metrics, policy, prev, payload.correlations)
-
-    async def _update_activation_state(
-        self,
-        world_id: str,
-        payload: Dict[str, Any],
-        *,
-        phase: str | None = None,
-        requires_ack: bool = False,
-        sequence: int | None = None,
-    ) -> Dict[str, Any]:
-        version, data = await self.store.update_activation(world_id, payload)
-        if self.bus:
-            full_state = await self.store.get_activation(world_id)
-            state_payload = json.dumps(full_state, sort_keys=True).encode()
-            state_hash = hash_bytes(state_payload)
-            event_payload = {
-                key: val
-                for key, val in {
-                    **data,
-                    "strategy_id": payload["strategy_id"],
-                    "side": payload["side"],
-                    "phase": phase,
-                }.items()
-                if key not in {"etag", "run_id", "ts"} and val is not None
-            }
-            await self.bus.publish_activation_update(
-                world_id,
-                etag=data.get("etag", str(version)),
-                run_id=str(data.get("run_id") or ""),
-                ts=str(data.get("ts")),
-                state_hash=state_hash,
-                payload=event_payload,
-                version=version,
-                requires_ack=requires_ack,
-                sequence=sequence,
-            )
-        return data
-
-    async def _freeze_world(
-        self,
-        world_id: str,
-        run_id: str,
-        snapshot: Dict[str, Any],
-        run_state: Dict[str, Any],
-    ) -> None:
-        state = snapshot.get("state", {})
-        if not state:
-            return
-        for strategy_id, sides in state.items():
-            for side, entry in sides.items():
-                payload = {
-                    "strategy_id": strategy_id,
-                    "side": side,
-                    "active": False,
-                    "weight": entry.get("weight", 0.0),
-                    "freeze": True,
-                    "drain": True,
-                    "effective_mode": entry.get("effective_mode"),
-                    "run_id": run_id,
-                }
-                sequence = self._next_sequence(run_state)
-                await self._update_activation_state(
-                    world_id,
-                    payload,
-                    phase="freeze",
-                    requires_ack=True,
-                    sequence=sequence,
-                )
-
-    async def _unfreeze_world(
-        self,
-        world_id: str,
-        run_id: str,
-        snapshot: Dict[str, Any],
-        run_state: Dict[str, Any],
-        target_active: Sequence[str],
-    ) -> None:
-        state = snapshot.get("state", {})
-        active_set = set(target_active)
-        seen: set[tuple[str, str]] = set()
-        for strategy_id, sides in state.items():
-            for side, entry in sides.items():
-                seen.add((strategy_id, side))
-                active_flag = strategy_id in active_set
-                payload = {
-                    "strategy_id": strategy_id,
-                    "side": side,
-                    "active": active_flag,
-                    "weight": entry.get("weight", 1.0 if active_flag else 0.0),
-                    "freeze": False,
-                    "drain": False,
-                    "effective_mode": entry.get("effective_mode"),
-                    "run_id": run_id,
-                }
-                sequence = self._next_sequence(run_state)
-                await self._update_activation_state(
-                    world_id,
-                    payload,
-                    phase="unfreeze",
-                    requires_ack=True,
-                    sequence=sequence,
-                )
-
-        for strategy_id in active_set:
-            if all(strategy_id != sid for sid, _ in seen):
-                sequence = self._next_sequence(run_state)
-                await self._update_activation_state(
-                    world_id,
-                    {
-                        "strategy_id": strategy_id,
-                        "side": "long",
-                        "active": True,
-                        "weight": 1.0,
-                        "freeze": False,
-                        "drain": False,
-                        "run_id": run_id,
-                    },
-                    phase="unfreeze",
-                    requires_ack=True,
-                    sequence=sequence,
-                )
+        return augment_metrics_with_linearity(metrics, series)
 
 
-__all__ = ["WorldService"]
+__all__ = [
+    "ApplyRunRegistry",
+    "ApplyRunState",
+    "ApplyStage",
+    "WorldService",
+]

--- a/tests/e2e/test_domain_transition.py
+++ b/tests/e2e/test_domain_transition.py
@@ -11,6 +11,7 @@ from qmtl.sdk.node import ProcessingNode, StreamInput
 from qmtl.sdk.runner import Runner
 from qmtl.worldservice.api import create_app
 from qmtl.worldservice.controlbus_producer import ControlBusProducer
+from qmtl.worldservice.run_state import ApplyStage
 from qmtl.worldservice.storage import Storage
 
 
@@ -297,8 +298,8 @@ async def test_apply_rollback_restores_state(monkeypatch):
         assert stages == ["requested", "freeze", "rolled_back"]
 
         state = app.state.apply_runs["w-rollback"]
-        assert state["stage"] == "rolled_back"
-        assert state["completed"] is False
+        assert state.stage is ApplyStage.ROLLED_BACK
+        assert state.completed is False
 
         activation_events = _activation_events(bus, world_id="w-rollback")
         assert activation_events

--- a/tests/worldservice/test_apply_coordinator.py
+++ b/tests/worldservice/test_apply_coordinator.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from qmtl.worldservice.apply_flow import ApplyCoordinator
+from qmtl.worldservice.decision import DecisionEvaluator
+from qmtl.worldservice.policy import GatingPolicy
+from qmtl.worldservice.run_state import ApplyRunRegistry, ApplyStage
+from qmtl.worldservice.schemas import ApplyPlan, ApplyRequest
+
+
+class _StubActivationPublisher:
+    def __init__(self) -> None:
+        self.freeze_calls: list[tuple[str, str]] = []
+        self.unfreeze_calls: list[tuple[str, str, tuple[str, ...]]] = []
+
+    async def freeze_world(self, world_id: str, run_id: str, snapshot, state) -> None:
+        self.freeze_calls.append((world_id, run_id))
+
+    async def unfreeze_world(
+        self, world_id: str, run_id: str, snapshot, state, target_active
+    ) -> None:
+        self.unfreeze_calls.append((world_id, run_id, tuple(target_active)))
+
+
+class _StubBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict]] = []
+
+    async def publish_policy_update(
+        self,
+        world_id: str,
+        policy_version: int,
+        checksum: str,
+        status: str,
+        ts: str,
+        *,
+        version: int,
+    ) -> None:
+        self.events.append(
+            (
+                world_id,
+                status,
+                {
+                    "policy_version": policy_version,
+                    "checksum": checksum,
+                    "ts": ts,
+                    "version": version,
+                },
+            )
+        )
+
+
+class _StubStore:
+    def __init__(self) -> None:
+        self.decisions = ["alpha"]
+        self.snapshot_state = {
+            "alpha": {"long": {"weight": 1.0, "effective_mode": "paper"}}
+        }
+        self.edge_overrides: dict[tuple[str, str, str], dict | None] = {}
+        self.apply_stages: list[tuple[str, dict]] = []
+        self.failures_remaining = 0
+
+    async def get_decisions(self, world_id: str):
+        return list(self.decisions)
+
+    async def set_decisions(self, world_id: str, strategies: list[str]) -> None:
+        if self.failures_remaining:
+            self.failures_remaining -= 1
+            raise RuntimeError("forced failure")
+        self.decisions = list(strategies)
+
+    async def snapshot_activation(self, world_id: str):
+        return SimpleNamespace(state=copy.deepcopy(self.snapshot_state))
+
+    async def restore_activation(self, world_id: str, snapshot) -> None:
+        self.snapshot_state = copy.deepcopy(snapshot.state)
+
+    async def record_apply_stage(self, world_id: str, run_id: str, stage: str, **details):
+        self.apply_stages.append((stage, details))
+
+    async def default_policy_version(self, world_id: str) -> int:
+        return 1
+
+    async def get_edge_override(self, world_id: str, src: str, dst: str):
+        return self.edge_overrides.get((world_id, src, dst))
+
+    async def upsert_edge_override(
+        self,
+        world_id: str,
+        src: str,
+        dst: str,
+        *,
+        active: bool,
+        reason: str | None,
+    ):
+        entry = {"active": active, "reason": reason}
+        self.edge_overrides[(world_id, src, dst)] = entry
+        return entry
+
+    async def delete_edge_override(self, world_id: str, src: str, dst: str) -> None:
+        self.edge_overrides.pop((world_id, src, dst), None)
+
+
+def _gating_policy() -> GatingPolicy:
+    return GatingPolicy.model_validate(
+        {
+            "dataset_fingerprint": "ohlcv:demo",
+            "share_policy": "feature-artifacts-only",
+            "snapshot": {"strategy_plane": "cow", "feature_plane": "readonly"},
+            "edges": {
+                "pre_promotion": {"disable_edges_to": "live"},
+                "post_promotion": {"enable_edges_to": ["live"]},
+            },
+            "observability": {"slo": {"cross_context_cache_hit": 0}},
+        }
+    )
+
+
+def _make_request(run_id: str) -> ApplyRequest:
+    return ApplyRequest(run_id=run_id, plan=ApplyPlan(activate=["beta"]))
+
+
+@pytest.mark.asyncio
+async def test_apply_coordinator_applies_gating_overrides() -> None:
+    store = _StubStore()
+    runs = ApplyRunRegistry()
+    activation = _StubActivationPublisher()
+    bus = _StubBus()
+    coordinator = ApplyCoordinator(
+        store=store,
+        bus=bus,
+        evaluator=DecisionEvaluator(store),
+        activation=activation,
+        runs=runs,
+    )
+
+    ack = await coordinator.apply("world", _make_request("run-1"), _gating_policy())
+
+    assert ack.phase == "completed"
+    assert runs.get("world").stage is ApplyStage.COMPLETED
+    key = ("world", "domain:backtest", "domain:live")
+    assert store.edge_overrides[key]["reason"] == "post_promotion_enable:run-1"
+    assert activation.freeze_calls and activation.unfreeze_calls
+    assert bus.events[0][0] == "world"
+
+
+@pytest.mark.asyncio
+async def test_apply_coordinator_rolls_back_and_clears_state() -> None:
+    store = _StubStore()
+    store.failures_remaining = 1
+    runs = ApplyRunRegistry()
+    coordinator = ApplyCoordinator(
+        store=store,
+        bus=None,
+        evaluator=DecisionEvaluator(store),
+        activation=_StubActivationPublisher(),
+        runs=runs,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await coordinator.apply("world", _make_request("run-err"), None)
+    assert exc.value.status_code == 500
+
+    state = runs.get("world")
+    assert state is not None
+    assert state.stage is ApplyStage.ROLLED_BACK
+
+    store.failures_remaining = 0
+    ack = await coordinator.apply("world", _make_request("run-ok"), None)
+    assert ack.phase == "completed"
+    assert runs.get("world").stage is ApplyStage.COMPLETED

--- a/tests/worldservice/test_edge_overrides.py
+++ b/tests/worldservice/test_edge_overrides.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.worldservice.edge_overrides import EdgeOverrideManager
+from qmtl.worldservice.policy import GatingPolicy
+
+
+class _StubStore:
+    def __init__(self) -> None:
+        self.overrides: dict[tuple[str, str, str], dict | None] = {}
+
+    async def get_edge_override(self, world_id: str, src: str, dst: str):
+        return self.overrides.get((world_id, src, dst))
+
+    async def upsert_edge_override(
+        self,
+        world_id: str,
+        src: str,
+        dst: str,
+        *,
+        active: bool,
+        reason: str | None,
+    ):
+        entry = {"active": active, "reason": reason}
+        self.overrides[(world_id, src, dst)] = entry
+        return entry
+
+    async def delete_edge_override(self, world_id: str, src: str, dst: str) -> None:
+        self.overrides.pop((world_id, src, dst), None)
+
+
+def _policy() -> GatingPolicy:
+    return GatingPolicy.model_validate(
+        {
+            "dataset_fingerprint": "demo",
+            "share_policy": "feature-artifacts-only",
+            "snapshot": {"strategy_plane": "cow", "feature_plane": "readonly"},
+            "edges": {
+                "pre_promotion": {"disable_edges_to": ["dryrun", "live"]},
+                "post_promotion": {"enable_edges_to": "live"},
+            },
+            "observability": {"slo": {"cross_context_cache_hit": 0}},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_edge_override_manager_plan_and_restore() -> None:
+    store = _StubStore()
+    manager = EdgeOverrideManager(store, "world")
+    plan = EdgeOverrideManager.plan_for(_policy())
+
+    assert plan.pre_disable == ["dryrun", "live"]
+    assert plan.post_enable == ["live"]
+
+    await manager.apply_pre_promotion(plan.pre_disable, "run-1")
+    await manager.apply_post_promotion(plan.post_enable, "run-1")
+
+    key = ("world", "domain:backtest", "domain:live")
+    assert store.overrides[key]["reason"] == "post_promotion_enable:run-1"
+
+    await manager.restore()
+    assert key not in store.overrides
+
+
+def test_edge_override_manager_rejects_unknown_domain() -> None:
+    policy = _policy().model_copy()
+    policy.edges.post_promotion.enable_edges_to = ["unknown"]
+    with pytest.raises(ValueError):
+        EdgeOverrideManager.plan_for(policy)


### PR DESCRIPTION
## Summary
- decompose `WorldService` so apply/evaluate orchestration uses modular helpers and exposes typed run state tracking
- add dedicated coordinator, activation publisher, decision evaluator, and edge override manager modules to isolate business logic
- introduce focused tests for gating, rollback, and edge override normalization alongside updated e2e assertions

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto`

Fixes #1054

------
https://chatgpt.com/codex/tasks/task_e_68d1d5292148832981e3262055e4f1c5