### PR TITLE
Modularize NodeCache internals

### DIFF
--- a/qmtl/sdk/cache.py
+++ b/qmtl/sdk/cache.py
@@ -1,93 +1,75 @@
 from __future__ import annotations
 
-import json
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable, Mapping
 
 import numpy as np
 import xarray as xr
 
-from .cache_view import CacheView
-from .backfill_state import BackfillState
-from . import metrics as sdk_metrics
 from . import hash_utils as default_hash_utils
+from . import metrics as sdk_metrics
+from .backfill_state import BackfillState
+from .cache_backfill import BackfillMerger
+from .cache_context import ContextSwitchStrategy, ComputeContext
+from .cache_reader import CacheWindowReader
+from .cache_ring_buffer import RingBuffer
+from .cache_view import CacheView
 from qmtl.common.compute_key import DEFAULT_EXECUTION_DOMAIN
 
-
-class _RingBuffer:
-    def __init__(self, period: int) -> None:
-        self.period = period
-        self.data = np.empty((period, 2), dtype=object)
-        self.data[:] = None
-        self.offset = 0
-        self.filled = 0
-
-    def append(self, timestamp: int, payload: Any) -> None:
-        self.data[self.offset, 0] = timestamp
-        self.data[self.offset, 1] = payload
-        self.offset = (self.offset + 1) % self.period
-        if self.filled < self.period:
-            self.filled += 1
-
-    def ordered(self) -> np.ndarray:
-        if self.filled < self.period:
-            return np.concatenate((self.data[self.filled :], self.data[: self.filled]))
-        return np.concatenate((self.data[self.offset :], self.data[: self.offset]))
-
-    def latest(self) -> tuple[int, Any] | None:
-        if self.filled == 0:
-            return None
-        idx = (self.offset - 1) % self.period
-        ts = self.data[idx, 0]
-        if ts is None:
-            return None
-        return int(ts), self.data[idx, 1]
+RingBufferFactory = Callable[[int], RingBuffer]
+ReaderFactory = Callable[[Mapping[tuple[str, int], RingBuffer], int], CacheWindowReader]
 
 
 class NodeCache:
     """In-memory cache backed by per-pair ring buffers."""
 
-    def __init__(self, period: int) -> None:
+    def __init__(
+        self,
+        period: int,
+        *,
+        metrics: Any = sdk_metrics,
+        context_strategy: ContextSwitchStrategy | None = None,
+        backfill_merger: BackfillMerger | None = None,
+        ring_buffer_factory: RingBufferFactory | None = None,
+        reader_factory: ReaderFactory | None = None,
+    ) -> None:
         self.period = period
-        self._buffers: dict[tuple[str, int], _RingBuffer] = {}
+        self._buffers: dict[tuple[str, int], RingBuffer] = {}
         self._last_ts: dict[tuple[str, int], int | None] = {}
         self._missing: dict[tuple[str, int], bool] = {}
-        self._filled: dict[tuple[str, int], int] = {}
-        self._offset: dict[tuple[str, int], int] = {}
         self.backfill_state = BackfillState()
+
+        self._context_strategy = context_strategy or ContextSwitchStrategy(metrics)
+        self._backfill_merger = backfill_merger or BackfillMerger(period)
+        self._ring_buffer_factory = ring_buffer_factory or RingBuffer
+        self._reader_factory: ReaderFactory = reader_factory or (
+            lambda buffers, period: CacheWindowReader(buffers, period=period)
+        )
+
         self._active_compute_key: str | None = None
         self._active_world_id: str = ""
         self._active_execution_domain: str = DEFAULT_EXECUTION_DOMAIN
         self._active_as_of: Any | None = None
         self._active_partition: Any | None = None
 
-    def _ordered_array(self, u: str, interval: int) -> np.ndarray:
-        """Return internal array for ``(u, interval)`` ordered oldest->latest."""
-        buf = self._buffers[(u, interval)]
-        filled = self._filled.get((u, interval), 0)
-        offset = self._offset.get((u, interval), 0)
-        if filled < self.period:
-            return np.concatenate((buf.data[filled:], buf.data[:filled]))
-        return np.concatenate((buf.data[offset:], buf.data[:offset]))
+    @property
+    def active_context(self) -> ComputeContext | None:
+        return self._context_strategy.active
 
-    # ------------------------------------------------------------------
-    def _ensure_buffer(self, u: str, interval: int) -> _RingBuffer:
-        key = (u, interval)
+    def _ensure_buffer(self, upstream_id: str, interval: int) -> RingBuffer:
+        key = (upstream_id, interval)
         if key not in self._buffers:
