### PR TITLE
Ship Seamless v2 observability assets and tooling

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -77,3 +77,30 @@ prometheus:
           annotations:
             summary: Cross-context cache hit detected (SLO=0)
             runbook: docs/operations/monitoring.html#runbook-cross-context-cache-hits-slo-0
+        - alert: SeamlessSla99thDegraded
+          expr: histogram_quantile(0.99, sum by (le) (rate(seamless_sla_deadline_seconds_bucket{phase="total"}[5m]))) > 240
+          for: 5m
+          labels:
+            severity: warning
+            service: seamless
+          annotations:
+            summary: Seamless SLA 99th percentile exceeded 240s for 5 minutes
+            runbook: docs/operations/seamless_sla_dashboards.html
+        - alert: SeamlessBackfillStuckLease
+          expr: min_over_time(backfill_completion_ratio[10m]) < 0.5
+          for: 10m
+          labels:
+            severity: critical
+            service: seamless
+          annotations:
+            summary: Seamless backfill lease stuck below 50% completion
+            runbook: docs/operations/seamless_sla_dashboards.html#runbooks
+        - alert: SeamlessConformanceFlagSpike
+          expr: sum(increase(seamless_conformance_flag_total[15m])) > 50
+          for: 15m
+          labels:
+            severity: warning
+            service: seamless
+          annotations:
+            summary: Surge in Seamless conformance flags over the last 15 minutes
+            runbook: docs/operations/seamless_sla_dashboards.html#validation-tooling

--- a/docs/guides/seamless_migration_v2.md
+++ b/docs/guides/seamless_migration_v2.md
@@ -37,13 +37,16 @@ milestone.
    the SDK instantiates `DistributedBackfillCoordinator` automatically.
 2. Validate `backfill_completion_ratio` in staging to ensure leases converge and
    shards are not duplicated.
-3. Document recovery procedures (`scripts/lease_recover.py`) for on-call use.
+3. Document recovery procedures (`scripts/lease_recover.py`) for on-call use and
+   rehearse dry runs in staging before cutting production traffic.
 
 ### 3. Enforce SLAPolicy Budgets
 
 1. Wire concrete deadlines into `SLAPolicy` instances for each Seamless consumer.
 2. Verify that breaches raise `SeamlessSLAExceeded` in staging and that alerts
-   fire via the `seamless-sla-*` rules.
+   fire via the `seamless-sla-*` rules. The helper script
+   `scripts/inject_sla_violation.py` can inject synthetic histogram samples to
+   validate the pipeline before production traffic hits the new thresholds.
 3. Update runbooks with the new troubleshooting flow described in the SLA
    dashboards guide.
 

