### PR TITLE
Add config CLI workflow docs and env fallback guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,39 @@ See `qmtl/examples/README.md` for additional strategies that can be executed
 in the same way. A more detailed walkthrough from project creation to
 testing is available in [docs/guides/strategy_workflow.md](docs/guides/strategy_workflow.md).
 
+## Quick Start (Validate → Export → Launch)
+
+Bring services up in three steps. This mirrors the detailed guidance in
+[Config CLI](docs/operations/config-cli.md) and [Backend Quickstart](docs/operations/backend_quickstart.md).
+
+1. **Validate configuration** – catch missing sections or offline resources
+   before booting services.
+
+   ```bash
+   uv run qmtl config validate --config qmtl/examples/qmtl.yml --offline
+   ```
+
+2. **Export and load environment variables** – persist overrides so Gateway
+   and DAG Manager pick them up without repeating `--config` flags.
+
+   ```bash
+   uv run qmtl config env export --config qmtl/examples/qmtl.yml > .env.qmtl
+   source .env.qmtl
+   export QMTL_CONFIG_FILE=$PWD/qmtl/examples/qmtl.yml
+   ```
+
+3. **Launch services** – with the environment in place you can start Gateway
+   and DAG Manager directly; each service falls back to `QMTL_CONFIG_FILE` if
+   no `--config` flag is provided.
+
+   ```bash
+   qmtl service gateway
+   qmtl service dagmanager server
+   ```
+
+If `QMTL_CONFIG_FILE` is invalid the services log a warning and continue with
+default settings, preventing silent misconfigurations.
+
 ## Trading Node Enhancements
 
 Recent releases introduce several nodes for building realistic trading pipelines:

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -26,4 +26,20 @@ See also: Architecture Glossary (architecture/glossary.md) for canonical terms s
 - [ControlBus](controlbus.md): Internal control bus (opaque to SDK).
 - [Lean Brokerage Model](lean_brokerage_model.md): Brokerage integration details.
 
+## 빠른 시작: 설정 검증 → 환경 등록 → 서비스 기동
+
+아키텍처 전반을 이해하기 전에 구성 파일을 검증하고 서비스를 띄워보면 흐름을
+빠르게 익힐 수 있다. 아래 순서는 [Operations/Config CLI](../operations/config-cli.md)
+와 [Backend Quickstart](../operations/backend_quickstart.md)를 요약한 것이다.
+
+1. `uv run qmtl config validate --config qmtl/examples/qmtl.yml --offline`
+   으로 게이트웨이/다그매니저 설정을 검증한다. 오류가 발생하면 아키텍처 설계
+   문서를 참고해 빠진 요소를 보완한다.
+2. `uv run qmtl config env export ... > .env.qmtl` 뒤 `source .env.qmtl` 로 환경 변수를
+   등록하고 `export QMTL_CONFIG_FILE=$PWD/qmtl/examples/qmtl.yml` 을 추가해 서비스가
+   동일한 YAML을 참조하도록 한다.
+3. `qmtl service gateway` 와 `qmtl service dagmanager server` 를 실행하면
+   환경 변수 폴백이 적용되어 별도의 `--config` 없이도 기동된다. 로그에
+   경고가 나오면 아키텍처 상 의존하는 외부 리소스를 점검한다.
+
 {{ nav_links() }}

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -20,6 +20,14 @@ last_modified: 2025-09-22
 - [ControlBus](controlbus.md)
 - [Exchange Node Sets](exchange_node_sets.md)
 
+!!! tip "빠른 시작: 검증 → 환경 → 기동"
+    운영용 YAML을 작성했다면 `uv run qmtl config validate --config <파일> --offline`
+    으로 구조를 확인하고, `uv run qmtl config env export --config <파일> > .env.qmtl`
+    후 `source .env.qmtl` + `export QMTL_CONFIG_FILE=<파일>` 을 실행하라. 그러면
+    `qmtl service gateway` / `qmtl service dagmanager server` 가 동일한 설정으로
+    부팅되며, 누락된 섹션이 있을 때 `QMTL_CONFIG_EXPORT` 메타데이터와 함께 경고가
+    출력된다.
+
 ---
 
 ## 0. 개요: 이론적 동기와 시스템화의 목적

