### PR TITLE
Include backend stack templates in init scaffolding

### DIFF
--- a/docs/reference/templates.md
+++ b/docs/reference/templates.md
@@ -102,6 +102,21 @@ state inside a strategy.
 qmtl init --path my_proj --strategy state_machine
 ```
 
+## Backend configuration templates
+
+When you scaffold a project with `qmtl init`, two backend configuration samples
+are included under the generated `templates/` directory:
+
+* `local_stack.example.yml` &mdash; lightweight backend stack that relies on
+  SQLite, optional Redis, and in-process fallbacks for Kafka and Neo4j. Useful
+  for local development or smoke tests without external dependencies.
+* `backend_stack.example.yml` &mdash; production-ready template covering Redis,
+  Postgres, Kafka, Neo4j, and observability services. Replace the placeholders
+  before deploying.
+
+Use these files as starting points when wiring up Gateway, DAG Manager, and
+WorldService for different environments.
+
 ## Tagging guidelines
 
 Modules can include a `TAGS` dictionary describing scope, family and other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ include = ["qmtl*"]
 "qmtl.examples" = [
   "*.py",
   "*.yml",
+  "templates/*.yml",
   "gitignore",
   "README.md",
   "data/*.csv",

--- a/qmtl/examples/templates/backend_stack.example.yml
+++ b/qmtl/examples/templates/backend_stack.example.yml
@@ -1,0 +1,122 @@
+# QMTL backend stack configuration template
+#
+# This file aggregates configuration for Gateway, DAG Manager, and WorldService
+# along with the shared infrastructure services they depend on. Replace
+# placeholders with deployment-specific values before using in production.
+version: 1
+metadata:
+  environment: production
+  maintained_by:
+    - ops@example.com
+  description: >-
+    Template for running the core QMTL backend services with durable storage,
+    messaging, and observability backends.
+
+backends:
+  redis:
+    # Dedicated logical databases per service prevent key collisions.
+    gateway_state: redis://redis:6379/0
+    worldservice_activation: redis://redis:6379/1
+    cache_ttl_seconds: 86400
+  sql:
+    # Use separate schemas or databases for Gateway and WorldService.
+    gateway_dsn: postgresql://qmtl_gw:CHANGE_ME@postgres:5432/qmtl_gw
+    worldservice_dsn: postgresql://qmtl_ws:CHANGE_ME@postgres:5432/qmtl_ws
+    pool_min_size: 5
+    pool_max_size: 20
+  neo4j:
+    dsn: bolt://neo4j:7687
+    user: neo4j
+    password: CHANGE_ME
+    database: neo4j
+  kafka:
+    brokers: &kafka_brokers
+      - redpanda-0:9092
+      - redpanda-1:9092
+      - redpanda-2:9092
+    security_protocol: SASL_SSL
+    sasl_mechanism: SCRAM-SHA-256
+    sasl_username: CHANGE_ME
+    sasl_password: CHANGE_ME
+    controlbus_topics:
+      activation: activation
+      policy: policy
+      queue: queue
+    commitlog_topic: gateway.ingest
+    replication_factor: 3
+  observability:
+    prometheus_pushgateway: http://prometheus-pushgateway:9091
+    tempo_collector: http://tempo:9411
+    loki_endpoint: http://loki:3100
+  object_storage:
+    artifacts_bucket: s3://qmtl-artifacts
+    region: us-east-1
+
+worldservice:
+  host: 0.0.0.0
+  port: 8080
+  # WorldService currently reads its durable storage configuration from
+  # environment variables. Export the values below before launching the API
+  # server (see docs/operations/backend_quickstart.md).
+  env:
+    QMTL_WORLDSERVICE_DB_DSN: ${backends.sql.worldservice_dsn}
+    QMTL_WORLDSERVICE_REDIS_DSN: ${backends.redis.worldservice_activation}
+  controlbus:
+    brokers: *kafka_brokers
+    topic: ${backends.kafka.controlbus_topics.policy}
+    consumer_group: worldservice
+  notes:
+    - >-
+      Start the service with:
+      uv run uvicorn qmtl.worldservice.api:create_app --factory \
+        --host ${worldservice.host} --port ${worldservice.port}
+    - "Ensure aiokafka is installed if ControlBus publishing is required."
+
+# Gateway section matches qmtl.gateway.config.GatewayConfig.
+gateway:
+  host: 0.0.0.0
+  port: 8000
+  redis_dsn: ${backends.redis.gateway_state}
+  database_backend: postgres
+  database_dsn: ${backends.sql.gateway_dsn}
+  insert_sentinel: true
+  controlbus_brokers: *kafka_brokers
+  controlbus_topics:
+    - ${backends.kafka.controlbus_topics.activation}
+    - ${backends.kafka.controlbus_topics.policy}
+    - ${backends.kafka.controlbus_topics.queue}
+  controlbus_group: gateway
+  commitlog_bootstrap: redpanda-0:9092,redpanda-1:9092,redpanda-2:9092
+  commitlog_topic: ${backends.kafka.commitlog_topic}
+  commitlog_group: gateway-commit
+  commitlog_transactional_id: gateway-commit-writer
+  worldservice_url: http://worldservice:8080
+  worldservice_timeout: 0.5
+  worldservice_retries: 3
+  enable_worldservice_proxy: true
+  enforce_live_guard: true
+
+# DAG Manager section matches qmtl.dagmanager.config.DagManagerConfig.
+dagmanager:
+  memory_repo_path: /var/lib/qmtl/dagmanager/memrepo.gpickle
+  neo4j_dsn: ${backends.neo4j.dsn}
+  neo4j_user: ${backends.neo4j.user}
+  neo4j_password: ${backends.neo4j.password}
+  kafka_dsn: redpanda-0:9092
+  grpc_host: 0.0.0.0
+  grpc_port: 50051
+  http_host: 0.0.0.0
+  http_port: 8001
+  controlbus_dsn: redpanda-0:9092
+  controlbus_queue_topic: ${backends.kafka.controlbus_topics.queue}
+  notes:
+    - >-
+      After provisioning Neo4j, initialise schema with:
+      qmtl dagmanager neo4j-init --uri ${backends.neo4j.dsn} \
+        --user ${backends.neo4j.user} --password <secret>
+
+# Additional operational hints for the full stack.
+notes:
+  - "Export QMTL_ENABLE_TOPIC_NAMESPACE=1 to keep Kafka topics partitioned by world/domain."
+  - "Provision alerts for gateway_e2e_latency_p95, dagmanager_diff_errors_total, and worldservice_decision_stale_total."
+  - "Store secrets (passwords, SASL credentials) in your secrets manager instead of committing them."

--- a/qmtl/examples/templates/local_stack.example.yml
+++ b/qmtl/examples/templates/local_stack.example.yml
@@ -1,0 +1,92 @@
+# QMTL local stack configuration template
+#
+# This template enumerates the lightweight backends bundled with Gateway,
+# DAG Manager, WorldService, and the qmtl CLI so the stack can run entirely on a
+# developer workstation. Copy it next to your service configs and replace paths
+# as needed before launching the processes.
+version: 1
+metadata:
+  environment: local
+  description: >-
+    Minimal configuration for local development. Uses SQLite databases,
+    optional Redis, and in-process fallbacks instead of Kafka or Neo4j.
+filesystem:
+  state_root: ./var
+  ensure:
+    - ${filesystem.state_root}
+    - ${filesystem.state_root}/dagmanager
+backends:
+  sqlite:
+    gateway_path: ${filesystem.state_root}/gateway.sqlite3
+    worldservice_path: ${filesystem.state_root}/worlds.sqlite3
+  redis:
+    url: redis://localhost:6379/0
+    notes:
+      - "Gateway falls back to InMemoryRedis when redis_dsn is omitted."
+      - "WorldService defaults to the in-memory activation store when QMTL_WORLDSERVICE_REDIS_DSN is unset."
+  controlbus:
+    mode: in-process
+    notes:
+      - "Leaving kafka_dsn unset activates the in-memory KafkaAdmin for DAG Manager."
+      - "Gateway skips ControlBus subscriptions without brokers/topics."
+  commitlog:
+    mode: disabled
+    notes:
+      - "Gateway buffers ingest events in process when commit log brokers are not configured."
+worldservice:
+  host: 0.0.0.0
+  port: 8080
+  storage:
+    backend: sqlite
+    db_dsn: sqlite:///${filesystem.state_root}/worlds.sqlite3
+    redis_dsn: ${backends.redis.url}
+  env:
+    QMTL_WORLDSERVICE_DB_DSN: ${worldservice.storage.db_dsn}
+    QMTL_WORLDSERVICE_REDIS_DSN: ${worldservice.storage.redis_dsn}
+  notes:
+    - "Unset the env vars above to use the bundled in-memory storage façade (handy for unit tests)."
+    - "Run with: uv run uvicorn qmtl.worldservice.api:create_app --factory --host ${worldservice.host} --port ${worldservice.port}"
+gateway:
+  host: 0.0.0.0
+  port: 8000
+  redis_dsn: ${backends.redis.url}  # remove to use the in-memory Redis clone
+  database_backend: sqlite
+  database_dsn: ${backends.sqlite.gateway_path}
+  insert_sentinel: true
+  worldservice_url: "http://localhost:${worldservice.port}"
+  enable_worldservice_proxy: true
+  enforce_live_guard: false
+  controlbus_brokers: []
+  controlbus_topics: []
+  notes:
+    - "Persistent storage defaults to SQLite; switch to Postgres by adjusting database_backend."
+    - "Commit log fields are omitted; Gateway falls back to its local queue implementation."
+dagmanager:
+  memory_repo_path: ${filesystem.state_root}/dagmanager/memrepo.gpickle
+  neo4j_dsn: null           # keep null to use MemoryNodeRepository
+  kafka_dsn: null           # keep null to use InMemoryAdminClient
+  grpc_host: 0.0.0.0
+  grpc_port: 50051
+  http_host: 0.0.0.0
+  http_port: 8001
+  controlbus_dsn: null      # omit to keep ControlBus events in process
+  controlbus_queue_topic: queue
+  notes:
+    - "Create the memrepo directory before launch: mkdir -p ${filesystem.state_root}/dagmanager"
+    - "Neo4j and Kafka dependencies stay disabled for pure local runs."
+qmtl:
+  config_file: qmtl/qmtl/examples/qmtl.yml
+  overrides:
+    gateway.database_dsn: ${gateway.database_dsn}
+    gateway.redis_dsn: ${gateway.redis_dsn}
+    gateway.worldservice_url: ${gateway.worldservice_url}
+    dagmanager.memory_repo_path: ${dagmanager.memory_repo_path}
+  sample_usage:
+    - "qmtl gw --config ${qmtl.config_file}"
+    - "qmtl dagmanager-server --config ${qmtl.config_file}"
+    - "python -m qmtl.examples.general_strategy --gateway-url http://localhost:${gateway.port} --world-id demo"
+notes:
+  - "Optional Redis container: docker run --rm -p 6379:6379 redis:7-alpine"
+  - "Create local state directories upfront: mkdir -p ./var/dagmanager"
+  - "Set QMTL_ENABLE_TOPIC_NAMESPACE=0 to reuse legacy topic names when testing against mocks."
+  - "Install dependencies with uv pip install -e .[dev] before starting services."

--- a/qmtl/scaffold.py
+++ b/qmtl/scaffold.py
@@ -117,6 +117,18 @@ def copy_pyproject(dest: Path) -> None:
         (dest / "pyproject.toml").write_bytes(py_src.read_bytes())
 
 
+def copy_backend_templates(dest: Path) -> None:
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    examples = resources.files(_EXAMPLES_PKG)
+    templates_dest = dest / "templates"
+    templates_dest.mkdir(exist_ok=True)
+    for name in ("local_stack.example.yml", "backend_stack.example.yml"):
+        src = examples.joinpath("templates", name)
+        if src.is_file():
+            (templates_dest / name).write_bytes(src.read_bytes())
+
+
 def copy_base_files(dest: Path) -> None:
     dest = Path(dest)
     dest.mkdir(parents=True, exist_ok=True)
@@ -142,6 +154,7 @@ def copy_base_files(dest: Path) -> None:
                 dst_file = tests_dest / file.relative_to(tests_src)
                 dst_file.parent.mkdir(parents=True, exist_ok=True)
                 dst_file.write_bytes(file.read_bytes())
+    copy_backend_templates(dest)
 
 
 def create_project(
@@ -184,6 +197,7 @@ __all__ = [
     "copy_sample_data",
     "copy_pyproject",
     "copy_base_files",
+    "copy_backend_templates",
     "TEMPLATES",
 ]
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,12 @@ import sys
 from qmtl.scaffold import create_project
 
 
+def _assert_backend_templates(dest: Path) -> None:
+    templates_dir = dest / "templates"
+    assert (templates_dir / "local_stack.example.yml").is_file()
+    assert (templates_dir / "backend_stack.example.yml").is_file()
+
+
 def test_create_project(tmp_path: Path):
     dest = tmp_path / "proj"
     create_project(dest)
@@ -17,6 +23,7 @@ def test_create_project(tmp_path: Path):
     dag = dest / "dags" / "example_strategy"
     assert (dag / "__init__.py").is_file()
     assert (dag / "config.yaml").is_file()
+    _assert_backend_templates(dest)
 
 
 def test_create_project_with_sample_data(tmp_path: Path):
@@ -28,6 +35,7 @@ def test_create_project_with_sample_data(tmp_path: Path):
     assert (dest / ".gitignore").is_file()
     assert (dest / "README.md").is_file()
     assert (dest / "tests" / "nodes" / "test_sequence_generator_node.py").is_file()
+    _assert_backend_templates(dest)
 
 
 def test_create_project_with_optionals(tmp_path: Path):
@@ -36,6 +44,7 @@ def test_create_project_with_optionals(tmp_path: Path):
     assert (dest / "docs" / "README.md").is_file()
     assert (dest / "scripts" / "example.py").is_file()
     assert (dest / "pyproject.toml").is_file()
+    _assert_backend_templates(dest)
 
 
 def test_init_cli(tmp_path: Path):
@@ -58,6 +67,7 @@ def test_init_cli(tmp_path: Path):
     dag = dest / "dags" / "example_strategy"
     assert (dag / "__init__.py").is_file()
     assert (dag / "config.yaml").is_file()
+    _assert_backend_templates(dest)
 
 
 def test_init_cli_with_optionals(tmp_path: Path):
@@ -77,6 +87,7 @@ def test_init_cli_with_optionals(tmp_path: Path):
     assert (dest / "docs" / "README.md").is_file()
     assert (dest / "scripts" / "example.py").is_file()
     assert (dest / "pyproject.toml").is_file()
+    _assert_backend_templates(dest)
 
 
 def test_init_cli_with_sample_data(tmp_path: Path):
@@ -97,3 +108,4 @@ def test_init_cli_with_sample_data(tmp_path: Path):
     assert (dest / ".gitignore").is_file()
     assert (dest / "README.md").is_file()
     assert (dest / "tests" / "nodes" / "test_sequence_generator_node.py").is_file()
+    _assert_backend_templates(dest)


### PR DESCRIPTION
## Summary
- add lightweight and full backend configuration templates to the example bundle
- ensure `qmtl init` copies the backend templates into new projects and document their availability
- extend the init tests to cover the new templates

## Testing
- uv run -m pytest -W error tests/test_init.py

------
https://chatgpt.com/codex/tasks/task_e_68d2da572e988329a26dfcff07a1205c