### PR TITLE
io: CCXT×QuestDB provider, OHLCV/Trades fetchers, shared/cluster rate limiter

### DIFF
--- a/docs/io/ccxt-questdb.md
+++ b/docs/io/ccxt-questdb.md
@@ -1,0 +1,109 @@
+# CCXT × QuestDB (IO)
+
+이 문서는 CCXT 기반 DataFetcher와 QuestDB 백엔드를 조합해, 요청 시 자동 백필되는 시계열을 제공하는 방법을 설명합니다. 구현은 정식 패키지(`qmtl/runtime/io/`)로 제공되며, 예제가 아닌 실사용 구성에 적합합니다.
+
+- 패키지: `qmtl.runtime.io`
+- 주요 구성 요소:
+  - `CcxtOHLCVFetcher` + `CcxtBackfillConfig`
+  - `CcxtQuestDBProvider` (QuestDB + AutoBackfill 전략 래퍼)
+  - 내부적으로 `AugmentedHistoryProvider` + `FetcherBackfillStrategy` 사용
+
+## 설치/환경
+
+- 플러그인 설치
+  - `uv pip install -e .[dev,ccxt,questdb]`
+- QuestDB 실행
+  - Docker 예시: `docker run -p 8812:8812 -p 9000:9000 questdb/questdb:latest`
+  - 또는 프로젝트의 Docker Compose에 QuestDB를 추가해 사용
+  
+- (선택) Redis 실행 — 클러스터 레이트리밋
+  - Docker 예시: `docker run -p 6379:6379 redis:7-alpine`
+  - 환경변수: `QMTL_CCXT_RATE_LIMITER_REDIS=redis://localhost:6379/0`
+
+## 빠른 시작
+
+```python
+from qmtl.runtime.sdk import StreamInput
+from qmtl.runtime.io import CcxtQuestDBProvider
+
+provider = CcxtQuestDBProvider.from_config({
+    "exchange": "binance",
+    "symbols": ["BTC/USDT"],
+    "timeframe": "1m",
+    "questdb": {"dsn": "postgresql://localhost:8812/qdb", "table": "crypto_ohlcv"},
+    # 전역(프로세스) 또는 클러스터 레이트리밋 예시
+    "rate_limiter": {
+        "max_concurrency": 1,
+        "min_interval_s": 1.2,
+        "scope": "cluster",  # 또는 "process"
+        "redis_dsn": "redis://localhost:6379/0",
+        "burst": 1
+    },
+})
+
+# interval/period은 원하는 윈도 크기에 맞춰 조정
+price = StreamInput(interval="60s", period=120, history_provider=provider)
+
+# 필요 시 워머프
+# from qmtl.runtime.sdk import Runner
+# await Runner._ensure_history(strategy, start, end)
+```
+
+## 동작 원리
+
+```mermaid
+sequenceDiagram
+    participant Node as Node/StreamInput
+    participant HP as AugmentedHistoryProvider
+    participant BE as QuestDB Backend
+    participant BF as FetcherBackfillStrategy
+    participant CX as CCXT Fetcher
+
+    Node->>HP: fetch(start, end, node_id, interval)
+    HP->>BE: coverage(node_id, interval)
+    BE-->>HP: [(covered_start, covered_end), ...]
+    HP->>BF: ensure_range(request, backend, coverage_cache)
+    BF->>CX: fetch_ohlcv(since, limit...) (loop)
+    CX-->>BF: DataFrame(ts, open, high, low, close, volume)
+    BF->>BE: write_rows(...)
+    BF->>BE: coverage(node_id, interval) (refresh if needed)
+    HP->>BE: read_range(start, end)
+    BE-->>HP: DataFrame(ts, ...)
+    HP-->>Node: DataFrame(ts, ...)
+```
+
+## 설정 항목
+
+- `mode`: `ohlcv`(기본) 또는 `trades`
+- `exchange`/`exchange_id`: CCXT 교환소 식별자 (예: `binance`, `okx`)
+- `symbols`: 심볼 목록. 단일 심볼 예제로 시작하는 것을 권장
+- `timeframe`: `"1m"`, `"5m"`, `"1h"` 등 CCXT 규약 (ohlcv 전용)
+- `questdb`: `dsn`(권장) 또는 `host/port/database`와 `table`(테이블명) 또는 `table_prefix` (예: `crypto` → `crypto_ohlcv`/`crypto_trades`)
+- 레이트리밋(옵션): `rate_limiter = {max_concurrency, min_interval_s, scope}`
+  - `scope`: `local`(페처별), `process`(프로세스 전역, 기본), `cluster`(분산)
+  - `cluster` 추가 옵션: `redis_dsn`, `tokens_per_sec`, `burst`, `key_suffix`
+    - `redis_dsn`: Redis DSN (미설정 시 `QMTL_CCXT_RATE_LIMITER_REDIS` → 기본값)
+    - `tokens_per_sec`: 초당 허용 호출 수(미설정 시 `1 / min_interval_s`)
+    - `burst`: 순간 버스트 허용량(기본 1)
+    - `key_suffix`: 버킷 분리용 서픽스(계정/엔드포인트별 분리)
+- 재시도(옵션): `max_retries`, `retry_backoff_s`
+
+## 테스트 & 검증
+
+- 프리플라이트(권장):
+  - `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'`
+- 전체 테스트:
+  - `uv run -m pytest -W error -n auto`
+
+## 확장/후속
+
+- Trades 지원: 동일한 패턴으로 `CcxtTradesFetcher` 추가 (row adapter)
+- 멀티 타임프레임/다심볼: node_id 규칙(`ohlcv:{exchange}:{symbol}:{timeframe}`) 기준으로 분기
+- QuestDB 커버리지 메타테이블: 대형 테이블에서 커버리지 질의 최적화
+- 데이터 검증: 타임스탬프 정렬/간격 정합성 검사 고도화
+- 알림/모니터링: 백필 실패 Slack/webhook 연동
+
+## Trades 모드 참고
+
+- 요청 구간의 이벤트(체결)들을 단순 시간 윈도로 수집합니다. 거래가 없는 구간은 비어 있을 수 있으며, 커버리지 계산은 제공된 `interval`(권장: 1초) 기준으로 근접 범위를 병합합니다.
+- Node ID 권장 규칙: `trades:{exchange}:{symbol}`. 도우미: `CcxtQuestDBProvider.make_node_id(...)`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Strategy Callbacks: guides/strategy_callbacks.md
       - Build NodeSet (SDK): guides/build_nodeset_sdk.md
       - CCXT Spot Recipe: guides/ccxt_spot_recipe.md
