### PR TITLE
Refactor Node base into mixins

### DIFF
--- a/qmtl/sdk/nodes/base.py
+++ b/qmtl/sdk/nodes/base.py
@@ -1,71 +1,20 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterable
-from typing import Any
-import logging
-import time
-
-from opentelemetry import trace
-
-try:  # Optional pandas dependency
-    import pandas as pd  # type: ignore
-except Exception:  # pragma: no cover - pandas not installed
-    pd = None  # type: ignore
+from typing import Any, Iterable
 
 from qmtl.common import CanonicalNodeSpec, compute_node_id
-from qmtl.common.compute_key import (
-    ComputeContext,
-    compute_compute_key,
-    DEFAULT_EXECUTION_DOMAIN,
-)
+from qmtl.common.compute_key import compute_compute_key
 
 from .. import arrow_cache
-from .. import metrics as sdk_metrics
-from .. import node_validation as default_validator
-from .. import hash_utils as default_hash_utils
 from ..cache import NodeCache
 from ..event_service import EventRecorderService
-from ..exceptions import NodeValidationError
-from ..util import parse_interval
+from .config import NodeConfig
+from .mixins import ComputeContextMixin, NodeFeedMixin
 
 
-logger = logging.getLogger(__name__)
-tracer = trace.get_tracer(__name__)
-
-
-def _extract_schema_compat_id(schema: Any, expected_schema: Any) -> str | None:
-    """Extract a schema compatibility identifier from provided schemas."""
-
-    compat_id: Any = None
-    if isinstance(schema, dict):
-        compat_id = (
-            schema.get("schema_compat_id")
-            or schema.get("compat_id")
-            or schema.get("compatId")
-        )
-    if compat_id is None and isinstance(expected_schema, dict):
-        compat_id = (
-            expected_schema.get("schema_compat_id")
-            or expected_schema.get("compat_id")
-            or expected_schema.get("compatId")
-        )
-    if compat_id is None:
-        return None
-    return str(compat_id)
-
-
-class Node:
-    """Represents a processing node in a strategy DAG.
-
-    ``compute_fn`` must accept exactly **one argument** – a :class:`CacheView`
-    returned by :py:meth:`NodeCache.view`. The view provides read-only access to
-    the cached data and mirrors the structure returned by
-    :py:meth:`NodeCache.view`. Positional arguments other than the cache view are
-    **not** supported. ``input`` may be a single ``Node`` or an iterable of
-    ``Node`` instances. Passing dictionaries is no longer supported. Tags can be
-    assigned at initialization or later via :py:meth:`add_tag`.
-    """
+class Node(ComputeContextMixin, NodeFeedMixin):
+    """Represents a processing node in a strategy DAG."""
 
     def __init__(
         self,
@@ -82,85 +31,71 @@ class Node:
         allowed_lateness: int = 0,
         on_late: str = "recompute",
         runtime_compat: str = "loose",
-        validator=default_validator,
-        hash_utils=default_hash_utils,
+        validator: Any = None,
+        hash_utils: Any = None,
         event_service: EventRecorderService | None = None,
     ) -> None:
-        self.validator = validator
-        self.hash_utils = hash_utils
+        from .. import node_validation as default_validator
+        from .. import hash_utils as default_hash_utils
+
+        self.validator = validator or default_validator
+        self.hash_utils = hash_utils or default_hash_utils
         self.event_service = event_service
 