-            self._buffers[key] = _RingBuffer(self.period)
+            self._buffers[key] = self._ring_buffer_factory(self.period)
             self._last_ts[key] = None
             self._missing[key] = False
-            self._filled[key] = 0
-            self._offset[key] = 0
         return self._buffers[key]
 
     def _clear_all(self) -> None:
         self._buffers.clear()
         self._last_ts.clear()
         self._missing.clear()
-        self._filled.clear()
-        self._offset.clear()
         self.backfill_state = BackfillState()
 
+    # ------------------------------------------------------------------
     def activate_compute_key(
         self,
         compute_key: str | None,
@@ -100,89 +82,57 @@ class NodeCache:
     ) -> None:
         """Activate ``compute_key`` and clear data when the context changes."""
 
-        key = compute_key or "__default__"
-        world = str(world_id or "")
-        domain = str(execution_domain or DEFAULT_EXECUTION_DOMAIN)
-        as_of_val = as_of
-        partition_val = partition
-        if self._active_compute_key is None:
-            self._active_compute_key = key
-            self._active_world_id = world
-            self._active_execution_domain = domain
-            self._active_as_of = as_of_val
-            self._active_partition = partition_val
-            return
-        if self._active_compute_key == key:
-            self._active_world_id = world
-            self._active_execution_domain = domain
-            self._active_as_of = as_of_val
-            self._active_partition = partition_val
-            return
-        had_data = bool(self._buffers)
-        self._clear_all()
-        self._active_compute_key = key
-        self._active_world_id = world
-        self._active_execution_domain = domain
-        self._active_as_of = as_of_val
-        self._active_partition = partition_val
-        if had_data:
-            sdk_metrics.observe_cross_context_cache_hit(
-                node_id,
-                world,
-                domain,
-                as_of=str(as_of_val) if as_of_val is not None else None,
-                partition=str(partition_val) if partition_val is not None else None,
-            )
+        context, cleared = self._context_strategy.ensure(
+            compute_key,
+            node_id=node_id,
+            world_id=world_id,
+            execution_domain=execution_domain,
+            as_of=as_of,
+            partition=partition,
+            had_data=bool(self._buffers),
+        )
+        self._active_compute_key = context.compute_key
+        self._active_world_id = context.world_id
+        self._active_execution_domain = context.execution_domain
+        self._active_as_of = context.as_of
+        self._active_partition = context.partition
+        if cleared:
+            self._clear_all()
 
-    def append(self, u: str, interval: int, timestamp: int, payload: Any) -> None:
-        """Insert ``payload`` with ``timestamp`` for ``(u, interval)``."""
-        buf = self._ensure_buffer(u, interval)
+    def append(self, upstream_id: str, interval: int, timestamp: int, payload: Any) -> None:
+        """Insert ``payload`` with ``timestamp`` for ``(upstream_id, interval)``."""
+
+        buffer = self._ensure_buffer(upstream_id, interval)
         timestamp_bucket = timestamp - (timestamp % interval)
-        prev = self._last_ts.get((u, interval))
+        key = (upstream_id, interval)
+        prev = self._last_ts.get(key)
         if prev is None:
-            self._missing[(u, interval)] = False
-            self._last_ts[(u, interval)] = timestamp_bucket
+            self._missing[key] = False
+            self._last_ts[key] = timestamp_bucket
         else:
             if timestamp_bucket < prev:
-                # Late arrival: do not regress last_ts nor set missing
-                self._missing[(u, interval)] = False
+                self._missing[key] = False
             else:
-                self._missing[(u, interval)] = prev + interval != timestamp_bucket
-                self._last_ts[(u, interval)] = timestamp_bucket
-        off = self._offset.get((u, interval), 0)
-        buf.data[off, 0] = timestamp_bucket
-        buf.data[off, 1] = payload
-        off = (off + 1) % self.period
-        self._offset[(u, interval)] = off
-        buf.offset = off
-        filled = self._filled.get((u, interval), 0)
-        if filled < self.period:
-            filled += 1
-        self._filled[(u, interval)] = filled
-        buf.filled = filled
+                self._missing[key] = prev + interval != timestamp_bucket
+                self._last_ts[key] = timestamp_bucket
+        buffer.append(timestamp_bucket, payload)
 
     # ------------------------------------------------------------------
     def ready(self) -> bool:
         if not self._buffers:
             return False
