### PR TITLE
Add env management CLI commands for configuration

### DIFF
--- a/qmtl/foundation/config_env.py
+++ b/qmtl/foundation/config_env.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Mapping
+
+from qmtl.foundation.config import UnifiedConfig
+
+MASK_PLACEHOLDER = "********"
+META_KEYS = ("QMTL_CONFIG_SOURCE", "QMTL_CONFIG_EXPORT")
+
+_SECTION_PREFIXES = {
+    "gateway": "QMTL__GATEWAY__",
+    "dagmanager": "QMTL__DAGMANAGER__",
+}
+
+_SECRET_KEYWORDS = ("PASSWORD", "SECRET", "TOKEN", "KEY", "DSN")
+
+
+@dataclass(frozen=True)
+class ConfigEnvVar:
+    key: str
+    value: str
+    secret: bool
+    section: str
+
+
+def _stringify(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (list, tuple, set)):
+        if not value:
+            return None
+        return ",".join(str(item) for item in value)
+    return str(value)
+
+
+def is_secret_field(name: str) -> bool:
+    upper = name.upper()
+    return any(token in upper for token in _SECRET_KEYWORDS)
+
+
+def unified_to_env(unified: UnifiedConfig) -> list[ConfigEnvVar]:
+    result: list[ConfigEnvVar] = []
+    for section, prefix in _SECTION_PREFIXES.items():
+        config_obj = getattr(unified, section)
+        data = asdict(config_obj)
+        for field, raw_value in sorted(data.items()):
+            value = _stringify(raw_value)
+            if value is None:
+                continue
+            secret = is_secret_field(field)
+            key = f"{prefix}{field.upper()}"
+            result.append(ConfigEnvVar(key=key, value=value, secret=secret, section=section))
+    return result
+
+
+def mask_value(value: str) -> str:
+    if not value:
+        return value
+    return MASK_PLACEHOLDER
+
+
+def is_managed_key(key: str) -> bool:
+    if key in META_KEYS:
+        return True
+    return any(key.startswith(prefix) for prefix in _SECTION_PREFIXES.values())
+
+
+def is_secret_key(key: str) -> bool:
+    if key in META_KEYS:
+        return False
+    if "__" not in key:
+        return False
+    field = key.split("__")[-1]
+    return is_secret_field(field)
+
+
+def collect_managed_keys(
+    environ: Mapping[str, str], *, include_missing_meta: bool = False
+) -> list[str]:
+    keys = {key for key in environ if is_managed_key(key)}
+    if include_missing_meta:
+        keys.update(META_KEYS)
+    else:
+        keys.update(key for key in META_KEYS if key in environ)
+    return sorted(keys)
+
+
+__all__ = [
+    "ConfigEnvVar",
+    "MASK_PLACEHOLDER",
+    "META_KEYS",
+    "collect_managed_keys",
+    "is_managed_key",
+    "is_secret_field",
+    "is_secret_key",
+    "mask_value",
+    "unified_to_env",
+]

--- a/qmtl/interfaces/cli/config.py
+++ b/qmtl/interfaces/cli/config.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import datetime
 import json
+import os
+import shlex
 import sys
 import textwrap
-from typing import Dict, Iterable, List, Mapping
+from typing import Dict, Iterable, List, Mapping, Sequence
 
 from qmtl.foundation.config import find_config_file, load_config
