### PR TITLE
Speed up wheel smoke test by reusing existing deps

### DIFF
--- a/tests/test_init_wheel.py
+++ b/tests/test_init_wheel.py
@@ -33,7 +33,19 @@ def test_init_wheel(tmp_path: Path) -> None:
     dest = tmp_path / "proj"
     env = os.environ.copy()
     existing = env.get("PYTHONPATH")
-    extra_paths = [str(Path(path)) for path in sys.path if path]
+    extra_paths = []
+    for entry in sys.path:
+        if not entry:
+            continue
+        resolved = Path(entry).resolve()
+        if resolved == project_dir:
+            continue
+        if project_dir in resolved.parents and not {
+            "site-packages",
+            "dist-packages",
+        }.intersection(resolved.parts):
+            continue
+        extra_paths.append(str(resolved))
     if existing:
         extra_paths.append(existing)
     env["PYTHONPATH"] = os.pathsep.join(extra_paths)


### PR DESCRIPTION
## Summary
- reuse already-installed dependencies when smoke-testing wheel
- avoid redundant downloads by adding --no-deps and forwarding PYTHONPATH
- filter the forwarded PYTHONPATH to exclude the repo source tree so the wheel remains authoritative

## Testing
- uv run -m pytest tests/test_init_wheel.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68d321601cb88329b1da870592857ef1