--- a/operations/monitoring/seamless_v2.jsonnet
+++ b/operations/monitoring/seamless_v2.jsonnet
@@ -1,0 +1,127 @@
+{
+  "bundle": "seamless_v2_observability",
+  "version": 1,
+  "dashboards": [
+    {
+      "uid": "seamless-sla-overview",
+      "title": "Seamless SLA Overview",
+      "tags": ["seamless", "sla"],
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "99th Percentile Deadline (Total)",
+          "description": "Tracks the p99 of seamless_sla_deadline_seconds across all phases.",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(seamless_sla_deadline_seconds_bucket{phase=\"total\"}[5m])))",
+              "legendFormat": "total"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Phase Breakdown",
+          "description": "Latency percentiles split by SLA phase.",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, phase) (rate(seamless_sla_deadline_seconds_bucket[5m])))",
+              "legendFormat": "{{phase}}"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "Current Total p95",
+          "description": "Displays the most recent 95th percentile of the total SLA histogram.",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(seamless_sla_deadline_seconds_bucket{phase=\"total\"}[5m])))"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uid": "seamless-backfill-health",
+      "title": "Backfill Coordinator Health",
+      "tags": ["seamless", "backfill"],
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Active Leases",
+          "targets": [
+            {
+              "expr": "sum(backfill_jobs_in_progress)"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Completion Ratio by Lease",
+          "targets": [
+            {
+              "expr": "avg by (lease_key) (backfill_completion_ratio)",
+              "legendFormat": "{{lease_key}}"
+            }
+          ]
+        },
+        {
+          "type": "table",
+          "title": "Recent Coordinator Updates",
+          "targets": [
+            {
+              "expr": "topk(10, backfill_last_timestamp)",
+              "legendFormat": "{{node_id}}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uid": "seamless-conformance-quality",
+      "title": "Conformance Quality",
+      "tags": ["seamless", "quality"],
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Total Flags (15m)",
+          "targets": [
+            {
+              "expr": "sum(increase(seamless_conformance_flag_total[15m]))",
+              "legendFormat": "flags"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Flags by Node",
+          "targets": [
+            {
+              "expr": "sum by (node_id) (increase(seamless_conformance_flag_total[5m]))",
+              "legendFormat": "{{node_id}}"
+            }
+          ]
+        },
+        {
+          "type": "table",
+          "title": "Flag Breakdown",
+          "targets": [
+            {
+              "expr": "sum by (flag_type) (increase(seamless_conformance_flag_total[1h]))",
+              "legendFormat": "{{flag_type}}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "recordingRules": [
+    {
+      "name": "seamless_sla_total_p99_seconds",
+      "expr": "histogram_quantile(0.99, sum by (le) (rate(seamless_sla_deadline_seconds_bucket{phase=\"total\"}[5m])))",
+      "labels": {
+        "component": "seamless"
+      }
+    }
+  ]
+}

--- a/qmtl/runtime/sdk/seamless_data_provider.py
+++ b/qmtl/runtime/sdk/seamless_data_provider.py
@@ -468,6 +468,11 @@ class SeamlessDataProvider(ABC):
                         interval=interval,
                     )
                     self._last_conformance_report = report
+                    sdk_metrics.observe_conformance_report(
+                        node_id=node_id,
+                        flags=report.flags_counts,
+                        warnings=report.warnings,
+                    )
                     if (report.warnings or report.flags_counts) and not self._partial_ok:
                         raise ConformancePipelineError(report)
             except ConformancePipelineError:

--- a/scripts/inject_sla_violation.py
+++ b/scripts/inject_sla_violation.py
@@ -1,0 +1,115 @@
+"""Emit synthetic Seamless SLA metrics for alert validation.
+
+Operators can use this helper to push controlled observations into the
+Prometheus registry that backs Seamless dashboards. The generated samples
+make it possible to verify alert rules, Grafana panels, and PagerDuty
+wiring without waiting for a production incident.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from qmtl.runtime.sdk import metrics as sdk_metrics
+
+_DEFAULT_PHASES: tuple[str, ...] = (
+    "storage_wait",
+    "backfill_wait",
+    "live_wait",
+    "total",
+)
+
+
+def inject_samples(
+    *,
+    node_id: str,
+    phases: Sequence[str] = _DEFAULT_PHASES,
+    duration_seconds: float = 180.0,
+    repetitions: int = 10,
+    output_path: Path | None = None,
+) -> str:
+    """Populate the SDK metrics registry with synthetic SLA samples."""
+
+    sdk_metrics.reset_metrics()
+    for _ in range(repetitions):
+        for phase in phases:
+            sdk_metrics.observe_sla_phase_duration(
+                node_id=node_id,
+                phase=phase,
+                duration_seconds=duration_seconds,
+            )
+    rendered = sdk_metrics.collect_metrics()
+    if output_path:
+        output_path.write_text(rendered)
+    return rendered
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("node_id", help="Node identifier used to label the synthetic samples.")
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=180.0,
+        help="Duration (seconds) recorded for each observation. Default: 180 seconds.",
+    )
+    parser.add_argument(
+        "--repetitions",
+        type=int,
+        default=10,
+        help="Number of samples to record for each phase. Default: 10 repetitions.",
+    )
+    parser.add_argument(
+        "--phase",
+        dest="phases",
+        action="append",
+        help="Specific phases to record. Can be specified multiple times. Defaults to all phases.",
+    )
+    parser.add_argument(
+        "--write-to",
+        type=Path,
+        help="Optional path that will receive the rendered Prometheus exposition text.",
+    )
+    parser.add_argument(
+        "--serve",
+        type=int,
+        metavar="PORT",
+        help="If provided, expose the generated metrics over HTTP on the given port.",
+    )
+    parser.add_argument(
+        "--hold",
+        type=float,
+        default=60.0,
+        help="How long to keep the HTTP server alive when --serve is set. Default: 60 seconds.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    phases = tuple(args.phases) if args.phases else _DEFAULT_PHASES
+    metrics_text = inject_samples(
+        node_id=args.node_id,
+        phases=phases,
+        duration_seconds=args.duration,
+        repetitions=args.repetitions,
+        output_path=args.write_to,
+    )
+
+    if args.serve:
+        sdk_metrics.start_metrics_server(port=args.serve)
+        print(f"Serving metrics on 0.0.0.0:{args.serve} for {args.hold} seconds...")
+        time.sleep(max(args.hold, 0.0))
+    else:
+        print(metrics_text)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/lease_recover.py
+++ b/scripts/lease_recover.py
@@ -1,0 +1,195 @@
+"""Manual recovery tooling for the Seamless backfill coordinator.
+
+The distributed coordinator protects backfill work through short-lived
+leases. When a worker crashes or loses connectivity the lease may remain
+allocated until it expires. Operators can use this script to explicitly
+release those leases so other workers can resume processing immediately.
+
+The script accepts ``KEY:TOKEN`` pairs on the command line or via a file
+of newline-delimited entries. Tokens are required so the coordinator can
+validate that the caller is taking over the correct lease; obtain them
+from the coordinator's ``/v1/leases/inspect`` endpoint or directly from
+logs emitted by stuck workers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from qmtl.runtime.sdk.backfill_coordinator import (
+    DistributedBackfillCoordinator,
+    Lease,
+)
+
+
+@dataclass(frozen=True)
+class LeaseSpec:
+    """Normalized representation of a lease identifier."""
+
+    key: str
+    token: str | None = None
+
+    @classmethod
+    def parse(cls, raw: str) -> "LeaseSpec":
+        if not raw:
+            raise ValueError("Empty lease spec")
+        parts = raw.split(":", 1)
+        if len(parts) == 1:
+            return cls(key=parts[0].strip() or raw.strip(), token=None)
+        key, token = parts[0].strip(), parts[1].strip()
+        if not key:
+            raise ValueError(f"Invalid lease spec '{raw}': missing key")
+        return cls(key=key, token=token or None)
+
+
+@dataclass(frozen=True)
+class LeaseRecoverySummary:
+    processed: int
+    released: int
+    skipped: int
+    errors: tuple[str, ...]
+
+
+async def recover_leases(
+    lease_specs: Sequence[LeaseSpec],
+    *,
+    coordinator: DistributedBackfillCoordinator | None = None,
+    base_url: str | None = None,
+    action: str = "fail",
+    reason: str = "manual_recovery",
+    dry_run: bool = False,
+) -> LeaseRecoverySummary:
+    """Release or complete leases via the distributed coordinator."""
+
+    if coordinator is None:
+        if not base_url:
+            raise ValueError("Either 'coordinator' or 'base_url' must be provided")
+        coordinator = DistributedBackfillCoordinator(base_url=base_url)
+
+    processed = 0
+    released = 0
+    skipped = 0
+    errors: list[str] = []
+
+    for spec in lease_specs:
+        processed += 1
+        if dry_run:
+            skipped += 1
+            continue
+        if spec.token is None:
+            skipped += 1
+            errors.append(f"missing token for lease '{spec.key}'")
+            continue
+        lease = Lease(key=spec.key, token=spec.token, lease_until_ms=0)
+        try:
+            if action == "complete":
+                await coordinator.complete(lease)
+            else:
+                await coordinator.fail(lease, reason)
+            released += 1
+        except Exception as exc:  # pragma: no cover - network errors
+            errors.append(f"{spec.key}: {exc}")
+
+    return LeaseRecoverySummary(
+        processed=processed,
+        released=released,
+        skipped=skipped,
+        errors=tuple(errors),
+    )
+
+
+def _read_specs(values: Sequence[str], from_file: Path | None) -> list[LeaseSpec]:
+    raw: list[str] = list(values)
+    if from_file:
+        raw.extend(line.strip() for line in from_file.read_text().splitlines())
+    specs: list[LeaseSpec] = []
+    for entry in raw:
+        entry = entry.strip()
+        if not entry:
+            continue
+        specs.append(LeaseSpec.parse(entry))
+    return specs
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "leases",
+        nargs="*",
+        help="Lease specs in KEY:TOKEN form. Tokens are required unless --dry-run is used.",
+    )
+    parser.add_argument(
+        "--coordinator-url",
+        dest="coordinator_url",
+        help="Base URL for the distributed backfill coordinator. Defaults to QMTL_SEAMLESS_COORDINATOR_URL.",
+    )
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        dest="from_file",
+        help="Path to a file containing newline-delimited lease specs.",
+    )
+    parser.add_argument(
+        "--action",
+        choices={"fail", "complete"},
+        default="fail",
+        help="Whether to mark the lease as failed (default) or completed.",
+    )
+    parser.add_argument(
+        "--reason",
+        default="manual_recovery",
+        help="Reason string submitted when failing leases.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse inputs but do not contact the coordinator.",
+    )
+    return parser
+
+
+async def _run_async(args: argparse.Namespace) -> LeaseRecoverySummary:
+    specs = _read_specs(args.leases, args.from_file)
+    if not specs:
+        raise SystemExit("No leases supplied")
+    summary = await recover_leases(
+        specs,
+        base_url=args.coordinator_url,
+        action=args.action,
+        reason=args.reason,
+        dry_run=args.dry_run,
+    )
+    return summary
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        summary = asyncio.run(_run_async(args))
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+    except SystemExit as exc:
+        raise exc
+    except Exception as exc:  # pragma: no cover - defensive
+        parser.error(str(exc))
+        return 2
+
+    if summary.errors:
+        for error in summary.errors:
+            print(f"error: {error}", file=sys.stderr)
+    print(
+        f"processed={summary.processed} released={summary.released} skipped={summary.skipped}",
+        file=sys.stdout,
+    )
+    return 0 if not summary.errors else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/operations/test_seamless_observability.py
+++ b/tests/operations/test_seamless_observability.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+BUNDLE_PATH = Path("operations/monitoring/seamless_v2.jsonnet")
+
+
+@pytest.fixture(scope="module")
+def bundle() -> dict:
+    text = BUNDLE_PATH.read_text()
+    data = json.loads(text)
+    return data
+
+
+def test_bundle_contains_expected_dashboards(bundle: dict) -> None:
+    titles = {dash["title"] for dash in bundle["dashboards"]}
+    assert {
+        "Seamless SLA Overview",
+        "Backfill Coordinator Health",
+        "Conformance Quality",
+    }.issubset(titles)
+
+
+def test_bundle_queries_reference_metrics(bundle: dict) -> None:
+    expressions = [
+        target["expr"]
+        for dashboard in bundle["dashboards"]
+        for panel in dashboard.get("panels", [])
+        for target in panel.get("targets", [])
+    ]
+    assert any("seamless_sla_deadline_seconds" in expr for expr in expressions)
+    assert any("backfill_completion_ratio" in expr for expr in expressions)
+    assert any("seamless_conformance_flag_total" in expr for expr in expressions)
+
+
+def test_recording_rules_defined(bundle: dict) -> None:
+    rules = bundle.get("recordingRules", [])
+    assert any(rule["name"] == "seamless_sla_total_p99_seconds" for rule in rules)

--- a/tests/scripts/test_seamless_tooling.py
+++ b/tests/scripts/test_seamless_tooling.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import inject_sla_violation, lease_recover
+
+
+class _StubCoordinator:
+    def __init__(self) -> None:
+        self.fail_calls: list[tuple[str, str]] = []
+        self.complete_calls: list[str] = []
+
+    async def fail(self, lease, reason: str) -> None:  # pragma: no cover - simple container
+        self.fail_calls.append((lease.key, reason))
+
+    async def complete(self, lease) -> None:
+        self.complete_calls.append(lease.key)
+
+
+@pytest.mark.asyncio
+async def test_recover_leases_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    coordinator = _StubCoordinator()
+    specs = [lease_recover.LeaseSpec.parse("node:token"), lease_recover.LeaseSpec.parse("other:token2")]
+    summary = await lease_recover.recover_leases(
+        specs,
+        coordinator=coordinator,
+        action="fail",
+        reason="stuck",
+    )
+    assert summary.processed == 2
+    assert summary.released == 2
+    assert summary.skipped == 0
+    assert summary.errors == ()
+    assert coordinator.fail_calls == [("node", "stuck"), ("other", "stuck")]
+
+
+@pytest.mark.asyncio
+async def test_recover_leases_missing_token() -> None:
+    coordinator = _StubCoordinator()
+    specs = [lease_recover.LeaseSpec.parse("node"), lease_recover.LeaseSpec.parse("node2:token")]
+    summary = await lease_recover.recover_leases(specs, coordinator=coordinator)
+    assert summary.processed == 2
+    assert summary.released == 1
+    assert summary.skipped == 1
+    assert "missing token" in summary.errors[0]
+
+
+def test_inject_samples_generates_metrics(tmp_path: Path) -> None:
+    output_file = tmp_path / "metrics.txt"
+    text = inject_sla_violation.inject_samples(
+        node_id="demo",
+        phases=("total",),
+        duration_seconds=42.0,
+        repetitions=3,
+        output_path=output_file,
+    )
+    assert "seamless_sla_deadline_seconds" in text
+    assert output_file.read_text() == text
+
+
+def test_lease_spec_parse_round_trip() -> None:
+    spec = lease_recover.LeaseSpec.parse("key:token")
+    assert spec.key == "key"
+    assert spec.token == "token"
+    with pytest.raises(ValueError):
+        lease_recover.LeaseSpec.parse("")


### PR DESCRIPTION
## Summary
- add the Seamless v2 Grafana/Jsonnet bundle and Prometheus alert rules referenced by the operations docs
- expose recovery and validation scripts for the distributed backfill coordinator and SLA metrics, updating runbooks and migration guidance
- instrument Seamless conformance metrics and add smoke tests that validate the new tooling and dashboard assets

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- uv run -m pytest -W error -n auto

Fixes #1151

------
https://chatgpt.com/codex/tasks/task_e_68d5a30f1f708329a4544099320f56bd