### PR TITLE
Prefer provider ensure_range during warmup

### DIFF
--- a/qmtl/runtime/sdk/history_provider_facade.py
+++ b/qmtl/runtime/sdk/history_provider_facade.py
@@ -76,6 +76,24 @@ class AugmentedHistoryProvider(HistoryProvider):
             return list(self._coverage_cache[key])
 
     # ------------------------------------------------------------------
+    async def ensure_range(
+        self, start: int, end: int, *, node_id: str, interval: int
+    ) -> None:
+        key = (node_id, interval)
+        lock = self._locks[key]
+        async with lock:
+            await self._prepare_backfill(
+                key,
+                AutoBackfillRequest(
+                    node_id=node_id,
+                    interval=interval,
+                    start=start,
+                    end=end,
+                ),
+                require_fetcher=False,
+            )
+
+    # ------------------------------------------------------------------
     async def fill_missing(
         self, start: int, end: int, *, node_id: str, interval: int
     ) -> None:


### PR DESCRIPTION
## Summary
- teach the history warmup poller to call a provider ensure_range hook before falling back to fill_missing loops
- expose ensure_range on AugmentedHistoryProvider and update warmup/backfill tests to cover auto-backfill and legacy providers
- document configuring auto backfill strategies and note that live and offline runners share the same warmup pipeline

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68d3f6e844788329858904948799dd3e