-        for count in self._filled.values():
-            if count < self.period:
+        for buffer in self._buffers.values():
+            if buffer.filled < self.period:
                 return False
         return True
 
-    def _snapshot(self) -> dict[str, dict[int, list[tuple[int, Any]]]]:
-        """Return a deep copy of the cache contents.
+    def _reader(self) -> CacheWindowReader:
+        return self._reader_factory(self._buffers, self.period)
 
-        This helper exists primarily for tests and should not be relied on by
-        strategy code. ``CacheView`` instances returned by :meth:`view` provide
-        the recommended read-only access to the cache.
-        """
-        result: dict[str, dict[int, list[tuple[int, Any]]]] = {}
-        for (u, i), buf in self._buffers.items():
-            result.setdefault(u, {})[i] = [
-                (int(t), v) for t, v in self._ordered_array(u, i) if t is not None
-            ]
-        return result
+    def _snapshot(self) -> dict[str, dict[int, list[tuple[int, Any]]]]:
+        """Return a deep copy of the cache contents (for tests)."""
+
+        return self._reader().snapshot()
 
     def view(
         self,
@@ -192,47 +142,34 @@ class NodeCache:
     ) -> CacheView:
         """Return a :class:`CacheView` over the current cache contents."""
 
-        data: dict[str, dict[int, list[tuple[int, Any]]]] = {}
-        for (u, i), buf in self._buffers.items():
-            data.setdefault(u, {})[i] = [
-                (int(t), v) for t, v in self._ordered_array(u, i) if t is not None
-            ]
+        data = self._reader().view_data()
         return CacheView(data, track_access=track_access, artifact_plane=artifact_plane)
 
     def missing_flags(self) -> dict[str, dict[int, bool]]:
-        """Return gap flags for all ``(u, interval)`` pairs."""
+        """Return gap flags for all ``(upstream_id, interval)`` pairs."""
+
         result: dict[str, dict[int, bool]] = {}
-        for (u, i), flag in self._missing.items():
-            result.setdefault(u, {})[i] = flag
+        for (upstream, interval), flag in self._missing.items():
+            result.setdefault(upstream, {})[interval] = flag
         return result
 
     def last_timestamps(self) -> dict[str, dict[int, int | None]]:
-        """Return last timestamps for all ``(u, interval)`` pairs."""
+        """Return last timestamps for all ``(upstream_id, interval)`` pairs."""
+
         result: dict[str, dict[int, int | None]] = {}
-        for (u, i), ts in self._last_ts.items():
-            result.setdefault(u, {})[i] = ts
+        for (upstream, interval), ts in self._last_ts.items():
+            result.setdefault(upstream, {})[interval] = ts
         return result
 
     def input_window_hash(self, *, hash_utils=default_hash_utils) -> str:
-        """Return a stable hash of the current cache window.
+        """Return a stable hash of the current cache window."""
 
-        The hash covers all ``(upstream_id, interval)`` slices ordered by
-        upstream and interval. It is suitable for commit-log de-duplication of
-        node outputs.
-        """
-
-        ordered: list[tuple[str, int, list[tuple[int, Any]]]] = []
-        for (u, i), buf in sorted(self._buffers.items()):
-            items = [
-                (int(t), v) for t, v in self._ordered_array(u, i) if t is not None
-            ]
-            ordered.append((u, i, items))
-        blob = json.dumps(ordered, sort_keys=True, default=repr).encode()
-        return hash_utils._sha256(blob)
+        return self._reader().input_window_hash(hash_utils=hash_utils)
 
     # ------------------------------------------------------------------
     def watermark(self, *, allowed_lateness: int = 0) -> int | None:
         """Return event-time watermark for the cache."""
+
         last = [ts for ts in self._last_ts.values() if ts is not None]
         if not last:
             return None
@@ -240,70 +177,52 @@ class NodeCache:
 
     def as_xarray(self) -> xr.DataArray:
         """Return a read-only ``xarray`` view of the internal tensor."""
-        u_vals = sorted({u for u, _ in self._buffers.keys()})
-        i_vals = sorted({i for _, i in self._buffers.keys()})
-        data = np.empty((len(u_vals), len(i_vals), self.period, 2), dtype=object)
-        data[:] = None
-        for u_idx, u in enumerate(u_vals):
-            for i_idx, i in enumerate(i_vals):
-                if (u, i) in self._buffers:
-                    data[u_idx, i_idx] = self._ordered_array(u, i)
-        da = xr.DataArray(
-            data,
-            dims=("u", "i", "p", "f"),
-            coords={"u": u_vals, "i": i_vals, "p": list(range(self.period)), "f": ["t", "v"]},
-        )
-        da.data = da.data.view()
-        da.data.setflags(write=False)
-        return da
+
+        return self._reader().as_xarray()
 
     @property
     def resident_bytes(self) -> int:
         """Return total memory used by cached arrays in bytes."""