-        if isinstance(interval, str):
-            interval = parse_interval(interval)
-
-        validator.validate_compute_fn(compute_fn)
-        (
-            validated_name,
-            validated_tags,
-            interval_val,
-            period_val,
-        ) = validator.validate_node_params(
-            name,
-            tags,
-            interval,
-            period,
-            config,
-            schema,
-            expected_schema,
+        config_payload = NodeConfig.build(
+            input=input,
+            compute_fn=compute_fn,
+            name=name,
+            tags=tags,
+            interval=interval,
+            period=period,
+            config=config,
+            schema=schema,
+            expected_schema=expected_schema,
+            allowed_lateness=allowed_lateness,
+            on_late=on_late,
+            runtime_compat=runtime_compat,
+            validator=self.validator,
+            hash_utils=self.hash_utils,
         )
-
-        if isinstance(interval_val, str):
-            interval_val = parse_interval(interval_val)
 
         self.input = input
-        self.inputs = validator.normalize_inputs(input)
+        self.inputs = config_payload.inputs
         self.compute_fn = compute_fn
-        self.name = validated_name
-        self.interval = interval_val
-        self.period = period_val
-        self.tags = validated_tags
-        self.config = config or {}
-        self.schema = schema or {}
-        self.expected_schema = expected_schema or {}
+        self.name = config_payload.name
+        self.interval = config_payload.interval
+        self.period = config_payload.period
+        self.tags = config_payload.tags
+        self.config = config_payload.config
+        self.schema = config_payload.schema
+        self.expected_schema = config_payload.expected_schema
         self.execute = True
         self.kafka_topic: str | None = None
-        self.enable_feature_artifacts = bool(
-            self.config.get("enable_feature_artifacts", False)
-        )
-        self.schema_compat_id: str = (
-            _extract_schema_compat_id(self.schema, self.expected_schema)
-            or self.schema_hash
-        )
-        if arrow_cache.ARROW_AVAILABLE and os.getenv("QMTL_ARROW_CACHE") == "1":
-            self.cache = arrow_cache.NodeCacheArrow(period_val or 0)
-        else:
-            self.cache = NodeCache(period_val or 0)
-        self.pre_warmup = True
-        self._warmup_started_at = time.perf_counter()
-        self.allowed_lateness: int = int(allowed_lateness)
-        self.on_late: str = on_late
+        self.enable_feature_artifacts = config_payload.enable_feature_artifacts
+        self.schema_compat_id = config_payload.schema_compat_id
+        self.runtime_compat: str = config_payload.runtime_compat
+        self.allowed_lateness: int = config_payload.allowed_lateness
+        self.on_late: str = config_payload.on_late
+
+        self.cache = self._create_cache(config_payload.period)
+        self._setup_compute_context()
+        self._activate_cache_key()
+
         self._last_watermark: int | None = None
         self._late_events: list[tuple[str, int, Any]] = []
-        self.runtime_compat: str = runtime_compat
-        self._compute_context = ComputeContext()
         self._dataset_fingerprint: str | None = None
-        self.cache.activate_compute_key(
-            self.compute_key,
-            node_id=self.node_id,
-            world_id=self._compute_context.world_id,
-            execution_domain=self._compute_context.execution_domain,
-            as_of=self._compute_context.as_of,
-            partition=self._compute_context.partition,
-        )
 
     def __repr__(self) -> str:  # pragma: no cover - simple repr
         return (
             f"Node(name={self.name!r}, interval={self.interval}, period={self.period})"
         )
 
-    def add_tag(self, tag: str) -> "Node":
-        """Append ``tag`` to :attr:`tags` if missing and return ``self``."""
+    def _create_cache(self, period: int | None) -> Any:
+        if arrow_cache.ARROW_AVAILABLE and os.getenv("QMTL_ARROW_CACHE") == "1":
+            return arrow_cache.NodeCacheArrow(period or 0)
+        return NodeCache(period or 0)
 
+    def add_tag(self, tag: str) -> "Node":
         validated_tag = self.validator.validate_tag(tag)
         if validated_tag not in self.tags:
             self.tags.append(validated_tag)
@@ -215,56 +150,8 @@ class Node:
         return self.node_id
 
     @property
-    def compute_context(self) -> ComputeContext:
-        return self._compute_context
-
-    @property
     def compute_key(self) -> str:
         return compute_compute_key(self.node_hash, self._compute_context)
-
-    def apply_compute_context(self, context: ComputeContext) -> None:
-        if context == self._compute_context:
-            return
-        self._compute_context = context
-        self.pre_warmup = True
-        self._warmup_started_at = time.perf_counter()
-        self.cache.activate_compute_key(
-            self.compute_key,
-            node_id=self.node_id,
-            world_id=context.world_id,
-            execution_domain=context.execution_domain,
-            as_of=context.as_of,
-            partition=context.partition,
-        )
-
-    @property
-    def world_id(self) -> str | None:
-        val = self._compute_context.world_id
-        return val or None
-
-    @world_id.setter
-    def world_id(self, value: str | None) -> None:
-        context = ComputeContext(
-            world_id=str(value or ""),
-            execution_domain=self._compute_context.execution_domain,
-            as_of=self._compute_context.as_of,
-            partition=self._compute_context.partition,
-        )
-        self.apply_compute_context(context)
-
-    @property
-    def execution_domain(self) -> str:
-        return self._compute_context.execution_domain
-
-    @execution_domain.setter
-    def execution_domain(self, value: str) -> None:
-        context = ComputeContext(
-            world_id=self._compute_context.world_id,
-            execution_domain=str(value or DEFAULT_EXECUTION_DOMAIN),
-            as_of=self._compute_context.as_of,
-            partition=self._compute_context.partition,
-        )
-        self.apply_compute_context(context)
 
     @property
     def dataset_fingerprint(self) -> str | None:
@@ -273,134 +160,6 @@ class Node:
     @dataset_fingerprint.setter
     def dataset_fingerprint(self, value: str | None) -> None:
         self._dataset_fingerprint = value or None
-
-    @property
-    def as_of(self) -> Any | None:
-        return self._compute_context.as_of
-
-    @as_of.setter
-    def as_of(self, value: Any | None) -> None:
-        context = ComputeContext(
-            world_id=self._compute_context.world_id,
-            execution_domain=self._compute_context.execution_domain,
-            as_of=value,
-            partition=self._compute_context.partition,
-        )
-        self.apply_compute_context(context)
-
-    @property
-    def partition(self) -> Any | None:
-        return self._compute_context.partition
-
-    @partition.setter
-    def partition(self, value: Any | None) -> None:
-        context = ComputeContext(
-            world_id=self._compute_context.world_id,
-            execution_domain=self._compute_context.execution_domain,
-            as_of=self._compute_context.as_of,
-            partition=value,
-        )
-        self.apply_compute_context(context)
-
-    def feed(
-        self,
-        upstream_id: str,
-        interval: int,
-        timestamp: int,
-        payload,
-        *,
-        on_missing: str = "skip",
-    ) -> bool:
-        from ..node_validation import validate_feed_params
-
-        validate_feed_params(upstream_id, interval, timestamp, on_missing)
-
-        mode = getattr(self, "_schema_enforcement", "fail").lower()
-        if (
-            self.expected_schema
-            and pd is not None
-            and isinstance(payload, pd.DataFrame)
-            and mode != "off"
-        ):
-            from ..schema_validation import validate_schema
-
-            try:
-                validate_schema(payload, self.expected_schema)
-            except NodeValidationError as e:
-                msg = f"{self.name or self.node_id}: {e}"
-                if mode == "warn":
-                    logger.warning(msg)
-                elif mode == "fail":
-                    raise NodeValidationError(msg) from e
-
-        with tracer.start_as_current_span(
-            "node.feed", attributes={"node.id": self.node_id}
-        ):
-            self.cache.activate_compute_key(
-                self.compute_key,
-                node_id=self.node_id,
-                world_id=self._compute_context.world_id,
-                execution_domain=self._compute_context.execution_domain,
-                as_of=self._compute_context.as_of,
-                partition=self._compute_context.partition,
-            )
-            self.cache.append(upstream_id, interval, timestamp, payload)
-            if hasattr(self.cache, "record_resident_bytes"):
-                self.cache.record_resident_bytes(self.node_id)
-            else:
-                sdk_metrics.observe_nodecache_resident_bytes(
-                    self.node_id, self.cache.resident_bytes
-                )
-
-        if self.event_service is not None:
-            self.event_service.record(self.node_id, interval, timestamp, payload)
-
-        if self.pre_warmup and self.cache.ready():
-            self.pre_warmup = False
-            try:
-                duration_ms = (
-                    time.perf_counter() - self._warmup_started_at
-                ) * 1000.0
-                sdk_metrics.observe_warmup_ready(self.node_id, duration_ms)
-            except Exception:
-                pass
-
-        missing = self.cache.missing_flags().get(upstream_id, {}).get(interval, False)
-        if missing:
-            if on_missing == "fail":
-                raise RuntimeError("gap detected")
-            if on_missing == "skip":
-                return False
-
-        try:
-            self._last_watermark = self.cache.watermark(
-                allowed_lateness=self.allowed_lateness
-            )
-        except Exception:
-            self._last_watermark = None
-
-        if self.pre_warmup or self.compute_fn is None:
-            return False
-
-        if self._last_watermark is None:
-            return False
-
-        bucket_ts = timestamp - (timestamp % (interval or 1))
-        wm = int(self._last_watermark)
-
-        if bucket_ts < wm:
-            policy = (self.on_late or "recompute").lower()
-            if policy == "ignore":
-                return False
-            if policy == "side_output":
-                self._late_events.append((upstream_id, bucket_ts, payload))
-                return False
-            return True
-
-        if bucket_ts >= wm:
-            return True
-
-        return False
 
     def watermark(self) -> int | None:
         return self._last_watermark

--- a/qmtl/sdk/nodes/config.py
+++ b/qmtl/sdk/nodes/config.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from qmtl.sdk.util import parse_interval
+
+
+def _extract_schema_compat_id(schema: Any, expected_schema: Any) -> str | None:
+    """Extract a schema compatibility identifier from provided schemas."""
+
+    compat_id: Any = None
+    if isinstance(schema, dict):
+        compat_id = (
+            schema.get("schema_compat_id")
+            or schema.get("compat_id")
+            or schema.get("compatId")
+        )
+    if compat_id is None and isinstance(expected_schema, dict):
+        compat_id = (
+            expected_schema.get("schema_compat_id")
+            or expected_schema.get("compat_id")
+            or expected_schema.get("compatId")
+        )
+    if compat_id is None:
+        return None
+    return str(compat_id)
+
+
+@dataclass(frozen=True)
+class NodeConfig:
+    """Validated configuration payload used to initialize :class:`Node`."""
+
+    name: str | None
+    tags: list[str]
+    interval: int | None
+    period: int | None
+    config: dict[str, Any]
+    schema: dict[str, Any]
+    expected_schema: dict[str, Any]
+    inputs: list[Any]
+    schema_compat_id: str
+    allowed_lateness: int
+    on_late: str
+    runtime_compat: str
+    enable_feature_artifacts: bool
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        input: Any,
+        compute_fn: Any,
+        name: str | None,
+        tags: list[str] | None,
+        interval: int | str | None,
+        period: int | None,
+        config: dict | None,
+        schema: dict | None,
+        expected_schema: dict | None,
+        allowed_lateness: int,
+        on_late: str,
+        runtime_compat: str,
+        validator,
+        hash_utils,
+    ) -> "NodeConfig":
+        if isinstance(interval, str):
+            interval = parse_interval(interval)
+
+        validator.validate_compute_fn(compute_fn)
+        (
+            validated_name,
+            validated_tags,
+            interval_val,
+            period_val,
+        ) = validator.validate_node_params(
+            name,
+            tags,
+            interval,
+            period,
+            config,
+            schema,
+            expected_schema,
+        )
+
+        if isinstance(interval_val, str):
+            interval_val = parse_interval(interval_val)
+
+        normalized_inputs = validator.normalize_inputs(input)
+        config = config or {}
+        schema = schema or {}
+        expected_schema = expected_schema or {}
+        enable_feature_artifacts = bool(
+            config.get("enable_feature_artifacts", False)
+        )
+        schema_compat_id = _extract_schema_compat_id(schema, expected_schema) or hash_utils.schema_hash(
+            schema
+        )
+
+        return cls(
+            name=validated_name,
+            tags=validated_tags,
+            interval=interval_val,
+            period=period_val,
+            config=config,
+            schema=schema,
+            expected_schema=expected_schema,
+            inputs=normalized_inputs,
+            schema_compat_id=schema_compat_id,
+            allowed_lateness=int(allowed_lateness),
+            on_late=on_late,
+            runtime_compat=runtime_compat,
+            enable_feature_artifacts=enable_feature_artifacts,
+        )
+
+
+__all__ = ["NodeConfig", "_extract_schema_compat_id"]
+

