### PR TITLE
Implement schema governance validation and tooling

### DIFF
--- a/docs/operations/schema_registry_governance.md
+++ b/docs/operations/schema_registry_governance.md
@@ -19,13 +19,27 @@ Workflow
 1) **Author**: propose schema change (PR touching `docs/reference/schemas/*.json` and any relevant code/data adapters).
 2) **Dry‑run**: validate against sample datasets and `SchemaRegistryClient` in a dedicated branch. Run `uv run mkdocs build` to confirm documentation references stay consistent.
 3) **Approval**: obtain double approval (data platform + strategy owner) and capture reviewer notes in the PR description.
-4) **Canary**: deploy with `validation_mode=canary` for at least 48 hours. Track `seamless_schema_validation_failures_total` and regression reports.
-5) **Strict Rollout**: switch to `validation_mode=strict` only after canary passes. Update the audit log below with the change reference, timestamp, and validation evidence.
+4) **Canary**: deploy with `validation_mode=canary` for at least 48 hours. Track `seamless_schema_validation_failures_total{subject,mode}` and regression reports. Canary mode allows incompatible schemas to publish but records failures for follow-up.
+5) **Strict Rollout**: switch to `validation_mode=strict` only after canary passes. Strict mode blocks incompatible schemas and raises `SchemaValidationError` when breaking fields are removed or mutated. Update the audit log below with the change reference, timestamp, and validation evidence.
 
 Tools
-- `qmtl.foundation.schema.SchemaRegistryClient` — in‑memory by default; set `QMTL_SCHEMA_REGISTRY_URL` for remote.
+- `qmtl.foundation.schema.SchemaRegistryClient` — in‑memory by default; set `QMTL_SCHEMA_REGISTRY_URL` for remote. Configure governance with `validation_mode` or `QMTL_SCHEMA_VALIDATION_MODE` (`canary` default, `strict` for enforcement).
 - `scripts/check_design_drift.py` — detects doc/code spec drift.
 - `scripts/schema/audit_log.py` — records promotions to strict mode and stores SHA fingerprints of schema bundles.
+
+Validation emits a structured `SchemaValidationReport` and increments the Prometheus counter `seamless_schema_validation_failures_total` when incompatibilities are detected. The counter is labelled by `subject` and `mode` so dashboards can alarm on strict-mode regressions.
+
+Run the audit helper whenever strict rollout completes:
+
+```bash
+uv run python scripts/schema/audit_log.py \
+  --schema-bundle-sha "<bundle sha>" \
+  --change-request "https://qmtl/changes/<id>" \
+  --validation-window "48h canary" \
+  --notes "no validation failures observed"
+```
+
+Pass `--dry-run` to preview the table updates without touching the repository.
 
 Guardrails
 - Always stage canary validation before strict mode; never skip the observation window.

