### PR TITLE
Wire ConformancePipeline into Seamless providers

### DIFF
--- a/docs/architecture/seamless_data_provider_v2.md
+++ b/docs/architecture/seamless_data_provider_v2.md
@@ -53,9 +53,11 @@ pass an explicit `ConformancePipeline` instance. The planned stages are:
 3. **Quality flags and reports** generate regression digests that are published
    to `qmtl://observability/seamless/<node>` and archived for audit.
 
-In the current implementation, normalization warnings are surfaced via the
-returned report only; reads continue even when issues are detected. Blocking
-behaviour is planned once the default runtime enables the pipeline globally.
+As of the September 2025 runtime update the pipeline is enabled by default via
+`EnhancedQuestDBProvider`. Any warnings or flags emitted by the pipeline raise a
+`ConformancePipelineError` unless the provider is instantiated with
+`partial_ok=True`. In partial-ok mode the normalized frame is returned while the
+report remains accessible through `SeamlessDataProvider.last_conformance_report`.
 
 ## Distributed Backfill Coordinator
 

--- a/docs/design/seamless_data_provider.md
+++ b/docs/design/seamless_data_provider.md
@@ -56,7 +56,7 @@ graph TB
 ## 핵심 컴포넌트
 
 ### 1. ConformancePipeline (컴포넌트)
-정합성 파이프라인은 `SchemaRollupStage`, `TemporalRollupStage`, `RegressionReportStage` 로 구성되며, 각 스테이지는 실패 시 요청을 차단하거나(기본값) `partial_ok=True` 옵션으로 허용할 수 있습니다. 생성된 리포트는 `qmtl://observability/seamless/<node>` 경로에 업로드되어 대시보드와 후속 감사 절차에 사용됩니다.
+정합성 파이프라인은 `SchemaRollupStage`, `TemporalRollupStage`, `RegressionReportStage` 로 구성되며, 각 스테이지는 실패 시 요청을 차단하거나(기본값) `partial_ok=True` 옵션으로 허용할 수 있습니다. 2025.09 릴리스부터 `EnhancedQuestDBProvider` 는 기본적으로 `ConformancePipeline` 을 주입하고, 경고나 플래그가 감지되면 `ConformancePipelineError` 를 발생시켜 응답을 막습니다. `partial_ok=True` 로 생성하면 동일한 리포트가 `SeamlessDataProvider.last_conformance_report` 에서 확인 가능하지만 응답은 통과합니다. 생성된 리포트는 `qmtl://observability/seamless/<node>` 경로에 업로드되어 대시보드와 후속 감사 절차에 사용됩니다.
 
 ### 2. SLAPolicy (구성)
 `SLAPolicy`는 지연(latency)과 신선도(freshness) 제한을 정의하며, `SeamlessDataProvider`는 각 요청의 단계별 소요 시간과 커버리지 정보를 추적하여 `seamless_sla_deadline_seconds` 히스토그램과 트레이스를 발행합니다. 위반 시 `SeamlessSLAExceeded` 예외가 발생하고, 경보는 `alert_rules.yml`의 `seamless-*` 규칙으로 전달됩니다.

--- a/qmtl/runtime/io/seamless_provider.py
+++ b/qmtl/runtime/io/seamless_provider.py
@@ -7,11 +7,12 @@ import logging
 
 from qmtl.runtime.sdk.data_io import HistoryProvider, DataFetcher
 from qmtl.runtime.sdk.seamless_data_provider import (
-    SeamlessDataProvider, 
-    DataSource, 
+    SeamlessDataProvider,
+    DataSource,
     DataSourcePriority,
     DataAvailabilityStrategy
 )
+from qmtl.runtime.sdk.conformance import ConformancePipeline
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +238,8 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
         live_fetcher: DataFetcher | None = None,
         cache_provider: HistoryProvider | None = None,
         strategy: DataAvailabilityStrategy = DataAvailabilityStrategy.SEAMLESS,
+        conformance: ConformancePipeline | None = None,
+        partial_ok: bool = False,
         **kwargs
     ):
         # Import here to avoid circular imports
@@ -261,6 +264,8 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
             storage_source=storage_source,
             backfiller=backfiller,
             live_feed=live_feed,
+            conformance=conformance or ConformancePipeline(),
+            partial_ok=partial_ok,
             **kwargs
         )
     


### PR DESCRIPTION
## Summary
- instantiate a default `ConformancePipeline` for seamless QuestDB providers and surface blocking via `ConformancePipelineError`
- add optional `partial_ok` handling plus last report tracking so callers can inspect conformance results
- document the new behaviour and extend seamless provider tests for blocking and partial-ok flows

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto
- uv run mkdocs build

Fixes #1149

------
https://chatgpt.com/codex/tasks/task_e_68d5884c867483299fd9c875a4f1d690