### PR TITLE
Propagate strategy_id from Gateway acknowledgements

### DIFF
--- a/qmtl/gateway/models.py
+++ b/qmtl/gateway/models.py
@@ -21,7 +21,7 @@ class StrategySubmit(BaseModel):
 
 
 class StrategyAck(BaseModel):
-    strategy_id: str
+    strategy_id: str | None = None
     queue_map: dict[str, object] = Field(default_factory=dict)
     # Include sentinel identifier for parity with dry-run/diff outputs
     sentinel_id: str | None = None


### PR DESCRIPTION
## Summary
- parse Gateway strategy submission responses into `StrategyAck` objects and return them from the SDK client
- surface the acknowledged `strategy_id` through the bootstrap result so strategies, tag services, and activation managers stay in sync
- update existing unit tests to exercise the new acknowledgement handling and optional strategy identifier plumbing
- allow `StrategyAck` to accept missing `strategy_id` values so older gateways still parse

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d216fa17d0832989e6131d2cf492d6