-        return sum(buf.data.nbytes for buf in self._buffers.values())
+
+        return sum(buffer.nbytes for buffer in self._buffers.values())
 
     # ------------------------------------------------------------------
-    def drop(self, u: str, interval: int) -> None:
-        """Remove cached data for ``(u, interval)``."""
-        key = (u, interval)
-        self._buffers.pop(key, None)
-        self._last_ts.pop(key, None)
-        self._missing.pop(key, None)
-        self._filled.pop(key, None)
-        self._offset.pop(key, None)
-        self.backfill_state._ranges.pop(key, None)
+    def drop(self, upstream_id: str, interval: int) -> None:
+        """Remove cached data for ``(upstream_id, interval)``."""
 
-    def drop_upstream(self, upstream_id: str, interval: int) -> None:
-        """Alias for :meth:`drop` removing cache for ``upstream_id``."""
         key = (upstream_id, interval)
         self._buffers.pop(key, None)
         self._last_ts.pop(key, None)
         self._missing.pop(key, None)
-        self._filled.pop(key, None)
-        self._offset.pop(key, None)
         self.backfill_state._ranges.pop(key, None)
 
+    def drop_upstream(self, upstream_id: str, interval: int) -> None:
+        """Alias for :meth:`drop` removing cache for ``upstream_id``."""
+
+        self.drop(upstream_id, interval)
+
     # ------------------------------------------------------------------
-    def latest(self, u: str, interval: int) -> tuple[int, Any] | None:
+    def latest(self, upstream_id: str, interval: int) -> tuple[int, Any] | None:
         """Return the most recent ``(timestamp, payload)`` for a pair."""
-        buf = self._buffers.get((u, interval))
-        if not buf:
+
+        buffer = self._buffers.get((upstream_id, interval))
+        if buffer is None:
             return None
-        return buf.latest()
+        return buffer.latest()
 
     def get_slice(
         self,
-        u: str,
+        upstream_id: str,
         interval: int,
         *,
         count: int | None = None,
         start: int | None = None,
         end: int | None = None,
     ):
-        """Return a windowed slice for ``(u, interval)``."""
+        """Return a windowed slice for ``(upstream_id, interval)``."""
 
-        buf = self._buffers.get((u, interval))
-        if buf is None:
+        buffer = self._buffers.get((upstream_id, interval))
+        if buffer is None:
             if count is not None:
                 return []
             return xr.DataArray(
@@ -312,22 +231,14 @@ class NodeCache:
                 coords={"p": [], "f": ["t", "v"]},
             )
 
-        filled = self._filled.get((u, interval), 0)
-        off = self._offset.get((u, interval), 0)
-        arr = buf.data
-
         if count is not None:
             if count <= 0:
                 return []
-            n = min(count, filled)
-            if filled < self.period:
-                data = arr[:filled]
-            else:
-                data = np.concatenate((arr[off:], arr[:off]))
-            subset = data[-n:]
-            return [(int(t), v) for t, v in subset if t is not None]
+            items = buffer.items()
+            subset = items[-min(count, len(items)) :]
+            return subset
 
-        ordered = self._ordered_array(u, interval)
+        ordered = buffer.ordered_array()
 
         slice_start = start if start is not None else 0
         slice_end = end if end is not None else self.period
@@ -346,68 +257,32 @@ class NodeCache:
 
     def backfill_bulk(
         self,
-        u: str,
+        upstream_id: str,
         interval: int,
         items: Iterable[tuple[int, Any]],
     ) -> None:
-        """Merge historical ``items`` with existing cache contents.
+        """Merge historical ``items`` with existing cache contents."""
 
-        ``items`` must be ordered by timestamp in ascending order. Existing
-        payloads are kept when timestamps collide so that live ``append()``
-        calls that happen during a backfill take precedence.
-        """
+        buffer = self._ensure_buffer(upstream_id, interval)
+        result = self._backfill_merger.merge(buffer, interval, items)
 
-        self._ensure_buffer(u, interval)
+        if result.bucketed_items:
+            self.backfill_state.mark_ranges(upstream_id, interval, result.ranges)
 
