### PR TITLE
Implement Kafka topic creation retry loop

### DIFF
--- a/tests/services/dagmanager/diff_fakes.py
+++ b/tests/services/dagmanager/diff_fakes.py
@@ -7,6 +7,7 @@ from typing import Any
 from qmtl.services.dagmanager.diff_service import NodeRepository, QueueManager, StreamSender
 from qmtl.services.dagmanager.monitor import AckStatus
 from qmtl.services.dagmanager.topic import topic_name
+from qmtl.services.dagmanager.kafka_admin import TopicExistsError
 
 
 class FakeRepo(NodeRepository):
@@ -156,7 +157,14 @@ class FakeAdmin:
         return self.topics
 
     def create_topic(self, name, *, num_partitions, replication_factor, config=None):
+        if name in self.topics:
+            raise TopicExistsError
         self.created.append((name, num_partitions, replication_factor, config))
+        self.topics[name] = {
+            "config": dict(config or {}),
+            "num_partitions": num_partitions,
+            "replication_factor": replication_factor,
+        }
 
 
 __all__ = [

--- a/tests/services/dagmanager/test_topic.py
+++ b/tests/services/dagmanager/test_topic.py
@@ -14,7 +14,11 @@ class FakeAdmin:
         if name in self.topics:
             raise TopicExistsError
         self.created.append((name, num_partitions, replication_factor, config))
-        self.topics[name] = config or {}
+        self.topics[name] = {
+            "config": dict(config or {}),
+            "num_partitions": num_partitions,
+            "replication_factor": replication_factor,
+        }
 
 
 def test_topic_name_generation():
@@ -58,7 +62,7 @@ def test_topic_config_values():
 
 def test_idempotent_topic_creation():
     admin = FakeAdmin({"exists": {}})
-    wrapper = KafkaAdmin(admin)
+    wrapper = KafkaAdmin(admin, wait_initial=0.0, wait_max=0.0)
 
     config = TopicConfig(1, 1, 1000)
     wrapper.create_topic_if_needed("exists", config)


### PR DESCRIPTION
## Summary
- implement the documented CREATE→VERIFY→WAIT→BACKOFF loop in `KafkaAdmin.create_topic_if_needed`
- add broker metadata verification to detect config/name conflicts and expose tuning knobs for retries
- refresh DAG manager fakes and tests to cover retry success, collision handling, and breaker behaviour

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1126

------
https://chatgpt.com/codex/tasks/task_e_68d4ff8af748832990e051c8b09cdfb8