### PR TITLE
Normalize TagQuery whitespace handling

### DIFF
--- a/docs/reference/tagquery.md
+++ b/docs/reference/tagquery.md
@@ -2,7 +2,7 @@
 title: "TagQuery Reference"
 tags: []
 author: "QMTL Team"
-last_modified: 2025-09-07
+last_modified: 2025-09-23
 ---
 
 {{ nav_links() }}
@@ -11,7 +11,7 @@ last_modified: 2025-09-07
 
 - Overview: `TagQueryNode` selects upstream queues by tag set and interval. The Runner wires a per‑strategy `TagQueryManager` that resolves the initial queue list and applies live updates via WebSocket.
 - Endpoint: Gateway exposes `GET /queues/by_tag` with params `tags` (comma‑separated), `interval` (seconds), `match_mode` (`any`|`all`), and optional `world_id`.
-- Matching: `match_mode=any` selects queues containing any tag; `all` requires all tags. Tags are normalized and sorted for stable keys.
+- Matching: `match_mode=any` selects queues containing any tag; `all` requires all tags. Tags are normalized (whitespace trimmed, empties removed) and sorted for stable keys.
 - Normalization: Gateway returns an array of descriptor objects:
   - `{"queue": "<id>", "global": <bool>}`. Entries with `global=true` are ignored by the SDK for node execution.
 

--- a/qmtl/common/tagquery.py
+++ b/qmtl/common/tagquery.py
@@ -21,11 +21,18 @@ class MatchMode(str, Enum):
 
 
 def split_tags(tags: str | Iterable[str] | None) -> list[str]:
+    """Normalize a raw ``tags`` payload into a list of tag strings."""
+
     if tags is None:
         return []
     if isinstance(tags, str):
-        return [t for t in tags.split(",") if t]
-    return [str(t) for t in tags]
+        return [segment for segment in (part.strip() for part in tags.split(",")) if segment]
+    normalized: list[str] = []
+    for item in tags:
+        text = str(item).strip()
+        if text:
+            normalized.append(text)
+    return normalized
 
 
 def normalize_match_mode(match_mode: str | None) -> MatchMode:

--- a/tests/gateway/test_tag_query.py
+++ b/tests/gateway/test_tag_query.py
@@ -107,6 +107,16 @@ def test_queues_by_tag_route(client):
     assert dag.called_with == (["t1", "t2"], 60, "any", None, None)
 
 
+def test_queues_by_tag_route_trims_whitespace(client):
+    c, dag = client
+    resp = c.get(
+        "/queues/by_tag",
+        params={"tags": " t1 ,  t2\t", "interval": "60", "match_mode": "any"},
+    )
+    assert resp.status_code == 200
+    assert dag.called_with == (["t1", "t2"], 60, "any", None, None)
+
+
 def test_queues_by_tag_route_default_match_mode(client):
     c, dag = client
     resp = c.get(

--- a/tests/tagquery/test_split_tags.py
+++ b/tests/tagquery/test_split_tags.py
@@ -1,0 +1,28 @@
+import pytest
+
+from qmtl.common.tagquery import split_tags
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, []),
+        ("", []),
+        (",,,", []),
+        ("t1,t2", ["t1", "t2"]),
+        (" t1 ,  t2\t,\n t3 ", ["t1", "t2", "t3"]),
+    ],
+)
+def test_split_tags_from_string(raw, expected):
+    assert split_tags(raw) == expected
+
+
+def test_split_tags_from_iterable_trims_and_filters():
+    tags = [" t1 ", "t2", "", "  ", "t3"]
+    assert split_tags(tags) == ["t1", "t2", "t3"]
+
+
+def test_split_tags_from_iterable_non_string_items():
+    tags = [" t1", 2, None]
+    # Non-string entries are coerced via str() and trimmed
+    assert split_tags(tags) == ["t1", "2", "None"]


### PR DESCRIPTION
## Summary
- Trim and filter whitespace in `split_tags` so gateway inputs produce normalized tag lists
- Add regression tests covering whitespace normalization in both unit and gateway layers
- Document the TagQuery normalization behaviour in the reference guide

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto
- uv run mkdocs build

Fixes #1082

------
https://chatgpt.com/codex/tasks/task_e_68d21050ed508329991ae630248026c9