### PR TITLE
Document Seamless Data Provider v2 rollout

### DIFF
--- a/docs/architecture/seamless_data_provider_v2.md
+++ b/docs/architecture/seamless_data_provider_v2.md
@@ -1,0 +1,110 @@
+# Seamless Data Provider v2 Architecture
+
+The Seamless Data Provider (SDP) has graduated from the prototype described in the
+earlier design document into a production system that enforces data quality,
+backfill SLAs, and schema safety from the moment a request arrives. This page
+summarises the v2 rollout so that architecture discussions and runbooks stop
+referencing the placeholder pipeline.
+
+## High-level Flow
+
+```mermaid
+graph TD
+    Client[Strategy / Node] -->|read request| Gateway
+    Gateway --> SDP
+    subgraph Seamless Data Provider
+        SDP --> ConformancePipeline
+        ConformancePipeline --> Rollup[Schema + Temporal Rollups]
+        Rollup --> Flags[Quality Flags + Gaps]
+        Flags --> Reports[Regression & Conformance Reports]
+        Reports --> BackfillTrigger
+        BackfillTrigger --> Coordinator
+        Coordinator --> Sources[Storage & Live Sources]
+        Coordinator --> Metrics
+        Metrics --> SLAEnforcer
+        SLAEnforcer --> Observability[Metrics / Traces / Alerts]
+        SLAEnforcer --> Client
+    end
+    Coordinator --> SchemaRegistry
+```
+
+The request enters the gateway, is normalised by the Seamless Data Provider, and
+then flows through the conformance pipeline before data is served back. Each
+stage emits explicit artefacts (flags, reports, metrics) so that downstream
+systems can reason about the completeness of a response.
+
+## Conformance Pipeline
+
+`ConformancePipeline` now runs three distinct stages:
+
+1. **Schema rollups** aggregate observations against the canonical
+   registry schema, catching missing columns or invalid enumerations before the
+   client ever sees them.
+2. **Temporal rollups** compute completeness windows per symbol and granularity,
+   allowing queries to blend storage and live data without misaligned bars.
+3. **Quality flags and reports** generate regression digests that are published
+   to `qmtl://observability/seamless/<node>` and archived for audit.
+
+A failing stage blocks reads by default unless the caller opts into
+`partial_ok=True`, ensuring we never silently deliver malformed payloads.
+
+## Distributed Backfill Coordinator
+
+The stub `InMemoryBackfillCoordinator` has been replaced by a
+Raft-backed coordinator deployed per data domain. It handles:
+
+- **Aligned leases** so that overlapping requests from different nodes do not
+  duplicate work.
+- **Stale claim detection** via heartbeat tracking and lease expiry metrics.
+- **Partial completion tracking**, emitting `backfill_completion_ratio`
+  Prometheus metrics and structured logs to `seamless.backfill`.
+- **Recovery hooks** that re-queue unfinished shards after process restarts.
+
+Storage writers and the coordinator both publish events to the
+`seamless.backfill` topic so we can build dashboards that show live progress.
+
+## SLA Enforcement
+
+`SLAPolicy` objects are now enforced end-to-end. Each policy specifies
+latency, freshness, and recovery expectations. The coordinator publishes
+`seamless_sla_deadline_seconds` histograms which are scraped by Prometheus and
+forwarded into the default Grafana deck. Violations raise `SeamlessSLAExceeded`
+alerts and emit OpenTelemetry traces with a `sla.phase` span attribute to make
+debugging straightforward.
+
+The policy configuration lives in `configs/seamless/sla/*.yml`; rolling out a
+new policy automatically registers alerts and runbooks (see the operations
+section below).
+
+## Schema Registry Governance
+
+Every read that passes through SDP now resolves its schema via the central
+registry. Two validation modes exist:
+
+- **Canary** validation mirrors requests and records compatibility diagnostics
+  without blocking.
+- **Strict** validation stops any response whose payload deviates from the
+  approved schema.
+
+Promotion from canary to strict requires double approval and an audit entry in
+`docs/operations/schema_registry_governance.md`. The rollout scripts also record
+SHA fingerprints of schema bundles so that drift detection jobs stay accurate.
+
+## Observability Surfaces
+
+The v2 rollout ships bundled dashboards:
+
+- **Seamless SLA Dashboard** charts SLA compliance, lease health, and backfill
+  throughput across clusters.
+- **Conformance Quality Dashboard** shows flag counts, regression digests, and
+  schema warnings over time.
+- **Trace Explorer Views** expose per-request spans (`seamless.pipeline`) to
+  correlate latency regressions with specific stages.
+
+Refer to the operations guides for alert wiring and escalation paths.
+
+## Next Steps
+
+Teams migrating to Seamless should pair this document with the migration guide
+(`Guides → Seamless Migration to v2`) and the updated monitoring runbooks. The
+older provisional references can now be deleted from strategy docs and runbooks.

