### PR TITLE
docs: add schema registry governance nav entry

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Monitoring: operations/monitoring.md
       - WS Load & Endurance: operations/ws_load_testing.md
       - World Activation Runbook: operations/activation.md
+      - Schema Registry Governance: operations/schema_registry_governance.md
       - Risk Management: operations/risk_management.md
       - Timing Controls: operations/timing_controls.md
       - Exchange Calendars: operations/exchange_calendars.md


### PR DESCRIPTION
## Summary
- add the Schema Registry Governance runbook to the Operations navigation so it builds with MkDocs

## Testing
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d515e83adc8329a78e8267dde9a129