### PR TITLE
Refactor WorldService client into reusable primitives

### DIFF
--- a/qmtl/gateway/caches.py
+++ b/qmtl/gateway/caches.py
@@ -1,0 +1,116 @@
+"""Reusable cache primitives for the Gateway WorldService proxy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import Callable, Dict, Generic, Mapping, MutableMapping, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class TTLCacheEntry(Generic[T]):
+    """Container storing cached values with an absolute expiry."""
+
+    value: T
+    expires_at: float
+
+    def is_valid(self, now: float) -> bool:
+        return now < self.expires_at
+
+
+@dataclass(frozen=True)
+class TTLCacheResult(Generic[T]):
+    """Result of a TTL cache lookup."""
+
+    value: Optional[T]
+    present: bool
+    fresh: bool
+
+    @property
+    def stale(self) -> bool:
+        return self.present and not self.fresh
+
+
+class TTLCache(Generic[T]):
+    """Time-based cache with optional stale reads."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.time,
+        store: Optional[MutableMapping[str, TTLCacheEntry[T]]] = None,
+    ) -> None:
+        self._clock = clock
+        self._store = store if store is not None else {}
+
+    def lookup(self, key: str) -> TTLCacheResult[T]:
+        """Retrieve a cached value and whether it is still valid."""
+
+        entry = self._store.get(key)
+        if entry is None:
+            return TTLCacheResult(value=None, present=False, fresh=False)
+        fresh = entry.is_valid(self._clock())
+        return TTLCacheResult(value=entry.value, present=True, fresh=fresh)
+
+    def set(self, key: str, value: T, ttl: float) -> None:
+        self._store[key] = TTLCacheEntry(value=value, expires_at=self._clock() + ttl)
+
+    def invalidate(self, key: str) -> None:
+        self._store.pop(key, None)
+
+    def expire(self, key: str) -> None:
+        """Force a cached value to become stale while retaining the payload."""
+
+        entry = self._store.get(key)
+        if entry is not None:
+            entry.expires_at = self._clock() - 1
+
+    def clear(self) -> None:
+        self._store.clear()
+
+
+@dataclass
+class ActivationCacheEntry(Generic[T]):
+    """Conditional request payload keyed by an ETag."""
+
+    etag: str
+    payload: T
+
+
+class ActivationCache(Generic[T]):
+    """Stores activation payloads indexed by composite identifiers."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, ActivationCacheEntry[T]] = {}
+
+    def get(self, key: str) -> Optional[ActivationCacheEntry[T]]:
+        return self._store.get(key)
+
+    def conditional_headers(
+        self, key: str, headers: Optional[Mapping[str, str]] = None
+    ) -> Dict[str, str]:
+        result: Dict[str, str] = dict(headers or {})
+        entry = self._store.get(key)
+        if entry and entry.etag:
+            result["If-None-Match"] = entry.etag
+        return result
+
+    def set(self, key: str, etag: str, payload: T) -> None:
+        self._store[key] = ActivationCacheEntry(etag=etag, payload=payload)
+
+    def invalidate(self, key: str) -> None:
+        self._store.pop(key, None)
+
+    def clear(self) -> None:
+        self._store.clear()
+
+
+__all__ = [
+    "ActivationCache",
+    "ActivationCacheEntry",
+    "TTLCache",
+    "TTLCacheResult",
+    "TTLCacheEntry",
+]

--- a/qmtl/gateway/transport.py
+++ b/qmtl/gateway/transport.py
@@ -1,0 +1,65 @@
+"""Transport primitives for composing the WorldService client."""
+from __future__ import annotations
+
+import time
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+import httpx
+
+from qmtl.common import AsyncCircuitBreaker
+
+RetryHook = Callable[[int, Exception], Awaitable[None]]
+LatencyObserver = Callable[[float], None]
+BreakerCallback = Callable[[AsyncCircuitBreaker], None]
+
+
+class BreakerRetryTransport:
+    """Retrying transport that integrates with an :class:`AsyncCircuitBreaker`."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        breaker: AsyncCircuitBreaker,
+        *,
+        timeout: float,
+        retries: int,
+        wait_for_service: Optional[RetryHook] = None,
+        observe_latency: Optional[LatencyObserver] = None,
+        on_success: Optional[BreakerCallback] = None,
+    ) -> None:
+        self._client = client
+        self._breaker = breaker
+        self._timeout = timeout
+        self._retries = retries
+        self._wait_for_service = wait_for_service
+        self._observe_latency = observe_latency
+        self._on_success = on_success
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        request_kwargs: Dict[str, Any] = dict(kwargs)
+        request_kwargs.setdefault("timeout", self._timeout)
+
+        @self._breaker
+        async def _call() -> httpx.Response:
+            for attempt in range(self._retries + 1):
+                try:
+                    start = time.perf_counter()
+                    response = await self._client.request(method, url, **request_kwargs)
+                    if self._observe_latency is not None:
+                        self._observe_latency((time.perf_counter() - start) * 1000)
+                    return response
+                except Exception as exc:
+                    if attempt == self._retries:
+                        raise
+                    if self._wait_for_service is not None:
+                        await self._wait_for_service(attempt + 1, exc)
+            raise RuntimeError("retry loop exhausted")
+
+        response = await _call()
+        self._breaker.reset()
+        if self._on_success is not None:
+            self._on_success(self._breaker)
+        return response
+
+
+__all__ = ["BreakerRetryTransport"]