+from qmtl.foundation.config_env import (
+    ConfigEnvVar,
+    collect_managed_keys,
+    is_secret_key,
+    mask_value,
+    unified_to_env,
+)
 from qmtl.foundation.config_validation import (
     ValidationIssue,
     validate_dagmanager_config,
@@ -29,9 +39,15 @@ def _build_help_parser() -> argparse.ArgumentParser:
 
         Subcommands:
           validate  Check connectivity and readiness for Gateway and DAG Manager.
+          env       Environment variable helpers for Gateway and DAG Manager config.
         """
     ).strip()
-    parser.add_argument("cmd", nargs="?", choices=["validate"], help="Subcommand to run")
+    parser.add_argument(
+        "cmd",
+        nargs="?",
+        choices=["validate", "env"],
+        help="Subcommand to run",
+    )
     return parser
 
 
@@ -57,6 +73,59 @@ def _build_validate_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit validation report as JSON in addition to the table",
     )
+    return parser
+
+
+def _build_env_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="qmtl config env")
+    subparsers = parser.add_subparsers(dest="subcmd")
+    subparsers.required = True
+
+    export = subparsers.add_parser(
+        "export",
+        help="Render environment assignments for the active configuration",
+    )
+    export.add_argument(
+        "--config",
+        help="Path to configuration file (defaults to qmtl.yml in CWD)",
+    )
+    export.add_argument(
+        "--shell",
+        choices=["posix", "powershell"],
+        default="posix",
+        help="Output format for the generated script",
+    )
+    export.add_argument(
+        "--include-secret",
+        action="store_true",
+        help="Include secrets in the output instead of omitting them",
+    )
+
+    show = subparsers.add_parser(
+        "show", help="Show relevant QMTL environment variables"
+    )
+    show.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON payload in addition to the table",
+    )
+    show.add_argument(
+        "--include-secret",
+        action="store_true",
+        help="Show secret values without masking",
+    )
+
+    clear = subparsers.add_parser(
+        "clear",
+        help="Generate commands to clear QMTL configuration environment variables",
+    )
+    clear.add_argument(
+        "--shell",
+        choices=["posix", "powershell"],
+        default="posix",
+        help="Output format for the generated script",
+    )
+
     return parser
 
 
@@ -134,6 +203,150 @@ async def _execute_validate(args: argparse.Namespace) -> Mapping[str, Mapping[st
     return results
 
 
+def _comment(shell: str, text: str) -> str:
+    return f"# {text}" if text else ""
+
+
+def _quote_value(shell: str, value: str) -> str:
+    if shell == "posix":
+        return shlex.quote(value)
+    escaped = value.replace("\"", '""')
+    return f'"{escaped}"'
+
+
+def _format_assignment(shell: str, key: str, value: str) -> str:
+    if shell == "posix":
+        return f"export {key}={_quote_value(shell, value)}"
+    return f"$Env:{key}={_quote_value(shell, value)}"
+
+
+def _format_clear(shell: str, key: str) -> str:
+    if shell == "posix":
+        return f"unset {key}"
+    return f"Remove-Item Env:{key} -ErrorAction SilentlyContinue"
+
+
+def _render_env_table(entries: Sequence[Dict[str, object]]) -> str:
+    if not entries:
+        return "(no QMTL config environment variables found)"
+
+    width = max(len("KEY"), *(len(entry["key"]) for entry in entries))
+    lines: List[str] = []
+    lines.append(f"{'KEY'.ljust(width)}  VALUE")
+    lines.append(f"{'-' * width}  {'-' * 5}")
+    for entry in entries:
+        value = entry.get("value", "")
+        lines.append(f"{entry['key'].ljust(width)}  {value}")
+    return "\n".join(lines)
+
+
+def _execute_env_export(args: argparse.Namespace) -> List[ConfigEnvVar]:
+    cfg_path = args.config or find_config_file()
+    if not cfg_path:
+        print("[qmtl] Configuration file not found. Specify --config.", file=sys.stderr)
+        raise SystemExit(2)
+
+    try:
+        unified = load_config(cfg_path)
+    except FileNotFoundError:
+        print(f"[qmtl] Configuration file '{cfg_path}' does not exist.", file=sys.stderr)
+        raise SystemExit(2)
+    except Exception as exc:  # pragma: no cover - defensive catch
+        print(f"[qmtl] Failed to load configuration: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    env_vars = unified_to_env(unified)
+    secrets = [var for var in env_vars if var.secret]
+    include_secret = getattr(args, "include_secret", False)
+    shell = getattr(args, "shell", "posix")
+
+    if not include_secret:
+        env_vars = [var for var in env_vars if not var.secret]
+
+    cfg_abs = os.path.abspath(cfg_path)
+    timestamp = (
+        datetime.datetime.now(datetime.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    metadata = {
+        "generated_at": timestamp,
+        "include_secret": include_secret,
+        "shell": shell,
+        "secrets_omitted": bool(secrets and not include_secret),
+        "variables": len(env_vars),
+    }
+
+    lines: List[str] = []
+    lines.append(_format_assignment(shell, "QMTL_CONFIG_SOURCE", cfg_abs))
+    lines.append(
+        _format_assignment(
+            shell,
+            "QMTL_CONFIG_EXPORT",
+            json.dumps(metadata, sort_keys=True),
+        )
+    )
+
+    if secrets and not include_secret:
+        skipped_keys = ", ".join(var.key for var in secrets)
+        lines.append(
+            _comment(
+                shell,
+                f"Secrets omitted ({skipped_keys}). Re-run with --include-secret to include them.",
+            )
+        )
+
+    for var in env_vars:
+        lines.append(_format_assignment(shell, var.key, var.value))
+
+    print("\n".join(line for line in lines if line))
+    return env_vars
+
+
+def _execute_env_show(args: argparse.Namespace) -> List[Dict[str, object]]:
+    include_secret = getattr(args, "include_secret", False)
+    env_keys = collect_managed_keys(os.environ)
+    entries: List[Dict[str, object]] = []
+    for key in env_keys:
+        raw = os.environ.get(key)
+        if raw is None:
+            continue
+        secret = is_secret_key(key)
+        value = raw if include_secret or not secret else mask_value(raw)
+        entries.append(
+            {
+                "key": key,
+                "value": value,
+                "secret": secret,
+                "masked": secret and not include_secret,
+            }
+        )
+
+    table = _render_env_table(entries)
+    print(table)
+    if getattr(args, "json", False):
+        if entries:
+            print()
+        print(json.dumps(entries, indent=2, sort_keys=True))
+
+    return entries
+
+
+def _execute_env_clear(args: argparse.Namespace) -> List[str]:
+    shell = getattr(args, "shell", "posix")
+    env_keys = collect_managed_keys(os.environ, include_missing_meta=True)
+    if not env_keys:
+        msg = _comment(shell, "No QMTL config environment variables found.")
+        if msg:
+            print(msg)
+        return []
+
+    lines = [_format_clear(shell, key) for key in env_keys]
+    print("\n".join(lines))
+    return env_keys
+
+
 def run(argv: List[str] | None = None) -> None:
     argv = list(argv) if argv is not None else []
 
@@ -149,6 +362,18 @@ def run(argv: List[str] | None = None) -> None:
         args = parser.parse_args(rest)
         asyncio.run(_execute_validate(args))
         return
+    if cmd == "env":
+        parser = _build_env_parser()
+        args = parser.parse_args(rest)
+        if args.subcmd == "export":
+            _execute_env_export(args)
+            return
+        if args.subcmd == "show":
+            _execute_env_show(args)
+            return
+        if args.subcmd == "clear":
+            _execute_env_clear(args)
+            return
 
     _build_help_parser().print_help()
     raise SystemExit(2)

--- a/tests/interfaces/cli/test_config_env.py
+++ b/tests/interfaces/cli/test_config_env.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from qmtl.interfaces.cli import config
+
+
+def _parse_assignment_value(raw: str) -> str:
+    value = raw.split("=", 1)[1].strip()
+    if value and value[0] in {'"', "'"}:
+        return ast.literal_eval(value)
+    return value
+
+
+def _clear_qmtl_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in list(os.environ):
+        if key.startswith("QMTL__") or key.startswith("QMTL_CONFIG_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_env_export_posix(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_qmtl_env(monkeypatch)
+    config_path = tmp_path / "qmtl.yml"
+    config_path.write_text(
+        """
+gateway:
+  host: 127.0.0.1
+  redis_dsn: redis://localhost:6379/0
+  controlbus_topics:
+    - ingest
+dagmanager:
+  neo4j_password: hunter2
+  kafka_dsn: kafka://broker:9092
+        """.strip()
+    )
+
+    config.run(["env", "export", "--config", str(config_path)])
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.strip().splitlines() if line]
+
+    source_line = next(line for line in lines if line.startswith("export QMTL_CONFIG_SOURCE="))
+    meta_line = next(line for line in lines if line.startswith("export QMTL_CONFIG_EXPORT="))
+
+    source_value = _parse_assignment_value(source_line)
+    meta_json = _parse_assignment_value(meta_line)
+    metadata = json.loads(meta_json)
+
+    assert Path(source_value) == config_path.resolve()
+    assert metadata["include_secret"] is False
+    assert metadata["secrets_omitted"] is True
+    assert metadata["variables"] > 0
+
+    # Secrets should be mentioned only in the comment, not exported.
+    assignments = [line for line in lines if line.startswith("export ")]
+    assert all(
+        not line.startswith("export QMTL__DAGMANAGER__NEO4J_PASSWORD") for line in assignments
+    )
+    assert any("--include-secret" in line for line in lines if line.startswith("# "))
+    assert any(line.startswith("export QMTL__GATEWAY__HOST") for line in assignments)
+
+
+def test_env_show_masks(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _clear_qmtl_env(monkeypatch)
+    monkeypatch.setenv("QMTL__GATEWAY__HOST", "0.0.0.0")
+    monkeypatch.setenv("QMTL__DAGMANAGER__NEO4J_PASSWORD", "hunter2")
+
+    config.run(["env", "show"])
+    captured = capsys.readouterr()
+    assert "QMTL__GATEWAY__HOST" in captured.out
+    assert "0.0.0.0" in captured.out
+    assert "hunter2" not in captured.out
+    assert "********" in captured.out
+
+    config.run(["env", "show", "--json"])
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.strip().splitlines() if line]
+    json_start = next(i for i, line in enumerate(lines) if line.startswith("["))
+    payload = json.loads("\n".join(lines[json_start:]))
+
+    password_entry = next(item for item in payload if item["key"].endswith("NEO4J_PASSWORD"))
+    host_entry = next(item for item in payload if item["key"].endswith("GATEWAY__HOST"))
+
+    assert password_entry["masked"] is True
+    assert password_entry["value"] == "********"
+    assert host_entry["masked"] is False
+    assert host_entry["value"] == "0.0.0.0"
+
+
+def test_env_clear_script(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _clear_qmtl_env(monkeypatch)
+    monkeypatch.setenv("QMTL__GATEWAY__HOST", "0.0.0.0")
+    monkeypatch.setenv("QMTL__DAGMANAGER__NEO4J_PASSWORD", "hunter2")
+
+    config.run(["env", "clear"])
+    captured = capsys.readouterr()
+    lines = [line.strip() for line in captured.out.strip().splitlines() if line.strip()]
+
+    assert "unset QMTL__GATEWAY__HOST" in lines
+    assert "unset QMTL__DAGMANAGER__NEO4J_PASSWORD" in lines
+    assert "unset QMTL_CONFIG_SOURCE" in lines
+    assert "unset QMTL_CONFIG_EXPORT" in lines


### PR DESCRIPTION
## Summary
- add a qmtl config env subcommand with export/show/clear helpers, shell-specific formatting, and metadata emission
- create a config-to-environment mapper that masks secrets by default and emits QMTL-prefixed keys
- cover the new env commands with targeted CLI tests

## Testing
- uv run -m pytest tests/interfaces/cli/test_config_env.py
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d36bd8c5dc832988e6d898e2291d00