### PR TITLE
Add configuration validation CLI

### DIFF
--- a/qmtl/foundation/config_validation.py
+++ b/qmtl/foundation/config_validation.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass
+from typing import Dict, Mapping, Sequence
+
+import aiosqlite
+import asyncpg
+import httpx
+import redis.asyncio as redis
+
+from qmtl.services.dagmanager.config import DagManagerConfig
+from qmtl.services.dagmanager.kafka_admin import KafkaAdmin
+from qmtl.services.gateway.config import GatewayConfig
+from qmtl.services.gateway.controlbus_consumer import ControlBusConsumer
+
+
+@dataclass(slots=True)
+class ValidationIssue:
+    """Represents the outcome of a single validation check."""
+
+    severity: str
+    hint: str
+
+
+def _normalise_sqlite_path(dsn: str | None) -> str:
+    if not dsn:
+        return ":memory:"
+    if dsn.startswith("sqlite:///"):
+        return dsn[len("sqlite:///") :]
+    if dsn.startswith("sqlite://"):
+        return dsn[len("sqlite://") :]
+    return dsn or ":memory:"
+
+
+def _count_topics(metadata: object) -> int:
+    if isinstance(metadata, Mapping):
+        return len(metadata)
+    topics = getattr(metadata, "topics", None)
+    if isinstance(topics, Mapping):
+        return len(topics)
+    if isinstance(topics, Sequence):
+        return len(topics)
+    if topics is None:
+        return 0
+    try:
+        return len(list(topics))
+    except Exception:
+        return 0
+
+
+async def _create_kafka_admin(dsn: str) -> KafkaAdmin:
+    from confluent_kafka.admin import AdminClient  # type: ignore[import]
+
+    client = AdminClient({"bootstrap.servers": dsn})
+    return KafkaAdmin(client)
+
+
+async def _check_controlbus(
+    brokers: Sequence[str], topics: Sequence[str], group: str, *, offline: bool
+) -> ValidationIssue:
+    broker_list = ", ".join(brokers)
+    if not brokers or not topics:
+        return ValidationIssue("ok", "ControlBus disabled; no brokers/topics configured")
+    if offline:
+        return ValidationIssue("warning", f"Offline mode: skipped ControlBus check for {broker_list}")
+    try:
+        import aiokafka  # type: ignore[import]  # noqa: F401
+    except ModuleNotFoundError:
+        return ValidationIssue("warning", "aiokafka not installed; skipping ControlBus validation")
+
+    consumer = ControlBusConsumer(brokers=list(brokers), topics=list(topics), group=group)
+    ready = await consumer._broker_ready()
+    if ready:
+        return ValidationIssue("ok", f"ControlBus brokers reachable ({broker_list})")
+    return ValidationIssue("error", f"ControlBus brokers unreachable ({broker_list})")
+
+
+async def validate_gateway_config(
+    config: GatewayConfig, *, offline: bool = False
+) -> Dict[str, ValidationIssue]:
+    issues: Dict[str, ValidationIssue] = {}
+
+    # Redis connectivity
+    if not config.redis_dsn:
+        issues["redis"] = ValidationIssue(
+            "warning", "Redis DSN not configured; falling back to in-memory store"
+        )
+    elif offline:
+        issues["redis"] = ValidationIssue(
+            "warning", f"Offline mode: skipped Redis ping for {config.redis_dsn}"
+        )
+    else:
+        client = None
+        try:
+            client = redis.from_url(config.redis_dsn)
+            await client.ping()
+        except Exception as exc:
+            issues["redis"] = ValidationIssue("error", f"Redis connection failed: {exc}")
+        else:
+            issues["redis"] = ValidationIssue("ok", f"Redis reachable at {config.redis_dsn}")
+        finally:
+            if client is not None:
+                with contextlib.suppress(Exception):
+                    await client.close()
+
+    # Database backend
+    backend = (config.database_backend or "").lower()
+    if backend == "postgres":
+        dsn = config.database_dsn or "postgresql://localhost/qmtl"
+        if offline:
+            issues["database"] = ValidationIssue(
+                "warning", f"Offline mode: skipped Postgres check for {dsn}"
+            )
+        else:
+            conn = None
+            try:
+                conn = await asyncpg.connect(dsn)
+            except Exception as exc:
+                issues["database"] = ValidationIssue(
+                    "error", f"Postgres connection failed: {exc}"
+                )
+            else:
+                issues["database"] = ValidationIssue(
+                    "ok", f"Postgres reachable at {dsn}"
+                )
+            finally:
+                if conn is not None:
+                    with contextlib.suppress(Exception):
+                        await conn.close()
+    elif backend == "sqlite":
+        path = _normalise_sqlite_path(config.database_dsn)
+        conn = None
+        try:
+            conn = await aiosqlite.connect(path)
+        except Exception as exc:
+            issues["database"] = ValidationIssue(
+                "error", f"SQLite open failed for {path}: {exc}"
+            )
+        else:
+            issues["database"] = ValidationIssue("ok", f"SQLite ready at {path}")
+        finally:
+            if conn is not None:
+                with contextlib.suppress(Exception):
+                    await conn.close()
+    elif backend == "memory":
+        issues["database"] = ValidationIssue(
+            "warning", "In-memory database configured; data will not persist"
+        )
+    else:
+        issues["database"] = ValidationIssue(
+            "error", f"Unsupported database backend '{config.database_backend}'"
+        )
+
+    # ControlBus consumer
+    issues["controlbus"] = await _check_controlbus(
+        config.controlbus_brokers,
+        config.controlbus_topics,
+        config.controlbus_group,
+        offline=offline,
+    )
+
+    # WorldService proxy
+    if not config.enable_worldservice_proxy or not config.worldservice_url:
+        issues["worldservice"] = ValidationIssue(
+            "ok", "WorldService proxy disabled"
+        )
+    elif offline:
+        issues["worldservice"] = ValidationIssue(
+            "warning",
+            f"Offline mode: skipped WorldService health check for {config.worldservice_url}",
+        )
+    else:
+        health_url = config.worldservice_url.rstrip("/") + "/health"
+        timeout = max(config.worldservice_timeout, 0.1)
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(health_url, timeout=timeout)
+        except Exception as exc:
+            issues["worldservice"] = ValidationIssue(
+                "error", f"WorldService request failed: {exc}"
+            )
+        else:
+            if resp.status_code == 200:
+                issues["worldservice"] = ValidationIssue(
+                    "ok", f"WorldService healthy at {config.worldservice_url}"
+                )
+            else:
+                issues["worldservice"] = ValidationIssue(
+                    "error",
+                    f"WorldService health returned HTTP {resp.status_code}",
+                )
+
+    return issues
+
+
+async def validate_dagmanager_config(
+    config: DagManagerConfig, *, offline: bool = False
+) -> Dict[str, ValidationIssue]:
+    issues: Dict[str, ValidationIssue] = {}
+
+    # Neo4j repository
+    if not config.neo4j_dsn:
+        issues["neo4j"] = ValidationIssue(
+            "ok", "Neo4j disabled; using memory repository"
+        )
+    elif offline:
+        issues["neo4j"] = ValidationIssue(
+            "warning", f"Offline mode: skipped Neo4j check for {config.neo4j_dsn}"
+        )
+    else:
+        try:
+            from neo4j import GraphDatabase  # type: ignore[import]
+        except ModuleNotFoundError:
+            issues["neo4j"] = ValidationIssue(
+                "warning", "neo4j driver not installed; skipping validation"
+            )
+        else:
+            loop = asyncio.get_running_loop()
+
+            def _probe() -> None:
+                driver = GraphDatabase.driver(
+                    config.neo4j_dsn, auth=(config.neo4j_user, config.neo4j_password)
+                )
+                try:
+                    with driver.session() as session:
+                        session.run("RETURN 1")
+                finally:
+                    driver.close()
+
+            try:
+                await loop.run_in_executor(None, _probe)
+            except Exception as exc:
+                issues["neo4j"] = ValidationIssue(
+                    "error", f"Neo4j connection failed: {exc}"
+                )
+            else:
+                issues["neo4j"] = ValidationIssue(
+                    "ok", f"Neo4j reachable at {config.neo4j_dsn}"
+                )
+
+    # Kafka queue manager
+    if not config.kafka_dsn:
+        issues["kafka"] = ValidationIssue(
+            "ok", "Kafka DSN not configured; using in-memory queue manager"
+        )
+    elif offline:
+        issues["kafka"] = ValidationIssue(
+            "warning", f"Offline mode: skipped Kafka admin check for {config.kafka_dsn}"
+        )
+    else:
+        try:
+            admin = await _create_kafka_admin(config.kafka_dsn)
+        except ModuleNotFoundError:
+            issues["kafka"] = ValidationIssue(
+                "warning", "confluent-kafka not installed; skipping Kafka validation"
+            )
+        except Exception as exc:
+            issues["kafka"] = ValidationIssue(
+                "error", f"Failed to initialise Kafka admin client: {exc}"
+            )
+        else:
+            loop = asyncio.get_running_loop()
+
+            def _fetch() -> object:
+                return admin.client.list_topics()
+
+            try:
+                metadata = await loop.run_in_executor(None, _fetch)
+            except Exception as exc:
+                issues["kafka"] = ValidationIssue(
+                    "error", f"Kafka metadata fetch failed: {exc}"
+                )
+            else:
+                count = _count_topics(metadata)
+                issues["kafka"] = ValidationIssue(
+                    "ok",
+                    f"Kafka reachable at {config.kafka_dsn} ({count} topics visible)",
+                )
+
+    # ControlBus producer
+    brokers = [config.controlbus_dsn] if config.controlbus_dsn else []
+    topics = [config.controlbus_queue_topic] if config.controlbus_queue_topic else []
+    issues["controlbus"] = await _check_controlbus(
+        brokers, topics, f"{config.controlbus_queue_topic}-validator", offline=offline
+    )
+
+    return issues
+
+
+__all__ = [
+    "ValidationIssue",
+    "validate_gateway_config",
+    "validate_dagmanager_config",
+]

