### PR TITLE
Address review feedback: interval-aware subtract for seamless fetch

### DIFF
--- a/tests/sdk/test_seamless_provider.py
+++ b/tests/sdk/test_seamless_provider.py
@@ -62,6 +62,18 @@ async def test_coverage_merges_adjacent_ranges_interval_aware() -> None:
 
 
 @pytest.mark.asyncio
+async def test_seamless_fetch_deduplicates_boundary_bars() -> None:
+    cache = _StaticSource([(0, 100)], DataSourcePriority.CACHE)
+    storage = _StaticSource([(100, 200)], DataSourcePriority.STORAGE)
+    provider = _DummyProvider(cache_source=cache, storage_source=storage)
+
+    df = await provider.fetch(0, 200, node_id="n", interval=10)
+
+    expected = list(range(0, 201, 10))
+    assert df["ts"].tolist() == expected
+
+
+@pytest.mark.asyncio
 async def test_find_missing_ranges_uses_interval_math() -> None:
     storage = _StaticSource([(0, 100)], DataSourcePriority.STORAGE)
     provider = _DummyProvider(storage_source=storage)


### PR DESCRIPTION
## Summary
- adjust seamless range subtraction to convert inclusive windows to half-open intervals and avoid refetching boundary bars
- pass the active interval into `_subtract_ranges` and reuse merge logic to normalize results
- add a regression test covering contiguous cache and storage coverage to ensure no duplicate timestamps are returned

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto


------
https://chatgpt.com/codex/tasks/task_e_68d438d64f008329b3d99a805221d464