-        backfill_items: list[tuple[int, Any]] = []
-        for ts, payload in items:
-            bucket = ts - (ts % interval)
-            backfill_items.append((bucket, payload))
+        if result.merged_items:
+            buffer.replace(result.merged_items)
+        else:
+            buffer.replace([])
 
-        if backfill_items:
-            ranges: list[tuple[int, int]] = []
-            start_range = backfill_items[0][0]
-            prev = start_range
-            for ts, _ in backfill_items[1:]:
-                if ts == prev + interval:
-                    prev = ts
-                else:
-                    ranges.append((start_range, prev))
-                    start_range = ts
-                    prev = ts
-            ranges.append((start_range, prev))
-            self.backfill_state.mark_ranges(u, interval, ranges)
-
-        # Capture latest data after collecting items so concurrent ``append``
-        # operations are taken into account during the merge.
-        arr = self._buffers[(u, interval)].data
-        existing: dict[int, Any] = {int(t): v for t, v in arr if t is not None}
-
-        ts_payload: dict[int, Any] = dict(existing)
-        for ts, payload in backfill_items:
-            ts_payload.setdefault(ts, payload)
-
-        merged = sorted(ts_payload.items())[-self.period :]
-
-        new_arr = np.empty((self.period, 2), dtype=object)
-        new_arr[:] = None
-        for idx, (ts, payload) in enumerate(merged):
-            new_arr[idx % self.period, 0] = ts
-            new_arr[idx % self.period, 1] = payload
-
-        self._buffers[(u, interval)].data = new_arr
-        filled = min(len(merged), self.period)
-        self._filled[(u, interval)] = filled
-        self._offset[(u, interval)] = len(merged) % self.period
-        self._buffers[(u, interval)].filled = filled
-        self._buffers[(u, interval)].offset = len(merged) % self.period
-
-        prev_last = self._last_ts.get((u, interval))
-        if merged:
-            last_ts = merged[-1][0]
+        key = (upstream_id, interval)
+        prev_last = self._last_ts.get(key)
+        if result.merged_items:
+            last_ts = result.merged_items[-1][0]
             if prev_last is None:
-                self._missing[(u, interval)] = False
+                self._missing[key] = False
             elif last_ts != prev_last:
-                self._missing[(u, interval)] = prev_last + interval != last_ts
-            self._last_ts[(u, interval)] = last_ts
+                self._missing[key] = prev_last + interval != last_ts
+            self._last_ts[key] = last_ts
 
+
+__all__ = ["NodeCache"]

--- a/qmtl/sdk/cache_backfill.py
+++ b/qmtl/sdk/cache_backfill.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+from .cache_ring_buffer import RingBuffer
+
+
+@dataclass(frozen=True)
+class BackfillMergeResult:
+    """Result of merging historical items into a :class:`RingBuffer`."""
+
+    bucketed_items: list[tuple[int, Any]]
+    ranges: list[tuple[int, int]]
+    merged_items: list[tuple[int, Any]]
+
+
+class BackfillMerger:
+    """Merge helper for :meth:`NodeCache.backfill_bulk`."""
+
+    def __init__(self, period: int) -> None:
+        self._period = period
+
+    def _bucketize(self, interval: int, items: Iterable[tuple[int, Any]]) -> list[tuple[int, Any]]:
+        bucketed: list[tuple[int, Any]] = []
+        for ts, payload in items:
+            bucket = ts - (ts % interval)
+            bucketed.append((bucket, payload))
+        return bucketed
+
+    def _ranges(self, interval: int, bucketed: Sequence[tuple[int, Any]]) -> list[tuple[int, int]]:
+        if not bucketed:
+            return []
+        ranges: list[tuple[int, int]] = []
+        start = bucketed[0][0]
+        prev = start
+        for ts, _ in bucketed[1:]:
+            if ts == prev + interval:
+                prev = ts
+            else:
+                ranges.append((start, prev))
+                start = ts
+                prev = ts
+        ranges.append((start, prev))
+        return ranges
+
+    def merge(
+        self,
+        buffer: RingBuffer,
+        interval: int,
+        items: Iterable[tuple[int, Any]],
+    ) -> BackfillMergeResult:
+        bucketed = self._bucketize(interval, items)
+        ranges = self._ranges(interval, bucketed)
+
+        existing = {ts: payload for ts, payload in buffer.items()}
+        merged = dict(existing)
+        for ts, payload in bucketed:
+            merged.setdefault(ts, payload)
+
+        merged_items = sorted(merged.items())[-self._period :]
+        return BackfillMergeResult(bucketed, ranges, merged_items)
+
+
+__all__ = ["BackfillMerger", "BackfillMergeResult"]

