### PR TITLE
Propagate strategy_id from Gateway acknowledgements

### DIFF
--- a/qmtl/sdk/runner.py
+++ b/qmtl/sdk/runner.py
@@ -415,7 +415,9 @@ class Runner:
             if gateway_url and not offline_mode:
                 try:
                     activation_manager = services.ensure_activation_manager(
-                        gateway_url=gateway_url, world_id=world_id
+                        gateway_url=gateway_url,
+                        world_id=world_id,
+                        strategy_id=bootstrap_result.strategy_id,
                     )
                     services.trade_dispatcher.set_activation_manager(
                         activation_manager

--- a/qmtl/sdk/services.py
+++ b/qmtl/sdk/services.py
@@ -108,14 +108,21 @@ class RunnerServices:
         self._trade_dispatcher.set_activation_manager(manager)
 
     def ensure_activation_manager(
-        self, *, gateway_url: str, world_id: str
+        self, *, gateway_url: str, world_id: str, strategy_id: str | None = None
     ) -> ActivationManager:
         manager = self._activation_manager
         if manager is None:
             manager = self._activation_manager_factory(
-                gateway_url=gateway_url, world_id=world_id, strategy_id=None
+                gateway_url=gateway_url,
+                world_id=world_id,
+                strategy_id=strategy_id,
             )
             self.set_activation_manager(manager)
+        else:
+            manager.gateway_url = gateway_url
+            manager.world_id = world_id
+            if strategy_id is not None:
+                manager.strategy_id = strategy_id
         return manager
 
     def set_feature_plane(self, plane: FeatureArtifactPlane | None) -> None:

--- a/tests/runner/test_runner_gateway.py
+++ b/tests/runner/test_runner_gateway.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from qmtl.dagmanager.kafka_admin import compute_key, partition_key
+from qmtl.gateway.models import StrategyAck
 from qmtl.sdk.execution_context import resolve_execution_context
 from qmtl.sdk.runner import Runner
 from tests.sample_strategy import SampleStrategy
@@ -60,7 +61,8 @@ def test_gateway_queue_mapping(gateway_mock, runner_with_gateway):
 
 def test_run_exits_when_all_nodes_mapped(monkeypatch, caplog):
     async def fake_post_gateway_async(*, gateway_url, dag, meta, context=None, world_id=None):
-        return {node["node_id"]: "topic" for node in dag["nodes"]}
+        queue_map = {node["node_id"]: "topic" for node in dag["nodes"]}
+        return StrategyAck(strategy_id="strategy-test", queue_map=queue_map)
 
     def fake_run_pipeline(strategy):
         raise RuntimeError("should not run")
@@ -84,7 +86,8 @@ def test_run_exits_when_all_nodes_mapped_live(monkeypatch, caplog):
     from qmtl.sdk.tagquery_manager import TagQueryManager
 
     async def fake_post_gateway_async(*, gateway_url, dag, meta, context=None, world_id=None):
-        return {node["node_id"]: "topic" for node in dag["nodes"]}
+        queue_map = {node["node_id"]: "topic" for node in dag["nodes"]}
+        return StrategyAck(strategy_id="strategy-test", queue_map=queue_map)
 
     def fake_run_pipeline(strategy):
         raise RuntimeError("should not run")

--- a/tests/sdk/test_runner_context.py
+++ b/tests/sdk/test_runner_context.py
@@ -54,6 +54,7 @@ async def test_runner_applies_context_once(monkeypatch) -> None:
             dataset_fingerprint=None,
             tag_service=object(),
             dag_meta=None,
+            strategy_id=None,
         )
 
     monkeypatch.setattr(StrategyBootstrapper, "bootstrap", fake_bootstrap, raising=False)

--- a/tests/test_runner_postprocess.py
+++ b/tests/test_runner_postprocess.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from qmtl.gateway.models import StrategyAck
 from qmtl.sdk.runner import Runner
 from qmtl.sdk.node import Node
 from qmtl.sdk.strategy import Strategy
@@ -48,7 +49,7 @@ def test_run_hooks_offline(monkeypatch):
         orders.append(order)
 
     async def fake_gateway(**kwargs):
-        return {}
+        return StrategyAck(strategy_id="strategy-offline", queue_map={})
 
     class DummyManager:
         async def resolve_tags(self, offline=False):
@@ -133,7 +134,7 @@ def test_run_hooks_live_like(monkeypatch):
         orders.append(order)
 
     async def fake_gateway(**kwargs):
-        return {}
+        return StrategyAck(strategy_id="strategy-offline", queue_map={})
 
     class DummyManager:
         async def resolve_tags(self, offline=False):

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -37,7 +37,7 @@ async def test_post_gateway_propagates_trace(monkeypatch):
             class DummyResp:
                 status_code = 202
                 def json(self):
-                    return {"queue_map": {}}
+                    return {"strategy_id": "trace-strategy", "queue_map": {}}
             return DummyResp()
 
     monkeypatch.setattr(httpx, "AsyncClient", lambda **_: DummyClient())


### PR DESCRIPTION
## Summary
- parse Gateway strategy submission responses into `StrategyAck` objects and return them from the SDK client
- surface the acknowledged `strategy_id` through the bootstrap result so strategies, tag services, and activation managers stay in sync
- update existing unit tests to exercise the new acknowledgement handling and optional strategy identifier plumbing

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1083

------
https://chatgpt.com/codex/tasks/task_e_68d212f3954c83298e4054c4b6a79198