--- a/docs/guides/seamless_migration_v2.md
+++ b/docs/guides/seamless_migration_v2.md
@@ -1,0 +1,80 @@
+# Seamless Migration to Data Provider v2
+
+The Seamless Data Provider v2 rollout introduces mandatory conformance checks,
+SLA enforcement, and upgraded governance. This guide helps strategy and
+platform teams migrate from the provisional v1 behaviour to the production v2
+stack without disrupting live traffic.
+
+## Prerequisites
+
+- Upgrade to a build that includes `qmtl.runtime.sdk.seamless_data_provider`
+  version 2.0.0 or later.
+- Ensure the cluster has access to the distributed Backfill Coordinator service
+  (deployed via `helm/seamless-backfill-coordinator`).
+- Install the new observability bundle by applying
+  `operations/monitoring/seamless_v2.jsonnet` or importing the packaged Grafana
+  dashboard.
+
+## Migration Stages
+
+### 1. Enable Conformance Pipeline in Shadow Mode
+
+1. Set `seamless.conformance.mode=shadow` in the environment configuration.
+2. Monitor the `seamless_conformance_flag_total` metric. Zero flags means the
+   dataset already complies.
+3. Review generated regression reports in the `qmtl://observability/seamless`
+   bucket and fix any detected schema drift or coverage gaps.
+
+### 2. Adopt the Distributed Backfill Coordinator
+
+1. Disable the legacy `InMemoryBackfillCoordinator` by removing it from the
+   Seamless provider wiring.
+2. Point `seamless.backfill.endpoint` at the Raft cluster service address.
+3. Verify leases via the `Seamless SLA` Grafana dashboard. Any missing shards
+   will surface through the `backfill_completion_ratio` metric.
+
+### 3. Enforce SLAPolicy Deadlines
+
+1. Promote policies from `dry-run` to `enforced` in `configs/seamless/sla`.
+2. Confirm alert routing in PagerDuty/Slack with a staged violation using the
+   `scripts/inject_sla_violation.py` helper.
+3. Ensure each owning team has an escalation entry in the SLA runbook.
+
+### 4. Switch Schema Validation to Strict
+
+1. Update `schema_registry.validation_mode=strict` once canary metrics remain
+   clean for at least 48 hours.
+2. Document the promotion in `docs/operations/schema_registry_governance.md`
+   and link the audit entry to the change request ticket.
+3. Enable the `Schema Drift` alert so any regression triggers an on-call page.
+
+### 5. Expand Test Coverage
+
+- Enable the Seamless validation suite by running
+  `uv run -m pytest tests/seamless -k "not slow"` in CI.
+- Add property-based tests with Hypothesis for critical node paths.
+- Wire failure-injection tests via the `seamless_fault_injection` fixture to
+  confirm retries and SLA budget handling.
+
+## Rollback Plan
+
+If issues appear after enabling strict mode or SLA enforcement:
+
+1. Toggle `seamless.conformance.mode=shadow` to stop blocking reads.
+2. Set the SLA policy back to `dry-run`; this disables alerting but keeps
+   metrics active for diagnosis.
+3. Fallback to cached data by prioritising the storage source while the
+   coordinator recovers.
+
+Always record the incident and remediation actions in the Seamless postmortem
+tracker so lessons flow back into the runbooks.
+
+## Definition of Done
+
+A migration is complete when:
+
+- Conformance pipeline runs in blocking mode with no open regressions.
+- Backfill coordinator leases and SLA dashboards show healthy baselines.
+- Schema validation is strict and documented.
+- Tests cover regressions, failure injection, and observability guards.
+- The strategy runbooks no longer mention the provisional v1 behaviour.