--- a/qmtl/sdk/cache_context.py
+++ b/qmtl/sdk/cache_context.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from qmtl.common.compute_key import DEFAULT_EXECUTION_DOMAIN
+
+
+class MetricsObserver(Protocol):
+    def observe_cross_context_cache_hit(
+        self,
+        node_id: str,
+        world_id: str,
+        execution_domain: str,
+        *,
+        as_of: str | None,
+        partition: str | None,
+    ) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class ComputeContext:
+    compute_key: str
+    world_id: str
+    execution_domain: str
+    as_of: Any | None
+    partition: Any | None
+
+
+class ContextSwitchStrategy:
+    """Track the active compute context and emit metrics when it changes."""
+
+    def __init__(self, metrics: MetricsObserver) -> None:
+        self._metrics = metrics
+        self._active: ComputeContext | None = None
+
+    @staticmethod
+    def _normalize(
+        compute_key: str | None,
+        *,
+        world_id: str | None,
+        execution_domain: str | None,
+        as_of: Any | None,
+        partition: Any | None,
+    ) -> ComputeContext:
+        key = compute_key or "__default__"
+        world = str(world_id or "")
+        domain = str(execution_domain or DEFAULT_EXECUTION_DOMAIN)
+        return ComputeContext(key, world, domain, as_of, partition)
+
+    @property
+    def active(self) -> ComputeContext | None:
+        return self._active
+
+    def ensure(
+        self,
+        compute_key: str | None,
+        *,
+        node_id: str,
+        world_id: str | None = None,
+        execution_domain: str | None = None,
+        as_of: Any | None = None,
+        partition: Any | None = None,
+        had_data: bool = False,
+    ) -> tuple[ComputeContext, bool]:
+        """Ensure the context is up to date, returning (context, cleared)."""
+
+        context = self._normalize(
+            compute_key,
+            world_id=world_id,
+            execution_domain=execution_domain,
+            as_of=as_of,
+            partition=partition,
+        )
+        if self._active is None:
+            self._active = context
+            return context, False
+        if self._active.compute_key == context.compute_key:
+            # Reuse existing buffer when only metadata changes.
+            self._active = context
+            return context, False
+
+        cleared = self._active.compute_key != context.compute_key
+        if cleared and had_data:
+            self._metrics.observe_cross_context_cache_hit(
+                node_id,
+                context.world_id,
+                context.execution_domain,
+                as_of=str(context.as_of) if context.as_of is not None else None,
+                partition=(
+                    str(context.partition) if context.partition is not None else None
+                ),
+            )
+        self._active = context
+        return context, cleared
+
+
+__all__ = ["ContextSwitchStrategy", "ComputeContext"]

--- a/qmtl/sdk/cache_reader.py
+++ b/qmtl/sdk/cache_reader.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+import numpy as np
+import xarray as xr
+
+from .cache_ring_buffer import RingBuffer
+
+
+class CacheWindowReader:
+    """Read-only helpers for exporting cache contents."""
+
+    def __init__(
+        self, buffers: Mapping[tuple[str, int], RingBuffer], *, period: int
+    ) -> None:
+        self._buffers = buffers
+        self._period = period
+
+    def view_data(self) -> dict[str, dict[int, list[tuple[int, Any]]]]:
+        data: dict[str, dict[int, list[tuple[int, Any]]]] = {}
+        for (upstream, interval), buffer in self._buffers.items():
+            data.setdefault(upstream, {})[interval] = buffer.items()
+        return data
+
+    def snapshot(self) -> dict[str, dict[int, list[tuple[int, Any]]]]:
+        """Return a deep copy of the cache contents for tests."""
+
+        data = self.view_data()
+        return {u: {i: list(items) for i, items in mp.items()} for u, mp in data.items()}
+
+    def input_window_hash(self, *, hash_utils) -> str:
+        ordered: list[tuple[str, int, list[tuple[int, Any]]]] = []
+        for (upstream, interval), buffer in sorted(self._buffers.items()):
+            ordered.append((upstream, interval, buffer.items()))
+        blob = json.dumps(ordered, sort_keys=True, default=repr).encode()
+        return hash_utils._sha256(blob)
+
+    def as_xarray(self) -> xr.DataArray:
+        upstreams = sorted({u for u, _ in self._buffers.keys()})
+        intervals = sorted({i for _, i in self._buffers.keys()})
+        data = np.empty((len(upstreams), len(intervals), self._period, 2), dtype=object)
+        data[:] = None
+        for u_idx, upstream in enumerate(upstreams):
+            for i_idx, interval in enumerate(intervals):
+                buffer = self._buffers.get((upstream, interval))
+                if buffer is not None:
+                    data[u_idx, i_idx] = buffer.ordered_array()
+        da = xr.DataArray(
+            data,
+            dims=("u", "i", "p", "f"),
+            coords={
+                "u": upstreams,
+                "i": intervals,
+                "p": list(range(self._period)),
+                "f": ["t", "v"],
+            },
+        )
+        da.data = da.data.view()
+        da.data.setflags(write=False)
+        return da
+
+
+__all__ = ["CacheWindowReader"]