+      - CCXT × QuestDB (IO): io/ccxt-questdb.md
       - Node Set Adapters: guides/nodeset_adapters.md
       - Advanced:
           - Node Set Portfolio Scope: guides/nodeset_portfolio_scope.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dev = [
 
 ray = ["ray"]
 io = ["pandas"]
+ccxt = ["ccxt"]
+questdb = ["asyncpg"]
 
 [project.scripts]
 qmtl = "qmtl.interfaces.cli:main"

--- a/qmtl/runtime/io/__init__.py
+++ b/qmtl/runtime/io/__init__.py
@@ -5,6 +5,14 @@ from qmtl.runtime.sdk.data_io import HistoryProvider, EventRecorder
 from .historyprovider import QuestDBBackend, QuestDBHistoryProvider, QuestDBLoader
 from .eventrecorder import QuestDBRecorder
 from .binance_fetcher import BinanceFetcher
+from .ccxt_fetcher import (
+    CcxtBackfillConfig,
+    RateLimiterConfig,
+    CcxtOHLCVFetcher,
+    CcxtTradesConfig,
+    CcxtTradesFetcher,
+)
+from .ccxt_provider import CcxtQuestDBProvider
 from .seamless_provider import EnhancedQuestDBProvider
 
 __all__ = [
@@ -17,4 +25,10 @@ __all__ = [
     "QuestDBRecorder",
     "BinanceFetcher",
     "EnhancedQuestDBProvider",
+    "CcxtBackfillConfig",
+    "RateLimiterConfig",
+    "CcxtOHLCVFetcher",
+    "CcxtTradesConfig",
+    "CcxtTradesFetcher",
+    "CcxtQuestDBProvider",
 ]

--- a/qmtl/runtime/io/ccxt_fetcher.py
+++ b/qmtl/runtime/io/ccxt_fetcher.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+"""CCXT-based DataFetcher implementations for OHLCV (and future Trades).
+
+This module is optional and only imported when used. It provides a thin
+asynchronous wrapper around ``ccxt.async_support`` to return DataFrames in the
+SDK's standard schema with a ``ts`` (seconds) column.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+import asyncio
+import time
+
+import pandas as pd
+
+from qmtl.runtime.sdk.data_io import DataFetcher
+
+
+@dataclass(slots=True)
+class RateLimiterConfig:
+    """Simple rate limiter configuration.
+
+    Attributes
+    ----------
+    max_concurrency:
+        Maximum number of in-flight CCXT requests.
+    min_interval_s:
+        Minimum seconds between consecutive requests (best-effort).
+    """
+
+    max_concurrency: int = 1
+    min_interval_s: float = 0.0
+    # scope: "local" → per-fetcher only; "process" → share across fetchers in-process;
+    # "cluster" → Redis-backed shared limiter across processes
+    scope: str = "process"
+    # Cluster options (when scope="cluster"): if not provided, sensible defaults are derived
+    redis_dsn: str | None = None
+    tokens_per_sec: float | None = None  # if None, 1/min_interval_s
+    burst: int | None = None  # capacity; default=1
+    key_suffix: str | None = None  # e.g., account id
+
+
+@dataclass(slots=True)
+class CcxtBackfillConfig:
+    exchange_id: str
+    symbols: list[str] | None
+    timeframe: str
+    window_size: int = 1000  # max candles per request
+    max_retries: int = 3
+    retry_backoff_s: float = 0.5
+    rate_limiter: RateLimiterConfig = RateLimiterConfig()
+
+
+def _try_parse_timeframe_s(timeframe: str) -> int:
+    """Return seconds for a CCXT timeframe string.
+
+    Tries ``ccxt.parse_timeframe`` when available; falls back to a static map.
+    """
+    try:  # pragma: no cover - optional dependency path
+        import ccxt  # type: ignore
+
+        seconds = int(getattr(ccxt, "parse_timeframe")(timeframe))
+        if seconds > 0:
+            return seconds
+    except Exception:
+        pass
+
+    table = {
+        "1s": 1,
+        "5s": 5,
+        "10s": 10,
+        "15s": 15,
+        "30s": 30,
+        "1m": 60,
+        "3m": 180,
+        "5m": 300,
+        "15m": 900,
+        "30m": 1800,
+        "1h": 3600,
+        "2h": 7200,
+        "4h": 14400,
+        "6h": 21600,
+        "8h": 28800,
+        "12h": 43200,
+        "1d": 86400,
+        "3d": 259200,
+        "1w": 604800,
+    }
+    if timeframe not in table:
+        raise ValueError(f"Unsupported timeframe: {timeframe}")
+    return table[timeframe]
+
+
+def _parse_symbol_from_node_id(node_id: str) -> tuple[str | None, str | None]:
+    """Extract ``(symbol, timeframe)`` from a conventional node_id if present.
+
+    Expected patterns (best-effort):
+      - "ohlcv:{exchange}:{symbol}:{timeframe}"
+      - "{symbol}:{timeframe}"
+    Returns (None, None) when not parseable.
+    """
+    parts = node_id.split(":")
+    if len(parts) >= 4 and parts[0] == "ohlcv":
+        return parts[2], parts[3]
+    if len(parts) >= 2:
+        return parts[-2], parts[-1]
+    return None, None
+
+
+from .ccxt_rate_limiter import get_limiter
+
+
+class CcxtOHLCVFetcher(DataFetcher):
+    """Asynchronous OHLCV fetcher backed by ccxt.async_support.
+
+    Notes
+    -----
+    - ``ccxt`` is imported lazily. Tests may inject a fake ``exchange`` object to
+      avoid the dependency.
+    - Returns a DataFrame with columns: ``ts, open, high, low, close, volume``.
+    """
+
+    def __init__(
+        self,
+        config: CcxtBackfillConfig,
+        *,
+        exchange: Any | None = None,
+    ) -> None:
+        self.config = config
+        self._exchange = exchange
+        self._limiter = None  # created lazily
+
+    # ------------------------------------------------------------------
+    async def fetch(
+        self, start: int, end: int, *, node_id: str, interval: int
+    ) -> pd.DataFrame:
+        symbol, tf_from_node = _parse_symbol_from_node_id(node_id)
+        symbol = symbol or (self.config.symbols[0] if self.config.symbols else None)
+        timeframe = tf_from_node or self.config.timeframe
+        if not symbol:
+            raise ValueError("symbol not provided in config and not parseable from node_id")
+
+        step_s = _try_parse_timeframe_s(timeframe)
+        # Trust caller-supplied interval alignment, but guard gross mismatches
+        if interval and step_s and interval % step_s != 0:
+            # Allow submultiples; primary alignment responsibility remains with caller
+            pass
+
+        rows: list[list[Any]] = []
+        ex = await self._get_or_create_exchange()
+        try:
+            start_ms = max(0, int(start) * 1000)
+            end_ms = max(0, int(end) * 1000)
+            step_ms = step_s * 1000
+
+            cursor = start_ms
+            hard_cap = 500_000  # safety valve against infinite loops
+            while cursor <= end_ms and hard_cap > 0:
+                hard_cap -= 1
+                remaining = end_ms - cursor
+                if remaining < 0:
+                    break
+                max_points = remaining // step_ms + 1
+                limit = int(min(self.config.window_size, max(1, max_points)))
+                batch = await self._fetch_ohlcv_with_retry(ex, symbol, timeframe, cursor, limit)
+                if not batch:
+                    break
+                rows.extend(batch)
+                last_ms = int(batch[-1][0])
+                next_cursor = last_ms + step_ms
+                if next_cursor <= cursor:
+                    break
+                cursor = next_cursor
+        finally:
+            await self._maybe_close_exchange(ex)
+
+        # Normalize
+        normalized = self._normalize_ohlcv(rows, start, end)
+        return normalized
+
+    # ------------------------------------------------------------------
+    async def _fetch_ohlcv_with_retry(
+        self,
+        exchange: Any,
+        symbol: str,
+        timeframe: str,
+        since_ms: int,
+        limit: int,
+    ) -> Sequence[Sequence[Any]]:
+        attempt = 0
+        backoff = self.config.retry_backoff_s
+        while True:
+            attempt += 1
+            try:
+                limiter = await self._ensure_limiter()
+                async with limiter:
+                    data = await exchange.fetch_ohlcv(
+                        symbol, timeframe, since=since_ms, limit=limit
+                    )
+                    return data or []
+            except Exception:  # pragma: no cover - error path exercised in tests via stub
+                if attempt >= max(1, self.config.max_retries):
+                    raise
+                await asyncio.sleep(backoff)
+                backoff *= 2.0
+
+    async def _ensure_limiter(self):
+        if self._limiter is not None:
+            return self._limiter
+        key = f"ccxt:{self.config.exchange_id.lower()}"
+        rl = self.config.rate_limiter
+        self._limiter = await get_limiter(
+            key,
+            max_concurrency=rl.max_concurrency,
+            min_interval_s=rl.min_interval_s,
+            scope=str(getattr(rl, "scope", "process")),
+            redis_dsn=getattr(rl, "redis_dsn", None),
+            tokens_per_sec=getattr(rl, "tokens_per_sec", None),
+            burst=getattr(rl, "burst", None),
+            key_suffix=getattr(rl, "key_suffix", None),
+        )
+        return self._limiter
+
+    # ------------------------------------------------------------------
+    async def _get_or_create_exchange(self) -> Any:
+        if self._exchange is not None:
+            return self._exchange
+        # Lazy import to keep ccxt optional
+        try:  # pragma: no cover - import path
+            import ccxt.async_support as ccxt_async  # type: ignore
+        except Exception as e:  # pragma: no cover - exercised when ccxt missing
+            raise RuntimeError("ccxt is required for CcxtOHLCVFetcher; install with [ccxt]") from e
+
+        eid = self.config.exchange_id.lower()
+        if not hasattr(ccxt_async, eid):
+            raise ValueError(f"Unknown ccxt exchange id: {eid}")
+        klass = getattr(ccxt_async, eid)
+        self._exchange = klass({"enableRateLimit": True})
+        return self._exchange
+
+    async def _maybe_close_exchange(self, exchange: Any) -> None:
+        if exchange is not self._exchange:
+            # external exchange injected by tests; don't close
+            return
+        close = getattr(exchange, "close", None)
+        if asyncio.iscoroutinefunction(close):  # type: ignore[arg-type]
+            try:
+                await close()  # type: ignore[misc]
+            except Exception:  # pragma: no cover - best-effort close
+                pass
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_ohlcv(rows: Iterable[Sequence[Any]], start: int, end: int) -> pd.DataFrame:
+        if not rows:
+            return pd.DataFrame()
+        records = []
+        for r in rows:
+            if not r:
+                continue
+            # CCXT OHLCV: [ timestamp(ms), open, high, low, close, volume, ... ]
+            ts = int(r[0]) // 1000
+            if ts < start or ts > end:
+                continue
+            rec = {
+                "ts": ts,
+                "open": float(r[1]),
+                "high": float(r[2]),
+                "low": float(r[3]),
+                "close": float(r[4]),
+                "volume": float(r[5]),
+            }
+            records.append(rec)
+        if not records:
+            return pd.DataFrame()
+        df = pd.DataFrame.from_records(records)
+        # Deduplicate on ts and sort
+        df = df.drop_duplicates(subset=["ts"]).sort_values("ts").reset_index(drop=True)
+        return df
+
+
+@dataclass(slots=True)
+class CcxtTradesConfig:
+    exchange_id: str
+    symbols: list[str] | None
+    window_size: int = 1000  # max trades per request
+    max_retries: int = 3
+    retry_backoff_s: float = 0.5
+    rate_limiter: RateLimiterConfig = RateLimiterConfig()
+
+
+class CcxtTradesFetcher(DataFetcher):
+    """Asynchronous Trades fetcher backed by ccxt.async_support.
+
+    Returns a DataFrame with at least: ``ts, price, amount``. ``side`` is
+    included when available. This is a stub suitable for unit testing and
+    incremental integration; production-hardening (e.g., pagination nuances
+    across exchanges) can be added iteratively.
+    """
+
+    def __init__(
+        self,
+        config: CcxtTradesConfig,
+        *,
+        exchange: Any | None = None,
+    ) -> None:
+        self.config = config
+        self._exchange = exchange
+        self._limiter = None
+
+    async def fetch(
+        self, start: int, end: int, *, node_id: str, interval: int
+    ) -> pd.DataFrame:
+        symbol, _ = _parse_symbol_from_node_id(node_id)
+        symbol = symbol or (self.config.symbols[0] if self.config.symbols else None)
+        if not symbol:
+            raise ValueError("symbol not provided in config and not parseable from node_id")
+
+        ex = await self._get_or_create_exchange()
+        rows: list[dict] = []
+        try:
+            start_ms = max(0, int(start) * 1000)
+            end_ms = max(0, int(end) * 1000)
+            cursor = start_ms
+            hard_cap = 1_000_000  # generous safety valve
+            while cursor <= end_ms and hard_cap > 0:
+                hard_cap -= 1
+                limit = int(max(1, min(self.config.window_size, 1000)))
+                batch = await self._fetch_trades_with_retry(ex, symbol, cursor, limit)
+                if not batch:
+                    break
+                # ccxt returns list of dict-like trade objects
+                rows.extend(batch)
+                last_ms = int(batch[-1].get("timestamp", cursor))
+                next_cursor = last_ms + 1
+                if next_cursor <= cursor:
+                    break
+                cursor = next_cursor
+                if cursor > end_ms:
+                    break
+        finally:
+            await self._maybe_close_exchange(ex)
+
+        return self._normalize_trades(rows, start, end)
+
+    async def _fetch_trades_with_retry(
+        self, exchange: Any, symbol: str, since_ms: int, limit: int
+    ) -> list[dict]:
+        attempt = 0
+        backoff = self.config.retry_backoff_s
+        while True:
+            attempt += 1
+            try:
+                limiter = await self._ensure_limiter()
+                async with limiter:
+                    data = await exchange.fetch_trades(
+                        symbol, since=since_ms, limit=limit
+                    )
+                    return list(data or [])
+            except Exception:  # pragma: no cover - error path in stub tests
+                if attempt >= max(1, self.config.max_retries):
+                    raise
+                await asyncio.sleep(backoff)
+                backoff *= 2.0
+
+    async def _ensure_limiter(self):
+        if self._limiter is not None:
+            return self._limiter
+        key = f"ccxt:{self.config.exchange_id.lower()}"
+        rl = self.config.rate_limiter
+        self._limiter = await get_limiter(
+            key,
+            max_concurrency=rl.max_concurrency,
+            min_interval_s=rl.min_interval_s,
+            scope=str(getattr(rl, "scope", "process")),
+            redis_dsn=getattr(rl, "redis_dsn", None),
+            tokens_per_sec=getattr(rl, "tokens_per_sec", None),
+            burst=getattr(rl, "burst", None),
+            key_suffix=getattr(rl, "key_suffix", None),
+        )
+        return self._limiter
+
+    async def _get_or_create_exchange(self) -> Any:
+        if self._exchange is not None:
+            return self._exchange
+        try:  # pragma: no cover - import path
+            import ccxt.async_support as ccxt_async  # type: ignore
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError("ccxt is required for CcxtTradesFetcher; install with [ccxt]") from e
+        eid = self.config.exchange_id.lower()
+        if not hasattr(ccxt_async, eid):
+            raise ValueError(f"Unknown ccxt exchange id: {eid}")
+        klass = getattr(ccxt_async, eid)
+        self._exchange = klass({"enableRateLimit": True})
+        return self._exchange
+
+    async def _maybe_close_exchange(self, exchange: Any) -> None:
+        if exchange is not self._exchange:
+            return
+        close = getattr(exchange, "close", None)
+        if asyncio.iscoroutinefunction(close):  # type: ignore[arg-type]
+            try:
+                await close()  # type: ignore[misc]
+            except Exception:  # pragma: no cover
+                pass
+
+    @staticmethod
+    def _normalize_trades(rows: Iterable[dict], start: int, end: int) -> pd.DataFrame:
+        if not rows:
+            return pd.DataFrame()
+        records = []
+        for tr in rows:
+            try:
+                ts = int(tr.get("timestamp")) // 1000
+            except Exception:
+                continue
+            if ts < start or ts > end:
+                continue
+            rec = {"ts": ts}
+            if "price" in tr:
+                rec["price"] = float(tr["price"])  # type: ignore[arg-type]
+            if "amount" in tr:
+                rec["amount"] = float(tr["amount"])  # type: ignore[arg-type]
+            if "side" in tr:
+                rec["side"] = tr["side"]
+            records.append(rec)
+        if not records:
+            return pd.DataFrame()
+        df = pd.DataFrame.from_records(records)
+        df = df.sort_values(["ts"]).reset_index(drop=True)
+        return df
+
+
+__all__ = [
+    "CcxtBackfillConfig",
+    "RateLimiterConfig",
+    "CcxtOHLCVFetcher",
+    "CcxtTradesConfig",
+    "CcxtTradesFetcher",
+]

--- a/qmtl/runtime/io/ccxt_provider.py
+++ b/qmtl/runtime/io/ccxt_provider.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+"""Convenience provider wiring CCXT fetcher with QuestDB backend.
+
+This module exposes a small helper class that composes
+``QuestDBHistoryProvider`` with ``FetcherBackfillStrategy`` using the
+``CcxtOHLCVFetcher`` implementation.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from qmtl.runtime.sdk.auto_backfill import FetcherBackfillStrategy
+from qmtl.runtime.io.historyprovider import QuestDBHistoryProvider
+from .ccxt_fetcher import (
+    CcxtBackfillConfig,
+    CcxtOHLCVFetcher,
+    RateLimiterConfig,
+    CcxtTradesConfig,
+    CcxtTradesFetcher,
+)
+
+
+@dataclass(slots=True)
+class QuestDBConn:
+    dsn: str | None = None
+    host: str | None = None
+    port: int | None = None
+    database: str | None = None
+    table: str | None = None
+
+    def resolve_dsn(self) -> str:
+        if self.dsn:
+            return self.dsn
+        host = self.host or "localhost"
+        port = int(self.port or 8812)
+        db = self.database or "qdb"
+        # asyncpg-compatible DSN
+        return f"postgresql://{host}:{port}/{db}"
+
+
+class CcxtQuestDBProvider(QuestDBHistoryProvider):
+    """QuestDB provider pre-configured with a CCXT OHLCV backfiller.
+
+    Typical usage:
+        provider = CcxtQuestDBProvider.from_config({
+            "exchange": "binance",
+            "symbols": ["BTC/USDT"],
+            "timeframe": "1m",
+            "questdb": {"dsn": "postgresql://localhost:8812/qdb", "table": "crypto_ohlcv"},
+        })
+    """
+
+    def __init__(
+        self,
+        dsn: str,
+        *,
+        table: str | None = None,
+        fetcher: CcxtOHLCVFetcher | None = None,
+    ) -> None:
+        auto = FetcherBackfillStrategy(fetcher) if fetcher is not None else None
+        super().__init__(dsn, table=table, fetcher=fetcher, auto_backfill=auto)
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_config(
+        cls,
+        cfg: Mapping[str, Any],
+        *,
+        exchange: Any | None = None,
+    ) -> "CcxtQuestDBProvider":
+        """Create a provider for OHLCV (default) or trades mode.
+
+        cfg keys:
+            - mode: "ohlcv" (default) or "trades"
+            - exchange/exchange_id, symbols, timeframe (for ohlcv)
+            - questdb: { dsn | host/port/database, table | table_prefix }
+            - backoff/rate_limiter/window_size/etc.; see fetcher configs
+        """
+        mode = str(cfg.get("mode", "ohlcv")).lower()
+        exchange_id = str(cfg.get("exchange") or cfg.get("exchange_id") or "binance")
+        symbols = list(cfg.get("symbols") or []) or None
+        rl_cfg = cfg.get("rate_limiter") or {}
+        rate_limiter = RateLimiterConfig(
+            max_concurrency=int(rl_cfg.get("max_concurrency", 1)),
+            min_interval_s=float(rl_cfg.get("min_interval_s", 0.0)),
+        )
+
+        fetcher: CcxtOHLCVFetcher | CcxtTradesFetcher
+        if mode == "trades":
+            backfill_t = CcxtTradesConfig(
+                exchange_id=exchange_id,
+                symbols=symbols,
+                window_size=int(cfg.get("window_size", 1000)),
+                max_retries=int(cfg.get("max_retries", 3)),
+                retry_backoff_s=float(cfg.get("retry_backoff_s", 0.5)),
+                rate_limiter=rate_limiter,
+            )
+            fetcher = CcxtTradesFetcher(backfill_t, exchange=exchange)
+        else:
+            timeframe = str(cfg.get("timeframe") or "1m")
+            backfill_o = CcxtBackfillConfig(
+                exchange_id=exchange_id,
+                symbols=symbols,
+                timeframe=timeframe,
+                window_size=int(cfg.get("window_size", 1000)),
+                max_retries=int(cfg.get("max_retries", 3)),
+                retry_backoff_s=float(cfg.get("retry_backoff_s", 0.5)),
+                rate_limiter=rate_limiter,
+            )
+            fetcher = CcxtOHLCVFetcher(backfill_o, exchange=exchange)
+
+        q = cfg.get("questdb") or {}
+        table = q.get("table")
+        table_prefix = q.get("table_prefix")
+        if not table and table_prefix:
+            # Derive a simple table name from prefix and mode
+            table = f"{table_prefix}_{mode}"
+        conn = QuestDBConn(
+            dsn=q.get("dsn"),
+            host=q.get("host"),
+            port=q.get("port"),
+            database=q.get("database") or q.get("db"),
+            table=table,
+        )
+        dsn = conn.resolve_dsn()
+        return cls(dsn, table=conn.table, fetcher=fetcher)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def make_node_id(
+        *, exchange_id: str, symbol: str, timeframe: str | None = None, mode: str = "ohlcv"
+    ) -> str:
+        mode = (mode or "ohlcv").lower()
+        if mode == "trades":
+            return f"trades:{exchange_id}:{symbol}"
+        tf = timeframe or "1m"
+        return f"ohlcv:{exchange_id}:{symbol}:{tf}"
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_config_multi(
+        cls, cfg: Mapping[str, Any], *, exchange: Any | None = None
+    ) -> dict[str, "CcxtQuestDBProvider"]:
+        """Create multiple providers for combinations of symbols/timeframes.
+
+        For mode=ohlcv, returns one per (symbol, timeframe). For trades, one per symbol.
+        Keys are constructed via make_node_id.
+        """
+        mode = str(cfg.get("mode", "ohlcv")).lower()
+        exchange_id = str(cfg.get("exchange") or cfg.get("exchange_id") or "binance")
+        symbols = list(cfg.get("symbols") or [])
+        timeframes = list(cfg.get("timeframes") or ([] if cfg.get("timeframe") is None else [cfg.get("timeframe")]))
+        if mode == "trades":
+            if not symbols:
+                return {}
+            out: dict[str, CcxtQuestDBProvider] = {}
+            for sym in symbols:
+                node_id = cls.make_node_id(exchange_id=exchange_id, symbol=sym, mode="trades")
+                provider = cls.from_config(cfg, exchange=exchange)
+                out[node_id] = provider
+            return out
+
+        # OHLCV
+        if not timeframes:
+            timeframes = ["1m"]
+        out2: dict[str, CcxtQuestDBProvider] = {}
+        for sym in symbols or []:
+            for tf in timeframes:
+                local_cfg = dict(cfg)
+                local_cfg["timeframe"] = tf
+                node_id = cls.make_node_id(exchange_id=exchange_id, symbol=sym, timeframe=tf, mode="ohlcv")
+                provider = cls.from_config(local_cfg, exchange=exchange)
+                out2[node_id] = provider
+        return out2
+
+
+__all__ = ["CcxtQuestDBProvider", "CcxtBackfillConfig", "RateLimiterConfig"]

--- a/qmtl/runtime/io/ccxt_rate_limiter.py
+++ b/qmtl/runtime/io/ccxt_rate_limiter.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+"""Process-wide shared rate limiter for CCXT calls.
+
+This module provides a per-exchange limiter to coordinate requests across
+multiple fetchers within a single Python process. For distributed (multi-host)
+coordination, consider extending this with a Redis-backed token bucket.
+"""
+
+from dataclasses import dataclass
+import asyncio
+import time
+from typing import Dict, Any
+
+try:  # Optional at runtime; required for cluster scope
+    from redis import asyncio as aioredis  # type: ignore
+except Exception:  # pragma: no cover - import guarded for environments without redis
+    aioredis = None  # type: ignore
+
+
+@dataclass(slots=True)
+class _LimiterShape:
+    max_concurrency: int
+    min_interval_s: float
+
+
+class _SharedLimiter:
+    def __init__(self, *, max_concurrency: int, min_interval_s: float) -> None:
+        self._sem = asyncio.Semaphore(max(1, int(max_concurrency)))
+        self._min_interval_s = max(0.0, float(min_interval_s))
+        self._last_call_at: float = 0.0
+        self._lock = asyncio.Lock()
+
+    async def __aenter__(self) -> "_SharedLimiter":
+        await self._sem.acquire()
+        # Enforce minimum gap between request starts
+        if self._min_interval_s > 0:
+            async with self._lock:
+                now = time.perf_counter()
+                elapsed = now - self._last_call_at
+                if elapsed < self._min_interval_s:
+                    await asyncio.sleep(self._min_interval_s - elapsed)
+                # mark start time to space subsequent calls
+                self._last_call_at = time.perf_counter()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self._sem.release()
+
+
+_REGISTRY: Dict[str, _SharedLimiter] = {}
+_SHAPES: Dict[str, _LimiterShape] = {}
+_REGISTRY_LOCK = asyncio.Lock()
+
+
+async def get_shared_limiter(
+    key: str, *, max_concurrency: int, min_interval_s: float
+) -> _SharedLimiter:
+    """Return a process-wide limiter identified by ``key``.
+
+    First configuration applied for a ``key`` wins. Subsequent calls with
+    different shapes are ignored to avoid runtime surprises.
+    """
+    if key in _REGISTRY:
+        return _REGISTRY[key]
+    async with _REGISTRY_LOCK:
+        if key in _REGISTRY:
+            return _REGISTRY[key]
+        limiter = _SharedLimiter(
+            max_concurrency=max_concurrency, min_interval_s=min_interval_s
+        )
+        _REGISTRY[key] = limiter
+        _SHAPES[key] = _LimiterShape(max_concurrency, min_interval_s)
+        return limiter
+
+
+class _LocalLimiter(_SharedLimiter):
+    """Local (per-instance) limiter using the same mechanics."""
+
+    pass
+
+
+class _RedisTokenBucketLimiter:
+    """Redis-backed token bucket limiter (cluster scope).
+
+    Simple cluster-wide limiter that enforces an average rate across processes
+    by consuming tokens from a bucket stored in Redis. It also includes a local
+    semaphore to limit per-process concurrency.
+    """
+
+    def __init__(
+        self,
+        *,
+        redis: Any,
+        bucket_key: str,
+        tokens_per_sec: float,
+        capacity: int,
+        local_concurrency: int,
+    ) -> None:
+        self._redis = redis
+        self._key = bucket_key
+        self._rate = float(max(0.000001, tokens_per_sec))
+        self._cap = int(max(1, capacity))
+        self._sem = asyncio.Semaphore(max(1, local_concurrency))
+
+    async def __aenter__(self) -> "_RedisTokenBucketLimiter":
+        await self._sem.acquire()
+        # Spin until a token is granted
+        backoff = 0.001
+        while True:
+            allowed = await self._reserve_token()
+            if allowed:
+                return self
+            await asyncio.sleep(backoff)
+            # exponential backoff capped to 100ms
+            backoff = min(0.1, backoff * 2)
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self._sem.release()
+
+    async def _reserve_token(self) -> bool:
+        # Use Redis TIME for a stable time source
+        try:
+            now_sec, now_usec = await self._redis.time()
+        except Exception:
+            # Fallback to local time (best effort)
+            t = time.time()
+            now_sec, now_usec = int(t), int((t - int(t)) * 1_000_000)
+        now_ms = now_sec * 1000 + (now_usec // 1000)
+
+        # Stored as hash fields: tokens (float), ts (ms)
+        pipe = self._redis.pipeline()
+        pipe.hget(self._key, "tokens")
+        pipe.hget(self._key, "ts")
+        tokens_raw, ts_raw = await pipe.execute()
+
+        try:
+            tokens = float(tokens_raw) if tokens_raw is not None else float(self._cap)
+            last_ms = int(ts_raw) if ts_raw is not None else now_ms
+        except Exception:
+            tokens = float(self._cap)
+            last_ms = now_ms
+
+        # Refill based on elapsed time
+        elapsed_ms = max(0, now_ms - last_ms)
+        refill = (elapsed_ms / 1000.0) * self._rate
+        tokens = min(self._cap, tokens + refill)
+        allowed = tokens >= 1.0
+        if allowed:
+            tokens -= 1.0
+
+        # Update back
+        await self._redis.hset(self._key, mapping={"tokens": tokens, "ts": now_ms})
+        # Set an expiry to avoid stale keys (10 minutes)
+        await self._redis.expire(self._key, 600)
+        return allowed
+
+
+_CLUSTER_CACHE: Dict[str, _RedisTokenBucketLimiter] = {}
+
+
+async def get_limiter(
+    key: str,
+    *,
+    max_concurrency: int,
+    min_interval_s: float,
+    scope: str,
+    redis_dsn: str | None = None,
+    tokens_per_sec: float | None = None,
+    burst: int | None = None,
+    key_suffix: str | None = None,
+) -> _SharedLimiter | _RedisTokenBucketLimiter:
+    if scope == "local":
+        return _LocalLimiter(
+            max_concurrency=max_concurrency, min_interval_s=min_interval_s
+        )
+    if scope == "cluster":
+        if aioredis is None:  # pragma: no cover - dependency missing
+            raise RuntimeError(
+                "redis is required for cluster scope rate limiting; install redis"
+            )
+        # Compose full bucket key; allow suffix to partition by account/scope
+        bucket_key = f"rl:{key}"
+        if key_suffix:
+            bucket_key = f"{bucket_key}:{key_suffix}"
+        # Determine rate from tokens_per_sec or min_interval
+        rate = float(tokens_per_sec if tokens_per_sec else (1.0 / max(0.000001, min_interval_s)))
+        capacity = int(burst if burst else 1)
+
+        # Cache a limiter per (bucket_key, rate, capacity, concurrency)
+        cache_key = f"{bucket_key}|{rate}|{capacity}|{max_concurrency}"
+        if cache_key in _CLUSTER_CACHE:
+            return _CLUSTER_CACHE[cache_key]
+
+        # Resolve Redis DSN from argument or environment
+        import os  # local import to avoid global dependency at import time
+        dsn = redis_dsn or os.getenv("QMTL_CCXT_RATE_LIMITER_REDIS") or "redis://localhost:6379/0"
+
+        client = aioredis.from_url(dsn, encoding=None, decode_responses=False)
+        limiter = _RedisTokenBucketLimiter(
+            redis=client,
+            bucket_key=bucket_key,
+            tokens_per_sec=rate,
+            capacity=capacity,
+            local_concurrency=max_concurrency,
+        )
+        _CLUSTER_CACHE[cache_key] = limiter
+        return limiter
+    # Default: process-wide
+    return await get_shared_limiter(
+        key, max_concurrency=max_concurrency, min_interval_s=min_interval_s
+    )
+
+
+__all__ = [
+    "get_limiter",
+]

--- a/tests/runtime/io/test_ccxt_fetcher.py
+++ b/tests/runtime/io/test_ccxt_fetcher.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+import pandas as pd
+import pytest
+
+from qmtl.runtime.io.ccxt_fetcher import (
+    CcxtBackfillConfig,
+    CcxtOHLCVFetcher,
+    RateLimiterConfig,
+)
+
+
+class _StubExchange:
+    def __init__(self, batches):
+        self._batches = list(batches)
+        self.calls = []
+
+    async def fetch_ohlcv(self, symbol, timeframe, since=None, limit=None):
+        self.calls.append((symbol, timeframe, since, limit))
+        # Pop next batch or return empty
+        if not self._batches:
+            return []
+        batch = self._batches.pop(0)
+        # Simulate async
+        await asyncio.sleep(0)
+        return batch
+
+    async def close(self):  # pragma: no cover - best-effort close in tests
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_ccxt_fetcher_normalizes_rows_and_filters_range():
+    # Frames across 60..180 seconds; include an out-of-range row (30s) and duplicate
+    rows = [
+        [30_000, 1, 1, 1, 1, 1],
+        [60_000, 1, 2, 0.5, 1.5, 10],
+        [120_000, 2, 3, 1, 2.5, 11],
+        [120_000, 2, 3, 1, 2.5, 11],  # duplicate ts
+        [180_000, 3, 4, 2, 3.5, 12],
+    ]
+    ex = _StubExchange([rows])
+    cfg = CcxtBackfillConfig(
+        exchange_id="binance",
+        symbols=["BTC/USDT"],
+        timeframe="1m",
+        rate_limiter=RateLimiterConfig(),
+    )
+    fetcher = CcxtOHLCVFetcher(cfg, exchange=ex)
+    df = await fetcher.fetch(60, 180, node_id="ohlcv:binance:BTC/USDT:1m", interval=60)
+    assert list(df.columns) == ["ts", "open", "high", "low", "close", "volume"]
+    assert df["ts"].tolist() == [60, 120, 180]
+    assert df.iloc[0]["open"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ccxt_fetcher_chunks_requests_with_window_size():
+    # Simulate two batches of 2 rows each (limit=2)
+    batch1 = [[60_000, 1, 1, 1, 1, 1], [120_000, 1, 1, 1, 1, 1]]
+    batch2 = [[180_000, 1, 1, 1, 1, 1], [240_000, 1, 1, 1, 1, 1]]
+    ex = _StubExchange([batch1, batch2])
+    cfg = CcxtBackfillConfig(
+        exchange_id="binance",
+        symbols=["BTC/USDT"],
+        timeframe="1m",
+        window_size=2,
+    )
+    fetcher = CcxtOHLCVFetcher(cfg, exchange=ex)
+    df = await fetcher.fetch(60, 240, node_id="ohlcv:binance:BTC/USDT:1m", interval=60)
+    assert df["ts"].tolist() == [60, 120, 180, 240]
+    # Two calls due to window_size
+    assert len(ex.calls) >= 2
+
+
+@pytest.mark.asyncio
+async def test_ccxt_fetcher_retries_on_error_then_succeeds():
+    class _FlakyExchange(_StubExchange):
+        def __init__(self):
+            super().__init__([[[60_000, 1, 1, 1, 1, 1]]])
+            self._fail = True
+
+        async def fetch_ohlcv(self, symbol, timeframe, since=None, limit=None):
+            if self._fail:
+                self._fail = False
+                raise RuntimeError("rate limit")
+            return await super().fetch_ohlcv(symbol, timeframe, since, limit)
+
+    ex = _FlakyExchange()
+    cfg = CcxtBackfillConfig(
+        exchange_id="binance",
+        symbols=["BTC/USDT"],
+        timeframe="1m",
+        max_retries=2,
+        retry_backoff_s=0.01,
+    )
+    fetcher = CcxtOHLCVFetcher(cfg, exchange=ex)
+    df = await fetcher.fetch(60, 60, node_id="ohlcv:binance:BTC/USDT:1m", interval=60)
+    assert df["ts"].tolist() == [60]
+

--- a/tests/runtime/io/test_ccxt_questdb_provider_trades.py
+++ b/tests/runtime/io/test_ccxt_questdb_provider_trades.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from qmtl.runtime.io import CcxtQuestDBProvider
+
+
+class _InMemoryBackend:
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, int], dict[int, dict]] = {}
+
+    async def read_range(self, start: int, end: int, *, node_id: str, interval: int) -> pd.DataFrame:
+        table = self._rows.get((node_id, interval), {})
+        data = []
+        for ts in sorted(table):
+            if start <= ts < end:
+                row = {"ts": ts}
+                row.update(table[ts])
+                data.append(row)
+        return pd.DataFrame(data)
+
+    async def write_rows(self, rows: pd.DataFrame, *, node_id: str, interval: int) -> None:
+        if rows is None or rows.empty:
+            return
+        table = self._rows.setdefault((node_id, interval), {})
+        for rec in rows.to_dict("records"):
+            ts = int(rec["ts"])
+            payload = {k: v for k, v in rec.items() if k != "ts"}
+            table[ts] = payload
+
+    async def coverage(self, *, node_id: str, interval: int) -> list[tuple[int, int]]:
+        table = self._rows.get((node_id, interval), {})
+        timestamps = sorted(table)
+        if not timestamps:
+            return []
+        ranges: list[tuple[int, int]] = []
+        start = prev = timestamps[0]
+        for ts in timestamps[1:]:
+            if ts == prev + interval:
+                prev = ts
+            else:
+                ranges.append((start, prev))
+                start = prev = ts
+        ranges.append((start, prev))
+        return ranges
+
+
+class _StubTradesExchange:
+    async def fetch_trades(self, symbol, since=None, limit=None):
+        # Return a single trade at 60s
+        return [{"timestamp": 60_000, "price": 10.0, "amount": 0.1, "side": "buy"}]
+
+    async def close(self):  # pragma: no cover
+        pass
+
+
+@pytest.mark.asyncio
+async def test_ccxt_questdb_provider_from_config_trades(monkeypatch):
+    cfg = {
+        "mode": "trades",
+        "exchange": "binance",
+        "symbols": ["BTC/USDT"],
+        "questdb": {"dsn": "postgresql://local:8812/qdb", "table": "node_data_trades"},
+    }
+    provider = CcxtQuestDBProvider.from_config(cfg, exchange=_StubTradesExchange())
+    backend = _InMemoryBackend()
+    provider.backend = backend  # type: ignore[attr-defined]
+
+    node_id = "trades:binance:BTC/USDT"
+    await provider.fill_missing(60, 60, node_id=node_id, interval=1)
+    df = await backend.read_range(0, 120, node_id=node_id, interval=1)
+    assert df["ts"].tolist() == [60]
+

--- a/tests/runtime/io/test_ccxt_rate_limiter_cluster.py
+++ b/tests/runtime/io/test_ccxt_rate_limiter_cluster.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import uuid
+import pytest
+
+from qmtl.runtime.io.ccxt_fetcher import (
+    CcxtBackfillConfig,
+    CcxtOHLCVFetcher,
+    RateLimiterConfig,
+)
+
+
+class _TimedExchange:
+    def __init__(self, ts_ms: int):
+        self._ts_ms = ts_ms
+        self.call_times: list[float] = []
+
+    async def fetch_ohlcv(self, symbol, timeframe, since=None, limit=None):
+        self.call_times.append(time.perf_counter())
+        await asyncio.sleep(0)
+        return [[self._ts_ms, 1, 1, 1, 1, 1]]
+
+    async def close(self):  # pragma: no cover
+        pass
+
+
+def _redis_available(url: str) -> bool:
+    try:
+        from redis import asyncio as aioredis  # type: ignore
+
+        async def _ping() -> bool:
+            try:
+                client = aioredis.from_url(url)
+                await client.ping()
+                await client.close()
+                return True
+            except Exception:
+                return False
+
+        return asyncio.get_event_loop().run_until_complete(_ping())
+    except Exception:
+        return False
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _redis_available(os.getenv("QMTL_CCXT_RATE_LIMITER_REDIS", "redis://localhost:6379/0")),
+    reason="Redis not available for cluster rate limiter test",
+)
+async def test_cluster_rate_limit_spreads_calls_across_fetchers():
+    redis_url = os.getenv("QMTL_CCXT_RATE_LIMITER_REDIS", "redis://localhost:6379/0")
+    ex1 = _TimedExchange(60_000)
+    ex2 = _TimedExchange(60_000)
+    # Use unique suffix to avoid collisions across parallel runs
+    suffix = uuid.uuid4().hex
+    rl = RateLimiterConfig(
+        max_concurrency=1,
+        min_interval_s=0.05,
+        scope="cluster",
+        redis_dsn=redis_url,
+        burst=1,
+        key_suffix=suffix,
+    )
+    cfg = CcxtBackfillConfig(exchange_id="binance", symbols=["BTC/USDT"], timeframe="1m", rate_limiter=rl)
+    f1 = CcxtOHLCVFetcher(cfg, exchange=ex1)
+    f2 = CcxtOHLCVFetcher(cfg, exchange=ex2)
+
+    async def _call(fetcher):
+        return await fetcher.fetch(60, 60, node_id="ohlcv:binance:BTC/USDT:1m", interval=60)
+
+    await asyncio.gather(_call(f1), _call(f2))
+    times = sorted(ex1.call_times + ex2.call_times)
+    assert len(times) == 2
+    assert (times[1] - times[0]) >= 0.04
+

--- a/tests/runtime/io/test_ccxt_rate_limiter_shared.py
+++ b/tests/runtime/io/test_ccxt_rate_limiter_shared.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+import time
+import pandas as pd
+import pytest
+
+from qmtl.runtime.io.ccxt_fetcher import (
+    CcxtBackfillConfig,
+    CcxtOHLCVFetcher,
+    RateLimiterConfig,
+)
+
+
+class _TimedExchange:
+    def __init__(self, ts_ms: int):
+        self._ts_ms = ts_ms
+        self.call_times: list[float] = []
+
+    async def fetch_ohlcv(self, symbol, timeframe, since=None, limit=None):
+        self.call_times.append(time.perf_counter())
+        await asyncio.sleep(0)
+        return [[self._ts_ms, 1, 1, 1, 1, 1]]
+
+    async def close(self):  # pragma: no cover
+        pass
+
+
+@pytest.mark.asyncio
+async def test_process_wide_rate_limit_serializes_calls_across_fetchers():
+    # Two fetchers share the same exchange_id → process-wide limiter should serialize starts
+    ex1 = _TimedExchange(60_000)
+    ex2 = _TimedExchange(60_000)
+    rl = RateLimiterConfig(max_concurrency=1, min_interval_s=0.05, scope="process")
+    cfg = CcxtBackfillConfig(exchange_id="binance", symbols=["BTC/USDT"], timeframe="1m", rate_limiter=rl)
+    f1 = CcxtOHLCVFetcher(cfg, exchange=ex1)
+    f2 = CcxtOHLCVFetcher(cfg, exchange=ex2)
+
+    async def _call(fetcher):
+        return await fetcher.fetch(60, 60, node_id="ohlcv:binance:BTC/USDT:1m", interval=60)
+
+    await asyncio.gather(_call(f1), _call(f2))
+    times = sorted(ex1.call_times + ex2.call_times)
+    assert len(times) == 2
+    # Ensure ~50ms spacing with a small tolerance
+    assert (times[1] - times[0]) >= 0.04
+

--- a/tests/runtime/io/test_ccxt_trades_fetcher.py
+++ b/tests/runtime/io/test_ccxt_trades_fetcher.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+import pandas as pd
+import pytest
+
+from qmtl.runtime.io.ccxt_fetcher import (
+    CcxtTradesConfig,
+    CcxtTradesFetcher,
+    RateLimiterConfig,
+)
+
+
+class _StubTradesExchange:
+    def __init__(self, batches):
+        self._batches = list(batches)
+        self.calls = []
+
+    async def fetch_trades(self, symbol, since=None, limit=None):
+        self.calls.append((symbol, since, limit))
+        if not self._batches:
+            return []
+        batch = self._batches.pop(0)
+        await asyncio.sleep(0)
+        return batch
+
+    async def close(self):  # pragma: no cover - best effort
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_trades_fetcher_normalizes_and_sorts():
+    rows = [
+        {"timestamp": 60_000, "price": 10.0, "amount": 0.1, "side": "buy"},
+        {"timestamp": 120_000, "price": 11.0, "amount": 0.2, "side": "sell"},
+        {"timestamp": 30_000, "price": 9.5, "amount": 0.05},  # filtered out
+    ]
+    ex = _StubTradesExchange([rows])
+    cfg = CcxtTradesConfig(
+        exchange_id="binance",
+        symbols=["BTC/USDT"],
+        rate_limiter=RateLimiterConfig(),
+    )
+    fetcher = CcxtTradesFetcher(cfg, exchange=ex)
+    df = await fetcher.fetch(60, 120, node_id="trades:binance:BTC/USDT", interval=60)
+    assert list(df.columns)[:1] == ["ts"]
+    assert df["ts"].tolist() == [60, 120]
+    assert df.iloc[0]["price"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_trades_fetcher_chunks_by_window_size():
+    batch1 = [
+        {"timestamp": 60_000, "price": 10.0, "amount": 0.1},
+        {"timestamp": 61_000, "price": 10.1, "amount": 0.1},
+    ]
+    batch2 = [
+        {"timestamp": 120_000, "price": 11.0, "amount": 0.2},
+        {"timestamp": 121_000, "price": 11.2, "amount": 0.2},
+    ]
+    ex = _StubTradesExchange([batch1, batch2])
+    cfg = CcxtTradesConfig(exchange_id="binance", symbols=["BTC/USDT"], window_size=2)
+    fetcher = CcxtTradesFetcher(cfg, exchange=ex)
+    df = await fetcher.fetch(60, 121, node_id="trades:binance:BTC/USDT", interval=60)
+    assert len(df) == 4
+    assert len(ex.calls) >= 2
+
+
+@pytest.mark.asyncio
+async def test_trades_fetcher_retries_then_succeeds():
+    class _Flaky(_StubTradesExchange):
+        def __init__(self):
+            super().__init__([[{"timestamp": 60_000, "price": 10.0, "amount": 0.1}]])
+            self._fail = True
+
+        async def fetch_trades(self, symbol, since=None, limit=None):
+            if self._fail:
+                self._fail = False
+                raise RuntimeError("rate limit")
+            return await super().fetch_trades(symbol, since=since, limit=limit)
+
+    ex = _Flaky()
+    cfg = CcxtTradesConfig(exchange_id="binance", symbols=["BTC/USDT"], max_retries=2, retry_backoff_s=0.01)
+    fetcher = CcxtTradesFetcher(cfg, exchange=ex)
+    df = await fetcher.fetch(60, 60, node_id="trades:binance:BTC/USDT", interval=60)
+    assert df["ts"].tolist() == [60]
+


### PR DESCRIPTION
Summary

Adds CCXT × QuestDB integration under io/ (not examples):
- CcxtOHLCVFetcher/CcxtTradesFetcher with chunking, retry, and rate limits
- CcxtQuestDBProvider.from_config(+multi) and node_id helpers
- Shared (process-wide) and cluster (Redis token bucket) rate limiter
- Exports in io package, extras in pyproject (ccxt, questdb)
- Docs (docs/io/ccxt-questdb.md) and mkdocs nav
- Unit tests for fetchers, provider wiring, and rate limiters

Details
- Fetchers return standard schema (ts, OHLCV or trades fields)
- Provider composes QuestDBHistoryProvider + FetcherBackfillStrategy
- Rate limiter scopes: local | process | cluster; cluster needs Redis (QMTL_CCXT_RATE_LIMITER_REDIS)
- Tests for cluster limiter are skipped if Redis is unavailable

Note
- No breaking changes to existing providers/examples
- Follow-ups: row_adapter for custom schemas; jitter; Lua-based atomic limiter; client singleton registry
