### PR TITLE
Align subtract ranges to interval grid without dropping bars

### DIFF
--- a/tests/sdk/test_seamless_provider.py
+++ b/tests/sdk/test_seamless_provider.py
@@ -74,6 +74,20 @@ async def test_seamless_fetch_deduplicates_boundary_bars() -> None:
 
 
 @pytest.mark.asyncio
+async def test_seamless_fetch_preserves_off_grid_cache_bounds() -> None:
+    cache = _StaticSource([(95, 100)], DataSourcePriority.CACHE)
+    storage = _StaticSource([(0, 200)], DataSourcePriority.STORAGE)
+    provider = _DummyProvider(cache_source=cache, storage_source=storage)
+
+    df = await provider.fetch(0, 200, node_id="n", interval=10)
+
+    ts = df["ts"].tolist()
+    assert 90 in ts  # previously dropped due to misaligned subtraction
+    assert ts.count(90) == 1
+    assert ts.count(95) == 1
+
+
+@pytest.mark.asyncio
 async def test_find_missing_ranges_uses_interval_math() -> None:
     storage = _StaticSource([(0, 100)], DataSourcePriority.STORAGE)
     provider = _DummyProvider(storage_source=storage)


### PR DESCRIPTION
## Summary
- revise `_subtract_ranges` to remove bars only when the subtraction range shares the same interval offset, preserving neighbours for off-grid coverage
- keep naive subtraction fallback for missing interval metadata and reuse the existing merge helper to normalize the resulting segments
- add a regression test that asserts cache ranges beginning off the interval grid keep the missing bar available to lower priority sources

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

------
https://chatgpt.com/codex/tasks/task_e_68d441650d908329b9db63462fc916ea