### PR TITLE
Re-export auditable helpers from repositories module

### DIFF
--- a/qmtl/worldservice/storage/repositories.py
+++ b/qmtl/worldservice/storage/repositories.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .activations import ActivationRepository
+from .auditable import AuditableRepository, AuditSink
 from .audit import AuditLogRepository
 from .bindings import BindingRepository
 from .decisions import DecisionRepository
@@ -15,6 +16,8 @@ from .worlds import WorldRepository
 
 __all__ = [
     "ActivationRepository",
+    "AuditableRepository",
+    "AuditSink",
     "AuditLogRepository",
     "BindingRepository",
     "DecisionRepository",

--- a/tests/worldservice/storage/test_repositories_module.py
+++ b/tests/worldservice/storage/test_repositories_module.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import inspect
+
+from qmtl.worldservice.storage import audit, edge_overrides, normalization, repositories
+
+
+def test_repositories_module_re_exports_expected_symbols() -> None:
+    assert repositories.AuditLogRepository is audit.AuditLogRepository
+    assert repositories.EdgeOverrideRepository is edge_overrides.EdgeOverrideRepository
+    assert repositories._REASON_UNSET is edge_overrides._REASON_UNSET
+    assert (
+        repositories._normalize_execution_domain
+        is normalization._normalize_execution_domain
+    )
+    assert (
+        repositories._normalize_world_node_status
+        is normalization._normalize_world_node_status
+    )
+    assert inspect.isclass(repositories.AuditableRepository)
+    assert inspect.isclass(repositories.AuditSink)


### PR DESCRIPTION
Summary:
- re-export AuditableRepository and AuditSink from qmtl.worldservice.storage.repositories to preserve the legacy public surface after the repository split
- add a regression test that ensures the import aggregator exposes the expected repository symbols and utilities

Fixes #1053

Testing:
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d206b9392883299fb644b643da0f22