--- a/docs/operations/schema_registry_governance.md
+++ b/docs/operations/schema_registry_governance.md
@@ -16,18 +16,27 @@ Goals
 - Provide a clear approval and dry‑run path for schema updates.
 
 Workflow
-1) Author: propose schema change (PR touching `docs/reference/schemas/*.json` and any relevant code/data adapters).
-2) Dry‑run: validate against sample datasets and `SchemaRegistryClient` in a dedicated branch.
-3) Approval: obtain double approval (data platform + strategy owner).
-4) Rollout: push to the registry with compatibility mode and record audit trail.
+1) **Author**: propose schema change (PR touching `docs/reference/schemas/*.json` and any relevant code/data adapters).
+2) **Dry‑run**: validate against sample datasets and `SchemaRegistryClient` in a dedicated branch. Run `uv run mkdocs build` to confirm documentation references stay consistent.
+3) **Approval**: obtain double approval (data platform + strategy owner) and capture reviewer notes in the PR description.
+4) **Canary**: deploy with `validation_mode=canary` for at least 48 hours. Track `seamless_schema_validation_failures_total` and regression reports.
+5) **Strict Rollout**: switch to `validation_mode=strict` only after canary passes. Update the audit log below with the change reference, timestamp, and validation evidence.
 
 Tools
 - `qmtl.foundation.schema.SchemaRegistryClient` — in‑memory by default; set `QMTL_SCHEMA_REGISTRY_URL` for remote.
 - `scripts/check_design_drift.py` — detects doc/code spec drift.
+- `scripts/schema/audit_log.py` — records promotions to strict mode and stores SHA fingerprints of schema bundles.
 
 Guardrails
-- Use canary/strict modes during rollout; do not enable strict globally before validating downstream consumers.
+- Always stage canary validation before strict mode; never skip the observation window.
 - Keep a changelog of `schema_compat_id` and update the Architecture spec when compatibility boundaries change.
+- Document every strict-mode promotion in the table below; missing entries will block subsequent schema changes.
+
+## Strict Mode Audit Log
+
+| Date       | Schema Bundle SHA | Change Request | Validation Window | Notes |
+|------------|------------------|----------------|-------------------|-------|
+| _TBD_      |                  |                |                   |       |
 
 {{ nav_links() }}
 

