### PR TITLE
Align compute key semantics with architecture spec

### DIFF
--- a/qmtl/common/compute_key.py
+++ b/qmtl/common/compute_key.py
@@ -19,6 +19,6 @@ def compute_compute_key(node_hash: str, context: ComputeContext) -> str:
     node_part = str(node_hash or "")
     world, domain, as_of, partition = context.hash_components()
     if not domain:
-        domain = DEFAULT_EXECUTION_DOMAIN
+        domain = "backtest"
     payload = "\x1f".join((node_part, world, domain, as_of, partition)).encode()
     return f"blake3:{blake3(payload).hexdigest()}"

--- a/tests/common/test_compute_context_defaults.py
+++ b/tests/common/test_compute_context_defaults.py
@@ -1,0 +1,30 @@
+import pytest
+
+from qmtl.common.compute_context import ComputeContext, DowngradeReason
+
+
+def test_default_context_enters_safe_mode_when_domain_missing() -> None:
+    ctx = ComputeContext()
+
+    assert ctx.execution_domain == "backtest"
+    assert ctx.safe_mode is True
+    assert ctx.downgraded is True
+    assert ctx.downgrade_reason is DowngradeReason.DECISION_UNAVAILABLE
+    assert ctx.hash_components()[1] == "backtest"
+
+
+def test_dryrun_without_as_of_downgrades_to_compute_only() -> None:
+    ctx = ComputeContext(world_id="w", execution_domain="dryrun", as_of=None)
+
+    assert ctx.execution_domain == "backtest"
+    assert ctx.safe_mode is True
+    assert ctx.downgraded is True
+    assert ctx.downgrade_reason is DowngradeReason.MISSING_AS_OF
+
+
+def test_live_domain_preserves_execution_state() -> None:
+    ctx = ComputeContext(world_id="w", execution_domain="live", as_of=None)
+
+    assert ctx.execution_domain == "live"
+    assert ctx.safe_mode is False
+    assert ctx.downgraded is False

--- a/tests/dagmanager/test_kafka_compute_key.py
+++ b/tests/dagmanager/test_kafka_compute_key.py
@@ -1,0 +1,24 @@
+from qmtl.common.compute_context import ComputeContext
+from qmtl.common.compute_key import compute_compute_key
+from qmtl.dagmanager.kafka_admin import compute_key
+
+
+def test_compute_key_matches_common_helper() -> None:
+    context = ComputeContext(world_id="world-x")
+    expected = compute_compute_key("node-1", context)
+
+    assert compute_key("node-1", world_id="world-x") == expected
+
+
+def test_compute_key_ignores_dataset_fingerprint() -> None:
+    base = compute_key("node-1", world_id="world-x", dataset_fingerprint="fp-a")
+    changed = compute_key("node-1", world_id="world-x", dataset_fingerprint="fp-b")
+
+    assert base == changed
+
+
+def test_compute_key_falls_back_to_compute_only_domain() -> None:
+    auto = compute_key("node-1", world_id="world-x")
+    explicit = compute_key("node-1", world_id="world-x", execution_domain="backtest")
+
+    assert auto == explicit

--- a/tests/gateway/test_submission_context_service.py
+++ b/tests/gateway/test_submission_context_service.py
@@ -135,4 +135,7 @@ async def test_build_without_worlds() -> None:
 
     assert strategy_ctx.context.world_id == ""
     assert strategy_ctx.worlds_list() == []
-    assert strategy_ctx.redis_mapping() == {}
+    assert strategy_ctx.redis_mapping() == {
+        "compute_execution_domain": "backtest",
+        "compute_downgrade_reason": "decision_unavailable",
+    }

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -161,7 +161,7 @@ def test_submit_tag_query_node(client):
             {"queue": "q2", "global": False},
         ]
     }
-    assert dag.called_with == (["t1"], 60, "any", None, None)
+    assert dag.called_with == (["t1"], 60, "any", None, "backtest")
 
 
 def test_multiple_tag_query_nodes_handle_errors(fake_redis):


### PR DESCRIPTION
## Summary
- treat missing execution domain metadata as compute-only by default and flag safe mode in `ComputeContext`
- reuse the shared compute key helper inside the DAG manager and drop dataset fingerprint from the key salt
- cover the new behaviour with targeted tests and adjust gateway expectations accordingly

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1072

------
https://chatgpt.com/codex/tasks/task_e_68d1e6881ef08329881ea7fdcabe50cc