### PR TITLE
Emit sentinel weight control events from DAG Manager

### DIFF
--- a/qmtl/services/dagmanager/controlbus_producer.py
+++ b/qmtl/services/dagmanager/controlbus_producer.py
@@ -9,9 +9,17 @@ from typing import Any, Iterable
 class ControlBusProducer:
     """Publish control events to the internal bus (e.g. Kafka)."""
 
-    def __init__(self, *, brokers: Iterable[str] | None = None, topic: str = "queue", producer: Any | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        brokers: Iterable[str] | None = None,
+        topic: str = "queue",
+        sentinel_topic: str = "sentinel_weight",
+        producer: Any | None = None,
+    ) -> None:
         self.brokers = list(brokers or [])
         self.topic = topic
+        self.sentinel_topic = sentinel_topic
         self._producer = producer
 
     async def start(self) -> None:
@@ -51,6 +59,45 @@ class ControlBusProducer:
         data = json.dumps(payload).encode()
         key = ",".join(tags_list).encode()
         await self._producer.send_and_wait(self.topic, data, key=key)
+
+    async def publish_sentinel_weight(
+        self,
+        sentinel_id: str,
+        weight: float,
+        *,
+        sentinel_version: str | None = None,
+        world_id: str | None = None,
+        version: int = 1,
+    ) -> None:
+        """Publish a sentinel weight control event."""
+
+        if self._producer is None:
+            return
+
+        ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        weight_value = float(weight)
+        if weight_value < 0.0:
+            weight_value = 0.0
+        elif weight_value > 1.0:
+            weight_value = 1.0
+        weight_str = f"{weight_value:.6f}"
+        version_label = sentinel_version or ""
+        etag = f"sw:{sentinel_id}:{version_label}:{weight_str}:{version}"
+        payload = {
+            "type": "SentinelWeightUpdated",
+            "sentinel_id": sentinel_id,
+            "weight": weight_value,
+            "version": version,
+            "etag": etag,
+            "ts": ts,
+        }
+        if version_label:
+            payload["sentinel_version"] = version_label
+        if world_id:
+            payload["world_id"] = world_id
+        data = json.dumps(payload).encode()
+        key = sentinel_id.encode()
+        await self._producer.send_and_wait(self.sentinel_topic, data, key=key)
 
 
 __all__ = ["ControlBusProducer"]

--- a/qmtl/services/dagmanager/diff_service.py
+++ b/qmtl/services/dagmanager/diff_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from typing import Dict, Iterable, List, TYPE_CHECKING
+import math
+from queue import Empty, Queue
 
 try:  # optional high performance json
     import orjson as _json
@@ -20,6 +22,7 @@ from .metrics import (
     diff_requests_total,
     diff_failures_total,
     cross_context_cache_violation_total,
+    set_active_version_weight,
 )
 from .models import (
     BufferInstruction,
@@ -57,6 +60,14 @@ class _CachedBinding:
     code_hash: str
     schema_hash: str
     context: ComputeContext
+
+
+@dataclass
+class _SentinelWeightEvent:
+    sentinel_id: str
+    weight: float
+    sentinel_version: str
+    world_id: str | None
 
 
 class CrossContextTopicReuseError(RuntimeError):
@@ -146,16 +157,81 @@ class DiffService:
         node_repo: NodeRepository,
         queue_manager: QueueManager,
         stream_sender: StreamSender,
+        *,
+        sentinel_weights: dict[tuple[str, str], float] | None = None,
     ) -> None:
         self.node_repo = node_repo
         self.queue_manager = queue_manager
         self.stream_sender = stream_sender
         self._bindings: Dict[str, Dict[str, _CachedBinding]] = {}