--- a/qmtl/sdk/nodes/mixins.py
+++ b/qmtl/sdk/nodes/mixins.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from opentelemetry import trace
+
+from qmtl.common.compute_key import ComputeContext, DEFAULT_EXECUTION_DOMAIN
+
+from .. import metrics as sdk_metrics
+from ..exceptions import NodeValidationError
+
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+class CacheActivationMixin:
+    """Utility mixin that knows how to activate a node cache."""
+
+    cache: Any
+    node_id: str
+    _compute_context: ComputeContext
+
+    def _activate_cache_key(self) -> None:
+        self.cache.activate_compute_key(
+            self.compute_key,
+            node_id=self.node_id,
+            world_id=self._compute_context.world_id,
+            execution_domain=self._compute_context.execution_domain,
+            as_of=self._compute_context.as_of,
+            partition=self._compute_context.partition,
+        )
+
+
+class ComputeContextMixin(CacheActivationMixin):
+    """Manage :class:`ComputeContext` lifecycle and convenience accessors."""
+
+    pre_warmup: bool
+    _warmup_started_at: float
+
+    def _setup_compute_context(self) -> None:
+        self._compute_context = ComputeContext()
+        self._reset_warmup_timer()
+
+    def _reset_warmup_timer(self) -> None:
+        self.pre_warmup = True
+        self._warmup_started_at = time.perf_counter()
+
+    @property
+    def compute_context(self) -> ComputeContext:
+        return self._compute_context
+
+    def apply_compute_context(self, context: ComputeContext) -> None:
+        if context == self._compute_context:
+            return
+        self._compute_context = context
+        self._reset_warmup_timer()
+        self._activate_cache_key()
+
+    @property
+    def world_id(self) -> str | None:
+        val = self._compute_context.world_id
+        return val or None
+
+    @world_id.setter
+    def world_id(self, value: str | None) -> None:
+        context = ComputeContext(
+            world_id=str(value or ""),
+            execution_domain=self._compute_context.execution_domain,
+            as_of=self._compute_context.as_of,
+            partition=self._compute_context.partition,
+        )
+        self.apply_compute_context(context)
+
+    @property
+    def execution_domain(self) -> str:
+        return self._compute_context.execution_domain
+
+    @execution_domain.setter
+    def execution_domain(self, value: str) -> None:
+        context = ComputeContext(
+            world_id=self._compute_context.world_id,
+            execution_domain=str(value or DEFAULT_EXECUTION_DOMAIN),
+            as_of=self._compute_context.as_of,
+            partition=self._compute_context.partition,
+        )
+        self.apply_compute_context(context)
+
+    @property
+    def as_of(self) -> Any | None:
+        return self._compute_context.as_of
+
+    @as_of.setter
+    def as_of(self, value: Any | None) -> None:
+        context = ComputeContext(
+            world_id=self._compute_context.world_id,
+            execution_domain=self._compute_context.execution_domain,
+            as_of=value,
+            partition=self._compute_context.partition,
+        )
+        self.apply_compute_context(context)
+
+    @property
+    def partition(self) -> Any | None:
+        return self._compute_context.partition
+
+    @partition.setter
+    def partition(self, value: Any | None) -> None:
+        context = ComputeContext(
+            world_id=self._compute_context.world_id,
+            execution_domain=self._compute_context.execution_domain,
+            as_of=self._compute_context.as_of,
+            partition=value,
+        )
+        self.apply_compute_context(context)
+
+
+class LateEventPolicy:
+    """Encapsulate how late arrivals should be treated."""
+
+    def __init__(self, mode: str, sink: list[tuple[str, int, Any]]) -> None:
+        self._mode = (mode or "recompute").lower()
+        self._sink = sink
+
+    def should_process(
+        self,
+        upstream_id: str,
+        bucket_ts: int,
+        watermark: int,
+        payload: Any,
+    ) -> bool:
+        if bucket_ts < watermark:
+            if self._mode == "ignore":
+                return False
+            if self._mode == "side_output":
+                self._sink.append((upstream_id, bucket_ts, payload))
+                return False
+            return True
+        if bucket_ts >= watermark:
+            return True
+        return False
+
+
+class NodeFeedMixin(CacheActivationMixin):
+    """Provide the :py:meth:`Node.feed` implementation."""
+
+    validator: Any
+    compute_fn: Any
+    expected_schema: dict[str, Any]
+    event_service: Any
+    pre_warmup: bool
+    _warmup_started_at: float
+    _last_watermark: int | None
+    allowed_lateness: int
+    cache: Any
+    _late_events: list[tuple[str, int, Any]]
+
+    def feed(
+        self,
+        upstream_id: str,
+        interval: int,
+        timestamp: int,
+        payload,
+        *,
+        on_missing: str = "skip",
+    ) -> bool:
+        from ..node_validation import validate_feed_params
+
+        validate_feed_params(upstream_id, interval, timestamp, on_missing)
+
+        mode = getattr(self, "_schema_enforcement", "fail").lower()
+        if (
+            self.expected_schema
+            and self._should_validate_schema(payload)
+            and mode != "off"
+        ):
+            from ..schema_validation import validate_schema
+
+            try:
+                validate_schema(payload, self.expected_schema)
+            except NodeValidationError as exc:
+                msg = f"{self.name or self.node_id}: {exc}"
+                if mode == "warn":
+                    logger.warning(msg)
+                elif mode == "fail":
+                    raise NodeValidationError(msg) from exc
+
+        with tracer.start_as_current_span(
+            "node.feed", attributes={"node.id": self.node_id}
+        ):
+            self._activate_cache_key()
+            self.cache.append(upstream_id, interval, timestamp, payload)
+            self._record_resident_bytes()
+
+        if self.event_service is not None:
+            self.event_service.record(self.node_id, interval, timestamp, payload)
+
+        self._maybe_record_warmup_ready()
+
+        if self._is_missing(upstream_id, interval, on_missing):
+            return False
+
+        try:
+            self._last_watermark = self.cache.watermark(
+                allowed_lateness=self.allowed_lateness
+            )
+        except Exception:
+            self._last_watermark = None
+
+        if self.pre_warmup or self.compute_fn is None:
+            return False
+
+        if self._last_watermark is None:
+            return False
+
+        bucket_ts = timestamp - (timestamp % (interval or 1))
+        watermark = int(self._last_watermark)
+        policy = LateEventPolicy(self.on_late, self._late_events)
+        return policy.should_process(upstream_id, bucket_ts, watermark, payload)
+
+    def _should_validate_schema(self, payload: Any) -> bool:
+        try:  # Optional pandas dependency
+            import pandas as pd  # type: ignore
+        except Exception:  # pragma: no cover - pandas not installed
+            return False
+
+        return isinstance(payload, pd.DataFrame)
+
+    def _record_resident_bytes(self) -> None:
+        if hasattr(self.cache, "record_resident_bytes"):
+            self.cache.record_resident_bytes(self.node_id)
+        else:
+            sdk_metrics.observe_nodecache_resident_bytes(
+                self.node_id, self.cache.resident_bytes
+            )
+
+    def _maybe_record_warmup_ready(self) -> None:
+        if self.pre_warmup and self.cache.ready():
+            self.pre_warmup = False
+            try:
+                duration_ms = (
+                    time.perf_counter() - self._warmup_started_at
+                ) * 1000.0
+                sdk_metrics.observe_warmup_ready(self.node_id, duration_ms)
+            except Exception:
+                pass
+
+    def _is_missing(
+        self, upstream_id: str, interval: int, on_missing: str
+    ) -> bool:
+        missing = (
+            self.cache.missing_flags().get(upstream_id, {}).get(interval, False)
+        )
+        if missing:
+            if on_missing == "fail":
+                raise RuntimeError("gap detected")
+            if on_missing == "skip":
+                return True
+        return False
+
+
+__all__ = [
+    "CacheActivationMixin",
+    "ComputeContextMixin",
+    "LateEventPolicy",
+    "NodeFeedMixin",
+]
+

