### PR TITLE
docs: add Backend Quickstart and fix compose commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,35 @@ Customize the sample YAML files in `qmtl/examples/` to match your environment.
 See [gateway.md](docs/architecture/gateway.md) and [dag-manager.md](docs/architecture/dag-manager.md) for more
 information on configuration and advanced usage.
 
+### WorldService
+
+WorldService owns world policies, decisions and activation state. Run it as a
+stand‑alone FastAPI app and enable the Gateway proxy when needed.
+
+1) Start WorldService (SQLite + Redis example)
+
+```bash
+export QMTL_WORLDSERVICE_DB_DSN=sqlite:///worlds.db
+export QMTL_WORLDSERVICE_REDIS_DSN=redis://localhost:6379/0
+uv run uvicorn qmtl.worldservice.api:create_app --factory --host 0.0.0.0 --port 8080
+```
+
+2) Point Gateway at WorldService (optional proxy)
+
+- In `qmtl/examples/qmtl.yml`, set:
+  - `gateway.worldservice_url: http://localhost:8080`
+  - `gateway.enable_worldservice_proxy: true`
+
+Then run Gateway with that config:
+
+```bash
+qmtl gw --config qmtl/examples/qmtl.yml
+```
+
+With the proxy enabled, SDKs can fetch decisions and activation via the
+Gateway. When the proxy is disabled, SDKs operate in offline/backtest modes
+without world decisions.
+
 ## SDK Tutorial
 
 For instructions on implementing strategies with the SDK, see

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
       - HTTPX Usage: guides/httpx_usage.md
   - Operations:
       - Overview: operations/README.md
+      - Backend Quickstart: operations/backend_quickstart.md
       - Docker & Compose: operations/docker.md
       - Backfill: operations/backfill.md
       - Canary Rollout: operations/canary_rollout.md

--- a/qmtl/examples/docs/worldservice_gating.md
+++ b/qmtl/examples/docs/worldservice_gating.md
@@ -25,8 +25,18 @@ WorldService gating flow.
 
 ## Running the demo
 
-1. Start Gateway and WorldService (for example via `uv run qmtl dev` or the
-   provided Docker compose).
+1. Start Gateway and WorldService. For a local run without Docker:
+   - WorldService (SQLite + Redis):
+     ```bash
+     export QMTL_WORLDSERVICE_DB_DSN=sqlite:///worlds.db
+     export QMTL_WORLDSERVICE_REDIS_DSN=redis://localhost:6379/0
+     uv run uvicorn qmtl.worldservice.api:create_app --factory --host 0.0.0.0 --port 8080
+     ```
+   - Gateway (optionally proxying WorldService):
+     - In `qmtl/examples/qmtl.yml` set `gateway.worldservice_url: http://localhost:8080`
+       and `gateway.enable_worldservice_proxy: true`.
+     - Start: `qmtl gw --config qmtl/examples/qmtl.yml`
+   - Alternatively, use the provided Docker Compose stack.
 2. Inspect the payload without side effects:
    ```bash
    python -m qmtl.examples.scripts.worldservice_apply_demo --world-id demo --dry-run

--- a/qmtl/examples/scripts/worldservice_apply_demo.py
+++ b/qmtl/examples/scripts/worldservice_apply_demo.py
@@ -3,7 +3,8 @@
 The script loads the example gating policy, attaches dummy evaluation
 metrics, and posts the payload to a WorldService instance. Use it to
 exercise the new gating hooks locally after spinning up Gateway and
-WorldService with ``uv run qmtl dev`` or docker-compose.
+WorldService (e.g., ``uv run uvicorn qmtl.worldservice.api:create_app --factory``)
+or via Docker Compose.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Summary: Add Backend Quickstart (WS+GW+DM) doc and align commands

- Add docs/operations/backend_quickstart.md with WS+GW+DM local/Docker paths
- Wire page into mkdocs navigation under Operations
- README: add WorldService run guide and Gateway proxy steps
- Examples: update WS gating doc and apply demo notes
- docker-compose: fix CLI names (dagmanager-server, remove legacy gw serve)

Notes:
- Documentation-only change plus compose command corrections; no runtime behavior changes.
- Python >=3.11 remains required; mkdocs build validated locally.