--- a/docs/operations/config-cli.md
+++ b/docs/operations/config-cli.md
@@ -1,0 +1,119 @@
+---
+title: "Config CLI"
+tags: [cli, config, operations]
+author: "QMTL Team"
+last_modified: 2025-09-24
+---
+
+{{ nav_links() }}
+
+# Config CLI (Validate, Export, Launch)
+
+Use `qmtl config` to verify service configuration files and generate
+environment assignments for Gateway and DAG Manager. The workflow pairs with
+the backend quickstart so operators can lint YAML before starting services.
+
+## Validate configuration files
+
+Run validation against a configuration file. The `--offline` flag skips
+connectivity checks and reports which external services are disabled:
+
+```bash
+uv run qmtl config validate --config qmtl/examples/qmtl.yml --offline
+```
+
+Sample output:
+
+```
+gateway:
+  redis         WARN   Offline mode: skipped Redis ping for redis://localhost:6379
+  database      OK     SQLite ready at ./qmtl.db
+  controlbus    OK     ControlBus disabled; no brokers/topics configured
+  worldservice  OK     WorldService proxy disabled
+
+dagmanager:
+  neo4j       OK     Neo4j disabled; using memory repository
+  kafka       OK     Kafka DSN not configured; using in-memory queue manager
+  controlbus  OK     ControlBus disabled; no brokers/topics configured
+```
+
+Warnings denote skipped checks or fallbacks. Any `ERROR` line exits with a
+non-zero status so CI/CD jobs can fail fast.
+
+## Export environment assignments
+
+Generate a shell script that exports configuration as environment variables
+(which services read before applying defaults):
+
+```bash
+uv run qmtl config env export --config qmtl/examples/qmtl.yml > .env.qmtl
+```
+
+The first lines show metadata and the managed variables. Secrets are omitted by
+default—re-run with `--include-secret` to inline them:
+
+```
+export QMTL_CONFIG_SOURCE=/workspace/qmtl/qmtl/examples/qmtl.yml
+export QMTL_CONFIG_EXPORT='{"generated_at": "2025-09-24T05:42:58Z", "include_secret": false, "secrets_omitted": true, "shell": "posix", "variables": 19}'
+# Secrets omitted (QMTL__GATEWAY__DATABASE_DSN, QMTL__GATEWAY__REDIS_DSN, QMTL__DAGMANAGER__NEO4J_PASSWORD). Re-run with --include-secret to include them.
+export QMTL__GATEWAY__COMMITLOG_GROUP=gateway-commit
+export QMTL__GATEWAY__COMMITLOG_TOPIC=gateway.ingest
+... (truncated)
+```
+
+Use `source .env.qmtl` (POSIX) or `.\. .env.qmtl` (PowerShell) to load the
+environment before launching services. For auditing, `qmtl config env show`
+prints the active variables (masking secrets) and `qmtl config env clear`
+produces commands to unset them.
+
+## Environment variable fallback
+
+Gateway and DAG Manager resolve configuration in this order:
+
+1. `--config /path/to/qmtl.yml` passed on the command line.
+2. `QMTL_CONFIG_FILE=/path/to/qmtl.yml` in the process environment.
+3. `qmtl.yml` or `qmtl.yaml` in the current working directory.
+4. Built-in defaults baked into the service configuration classes.
+
+`qmtl config env export` writes two helper variables:
+
+- `QMTL_CONFIG_SOURCE` – absolute path of the exported YAML for logging.
+- `QMTL_CONFIG_EXPORT` – JSON metadata (timestamp, variable count, whether
+  secrets were omitted). Services include this in warnings when sections are
+  missing so operators know the environment was generated from an older export.
+
+Combine them with `QMTL_CONFIG_FILE` to let daemons pick the YAML without
+repeating `--config`:
+
+```bash
+source .env.qmtl
+export QMTL_CONFIG_FILE=$PWD/qmtl/examples/qmtl.yml
+```
+
+If `QMTL_CONFIG_FILE` points to a missing file, the services log a warning and
+fall back to the next rule. This prevents deployments from silently using stale
+paths.
+
+## End-to-end launch sequence
+
+Putting it together:
+
+```bash
+# 1. Validate the configuration (fails on hard errors).
+uv run qmtl config validate --config qmtl/examples/qmtl.yml --offline
+
+# 2. Export and source environment overrides.
+uv run qmtl config env export --config qmtl/examples/qmtl.yml > .env.qmtl
+source .env.qmtl
+export QMTL_CONFIG_FILE=$PWD/qmtl/examples/qmtl.yml
+
+# 3. Launch services (env fallback picks up the same config file).
+qmtl service gateway
+qmtl service dagmanager server
+```
+
+WorldService continues to rely on `QMTL_WORLDSERVICE_*` variables. The config
+CLI focuses on Gateway and DAG Manager overrides so the entire stack can start
+with consistent settings.
+
+{{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Operations:
       - Overview: operations/README.md
       - Backend Quickstart: operations/backend_quickstart.md
+      - Config CLI: operations/config-cli.md
       - Docker & Compose: operations/docker.md
       - Backfill: operations/backfill.md
       - Canary Rollout: operations/canary_rollout.md

--- a/qmtl/examples/templates/backend_stack.example.yml
+++ b/qmtl/examples/templates/backend_stack.example.yml
@@ -120,3 +120,5 @@ notes:
   - "Export QMTL_ENABLE_TOPIC_NAMESPACE=1 to keep Kafka topics partitioned by world/domain."
   - "Provision alerts for gateway_e2e_latency_p95, dagmanager_diff_errors_total, and worldservice_decision_stale_total."
   - "Store secrets (passwords, SASL credentials) in your secrets manager instead of committing them."
+  - "Validate and export config before launch: uv run qmtl config validate --config /etc/qmtl/backend.yml && uv run qmtl config env export --config /etc/qmtl/backend.yml > /etc/qmtl/.env"
+  - "Source the export and set QMTL_CONFIG_FILE=/etc/qmtl/backend.yml so qmtl service gateway/dagmanager reuse the same YAML and emit QMTL_CONFIG_EXPORT metadata if sections are missing."

--- a/qmtl/examples/templates/local_stack.example.yml
+++ b/qmtl/examples/templates/local_stack.example.yml
@@ -82,6 +82,9 @@ qmtl:
     gateway.worldservice_url: ${gateway.worldservice_url}
     dagmanager.memory_repo_path: ${dagmanager.memory_repo_path}
   sample_usage:
+    - "uv run qmtl config validate --config ${qmtl.foundation.config_file} --offline"
+    - "uv run qmtl config env export --config ${qmtl.foundation.config_file} > .env.qmtl"
+    - "source .env.qmtl && export QMTL_CONFIG_FILE=${qmtl.foundation.config_file}"
     - "qmtl service gateway --config ${qmtl.foundation.config_file}"
     - "qmtl service dagmanager server --config ${qmtl.foundation.config_file}"
     - "python -m qmtl.examples.general_strategy --gateway-url http://localhost:${gateway.port} --world-id demo"
@@ -90,3 +93,4 @@ notes:
   - "Create local state directories upfront: mkdir -p ./var/dagmanager"
   - "Set QMTL_ENABLE_TOPIC_NAMESPACE=0 to reuse legacy topic names when testing against mocks."
   - "Install dependencies with uv pip install -e .[dev] before starting services."
+  - "Set QMTL_CONFIG_FILE to this template's YAML so service CLIs pick it up without passing --config each time."


### PR DESCRIPTION
## Summary
- add an operations/Config CLI guide with sample validate/env output and register it in mkdocs navigation
- extend README and architecture docs with a validate → export → launch quickstart linking to the new guide
- update stack templates to reference the new QMTL_CONFIG_FILE workflow for reusing YAML without repeated flags

## Testing
- uv run mkdocs build
- uv run -m pytest tests/interfaces/cli/test_config_env.py tests/services/gateway/test_cli_config_fallback.py tests/services/dagmanager/test_cli_config_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68d3843be5a48329aef9ab12fb7140b5