--- a/qmtl/sdk/cache_ring_buffer.py
+++ b/qmtl/sdk/cache_ring_buffer.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+
+
+class RingBuffer:
+    """Lightweight fixed-length buffer for ``(timestamp, payload)`` pairs.
+
+    The buffer stores items in a two-column ``numpy`` array. Consumers can append
+    new entries, request the ordered contents, or replace the buffer with a new
+    set of items. Ordering is always returned from oldest to newest entries.
+    """
+
+    def __init__(self, period: int) -> None:
+        if period <= 0:
+            msg = "RingBuffer period must be a positive integer"
+            raise ValueError(msg)
+        self.period = period
+        self._data = np.empty((period, 2), dtype=object)
+        self._data[:] = None
+        self._offset = 0
+        self._filled = 0
+
+    def append(self, timestamp: int, payload: Any) -> None:
+        """Append ``payload`` at ``timestamp`` overwriting the oldest entry."""
+
+        self._data[self._offset, 0] = timestamp
+        self._data[self._offset, 1] = payload
+        self._offset = (self._offset + 1) % self.period
+        if self._filled < self.period:
+            self._filled += 1
+
+    def ordered_array(self) -> np.ndarray:
+        """Return a new array ordered from oldest to newest entries."""
+
+        if self._filled < self.period:
+            return np.concatenate((self._data[self._filled :], self._data[: self._filled]))
+        return np.concatenate((self._data[self._offset :], self._data[: self._offset]))
+
+    def items(self) -> list[tuple[int, Any]]:
+        """Return buffered items ordered from oldest to newest."""
+
+        return [
+            (int(ts), payload)
+            for ts, payload in self.ordered_array()
+            if ts is not None
+        ]
+
+    def latest(self) -> tuple[int, Any] | None:
+        """Return the most recent ``(timestamp, payload)`` pair or ``None``."""
+
+        if self._filled == 0:
+            return None
+        idx = (self._offset - 1) % self.period
+        ts = self._data[idx, 0]
+        if ts is None:
+            return None
+        return int(ts), self._data[idx, 1]
+
+    def replace(self, items: Sequence[tuple[int, Any]]) -> None:
+        """Replace buffer contents with ``items`` ordered oldest -> newest."""
+
+        trimmed = list(items)[-self.period :]
+        data = np.empty((self.period, 2), dtype=object)
+        data[:] = None
+        for idx, (ts, payload) in enumerate(trimmed):
+            data[idx, 0] = ts
+            data[idx, 1] = payload
+        self._data = data
+        self._filled = min(len(trimmed), self.period)
+        self._offset = len(trimmed) % self.period if self._filled else 0
+
+    @property
+    def filled(self) -> int:
+        return self._filled
+
+    @property
+    def offset(self) -> int:
+        return self._offset
+
+    @property
+    def data(self) -> np.ndarray:
+        return self._data
+
+    @property
+    def nbytes(self) -> int:
+        return self._data.nbytes
+
+
+__all__ = ["RingBuffer"]