--- a/qmtl/gateway/world_payloads.py
+++ b/qmtl/gateway/world_payloads.py
@@ -1,0 +1,41 @@
+"""Helpers for shaping WorldService request and response payloads."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from qmtl.common.compute_context import (
+    ComputeContext,
+    build_worldservice_compute_context,
+)
+
+from . import metrics as gw_metrics
+
+
+def assemble_compute_context(world_id: str, payload: Mapping[str, Any]) -> ComputeContext:
+    """Build and record compute-context metadata for a decision payload."""
+
+    context = build_worldservice_compute_context(world_id, payload)
+    if context.downgraded and context.downgrade_reason:
+        reason = getattr(context.downgrade_reason, "value", context.downgrade_reason)
+        gw_metrics.worlds_compute_context_downgrade_total.labels(reason=reason).inc()
+    return context
+
+
+def augment_decision_payload(world_id: str, payload: Any) -> Any:
+    """Attach compute-context metadata to decision envelopes when available."""
+
+    if not isinstance(payload, dict):
+        return payload
+    if "effective_mode" not in payload:
+        return payload
+
+    context = assemble_compute_context(world_id, payload)
+    payload["execution_domain"] = context.execution_domain or None
+    payload["compute_context"] = context.to_dict(include_flags=True)
+    return payload
+
+
+__all__ = [
+    "assemble_compute_context",
+    "augment_decision_payload",
+]

--- a/tests/gateway/test_world_client.py
+++ b/tests/gateway/test_world_client.py
@@ -72,7 +72,7 @@ async def test_get_decide_returns_cached_payload_on_backend_error() -> None:
         assert stale_first is False
 
         # Force cache expiration to trigger a new request that will fail.
-        client._decision_cache["w1"].expires_at = 0
+        client._decision_cache.expire("w1")
 
         second, stale_second = await client.get_decide("w1")
         assert second == {"decision": "ok"}

--- a/tests/gateway/test_world_client_components.py
+++ b/tests/gateway/test_world_client_components.py
@@ -1,0 +1,150 @@
+"""Unit tests for reusable primitives in the WorldService proxy."""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from qmtl.common import AsyncCircuitBreaker
+from qmtl.common.compute_context import DowngradeReason
+from qmtl.gateway.caches import ActivationCache, TTLCache
+from qmtl.gateway.transport import BreakerRetryTransport
+from qmtl.gateway.world_payloads import augment_decision_payload
+
+
+class StubAsyncClient:
+    """Deterministic httpx.AsyncClient stand-in for transport tests."""
+
+    def __init__(self, outcomes: list[httpx.Response | Exception]) -> None:
+        self._outcomes = list(outcomes)
+        self.calls: list[tuple[str, str]] = []
+
+    async def request(self, method: str, url: str, **_: object) -> httpx.Response:
+        self.calls.append((method, url))
+        if not self._outcomes:
+            raise AssertionError("Unexpected request")
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def test_ttl_cache_tracks_freshness() -> None:
+    clock = [1_000.0]
+    cache = TTLCache[str](clock=lambda: clock[0])
+
+    result = cache.lookup("alpha")
+    assert result.present is False
+
+    cache.set("alpha", "payload", ttl=10)
+    fresh = cache.lookup("alpha")
+    assert fresh.present is True
+    assert fresh.fresh is True
+    assert fresh.value == "payload"
+
+    clock[0] += 15
+    stale = cache.lookup("alpha")
+    assert stale.present is True
+    assert stale.fresh is False
+    assert stale.stale is True
+
+    cache.invalidate("alpha")
+    empty = cache.lookup("alpha")
+    assert empty.present is False
+
+
+def test_activation_cache_roundtrip() -> None:
+    cache = ActivationCache[dict[str, int]]()
+
+    assert cache.get("key") is None
+    headers = cache.conditional_headers("key")
+    assert "If-None-Match" not in headers
+
+    cache.set("key", "etag-1", {"value": 1})
+    entry = cache.get("key")
+    assert entry is not None
+    assert entry.payload == {"value": 1}
+
+    headers = cache.conditional_headers("key", {"Accept": "application/json"})
+    assert headers["If-None-Match"] == "etag-1"
+    assert headers["Accept"] == "application/json"
+
+    cache.invalidate("key")
+    assert cache.get("key") is None
+
+
+@pytest.mark.asyncio
+async def test_breaker_transport_retries_and_recovers() -> None:
+    client = StubAsyncClient(
+        [
+            httpx.ConnectError("boom"),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    wait_calls: list[tuple[int, Exception]] = []
+    latency: list[float] = []
+    on_success: list[int] = []
+
+    async def wait_for_service(attempt: int, exc: Exception) -> None:
+        wait_calls.append((attempt, exc))
+
+    transport = BreakerRetryTransport(
+        client,
+        AsyncCircuitBreaker(max_failures=2),
+        timeout=0.05,
+        retries=1,
+        wait_for_service=wait_for_service,
+        observe_latency=latency.append,
+        on_success=lambda breaker: on_success.append(breaker.failures),
+    )
+
+    response = await transport.request("GET", "http://example.com")
+
+    assert response.status_code == 200
+    assert len(client.calls) == 2
+    assert wait_calls and wait_calls[0][0] == 1
+    assert latency  # latency observer invoked
+    assert on_success == [0]
+
+
+@pytest.mark.asyncio
+async def test_breaker_transport_opens_circuit() -> None:
+    events: list[str] = []
+    breaker = AsyncCircuitBreaker(max_failures=1, on_open=lambda: events.append("open"))
+    client = StubAsyncClient([httpx.ConnectError("boom")])
+    transport = BreakerRetryTransport(
+        client,
+        breaker,
+        timeout=0.05,
+        retries=0,
+    )
+
+    with pytest.raises(httpx.ConnectError):
+        await transport.request("GET", "http://example.com")
+
+    assert events == ["open"]
+    assert breaker.is_open
+
+    with pytest.raises(RuntimeError, match="circuit open"):
+        await transport.request("GET", "http://example.com")
+
+    # Second attempt should fail fast without touching the client
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_augment_decision_payload_records_downgrade(reset_gateway_metrics) -> None:
+    payload = {"effective_mode": "paper"}
+    augmented = augment_decision_payload("world-123", payload)
+
+    assert augmented["execution_domain"] == "backtest"
+    context = augmented["compute_context"]
+    assert context["world_id"] == "world-123"
+    assert context["downgraded"] is True
+    assert context["downgrade_reason"] == DowngradeReason.MISSING_AS_OF
+
+    metric_value = (
+        reset_gateway_metrics.worlds_compute_context_downgrade_total.labels(
+            reason=DowngradeReason.MISSING_AS_OF.value
+        )._value.get()
+    )
+    assert metric_value == 1

--- a/tests/gateway/test_world_proxy_decide.py
+++ b/tests/gateway/test_world_proxy_decide.py
@@ -130,7 +130,7 @@ async def test_decide_stale_on_backend_error(
 
     async with gateway_app_factory(handler) as ctx:
         r1 = await ctx.client.get("/worlds/abc/decide")
-        ctx.world_client._decision_cache["abc"].expires_at = 0
+        ctx.world_client._decision_cache.expire("abc")
         r2 = await ctx.client.get("/worlds/abc/decide")
 
     assert r1.json() == {"v": 1}


### PR DESCRIPTION
## Summary
- extract reusable TTL and activation cache helpers for the gateway WorldService proxy
- introduce a breaker-aware transport and payload augmentation helpers used by `WorldServiceClient`
- add unit tests covering cache behaviour, transport retries, and compute-context augmentation while updating existing stale-cache tests

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1058

------
https://chatgpt.com/codex/tasks/task_e_68d1f85f9f948329abf70c2f13bb0615