--- a/tests/sdk/test_node_helpers.py
+++ b/tests/sdk/test_node_helpers.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from qmtl.sdk import hash_utils, node_validation
+from qmtl.sdk.nodes.config import NodeConfig
+from qmtl.sdk.nodes.mixins import LateEventPolicy
+
+
+def _dummy_compute(view) -> None:  # pragma: no cover - simple stub
+    return None
+
+
+def test_node_config_builds_with_validator() -> None:
+    config = NodeConfig.build(
+        input=None,
+        compute_fn=_dummy_compute,
+        name="example",
+        tags=["t1"],
+        interval="60s",
+        period=5,
+        config={"enable_feature_artifacts": True},
+        schema={"schema_compat_id": "compat"},
+        expected_schema={},
+        allowed_lateness=3,
+        on_late="ignore",
+        runtime_compat="loose",
+        validator=node_validation,
+        hash_utils=hash_utils,
+    )
+
+    assert config.interval == 60
+    assert config.period == 5
+    assert config.tags == ["t1"]
+    assert config.enable_feature_artifacts is True
+    assert config.schema_compat_id == "compat"
+    assert config.allowed_lateness == 3
+    assert config.on_late == "ignore"
+    assert config.inputs == []
+
+
+def test_node_config_schema_fallback_to_hash() -> None:
+    config = NodeConfig.build(
+        input=None,
+        compute_fn=_dummy_compute,
+        name="example",
+        tags=None,
+        interval=60,
+        period=1,
+        config=None,
+        schema={},
+        expected_schema={},
+        allowed_lateness=0,
+        on_late="recompute",
+        runtime_compat="loose",
+        validator=node_validation,
+        hash_utils=hash_utils,
+    )
+
+    assert config.schema_compat_id == hash_utils.schema_hash({})
+
+
+def test_late_event_policy_behaviour() -> None:
+    sink: list[tuple[str, int, object]] = []
+    policy = LateEventPolicy("side_output", sink)
+
+    assert policy.should_process("up", 30, 20, object()) is True
+    late_payload = object()
+    assert (
+        policy.should_process("up", 10, 20, late_payload) is False
+    )  # late event captured
+    assert sink == [("up", 10, late_payload)]
+
+    ignore_policy = LateEventPolicy("ignore", sink)
+    assert ignore_policy.should_process("up", 5, 20, None) is False
+


### PR DESCRIPTION
## Summary
- split Node initialization concerns into a reusable NodeConfig builder and cache/context mixins
- relocate feed, cache activation, and late-event handling into dedicated helpers to shrink the base module and improve reuse
- add focused unit tests covering NodeConfig validation and LateEventPolicy behaviour

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1055

------
https://chatgpt.com/codex/tasks/task_e_68d1ec65eb948329a65813fe866c6932