--- a/tests/sdk/test_cache_components.py
+++ b/tests/sdk/test_cache_components.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import pytest
+import xarray as xr
+
+from qmtl.sdk import hash_utils as default_hash_utils
+from qmtl.sdk.cache_backfill import BackfillMerger
+from qmtl.sdk.cache_context import ContextSwitchStrategy
+from qmtl.sdk.cache_reader import CacheWindowReader
+from qmtl.sdk.cache_ring_buffer import RingBuffer
+
+
+class _StubMetrics:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str, str | None, str | None]] = []
+
+    def observe_cross_context_cache_hit(
+        self,
+        node_id: str,
+        world_id: str,
+        execution_domain: str,
+        *,
+        as_of: str | None,
+        partition: str | None,
+    ) -> None:
+        self.calls.append((node_id, world_id, execution_domain, as_of, partition))
+
+
+def test_ring_buffer_append_and_replace() -> None:
+    buf = RingBuffer(period=3)
+    buf.append(1, "a")
+    buf.append(2, "b")
+    assert buf.items() == [(1, "a"), (2, "b")]
+    assert buf.latest() == (2, "b")
+
+    buf.append(3, "c")
+    buf.append(4, "d")  # wrap
+    assert buf.items() == [(2, "b"), (3, "c"), (4, "d")]
+
+    buf.replace([(10, "x"), (20, "y")])
+    assert buf.items() == [(10, "x"), (20, "y")]
+    assert buf.latest() == (20, "y")
+
+
+def test_backfill_merger_prefers_existing_payloads() -> None:
+    buf = RingBuffer(period=4)
+    buf.replace([(60, {"v": "live1"}), (120, {"v": "live2"})])
+
+    merger = BackfillMerger(period=4)
+    result = merger.merge(
+        buf,
+        60,
+        [
+            (60, {"v": "bf1"}),
+            (120, {"v": "bf-dup"}),
+            (180, {"v": "bf3"}),
+            (240, {"v": "bf4"}),
+        ],
+    )
+
+    assert result.bucketed_items == [
+        (60, {"v": "bf1"}),
+        (120, {"v": "bf-dup"}),
+        (180, {"v": "bf3"}),
+        (240, {"v": "bf4"}),
+    ]
+    assert result.ranges == [(60, 240)]
+    # Existing payload for 120 should win over the backfilled duplicate.
+    assert result.merged_items == [
+        (60, {"v": "live1"}),
+        (120, {"v": "live2"}),
+        (180, {"v": "bf3"}),
+        (240, {"v": "bf4"}),
+    ]
+
+
+def test_context_switch_strategy_emits_metric_on_change() -> None:
+    metrics = _StubMetrics()
+    strategy = ContextSwitchStrategy(metrics)
+
+    context, cleared = strategy.ensure(
+        "key-a",
+        node_id="node-1",
+        world_id="w1",
+        execution_domain="backtest",
+        had_data=False,
+    )
+    assert not cleared
+    assert context.compute_key == "key-a"
+    assert not metrics.calls
+
+    _, cleared = strategy.ensure(
+        "key-b",
+        node_id="node-1",
+        world_id="w2",
+        execution_domain="live",
+        as_of=123,
+        partition="p1",
+        had_data=True,
+    )
+    assert cleared
+    assert metrics.calls == [("node-1", "w2", "live", "123", "p1")]
+
+    _, cleared = strategy.ensure(
+        "key-b",
+        node_id="node-1",
+        world_id="w3",
+        execution_domain="live",
+        had_data=True,
+    )
+    assert not cleared
+    # No additional metric for metadata-only updates.
+    assert len(metrics.calls) == 1
+
+
+def test_cache_window_reader_exports_numpy_and_hashes() -> None:
+    buf1 = RingBuffer(period=3)
+    buf1.replace([(1, {"v": 1}), (2, {"v": 2})])
+    buf2 = RingBuffer(period=3)
+    buf2.replace([(10, {"v": "a"})])
+
+    reader = CacheWindowReader({("u1", 1): buf1, ("u2", 1): buf2}, period=3)
+
+    data = reader.view_data()
+    assert data == {
+        "u1": {1: [(1, {"v": 1}), (2, {"v": 2})]},
+        "u2": {1: [(10, {"v": "a"})]},
+    }
+
+    snapshot = reader.snapshot()
+    snapshot["u1"][1].append((99, {}))
+    # Underlying buffers should remain unchanged.
+    assert reader.view_data()["u1"][1] == [(1, {"v": 1}), (2, {"v": 2})]
+
+    h1 = reader.input_window_hash(hash_utils=default_hash_utils)
+    buf1.append(3, {"v": 3})
+    h2 = reader.input_window_hash(hash_utils=default_hash_utils)
+    assert h1 != h2
+
+    da = reader.as_xarray()
+    assert isinstance(da, xr.DataArray)
+    assert da.shape == (2, 1, 3, 2)
+    with pytest.raises(ValueError):
+        da.data[0, 0, 0, 0] = 10
+


### PR DESCRIPTION
## Summary
- extract reusable cache components covering ring buffers, backfill merging, context switching, and read-only window export helpers
- refactor `NodeCache` to delegate to the new components while preserving compute-context state for compatibility
- add focused unit tests for the modularized cache components

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto`

Closes #1056

------
https://chatgpt.com/codex/tasks/task_e_68d1e63947588329ae9e500b6802f1bd