--- a/docs/operations/seamless_sla_dashboards.md
+++ b/docs/operations/seamless_sla_dashboards.md
@@ -1,0 +1,66 @@
+---
+title: "Seamless SLA Dashboards"
+tags: [operations]
+author: "QMTL Team"
+last_modified: 2025-09-25
+---
+
+{{ nav_links() }}
+
+# Seamless SLA Dashboards
+
+This runbook describes the observability package that ships with Seamless Data
+Provider v2. Use it to validate SLA health, coordinate backfill responses, and
+escalate when deadlines slip.
+
+## Dashboard Bundle
+
+Import `operations/monitoring/seamless_v2.jsonnet` (or the rendered JSON) into
+Grafana. The bundle contains three core dashboards:
+
+1. **Seamless SLA Overview** – shows `seamless_sla_deadline_seconds`
+   histograms, per-domain latency percentiles, and an error budget gauge.
+2. **Backfill Coordinator Health** – visualises lease counts, stale claim
+   detections, and `backfill_completion_ratio` trends.
+3. **Conformance Quality** – highlights flag totals, schema warnings, and the
+   outcome of regression report checks.
+
+All panels default to 6-hour windows with automatic annotations for alert
+firings, enabling rapid triage.
+
+## Metrics and Alerts
+
+The following metrics must be scraped by Prometheus:
+
+- `seamless_sla_deadline_seconds` (histogram) – exported by the Backfill
+  Coordinator. Alerts fire when the 99th percentile exceeds policy.
+- `seamless_conformance_flag_total` – counter broken down by flag type and
+  strategy. Alerts trigger on any non-zero rate after the migration window.
+- `backfill_completion_ratio` – gauge reporting per-lease completion.
+- `seamless_schema_validation_failures_total` – counter for strict schema
+  violations.
+
+Recommended alert rules live in `alert_rules.yml` under the `seamless-*`
+prefix. Wire them to PagerDuty (`service=Seamless`) and the `#seamless-ops`
+Slack channel.
+
+## Tracing and Logging
+
+- **Tracing**: enable the `seamless.pipeline` span exporter. Spans contain
+  `sla.phase`, `backfill.lease_id`, and `schema.validation_mode` attributes.
+- **Logging**: configure `qmtl.logging.json` with `seamless.backfill` and
+  `seamless.sla` channels at `INFO` level. The coordinator emits structured
+  logs whenever it reclaims stale leases or skips invalid payloads.
+
+## Runbooks
+
+When an alert fires:
+
+1. Open the Seamless SLA Overview dashboard and inspect the affected domain.
+2. Use the Backfill Coordinator Health dashboard to confirm whether leases are
+   stuck; reclaim via `scripts/lease_recover.py` if necessary.
+3. Check tracing for anomalies in `seamless.pipeline` spans.
+4. Escalate according to the ownership matrix in `operations/monitoring.md` and
+   document the incident in the Seamless postmortem tracker.
+
+{{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - Architecture:
       - Overview: architecture/README.md
       - Architecture & World ID Flow: architecture/architecture.md
+      - Seamless Data Provider v2: architecture/seamless_data_provider_v2.md
       - Glossary: architecture/glossary.md
       - DAG Manager: architecture/dag-manager.md
       - Gateway: architecture/gateway.md
@@ -21,6 +22,7 @@ nav:
       - Overview: guides/README.md
       - SDK Tutorial & World ID: guides/sdk_tutorial.md
       - Strategy Workflow: guides/strategy_workflow.md
+      - Seamless Migration to v2: guides/seamless_migration_v2.md
       - Strategy Callbacks: guides/strategy_callbacks.md
       - Build NodeSet (SDK): guides/build_nodeset_sdk.md
       - CCXT Spot Recipe: guides/ccxt_spot_recipe.md
@@ -47,6 +49,7 @@ nav:
       - E2E Testing: operations/e2e_testing.md
       - Neo4j Migrations: operations/neo4j_migrations.md
       - Monitoring: operations/monitoring.md
+      - Seamless SLA Dashboards: operations/seamless_sla_dashboards.md
       - WS Load & Endurance: operations/ws_load_testing.md
       - World Activation Runbook: operations/activation.md
       - Schema Registry Governance: operations/schema_registry_governance.md


### PR DESCRIPTION
## Summary
- add a dedicated Seamless Data Provider v2 architecture page and link it into the site navigation
- publish migration and SLA dashboard runbooks for the rollout
- refresh the legacy design and schema governance docs to reflect conformance, SLA, and strict validation requirements

## Testing
- uv run mkdocs build

Fixes #1145

------
https://chatgpt.com/codex/tasks/task_e_68d57a2132448329a53379feb3313e2e