### PR TITLE
Consolidate CCXT × Seamless integrated architecture guidance

### DIFF
--- a/docs/architecture/ccxt-seamless-hybrid.md
+++ b/docs/architecture/ccxt-seamless-hybrid.md
@@ -450,8 +450,7 @@ provider = EnhancedQuestDBProvider(
 
 ### C. 기존 문서 대비 변경점 맵
 
-* [`ccxt-seamless-integrated.md`](ccxt-seamless-integrated.md)의 SLA/coverage/backfill/RL/Conformance 지침을 **핵심 데이터 평면**으로 채택.
-* `ccxt-seamless-gpt5codex.md`의 `dataset_fingerprint/as_of`, World/Execution 도메인, Gateway 컨텍스트를 **거버넌스 평면**으로 채택.
+* [`ccxt-seamless-integrated.md`](ccxt-seamless-integrated.md)의 SLA/coverage/backfill/RL/Conformance **및** `dataset_fingerprint/as_of` 거버넌스 지침을 단일 참조로 채택.
 * `ccxt-seamless-sonnet4` 설계는 폐기됨(Deprecated/Removed). 관련 편의 API가 필요할 경우에도 본 하이브리드 설계의 NodeID 규약·클러스터 RL·도메인 게이팅·아티팩트 규칙을 따라야 한다.
 
 ---

--- a/docs/architecture/ccxt-seamless-legacy-audit.md
+++ b/docs/architecture/ccxt-seamless-legacy-audit.md
@@ -21,21 +21,21 @@ The following tables list sections, diagrams, or code samples that have no equiv
 
 | Legacy topic | Migration status | Notes |
 | --- | --- | --- |
-| **Feature Artifact Plane guardrails** (dataset_fingerprint-as_of discipline preventing domain bleed) | Partially captured | Integrated spec notes fingerprint/as_of usage but does not restate the rationale around read-only artifact sharing across domains. |
-| **CCXT worker metadata workflow** (computing dataset_fingerprint/as_of at snapshot time) | Missing | No equivalent description exists for when fingerprints should be produced inside the ingestion workers. |
-| **Artifact storage policy** (versioned retention in Feature Artifact store) | Partially captured | Integrated doc names the artifact store but omits the explicit requirement to persist each backfilled segment as an immutable version. |
-| **Observability metrics** (`backfill_completion_ratio` alongside SLA counters) | Missing | Current Operational Practices omit this metric carried over from Codex guidance. |
-| **Implementation roadmap** (connector packaging, Seamless adapter layer, persistence, domain gating, observability) | Missing | Translate the phased roadmap into the integrated doc’s Implementation Guidance so teams can track migration progress. |
+| **Feature Artifact Plane guardrails** (dataset_fingerprint-as_of discipline preventing domain bleed) | ✅ Migrated | Integrated doc now details read-only sharing, provenance, and the reproducibility contract under "Feature Artifact Plane". |
+| **CCXT worker metadata workflow** (computing dataset_fingerprint/as_of at snapshot time) | ✅ Migrated | Publication workflow pseudo-code specifies when workers conform, fingerprint, and publish manifests. |
+| **Artifact storage policy** (versioned retention in Feature Artifact store) | ✅ Migrated | Storage policy section clarifies hot vs cold roles, versioning, and watermark promotion. |
+| **Observability metrics** (`backfill_completion_ratio` alongside SLA counters) | ✅ Migrated | Operational Practices → Metrics Catalog lists SLA timers, backfill ratios, and gating counters with alert guidance. |
+| **Implementation roadmap** (connector packaging, Seamless adapter layer, persistence, domain gating, observability) | ✅ Migrated | Migration Path and Validation Benchmarks outline the phased rollout and acceptance criteria. |
 
 ### `ccxt-seamless-hybrid.md`
 
 | Legacy element | Migration status | Notes |
 | --- | --- | --- |
-| **Comprehensive configuration schema** (retry tuning, metrics catalog, partitioning, fingerprint options) | Partially captured | Integrated YAML includes only a subset of parameters; retry policy, metrics, and artifact partitioning options are still unique to the hybrid doc. |
-| **Reference implementation snippets** (`conform_frame`, `compute_fingerprint`, `maybe_publish_artifact`, domain gating helper) | Missing | Integrated doc references `maybe_publish_artifact` conceptually but omits concrete pseudo-code. |
-| **Operations & observability checklist** (metric names, alert thresholds, env vars) | Partially captured | Some SLA metrics are listed, but counters like `seamless_storage_wait_ms`, `seamless_backfill_wait_ms`, and alert heuristics remain undocumented. |
-| **Storage strategy (Hot vs. Cold) and stabilization workflow** | Missing | No section in the integrated doc calls out QuestDB vs. artifact responsibilities or watermark promotion rules. |
-| **Migration pathway & acceptance criteria** | Missing | The actionable seven-step migration plan and validation criteria need a new “Migration Path” section in the integrated blueprint. |
+| **Comprehensive configuration schema** (retry tuning, metrics catalog, partitioning, fingerprint options) | ✅ Migrated | Configuration blueprint now includes retry knobs, observability thresholds, and artifact partition templates. |
+| **Reference implementation snippets** (`conform_frame`, `compute_fingerprint`, `maybe_publish_artifact`, domain gating helper) | ✅ Migrated | Publication workflow pseudo-code replaces the hybrid draft’s snippets. |
+| **Operations & observability checklist** (metric names, alert thresholds, env vars) | ✅ Migrated | Operational Practices enumerate metrics, alerts, and environment variables, consolidating the hybrid guidance. |
+| **Storage strategy (Hot vs. Cold) and stabilization workflow** | ✅ Migrated | Dedicated storage strategy section documents QuestDB vs artifact responsibilities and promotion sequencing. |
+| **Migration pathway & acceptance criteria** | ✅ Migrated | Migration Path and Validation Benchmarks capture the seven-step rollout and readiness checks. |
 
 ## External Links that Depend on the Legacy Docs
 - ✅ `mkdocs.yml` navigation now routes readers directly to the integrated blueprint (the GPT5-High entry was removed).
@@ -43,6 +43,6 @@ The following tables list sections, diagrams, or code samples that have no equiv
 - [`ccxt-seamless-hybrid.md`](ccxt-seamless-hybrid.md) now references the integrated blueprint for its data-plane lineage; future cleanup can drop the parenthetical entirely once the Codex content is migrated.
 
 ## Recommended Follow-Up
-1. Incorporate the missing sections listed above into `ccxt-seamless-integrated.md`, preserving diagrams (Mermaid) where appropriate.
-2. Update navigation so that the integrated blueprint replaces direct links to the legacy drafts once migration is complete.
-3. After porting, archive or delete the redundant documents and post these findings as a comment in [#1162](https://github.com/hyophyop/qmtl/issues/1162) referencing this audit (Fixes #1163).
+1. Confirm the integrated blueprint remains the single source and archive or delete the redundant legacy drafts.
+2. Keep navigation entries pointing at the integrated document and remove residual references to the archived files across the docset.
+3. Post migration notes in [#1162](https://github.com/hyophyop/qmtl/issues/1162) summarizing the consolidation status (Fixes #1163).


### PR DESCRIPTION
## Summary
- expand the CCXT × Seamless integrated blueprint with codex-derived guardrails, publication workflow pseudo-code, and storage policy details
- extend configuration, observability, and rollout guidance so operations, testing, and governance depend on the single integrated document
- update the legacy audit and hybrid addendum to point exclusively at the integrated reference now that migrations are complete

## Testing
- uv run --with mkdocs --with mkdocs-material --with mkdocs-macros-plugin --with mkdocs-breadcrumbs-plugin mkdocs build

Fixes #1166

------
https://chatgpt.com/codex/tasks/task_e_68d5e772dea88329888036b60af1476f