--- a/qmtl/foundation/schema/__init__.py
+++ b/qmtl/foundation/schema/__init__.py
@@ -1,4 +1,11 @@
-from .registry import SchemaRegistryClient, Schema
+from .registry import (
+    Schema,
+    SchemaRegistryClient,
+    SchemaRegistryError,
+    SchemaValidationError,
+    SchemaValidationMode,
+    SchemaValidationReport,
+)
 from .validator import SCHEMAS, validate_schema
 from .order_events import (
     OrderAck,
@@ -11,6 +18,10 @@ from .order_events import (
 __all__ = [
     "SchemaRegistryClient",
     "Schema",
+    "SchemaValidationMode",
+    "SchemaValidationReport",
+    "SchemaValidationError",
+    "SchemaRegistryError",
     "SCHEMAS",
     "validate_schema",
     "OrderPayload",

--- a/qmtl/foundation/schema/registry.py
+++ b/qmtl/foundation/schema/registry.py
@@ -1,11 +1,85 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from enum import Enum
 from typing import Dict, Optional
 import json
+import logging
 import os
 import urllib.request
 import urllib.error
+
+from qmtl.foundation.common.metrics_factory import get_or_create_counter
+
+
+logger = logging.getLogger(__name__)
+
+
+class SchemaValidationMode(Enum):
+    """Supported validation modes for schema governance."""
+
+    CANARY = "canary"
+    STRICT = "strict"
+
+    @classmethod
+    def parse(cls, value: str | "SchemaValidationMode" | None) -> "SchemaValidationMode":
+        if isinstance(value, cls):
+            return value
+        if value is None:
+            return cls.CANARY
+        normalized = str(value).strip().lower()
+        for mode in cls:
+            if mode.value == normalized:
+                return mode
+        raise ValueError(f"Unsupported schema validation mode: {value!r}")
+
+
+@dataclass
+class SchemaValidationReport:
+    """Outcome of a schema compatibility check."""
+
+    subject: str
+    mode: SchemaValidationMode
+    compatible: bool
+    previous_version: int | None
+    breaking_changes: list[str]
+    added_fields: list[str]
+    schema_id: int | None = None
+    registered_version: int | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a serializable representation of the report."""
+
+        return {
+            "subject": self.subject,
+            "mode": self.mode.value,
+            "compatible": self.compatible,
+            "previous_version": self.previous_version,
+            "breaking_changes": list(self.breaking_changes),
+            "added_fields": list(self.added_fields),
+            "schema_id": self.schema_id,
+            "registered_version": self.registered_version,
+        }
+
+
+class SchemaValidationError(RuntimeError):
+    """Raised when validation fails in strict mode."""
+
+
+class SchemaRegistryError(RuntimeError):
+    """Raised for transport-level registry failures."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+_VALIDATION_FAILURES = get_or_create_counter(
+    "seamless_schema_validation_failures_total",
+    "Total number of schema validation failures detected by the registry governance layer.",
+    labelnames=("subject", "mode"),
+    test_value_attr="_value",
+)
 
 
 @dataclass
@@ -17,25 +91,98 @@ class Schema:
 
 
 class SchemaRegistryClient:
-    """In-memory schema registry client.
+    """In-memory schema registry client with governance hooks."""
 
-    Note: This class stores schemas locally in memory and does not perform any
-    network I/O. For environments that expose a remote registry, use
-    :meth:`SchemaRegistryClient.from_env` to obtain a client that delegates to
-    a minimal HTTP implementation when ``QMTL_SCHEMA_REGISTRY_URL`` is set.
-    """
-
-    def __init__(self) -> None:
+    def __init__(self, *, validation_mode: SchemaValidationMode | str | None = None) -> None:
         self._url = os.getenv("QMTL_SCHEMA_REGISTRY_URL")
         self._by_subject: Dict[str, list[Schema]] = {}
         self._next_id = 1
+        env_mode = os.getenv("QMTL_SCHEMA_VALIDATION_MODE")
+        self._validation_mode = SchemaValidationMode.parse(validation_mode or env_mode)
+        self._last_reports: Dict[str, SchemaValidationReport] = {}
 
-    def register(self, subject: str, schema_str: str) -> Schema:
-        versions = self._by_subject.setdefault(subject, [])
-        sch = Schema(subject=subject, id=self._next_id, schema=schema_str, version=len(versions) + 1)
-        self._next_id += 1
-        versions.append(sch)
-        return sch
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def validation_mode(self) -> SchemaValidationMode:
+        return self._validation_mode
+
+    def set_validation_mode(self, mode: SchemaValidationMode | str) -> None:
+        self._validation_mode = SchemaValidationMode.parse(mode)
+
+    def last_validation(self, subject: str) -> SchemaValidationReport | None:
+        return self._last_reports.get(subject)
+
+    def register(
+        self,
+        subject: str,
+        schema_str: str,
+        *,
+        validation_mode: SchemaValidationMode | str | None = None,
+    ) -> Schema:
+        mode = SchemaValidationMode.parse(validation_mode or self._validation_mode)
+        previous = self.latest(subject)
+        report = self.validate(subject, schema_str, previous_schema=previous, mode=mode)
+        if not report.compatible:
+            _VALIDATION_FAILURES.labels(subject=subject, mode=mode.value).inc()
+            logger.warning(
+                "Schema validation failure for subject '%s' in %s mode: breaking=%s added=%s",
+                subject,
+                mode.value,
+                report.breaking_changes,
+                report.added_fields,
+            )
+            if mode is SchemaValidationMode.STRICT:
+                self._last_reports[subject] = report
+                raise SchemaValidationError(
+                    f"Schema update rejected: incompatible with previous version {previous.version if previous else 'N/A'}"
+                )
+        schema = self._register_impl(subject, schema_str, previous)
+        self._last_reports[subject] = replace(
+            report,
+            schema_id=schema.id,
+            registered_version=schema.version,
+        )
+        return schema
+
+    def validate(
+        self,
+        subject: str,
+        schema_str: str,
+        *,
+        previous_schema: Schema | None = None,
+        mode: SchemaValidationMode | str | None = None,
+    ) -> SchemaValidationReport:
+        mode_obj = SchemaValidationMode.parse(mode or self._validation_mode)
+        previous = previous_schema or self.latest(subject)
+        breaking_changes: list[str] = []
+        added_fields: list[str] = []
+
+        if previous is None:
+            compatible = True
+        else:
+            prev_paths = _flatten_schema(previous.schema)
+            new_paths = _flatten_schema(schema_str)
+            prev_keys = set(prev_paths)
+            new_keys = set(new_paths)
+            missing = sorted(prev_keys - new_keys)
+            breaking_changes.extend(missing)
+            changed = sorted(path for path in (prev_keys & new_keys) if prev_paths[path] != new_paths[path])
+            breaking_changes.extend(changed)
+            added_fields.extend(sorted(new_keys - prev_keys))
+            compatible = not breaking_changes
+
+        report = SchemaValidationReport(
+            subject=subject,
+            mode=mode_obj,
+            compatible=compatible,
+            previous_version=previous.version if previous else None,
+            breaking_changes=breaking_changes,
+            added_fields=added_fields,
+        )
+        return report
 
     def latest(self, subject: str) -> Optional[Schema]:
         versions = self._by_subject.get(subject)
@@ -54,6 +201,17 @@ class SchemaRegistryClient:
                 if sch.id == schema_id:
                     return sch
         return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _register_impl(self, subject: str, schema_str: str, previous: Schema | None) -> Schema:
+        versions = self._by_subject.setdefault(subject, [])
+        sch = Schema(subject=subject, id=self._next_id, schema=schema_str, version=len(versions) + 1)
+        self._next_id += 1
+        versions.append(sch)
+        return sch
 
     @classmethod
     def from_env(cls) -> "SchemaRegistryClient | RemoteSchemaRegistryClient":
@@ -88,24 +246,82 @@ class RemoteSchemaRegistryClient(SchemaRegistryClient):
             with urllib.request.urlopen(req, timeout=5) as resp:
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
-            raise RuntimeError(f"schema registry error: {e.code}") from e
+            raise SchemaRegistryError(f"schema registry error: {e.code}", status_code=e.code) from e
         except urllib.error.URLError as e:  # pragma: no cover - network
-            raise RuntimeError("schema registry unreachable") from e
+            raise SchemaRegistryError("schema registry unreachable") from e
 
-    def register(self, subject: str, schema_str: str) -> Schema:
-        out = self._req("POST", f"/subjects/{subject}/versions", {"schema": schema_str})
-        sid = int(out.get("id"))
-        latest = self.latest(subject)
-        ver = (latest.version + 1) if latest else 1
-        return Schema(subject=subject, id=sid, schema=schema_str, version=ver)
+    def register(
+        self,
+        subject: str,
+        schema_str: str,
+        *,
+        validation_mode: SchemaValidationMode | str | None = None,
+    ) -> Schema:
+        return super().register(subject, schema_str, validation_mode=validation_mode)
 
     def latest(self, subject: str) -> Optional[Schema]:
-        out = self._req("GET", f"/subjects/{subject}/versions/latest")
+        try:
+            out = self._req("GET", f"/subjects/{subject}/versions/latest")
+        except SchemaRegistryError as exc:
+            if exc.status_code == 404:
+                return None
+            raise
         return Schema(subject=subject, id=int(out["id"]), schema=out["schema"], version=int(out.get("version", 1)))
 
     def get_by_id(self, schema_id: int) -> Optional[Schema]:
-        out = self._req("GET", f"/schemas/ids/{int(schema_id)}")
+        try:
+            out = self._req("GET", f"/schemas/ids/{int(schema_id)}")
+        except SchemaRegistryError as exc:
+            if exc.status_code == 404:
+                return None
+            raise
         return Schema(subject="", id=int(schema_id), schema=out["schema"], version=0)
 
+    def _register_impl(self, subject: str, schema_str: str, previous: Schema | None) -> Schema:
+        out = self._req("POST", f"/subjects/{subject}/versions", {"schema": schema_str})
+        sid = int(out.get("id"))
+        try:
+            latest = self.latest(subject)
+        except SchemaRegistryError:
+            latest = None
+        if latest is not None:
+            return latest
+        version = (previous.version + 1) if previous else 1
+        return Schema(subject=subject, id=sid, schema=schema_str, version=version)
 
-__all__ = ["SchemaRegistryClient", "RemoteSchemaRegistryClient", "Schema"]
+
+def _flatten_schema(schema_str: str) -> Dict[str, str]:
+    try:
+        parsed = json.loads(schema_str)
+    except json.JSONDecodeError:
+        return {"<raw>": "text"}
+    if isinstance(parsed, dict):
+        return _flatten_dict(parsed)
+    return {"<root>": type(parsed).__name__}
+
+
+def _flatten_dict(value: dict, prefix: str = "") -> Dict[str, str]:
+    flattened: Dict[str, str] = {}
+    for key, inner in value.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(inner, dict):
+            if inner:
+                flattened.update(_flatten_dict(inner, path))
+            else:
+                flattened[path] = "object"
+        elif isinstance(inner, list):
+            flattened[path] = "list"
+        else:
+            flattened[path] = type(inner).__name__
+    return flattened
+
+
+__all__ = [
+    "SchemaRegistryClient",
+    "RemoteSchemaRegistryClient",
+    "Schema",
+    "SchemaValidationMode",
+    "SchemaValidationReport",
+    "SchemaValidationError",
+    "SchemaRegistryError",
+]

--- a/scripts/schema/audit_log.py
+++ b/scripts/schema/audit_log.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Manage the strict-mode audit log table for schema governance."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_DOC = Path(__file__).resolve().parents[1] / "docs" / "operations" / "schema_registry_governance.md"
+
+
+@dataclass
+class AuditEntry:
+    date: str
+    schema_bundle_sha: str
+    change_request: str
+    validation_window: str
+    notes: str
+
+
+def format_row(values: Iterable[str]) -> str:
+    return "| " + " | ".join(values) + " |"
+
+
+def update_table(text: str, entry: AuditEntry) -> str:
+    lines = text.splitlines()
+    header_idx = None
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("| Date") and "Schema Bundle SHA" in line:
+            header_idx = idx
+            break
+    if header_idx is None:
+        raise ValueError("Strict mode audit table header not found")
+
+    rows_start = header_idx + 2  # skip header and separator
+    table_end = rows_start
+    while table_end < len(lines) and lines[table_end].strip().startswith("|"):
+        table_end += 1
+
+    new_row = format_row(
+        [
+            entry.date,
+            entry.schema_bundle_sha,
+            entry.change_request,
+            entry.validation_window,
+            entry.notes,
+        ]
+    )
+
+    existing_rows = [line for line in lines[rows_start:table_end] if line.strip()]
+    existing_rows = [row for row in existing_rows if "_TBD_" not in row]
+    existing_rows = [row for row in existing_rows if entry.change_request not in row]
+    existing_rows.insert(0, new_row)
+    existing_rows.append(format_row(["_TBD_", "", "", "", ""]))
+
+    lines[rows_start:table_end] = existing_rows
+    return "\n".join(lines) + "\n"
+
+
+def update_audit_log(doc: Path, entry: AuditEntry, *, dry_run: bool = False) -> str:
+    text = doc.read_text(encoding="utf-8")
+    updated = update_table(text, entry)
+    if not dry_run:
+        doc.write_text(updated, encoding="utf-8")
+    return updated
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Update the schema registry strict-mode audit log table.")
+    parser.add_argument("--doc", type=Path, default=DEFAULT_DOC, help="Path to schema governance document")
+    parser.add_argument("--date", dest="entry_date", default=None, help="ISO date for the promotion (default: today)")
+    parser.add_argument("--schema-bundle-sha", required=True, help="SHA fingerprint of the schema bundle")
+    parser.add_argument("--change-request", required=True, help="Link or reference for the change request")
+    parser.add_argument("--validation-window", required=True, help="Duration of the canary validation window")
+    parser.add_argument("--notes", default="", help="Additional rollout notes")
+    parser.add_argument("--dry-run", action="store_true", help="Preview the updated table without writing")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    entry = AuditEntry(
+        date=args.entry_date or date.today().isoformat(),
+        schema_bundle_sha=args.schema_bundle_sha,
+        change_request=args.change_request,
+        validation_window=args.validation_window,
+        notes=args.notes,
+    )
+    updated = update_audit_log(args.doc, entry, dry_run=args.dry_run)
+    if args.dry_run:
+        print(updated, end="")
+    else:
+        print(f"Updated {args.doc} with audit entry for {entry.change_request}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/foundation/schema/test_registry.py
+++ b/tests/foundation/schema/test_registry.py
@@ -1,9 +1,48 @@
-from qmtl.foundation.schema import SchemaRegistryClient
+import json
+
+import pytest
+
+from qmtl.foundation.common.metrics_factory import reset_metrics
+from qmtl.foundation.schema import (
+    SchemaRegistryClient,
+    SchemaValidationError,
+    SchemaValidationMode,
+)
+from qmtl.foundation.schema.registry import _VALIDATION_FAILURES
 
 
 def test_register_and_latest():
     reg = SchemaRegistryClient()
-    s1 = reg.register("prices", "{\"a\": 1}")
+    s1 = reg.register("prices", json.dumps({"a": 1}))
     assert s1.id > 0 and s1.version == 1
     assert reg.latest("prices").id == s1.id
+
+
+def test_canary_mode_allows_incompatible_and_emits_metric():
+    reset_metrics(["seamless_schema_validation_failures_total"])
+    reg = SchemaRegistryClient(validation_mode=SchemaValidationMode.CANARY)
+    reg.register("prices", json.dumps({"a": 1, "b": 2}))
+    reg.register("prices", json.dumps({"a": 1}))
+
+    report = reg.last_validation("prices")
+    assert report is not None
+    assert not report.compatible
+    assert "b" in report.breaking_changes
+
+    metric = _VALIDATION_FAILURES.labels(subject="prices", mode="canary")
+    assert metric._value.get() == 1  # type: ignore[attr-defined]
+
+
+def test_strict_mode_blocks_incompatible_change():
+    reset_metrics(["seamless_schema_validation_failures_total"])
+    reg = SchemaRegistryClient(validation_mode=SchemaValidationMode.STRICT)
+    reg.register("prices", json.dumps({"a": 1, "nested": {"b": 2}}))
+
+    with pytest.raises(SchemaValidationError):
+        reg.register("prices", json.dumps({"a": 1, "nested": {}}))
+
+    report = reg.last_validation("prices")
+    assert report is not None
+    assert not report.compatible
+    assert any(path.endswith("nested.b") for path in report.breaking_changes)
 

--- a/tests/scripts/test_schema_audit_log.py
+++ b/tests/scripts/test_schema_audit_log.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+from scripts.schema.audit_log import AuditEntry, update_audit_log
+
+
+SAMPLE_DOC = """---
+title: example
+---
+
+# Header
+
+| Date       | Schema Bundle SHA | Change Request | Validation Window | Notes |
+|------------|------------------|----------------|-------------------|-------|
+| _TBD_      |                  |                |                   |       |
+
+"""
+
+
+def _table_rows(text: str) -> list[str]:
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("| Date"):
+            rows: list[str] = []
+            j = idx + 2
+            while j < len(lines) and lines[j].strip().startswith("|"):
+                rows.append(lines[j])
+                j += 1
+            return rows
+    raise AssertionError("table header missing")
+
+
+def test_update_audit_log_inserts_entry(tmp_path: Path) -> None:
+    doc = tmp_path / "doc.md"
+    doc.write_text(SAMPLE_DOC, encoding="utf-8")
+    entry = AuditEntry(
+        date="2025-10-01",
+        schema_bundle_sha="abcd1234",
+        change_request="CR-42",
+        validation_window="48h",
+        notes="all clear",
+    )
+
+    update_audit_log(doc, entry)
+    updated = doc.read_text(encoding="utf-8")
+
+    rows = _table_rows(updated)
+    assert rows[0].startswith("| 2025-10-01 | abcd1234 | CR-42 | 48h | all clear |")
+    assert sum(1 for row in rows if "_TBD_" in row) == 1
+
+
+def test_dry_run_leaves_file_untouched(tmp_path: Path) -> None:
+    doc = tmp_path / "doc.md"
+    doc.write_text(SAMPLE_DOC, encoding="utf-8")
+    entry = AuditEntry(
+        date="2025-10-02",
+        schema_bundle_sha="deadbeef",
+        change_request="CR-99",
+        validation_window="72h",
+        notes="",
+    )
+
+    preview = update_audit_log(doc, entry, dry_run=True)
+    assert doc.read_text(encoding="utf-8") == SAMPLE_DOC
+    assert "CR-99" in preview
+    assert "_TBD_" in preview


### PR DESCRIPTION
## Summary
- add governance-aware schema registry validation with explicit modes, reporting, metrics, and remote error handling
- ship scripts/schema/audit_log.py plus tests to manage the strict-mode audit log table
- update schema governance and registry docs alongside validation-focused unit tests

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1150

------
https://chatgpt.com/codex/tasks/task_e_68d58155b0c083298333911353ebfee0