### PR TITLE
Handle QMTL_CONFIG_FILE override with warnings and tests

### DIFF
--- a/qmtl/services/dagmanager/server.py
+++ b/qmtl/services/dagmanager/server.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 import argparse
 import asyncio
+import json
+import logging
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable
 
 from qmtl.foundation.common import AsyncCircuitBreaker
@@ -10,7 +14,99 @@ import uvicorn
 
 from .grpc_server import serve
 from .config import DagManagerConfig
-from qmtl.foundation.config import load_config, find_config_file
+from qmtl.foundation.config import load_config, find_config_file, has_config_section
+
+
+def _log_config_source(
+    cfg_path: str | None,
+    *,
+    cli_override: str | None,
+    env_override: str | None,
+) -> None:
+    if cli_override:
+        logging.info("DAG Manager configuration loaded from %s (--config)", cli_override)
+        return
+
+    if env_override:
+        env_candidate = Path(env_override)
+        if not env_candidate.is_absolute():
+            env_candidate = Path.cwd() / env_candidate
+
+        if cfg_path and Path(cfg_path) == env_candidate:
+            logging.info(
+                "DAG Manager configuration loaded from %s (QMTL_CONFIG_FILE)",
+                cfg_path,
+            )
+            return
+
+        if cfg_path:
+            logging.warning(
+                "QMTL_CONFIG_FILE=%s was ignored because the file could not be read; "
+                "using %s instead",
+                env_override,
+                cfg_path,
+            )
+        else:
+            logging.error(
+                "QMTL_CONFIG_FILE=%s did not resolve to a readable file; using built-in defaults",
+                env_override,
+            )
+        return
+
+    if cfg_path:
+        logging.info("DAG Manager configuration loaded from %s", cfg_path)
+    else:
+        logging.info("DAG Manager configuration file not provided; using built-in defaults")
+
+
+def _warn_missing_section(section: str, cfg_path: str | None) -> None:
+    if not cfg_path:
+        return
+    if has_config_section(cfg_path, section):
+        return
+
+    meta_raw = os.getenv("QMTL_CONFIG_EXPORT")
+    source_hint = os.getenv("QMTL_CONFIG_SOURCE")
+
+    if meta_raw:
+        try:
+            metadata = json.loads(meta_raw)
+        except json.JSONDecodeError:
+            logging.warning(
+                "DAG Manager configuration file %s lacks the '%s' section; "
+                "QMTL_CONFIG_EXPORT metadata is not valid JSON (%s). Using default values.",
+                cfg_path,
+                section,
+                meta_raw,
+            )
+            return
+
+        generated = metadata.get("generated_at")
+        variables = metadata.get("variables")
+        details: list[str] = []
+        if generated:
+            details.append(f"generated at {generated}")
+        if variables is not None:
+            details.append(f"{variables} variables")
+        if source_hint:
+            details.append(f"source {source_hint}")
+        detail_str = ", ".join(details) if details else "export metadata available"
+
+        logging.warning(
+            "DAG Manager configuration file %s does not define the '%s' section. "
+            "QMTL_CONFIG_EXPORT (%s) suggests the export omitted it; the server will use default settings. "
+            "Re-run 'qmtl interfaces config env export' to regenerate a complete configuration.",
+            cfg_path,
+            section,
+            detail_str,
+        )
+        return
+
+    logging.warning(
+        "DAG Manager configuration file %s does not define the '%s' section; using default DAG Manager settings.",
+        cfg_path,
+        section,
+    )
 from .api import create_app
 from .garbage_collector import GarbageCollector, QueueInfo, MetricsProvider, QueueStore
 from .diff_service import StreamSender
@@ -131,10 +227,14 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--config", help="Path to configuration file")
     args = parser.parse_args(argv)
 
+    env_override = os.getenv("QMTL_CONFIG_FILE")
     cfg_path = args.config or find_config_file()
+    _log_config_source(cfg_path, cli_override=args.config, env_override=env_override)
+
     cfg = DagManagerConfig()
     if cfg_path:
         cfg = load_config(cfg_path).dagmanager
+        _warn_missing_section("dagmanager", cfg_path)
 
     asyncio.run(_run(cfg))
 