+        self._sentinel_weights = sentinel_weights if sentinel_weights is not None else {}
+        self._weight_events: Queue[_SentinelWeightEvent] = Queue()
+
+    @staticmethod
+    def _coerce_weight(raw: object) -> float | None:
+        """Convert ``raw`` to a bounded float in ``[0, 1]``."""
+
+        if raw is None:
+            return None
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return None
+        if math.isnan(value) or math.isinf(value):
+            return None
+        if value < 0.0:
+            value = 0.0
+        elif value > 1.0:
+            value = 1.0
+        return value
+
+    def consume_weight_events(self) -> list[_SentinelWeightEvent]:
+        """Return sentinel weight events recorded during the last diff."""
+
+        events: list[_SentinelWeightEvent] = []
+        while True:
+            try:
+                events.append(self._weight_events.get_nowait())
+            except Empty:
+                break
+        return events
+
+    def _record_sentinel_weight(
+        self,
+        sentinel_id: str,
+        sentinel_version: str,
+        weight: float | None,
+        *,
+        world_id: str | None,
+    ) -> None:
+        """Store sentinel weight change and emit metrics when updated."""
+
+        normalized = self._coerce_weight(weight)
+        if normalized is None:
+            return
+
+        version_label = sentinel_version or sentinel_id
+        set_active_version_weight(version_label, normalized)
+
+        cache_key = (world_id or "", sentinel_id)
+        prev = self._sentinel_weights.get(cache_key)
+        if prev is not None and math.isclose(prev, normalized, rel_tol=1e-6, abs_tol=1e-6):
+            return
+
+        self._sentinel_weights[cache_key] = normalized
+        self._weight_events.put(
+            _SentinelWeightEvent(
+                sentinel_id=sentinel_id,
+                weight=normalized,
+                sentinel_version=version_label,
+                world_id=world_id,
+            )
+        )
 
     # Step 1 ---------------------------------------------------------------
     def _pre_scan(
         self, dag_json: str
-    ) -> tuple[List[NodeInfo], str, ComputeContext, str | None]:
+    ) -> tuple[List[NodeInfo], str, ComputeContext, str | None, float | None]:
         """Parse DAG JSON and return nodes, version, compute context, namespace."""
         data = _json_loads(dag_json)
 
@@ -163,6 +239,7 @@ class DiffService:
         meta_obj = data.get("meta")
         meta = meta_obj if isinstance(meta_obj, dict) else {}
         sentinel_version: str | None = None
+        sentinel_weight: float | None = None
         filtered_nodes: list[dict] = []
         context = self._extract_compute_context(data)
         namespace: str | None = None
@@ -193,6 +270,12 @@ class DiffService:
                                 break
                     if not sentinel_version:
                         sentinel_version = normalize_version(entry.get("node_id"))
+                if sentinel_weight is None:
+                    for key in ("traffic_weight", "sentinel_weight", "weight"):
+                        if key in entry:
+                            sentinel_weight = self._coerce_weight(entry.get(key))
+                            if sentinel_weight is not None:
+                                break
                 continue
             filtered_nodes.append(entry)
 
@@ -248,7 +331,13 @@ class DiffService:
                 or meta.get("strategy_version")
                 or meta.get("build_version")
             )
-        return nodes, version, context, namespace
+        if sentinel_weight is None:
+            for key in ("traffic_weight", "sentinel_weight", "weight"):
+                if key in meta:
+                    sentinel_weight = self._coerce_weight(meta.get(key))
+                    if sentinel_weight is not None:
+                        break
+        return nodes, version, context, namespace, sentinel_weight
 
     # Step 2 ---------------------------------------------------------------
     def _db_fetch(self, node_ids: Iterable[str]) -> Dict[str, NodeRecord]:
@@ -488,7 +577,7 @@ class DiffService:
     def diff(self, request: DiffRequest) -> DiffChunk:
         start = time.perf_counter()
         try:
-            nodes, version, inferred_context, namespace = self._pre_scan(
+            nodes, version, inferred_context, namespace, sentinel_weight = self._pre_scan(
                 request.dag_json
             )
             merged_context = replace(
@@ -517,6 +606,12 @@ class DiffService:
             if not new_nodes:
                 sentinel_gap_count.inc()
                 sentinel_gap_count._val = sentinel_gap_count._value.get()  # type: ignore[attr-defined]
+            self._record_sentinel_weight(
+                sentinel_id,
+                version,
+                sentinel_weight,
+                world_id=merged_context.world_id or None,
+            )
             self._stream_send(queue_map, sentinel_id, version, new_nodes, instructions)
             # success path accounted as processed request
             diff_requests_total.inc()

--- a/qmtl/services/dagmanager/grpc_server.py
+++ b/qmtl/services/dagmanager/grpc_server.py
@@ -84,6 +84,11 @@ class DiffServiceServicer(dagmanager_pb2_grpc.DiffServiceServicer):
         self._service = service
         self._bus = bus
         self._streams: Dict[str, _GrpcStream] = {}
+        sentinel_weights = getattr(service, "_sentinel_weights", None)
+        if sentinel_weights is None:
+            sentinel_weights = {}
+            setattr(service, "_sentinel_weights", sentinel_weights)
+        self._sentinel_weights = sentinel_weights
 
     async def Diff(
         self,
@@ -93,7 +98,12 @@ class DiffServiceServicer(dagmanager_pb2_grpc.DiffServiceServicer):
         sentinel_id = f"{request.strategy_id}-sentinel"
         stream = _GrpcStream(asyncio.get_running_loop())
         self._streams[sentinel_id] = stream
-        svc = DiffService(self._service.node_repo, self._service.queue_manager, stream)
+        svc = DiffService(
+            self._service.node_repo,
+            self._service.queue_manager,
+            stream,
+            sentinel_weights=self._sentinel_weights,
+        )
         fut = asyncio.create_task(
             svc.diff_async(
                 DiffRequest(
@@ -113,6 +123,15 @@ class DiffServiceServicer(dagmanager_pb2_grpc.DiffServiceServicer):
                 chunk = await stream.queue.get()
                 if chunk is None:
                     break
+                events = svc.consume_weight_events()
+                if self._bus:
+                    for event in events:
+                        await self._bus.publish_sentinel_weight(
+                            event.sentinel_id,
+                            event.weight,
+                            sentinel_version=event.sentinel_version,
+                            world_id=event.world_id,
+                        )
                 pb = dagmanager_pb2.DiffChunk(
                     queue_map=chunk.queue_map,
                     sentinel_id=chunk.sentinel_id,
@@ -153,6 +172,15 @@ class DiffServiceServicer(dagmanager_pb2_grpc.DiffServiceServicer):
         finally:
             fut.cancel()
             await fut
+            events = svc.consume_weight_events()
+            if self._bus:
+                for event in events:
+                    await self._bus.publish_sentinel_weight(
+                        event.sentinel_id,
+                        event.weight,
+                        sentinel_version=event.sentinel_version,
+                        world_id=event.world_id,
+                    )
             self._streams.pop(sentinel_id, None)
 
     async def AckChunk(

--- a/tests/services/dagmanager/test_grpc_server.py
+++ b/tests/services/dagmanager/test_grpc_server.py
@@ -20,6 +20,7 @@ from qmtl.services.dagmanager.garbage_collector import GarbageCollector, QueueIn
 from qmtl.foundation.proto import dagmanager_pb2, dagmanager_pb2_grpc
 from qmtl.services.dagmanager.monitor import AckStatus
 from qmtl.services.dagmanager.controlbus_producer import ControlBusProducer
+from qmtl.services.gateway.controlbus_consumer import ControlBusConsumer, ControlBusMessage
 
 
 class FakeSession:
@@ -355,3 +356,98 @@ async def test_grpc_diff_publishes_controlbus():
     assert topic == "queue"
     payload = json.loads(data.decode())
     assert payload["tags"] == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_grpc_diff_emits_sentinel_weight_and_gateway_consumes():
+    driver = FakeDriver()
+    admin = FakeAdmin()
+    stream = FakeStream()
+    producer = DummyProducer()
+    bus = ControlBusProducer(producer=producer, topic="queue")
+    server, port = serve(driver, admin, stream, host="127.0.0.1", port=0, bus=bus)
+    await server.start()
+
+    sentinel_msgs: list[tuple[str, bytes, bytes | None]] = []
+    try:
+        async with grpc.aio.insecure_channel(f"127.0.0.1:{port}") as channel:
+            stub = dagmanager_pb2_grpc.DiffServiceStub(channel)
+
+            async def run_diff(weight: float) -> None:
+                dag_json = json.dumps(
+                    {
+                        "nodes": [
+                            {
+                                "node_id": "n1",
+                                "node_type": "Compute",
+                                "code_hash": "c",
+                                "config_hash": "cfg",
+                                "schema_hash": "s",
+                                "schema_compat_id": "s-major",
+                                "params": {},
+                                "dependencies": [],
+                                "interval": 60,
+                                "tags": ["x"],
+                            },
+                            {
+                                "node_type": "VersionSentinel",
+                                "node_id": "s-sentinel",
+                                "traffic_weight": weight,
+                                "version": "v1",
+                            },
+                        ]
+                    }
+                )
+                request = dagmanager_pb2.DiffRequest(strategy_id="s", dag_json=dag_json)
+                async for chunk in stub.Diff(request):
+                    await stub.AckChunk(
+                        dagmanager_pb2.ChunkAck(sentinel_id=chunk.sentinel_id, chunk_id=0)
+                    )
+
+            await run_diff(0.25)
+            sentinel_msgs = [entry for entry in producer.sent if entry[0] == "sentinel_weight"]
+            assert len(sentinel_msgs) == 1
+
+            await run_diff(0.25)
+            sentinel_msgs = [entry for entry in producer.sent if entry[0] == "sentinel_weight"]
+            assert len(sentinel_msgs) == 1
+
+            await run_diff(0.75)
+            sentinel_msgs = [entry for entry in producer.sent if entry[0] == "sentinel_weight"]
+            assert len(sentinel_msgs) == 2
+    finally:
+        await server.stop(None)
+
+    topic, data, key = sentinel_msgs[-1]
+    assert topic == "sentinel_weight"
+    assert key == b"s-sentinel"
+    payload = json.loads(data.decode())
+    assert payload["sentinel_id"] == "s-sentinel"
+    assert payload["weight"] == pytest.approx(0.75)
+    assert payload["version"] == 1
+    assert payload["etag"].startswith("sw:s-sentinel")
+    assert payload["ts"].endswith("Z")
+    assert payload.get("sentinel_version") == "v1"
+
+    class SentinelHub:
+        def __init__(self) -> None:
+            self.events: list[tuple[str, float]] = []
+
+        async def send_sentinel_weight(self, sentinel_id: str, weight: float) -> None:
+            self.events.append((sentinel_id, weight))
+
+    hub = SentinelHub()
+    consumer = ControlBusConsumer(brokers=[], topics=["sentinel_weight"], group="g", ws_hub=hub)
+    message = ControlBusMessage(
+        topic="sentinel_weight",
+        key="s-sentinel",
+        etag=payload.get("etag", ""),
+        run_id="",
+        data=payload,
+        timestamp_ms=None,
+    )
+    await consumer._handle_message(message)
+    assert len(hub.events) == 1
+    sid, weight = hub.events[0]
+    assert sid == "s-sentinel"
+    assert weight == pytest.approx(0.75)


### PR DESCRIPTION
## Summary
- add a `publish_sentinel_weight` helper to the DAG Manager ControlBus producer so traffic updates include the documented metadata
- track sentinel weight inputs inside `DiffService`, updating metrics and queueing change events for downstream consumers
- publish the queued sentinel weight events from the gRPC servicer and add an integration test that exercises the Gateway ControlBus consumer

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1124

------
https://chatgpt.com/codex/tasks/task_e_68d4ff7ad35483298a4d608184e574f9