### PR TITLE
Add local stack configuration template

### DIFF
--- a/docs/templates/index.md
+++ b/docs/templates/index.md
@@ -2,3 +2,4 @@
 
 - [Document skeleton](template.md)
 - [Backend stack configuration template](backend_stack.example.yml)
+- [Local stack configuration template](local_stack.example.yml)

--- a/docs/templates/local_stack.example.yml
+++ b/docs/templates/local_stack.example.yml
@@ -1,0 +1,92 @@
+# QMTL local stack configuration template
+#
+# This template enumerates the lightweight backends bundled with Gateway,
+# DAG Manager, WorldService, and the qmtl CLI so the stack can run entirely on a
+# developer workstation. Copy it next to your service configs and replace paths
+# as needed before launching the processes.
+version: 1
+metadata:
+  environment: local
+  description: >-
+    Minimal configuration for local development. Uses SQLite databases,
+    optional Redis, and in-process fallbacks instead of Kafka or Neo4j.
+filesystem:
+  state_root: ./var
+  ensure:
+    - ${filesystem.state_root}
+    - ${filesystem.state_root}/dagmanager
+backends:
+  sqlite:
+    gateway_path: ${filesystem.state_root}/gateway.sqlite3
+    worldservice_path: ${filesystem.state_root}/worlds.sqlite3
+  redis:
+    url: redis://localhost:6379/0
+    notes:
+      - "Gateway falls back to InMemoryRedis when redis_dsn is omitted."
+      - "WorldService defaults to the in-memory activation store when QMTL_WORLDSERVICE_REDIS_DSN is unset."
+  controlbus:
+    mode: in-process
+    notes:
+      - "Leaving kafka_dsn unset activates the in-memory KafkaAdmin for DAG Manager."
+      - "Gateway skips ControlBus subscriptions without brokers/topics."
+  commitlog:
+    mode: disabled
+    notes:
+      - "Gateway buffers ingest events in process when commit log brokers are not configured."
+worldservice:
+  host: 0.0.0.0
+  port: 8080
+  storage:
+    backend: sqlite
+    db_dsn: sqlite:///${filesystem.state_root}/worlds.sqlite3
+    redis_dsn: ${backends.redis.url}
+  env:
+    QMTL_WORLDSERVICE_DB_DSN: ${worldservice.storage.db_dsn}
+    QMTL_WORLDSERVICE_REDIS_DSN: ${worldservice.storage.redis_dsn}
+  notes:
+    - "Unset the env vars above to use the bundled in-memory storage façade (handy for unit tests)."
+    - "Run with: uv run uvicorn qmtl.worldservice.api:create_app --factory --host ${worldservice.host} --port ${worldservice.port}"
+gateway:
+  host: 0.0.0.0
+  port: 8000
+  redis_dsn: ${backends.redis.url}  # remove to use the in-memory Redis clone
+  database_backend: sqlite
+  database_dsn: ${backends.sqlite.gateway_path}
+  insert_sentinel: true
+  worldservice_url: "http://localhost:${worldservice.port}"
+  enable_worldservice_proxy: true
+  enforce_live_guard: false
+  controlbus_brokers: []
+  controlbus_topics: []
+  notes:
+    - "Persistent storage defaults to SQLite; switch to Postgres by adjusting database_backend."
+    - "Commit log fields are omitted; Gateway falls back to its local queue implementation."
+dagmanager:
+  memory_repo_path: ${filesystem.state_root}/dagmanager/memrepo.gpickle
+  neo4j_dsn: null           # keep null to use MemoryNodeRepository
+  kafka_dsn: null           # keep null to use InMemoryAdminClient
+  grpc_host: 0.0.0.0
+  grpc_port: 50051
+  http_host: 0.0.0.0
+  http_port: 8001
+  controlbus_dsn: null      # omit to keep ControlBus events in process
+  controlbus_queue_topic: queue
+  notes:
+    - "Create the memrepo directory before launch: mkdir -p ${filesystem.state_root}/dagmanager"
+    - "Neo4j and Kafka dependencies stay disabled for pure local runs."
+qmtl:
+  config_file: qmtl/qmtl/examples/qmtl.yml
+  overrides:
+    gateway.database_dsn: ${gateway.database_dsn}
+    gateway.redis_dsn: ${gateway.redis_dsn}
+    gateway.worldservice_url: ${gateway.worldservice_url}
+    dagmanager.memory_repo_path: ${dagmanager.memory_repo_path}
+  sample_usage:
+    - "qmtl gw --config ${qmtl.config_file}"
+    - "qmtl dagmanager-server --config ${qmtl.config_file}"
+    - "python -m qmtl.examples.general_strategy --gateway-url http://localhost:${gateway.port} --world-id demo"
+notes:
+  - "Optional Redis container: docker run --rm -p 6379:6379 redis:7-alpine"
+  - "Create local state directories upfront: mkdir -p ./var/dagmanager"
+  - "Set QMTL_ENABLE_TOPIC_NAMESPACE=0 to reuse legacy topic names when testing against mocks."
+  - "Install dependencies with uv pip install -e .[dev] before starting services."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Index: templates/index.md
       - Document Skeleton: templates/template.md
       - Backend Stack Config: templates/backend_stack.example.yml
+      - Local Stack Config: templates/local_stack.example.yml
 plugins:
   - search
   - macros


### PR DESCRIPTION
## Summary
- add a local stack configuration template that enumerates the lightweight backends for Gateway, DAG Manager, WorldService, and the qmtl CLI
- link the new template from the templates index and mkdocs navigation so it appears alongside the existing stack example

## Testing
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d24f9301848329bedc5eda0a79bf88