--- a/tests/services/dagmanager/test_cli_config_fallback.py
+++ b/tests/services/dagmanager/test_cli_config_fallback.py
@@ -1,0 +1,99 @@
+import json
+import logging
+
+import pytest
+
+from qmtl.services.dagmanager import server
+
+
+@pytest.fixture
+def dagmanager_testbed(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_run(cfg):
+        captured["config"] = cfg
+
+    monkeypatch.setattr(server, "_run", fake_run)
+    return captured
+
+
+def test_dagmanager_cli_prefers_env_path(tmp_path, monkeypatch, caplog, dagmanager_testbed):
+    config_path = tmp_path / "external.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "dagmanager:",
+                "  grpc_port: 60000",
+                "  http_port: 61000",
+            ]
+        )
+    )
+
+    workdir = tmp_path / "run"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    monkeypatch.setenv("QMTL_CONFIG_FILE", str(config_path))
+
+    caplog.set_level(logging.INFO)
+    server.main([])
+
+    cfg = dagmanager_testbed["config"]
+    assert cfg.grpc_port == 60000
+    assert cfg.http_port == 61000
+    assert any(
+        "QMTL_CONFIG_FILE" in record.message and "loaded" in record.message
+        for record in caplog.records
+    )
+
+
+def test_dagmanager_cli_invalid_env_path_warns_and_falls_back(
+    tmp_path, monkeypatch, caplog, dagmanager_testbed
+):
+    bad_path = tmp_path / "missing.yml"
+    workdir = tmp_path / "cwd"
+    workdir.mkdir()
+    fallback = workdir / "qmtl.yaml"
+    fallback.write_text(
+        "\n".join(
+            [
+                "dagmanager:",
+                "  grpc_port: 61001",
+                "  http_port: 62001",
+            ]
+        )
+    )
+
+    monkeypatch.chdir(workdir)
+    monkeypatch.setenv("QMTL_CONFIG_FILE", str(bad_path))
+
+    caplog.set_level(logging.WARNING)
+    server.main([])
+
+    cfg = dagmanager_testbed["config"]
+    assert cfg.grpc_port == 61001
+    assert cfg.http_port == 62001
+    assert any("QMTL_CONFIG_FILE" in record.message and "ignored" in record.message for record in caplog.records)
+
+
+def test_dagmanager_cli_warns_when_section_missing_with_metadata(
+    tmp_path, monkeypatch, caplog, dagmanager_testbed
+):
+    config_path = tmp_path / "no_dagmanager.yml"
+    config_path.write_text("gateway:\n  host: example\n")
+
+    monkeypatch.setenv(
+        "QMTL_CONFIG_EXPORT",
+        json.dumps({"generated_at": "2024-03-10T00:00:00Z", "variables": 2}),
+    )
+    monkeypatch.setenv("QMTL_CONFIG_SOURCE", str(config_path))
+
+    caplog.set_level(logging.WARNING)
+    server.main(["--config", str(config_path)])
+
+    cfg = dagmanager_testbed["config"]
+    assert cfg.grpc_port == 50051
+    assert cfg.http_port == 8001
+    assert any(
+        "does not define the 'dagmanager' section" in record.message and "QMTL_CONFIG_EXPORT" in record.message
+        for record in caplog.records
+    )

--- a/tests/services/gateway/test_cli_config_fallback.py
+++ b/tests/services/gateway/test_cli_config_fallback.py
@@ -1,0 +1,115 @@
+import json
+import logging
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from qmtl.services.gateway import cli
+
+
+@pytest.fixture
+def gateway_testbed(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class DummyDB:
+        async def connect(self):
+            captured["connected"] = True
+
+        async def close(self):
+            captured["closed"] = True
+
+    def fake_create_app(**kwargs):
+        captured["app_kwargs"] = kwargs
+        return SimpleNamespace(state=SimpleNamespace(database=DummyDB()))
+
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+    monkeypatch.setitem(
+        sys.modules,
+        "uvicorn",
+        SimpleNamespace(
+            run=lambda app, host, port: captured.update({"uvicorn": {"host": host, "port": port}})
+        ),
+    )
+    return captured
+
+
+def test_gateway_cli_prefers_env_path(tmp_path, monkeypatch, caplog, gateway_testbed):
+    config_path = tmp_path / "external.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "gateway:",
+                "  host: 127.0.0.1",
+                "  port: 12345",
+                "  database_backend: memory",
+                "  database_dsn: 'sqlite:///:memory:'",
+            ]
+        )
+    )
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monkeypatch.chdir(run_dir)
+    monkeypatch.setenv("QMTL_CONFIG_FILE", str(config_path))
+
+    caplog.set_level(logging.INFO)
+    cli.main([])
+
+    assert gateway_testbed["uvicorn"] == {"host": "127.0.0.1", "port": 12345}
+    assert gateway_testbed["app_kwargs"]["database_backend"] == "memory"
+    assert any(
+        "QMTL_CONFIG_FILE" in record.message and "loaded" in record.message
+        for record in caplog.records
+    )
+
+
+def test_gateway_cli_invalid_env_path_warns_and_falls_back(
+    tmp_path, monkeypatch, caplog, gateway_testbed
+):
+    env_path = tmp_path / "missing.yml"
+    run_dir = tmp_path / "cwd"
+    run_dir.mkdir()
+    fallback = run_dir / "qmtl.yml"
+    fallback.write_text(
+        "\n".join(
+            [
+                "gateway:",
+                "  host: 10.0.0.5",
+                "  port: 2222",
+                "  database_backend: memory",
+                "  database_dsn: 'sqlite:///:memory:'",
+            ]
+        )
+    )
+
+    monkeypatch.chdir(run_dir)
+    monkeypatch.setenv("QMTL_CONFIG_FILE", str(env_path))
+
+    caplog.set_level(logging.WARNING)
+    cli.main([])
+
+    assert gateway_testbed["uvicorn"] == {"host": "10.0.0.5", "port": 2222}
+    assert any("QMTL_CONFIG_FILE" in record.message and "ignored" in record.message for record in caplog.records)
+
+
+def test_gateway_cli_warns_when_section_missing_with_metadata(
+    tmp_path, monkeypatch, caplog, gateway_testbed
+):
+    config_path = tmp_path / "no_gateway.yml"
+    config_path.write_text("dagmanager:\n  grpc_port: 1234\n")
+
+    monkeypatch.setenv(
+        "QMTL_CONFIG_EXPORT",
+        json.dumps({"generated_at": "2024-03-10T00:00:00Z", "variables": 5}),
+    )
+    monkeypatch.setenv("QMTL_CONFIG_SOURCE", str(config_path))
+
+    caplog.set_level(logging.WARNING)
+    cli.main(["--config", str(config_path)])
+
+    assert gateway_testbed["uvicorn"] == {"host": "0.0.0.0", "port": 8000}
+    assert any(
+        "does not define the 'gateway' section" in record.message and "QMTL_CONFIG_EXPORT" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- prefer the QMTL_CONFIG_FILE override in find_config_file and expose a helper to detect missing sections
- log configuration source usage in the gateway and DAG manager CLIs and surface metadata-aware warnings when sections are absent
- add CLI fallback tests that exercise environment overrides, invalid paths, and QMTL_CONFIG_EXPORT metadata guidance

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d377e6bed083298c717b38a63fb4c6