--- a/qmtl/interfaces/cli/__init__.py
+++ b/qmtl/interfaces/cli/__init__.py
@@ -21,6 +21,7 @@ from typing import List
 
 
 PRIMARY_DISPATCH = {
+    "config": "qmtl.interfaces.cli.config",
     "service": "qmtl.interfaces.cli.service",
     "tools": "qmtl.interfaces.cli.tools",
     "project": "qmtl.interfaces.cli.project",
@@ -44,6 +45,7 @@ def _build_top_help_parser() -> argparse.ArgumentParser:
     description = textwrap.dedent(
         """
         Subcommands:
+          config    Validate gateway and DAG Manager configuration files.
           service   Manage long-running services such as Gateway and DAG Manager.
           tools     Developer tooling including SDK runners and linters.
           project   Project scaffolding and template helpers.

--- a/qmtl/interfaces/cli/config.py
+++ b/qmtl/interfaces/cli/config.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import textwrap
+from typing import Dict, Iterable, List, Mapping
+
+from qmtl.foundation.config import find_config_file, load_config
+from qmtl.foundation.config_validation import (
+    ValidationIssue,
+    validate_dagmanager_config,
+    validate_gateway_config,
+)
+
+_STATUS_LABELS = {
+    "ok": "OK",
+    "warning": "WARN",
+    "error": "ERROR",
+}
+
+
+def _build_help_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="qmtl config", add_help=True)
+    parser.description = textwrap.dedent(
+        """
+        Configuration utilities.
+
+        Subcommands:
+          validate  Check connectivity and readiness for Gateway and DAG Manager.
+        """
+    ).strip()
+    parser.add_argument("cmd", nargs="?", choices=["validate"], help="Subcommand to run")
+    return parser
+
+
+def _build_validate_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="qmtl config validate")
+    parser.add_argument(
+        "--config",
+        help="Path to configuration file (defaults to qmtl.yml in CWD)",
+    )
+    parser.add_argument(
+        "--target",
+        choices=["gateway", "dagmanager", "all"],
+        default="all",
+        help="Limit validation to a specific service",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Skip network-dependent checks (assume services are offline)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit validation report as JSON in addition to the table",
+    )
+    return parser
+
+
+def _issues_to_json(results: Mapping[str, Mapping[str, ValidationIssue]]) -> Dict[str, object]:
+    data: Dict[str, Dict[str, Dict[str, str]]] = {}
+    overall = "ok"
+    for target, checks in results.items():
+        data[target] = {
+            name: {"severity": issue.severity, "hint": issue.hint}
+            for name, issue in checks.items()
+        }
+        if any(issue.severity == "error" for issue in checks.values()):
+            overall = "error"
+    return {"status": overall, "results": data}
+
+
+def _format_checks(checks: Mapping[str, ValidationIssue]) -> Iterable[str]:
+    if not checks:
+        return ["  (no checks executed)"]
+    width = max(len(name) for name in checks)
+    for name, issue in checks.items():
+        label = _STATUS_LABELS.get(issue.severity, issue.severity.upper())
+        yield f"  {name.ljust(width)}  {label:<5}  {issue.hint}"
+
+
+def _render_table(results: Mapping[str, Mapping[str, ValidationIssue]]) -> str:
+    lines: List[str] = []
+    for target, checks in results.items():
+        lines.append(f"{target}:")
+        lines.extend(_format_checks(checks))
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+async def _execute_validate(args: argparse.Namespace) -> Mapping[str, Mapping[str, ValidationIssue]]:
+    cfg_path = args.config or find_config_file()
+    if not cfg_path:
+        print("[qmtl] Configuration file not found. Specify --config.", file=sys.stderr)
+        raise SystemExit(2)
+
+    try:
+        unified = load_config(cfg_path)
+    except FileNotFoundError:
+        print(f"[qmtl] Configuration file '{cfg_path}' does not exist.", file=sys.stderr)
+        raise SystemExit(2)
+    except Exception as exc:  # pragma: no cover - defensive catch
+        print(f"[qmtl] Failed to load configuration: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    targets: List[str] = []
+    if args.target in {"gateway", "all"}:
+        targets.append("gateway")
+    if args.target in {"dagmanager", "all"}:
+        targets.append("dagmanager")
+
+    results: Dict[str, Dict[str, ValidationIssue]] = {}
+    if "gateway" in targets:
+        results["gateway"] = await validate_gateway_config(unified.gateway, offline=args.offline)
+    if "dagmanager" in targets:
+        results["dagmanager"] = await validate_dagmanager_config(
+            unified.dagmanager, offline=args.offline
+        )
+
+    table = _render_table(results)
+    if table:
+        print(table)
+    if args.json:
+        if table:
+            print()
+        print(json.dumps(_issues_to_json(results), indent=2, sort_keys=True))
+
+    if any(issue.severity == "error" for checks in results.values() for issue in checks.values()):
+        raise SystemExit(1)
+
+    return results
+
+
+def run(argv: List[str] | None = None) -> None:
+    argv = list(argv) if argv is not None else []
+
+    if not argv or argv[0] in {"-h", "--help"}:
+        _build_help_parser().print_help()
+        return
+
+    cmd = argv[0]
+    rest = argv[1:]
+
+    if cmd == "validate":
+        parser = _build_validate_parser()
+        args = parser.parse_args(rest)
+        asyncio.run(_execute_validate(args))
+        return
+
+    _build_help_parser().print_help()
+    raise SystemExit(2)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    run()

--- a/tests/interfaces/cli/test_config_validate.py
+++ b/tests/interfaces/cli/test_config_validate.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from qmtl.interfaces.cli import config as cli_config
+
+
+@pytest.fixture
+def config_file(tmp_path: Path) -> Path:
+    content = {
+        "gateway": {
+            "redis_dsn": "redis://localhost:6379/0",
+            "database_backend": "sqlite",
+            "database_dsn": str(tmp_path / "gateway.db"),
+            "controlbus_brokers": ["localhost:9092"],
+            "controlbus_topics": ["events"],
+            "worldservice_url": "http://localhost:8080",
+        },
+        "dagmanager": {
+            "kafka_dsn": "localhost:9092",
+            "controlbus_dsn": "localhost:9092",
+            "controlbus_queue_topic": "queue",
+        },
+    }
+    path = tmp_path / "qmtl.yml"
+    path.write_text(yaml.safe_dump(content))
+    return path
+
+
+@pytest.fixture
+def mock_validation_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyRedis:
+        async def ping(self) -> bool:  # pragma: no cover - simple stub
+            return True
+
+        async def close(self) -> None:  # pragma: no cover - simple stub
+            return None
+
+    monkeypatch.setattr(
+        "qmtl.foundation.config_validation.redis.from_url",
+        lambda dsn: DummyRedis(),
+    )
+
+    class DummyResponse:
+        status_code = 200
+        content = b"{}"
+
+        def json(self) -> dict:
+            return {}
+
+    class DummyClient:
+        async def __aenter__(self) -> "DummyClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def get(self, url: str, *, timeout: float):
+            return DummyResponse()
+
+    monkeypatch.setattr(
+        "qmtl.foundation.config_validation.httpx.AsyncClient",
+        lambda: DummyClient(),
+    )
+
+    async def fake_ready(self):
+        return True
+
+    monkeypatch.setattr(
+        "qmtl.foundation.config_validation.ControlBusConsumer._broker_ready",
+        fake_ready,
+    )
+
+    class DummyKafkaAdmin:
+        def __init__(self) -> None:
+            self.client = self
+
+        def list_topics(self):  # pragma: no cover - simple stub
+            return {"topic": {}}
+
+    async def fake_admin(dsn: str):
+        return DummyKafkaAdmin()
+
+    monkeypatch.setattr(
+        "qmtl.foundation.config_validation._create_kafka_admin",
+        fake_admin,
+    )
+
+
+def test_validate_success_outputs_table(
+    config_file: Path, mock_validation_deps: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cli_config.run(["validate", "--config", str(config_file)])
+    captured = capsys.readouterr()
+    assert "gateway:" in captured.out
+    assert "redis" in captured.out
+    assert "OK" in captured.out
+    assert "dagmanager:" in captured.out
+    assert "Kafka reachable" in captured.out
+
+
+def test_validate_failure_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    content = {
+        "gateway": {
+            "database_backend": "postgres",
+            "database_dsn": "postgresql://example.invalid/db",
+            "enable_worldservice_proxy": False,
+        },
+        "dagmanager": {},
+    }
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text(yaml.safe_dump(content))
+
+    async def fail_connect(dsn: str):
+        raise RuntimeError("postgres unavailable")
+
+    monkeypatch.setattr("qmtl.foundation.config_validation.asyncpg.connect", fail_connect)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_config.run(["validate", "--config", str(cfg), "--target", "gateway"])
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "database" in captured.out
+    assert "ERROR" in captured.out
+
+
+def test_validate_offline_skips_checks(
+    config_file: Path, mock_validation_deps: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cli_config.run(["validate", "--config", str(config_file), "--offline"])
+    captured = capsys.readouterr()
+    assert "Offline mode" in captured.out
+    assert "skipped Kafka admin" in captured.out
+
+
+def test_validate_json_output(
+    config_file: Path, mock_validation_deps: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cli_config.run(
+        [
+            "validate",
+            "--config",
+            str(config_file),
+            "--target",
+            "gateway",
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out[captured.out.index("{") :])
+    assert payload["status"] == "ok"
+    assert payload["results"]["gateway"]["redis"]["severity"] == "ok"
+
+
+def test_validate_missing_config_path(capsys: pytest.CaptureFixture[str]) -> None:
+    missing = Path("/nonexistent/qmtl.yml")
+    with pytest.raises(SystemExit) as excinfo:
+        cli_config.run(["validate", "--config", str(missing)])
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err


### PR DESCRIPTION
## Summary
- add the config dispatcher and a new `qmtl config validate` command
- implement asynchronous gateway and DAG Manager validation helpers that reuse Redis, database, ControlBus, Kafka, and WorldService integrations
- cover success, failure, offline, JSON output, and missing file paths with dedicated CLI tests

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d365c88a908329a6e199622b97d2f0