### PR TITLE
Propagate Seamless history metadata

### DIFF
--- a/qmtl/runtime/io/__init__.py
+++ b/qmtl/runtime/io/__init__.py
@@ -14,6 +14,7 @@ from .ccxt_fetcher import (
 )
 from .ccxt_provider import CcxtQuestDBProvider
 from .seamless_provider import EnhancedQuestDBProvider
+from .artifact import ArtifactRegistrar, ArtifactPublication
 from .ccxt_live_feed import CcxtProLiveFeed, CcxtProConfig
 
 __all__ = [
@@ -34,4 +35,6 @@ __all__ = [
     "CcxtQuestDBProvider",
     "CcxtProLiveFeed",
     "CcxtProConfig",
+    "ArtifactRegistrar",
+    "ArtifactPublication",
 ]

--- a/qmtl/runtime/io/artifact.py
+++ b/qmtl/runtime/io/artifact.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+"""Helpers for publishing stabilized Seamless artifacts."""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import inspect
+import io
+import logging
+from typing import Any, Awaitable, Callable, MutableMapping, Sequence
+
+import pandas as pd
+
+from qmtl.runtime.sdk.conformance import ConformanceReport
+
+logger = logging.getLogger(__name__)
+
+ArtifactStore = Callable[[pd.DataFrame, MutableMapping[str, Any]], Awaitable[str | None] | str | None]
+
+
+@dataclass(slots=True)
+class ArtifactPublication:
+    """Metadata describing a stabilized artifact publication."""
+
+    dataset_fingerprint: str
+    as_of: str
+    node_id: str
+    start: int
+    end: int
+    rows: int
+    uri: str | None = None
+    manifest: dict[str, Any] = field(default_factory=dict)
+
+
+class ArtifactRegistrar:
+    """Compute dataset fingerprints and optionally persist stabilized artifacts."""
+
+    _PREFERRED_COLUMNS: Sequence[str] = ("ts", "open", "high", "low", "close", "volume")
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore | None = None,
+        stabilization_bars: int = 2,
+        conformance_version: str = "v2",
+        float_format: str = "%.10f",
+    ) -> None:
+        if stabilization_bars < 0:
+            raise ValueError("stabilization_bars must be >= 0")
+        self._store = store
+        self._stabilization_bars = int(stabilization_bars)
+        self._conformance_version = str(conformance_version)
+        self._float_format = float_format
+
+    @property
+    def stabilization_bars(self) -> int:
+        return self._stabilization_bars
+
+    @property
+    def conformance_version(self) -> str:
+        return self._conformance_version
+
+    async def publish(
+        self,
+        frame: pd.DataFrame,
+        *,
+        node_id: str,
+        interval: int,
+        conformance_report: ConformanceReport | None = None,
+        requested_range: tuple[int, int] | None = None,
+    ) -> ArtifactPublication | None:
+        """Stabilize ``frame`` and return publication metadata.
+
+        When ``store`` was supplied at construction time the stabilized frame and
+        manifest metadata are handed to it. Failures during persistence are
+        logged and do not raise.
+        """
+
+        if not isinstance(frame, pd.DataFrame) or frame.empty or "ts" not in frame.columns:
+            return None
+
+        canonical = self._canonicalize_frame(frame)
+        stabilized = self._stabilize_frame(canonical)
+        if stabilized.empty:
+            return None
+
+        start = int(stabilized["ts"].min())
+        end = int(stabilized["ts"].max())
+        rows = int(stabilized.shape[0])
+        as_of = self._now_iso()
+        fingerprint = self._compute_fingerprint(stabilized)
+
+        manifest: dict[str, Any] = {
+            "node_id": node_id,
+            "range": [start, end],
+            "row_count": rows,
+            "interval": int(interval),
+            "dataset_fingerprint": fingerprint,
+            "as_of": as_of,
+            "conformance_version": self._conformance_version,
+            "stabilization_bars": self._stabilization_bars,
+        }
+        if requested_range is not None:
+            manifest["requested_range"] = [int(requested_range[0]), int(requested_range[1])]
+        if conformance_report is not None:
+            manifest["conformance"] = {
+                "flags": dict(conformance_report.flags_counts),
+                "warnings": list(conformance_report.warnings),
+            }
+
+        uri: str | None = None
+        if self._store is not None:
+            try:
+                result = self._store(stabilized.copy(deep=True), manifest)
+                if inspect.isawaitable(result):
+                    uri = await result  # type: ignore[assignment]
+                else:
+                    uri = result
+            except Exception:  # pragma: no cover - defensive logging only
+                logger.exception("artifact store failure for node %s", node_id)
+
+        return ArtifactPublication(
+            dataset_fingerprint=fingerprint,
+            as_of=as_of,
+            node_id=node_id,
+            start=start,
+            end=end,
+            rows=rows,
+            uri=uri,
+            manifest=manifest,
+        )
+
+    # ------------------------------------------------------------------
+    def _canonicalize_frame(self, frame: pd.DataFrame) -> pd.DataFrame:
+        working = frame.copy(deep=True)
+        if "ts" in working.columns:
+            working["ts"] = pd.to_numeric(working["ts"], errors="coerce").astype("Int64")
+            working.dropna(subset=["ts"], inplace=True)
+            working["ts"] = working["ts"].astype("int64")
+            working.sort_values("ts", inplace=True)
+            working.reset_index(drop=True, inplace=True)
+
+        preferred = [col for col in self._PREFERRED_COLUMNS if col in working.columns]
+        extras = [col for col in working.columns if col not in preferred]
+        ordered = preferred + extras
+        working = working.loc[:, ordered]
+
+        for col in ("open", "high", "low", "close", "volume"):
+            if col in working.columns:
+                working[col] = pd.to_numeric(working[col], errors="coerce").astype("float64")
+
+        return working
+
+    def _stabilize_frame(self, frame: pd.DataFrame) -> pd.DataFrame:
+        if self._stabilization_bars <= 0:
+            return frame.copy(deep=True)
+        total = frame.shape[0]
+        if total <= self._stabilization_bars:
+            return frame.iloc[0:0].copy(deep=True)
+        return frame.iloc[: total - self._stabilization_bars].copy(deep=True)
+
+    def _compute_fingerprint(self, frame: pd.DataFrame) -> str:
+        buffer = io.StringIO()
+        frame.to_csv(buffer, index=False, header=True, float_format=self._float_format)
+        data = buffer.getvalue().encode("utf-8")
+        return hashlib.sha256(data).hexdigest()
+
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+__all__ = ["ArtifactRegistrar", "ArtifactPublication"]

--- a/qmtl/runtime/io/seamless_provider.py
+++ b/qmtl/runtime/io/seamless_provider.py
@@ -14,6 +14,7 @@ from qmtl.runtime.sdk.seamless_data_provider import (
     LiveDataFeed,
 )
 from qmtl.runtime.sdk.conformance import ConformancePipeline
+from qmtl.runtime.io.artifact import ArtifactRegistrar
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +243,7 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
         strategy: DataAvailabilityStrategy = DataAvailabilityStrategy.SEAMLESS,
         conformance: ConformancePipeline | None = None,
         partial_ok: bool = False,
+        artifact_registrar: ArtifactRegistrar | None = None,
         **kwargs
     ):
         # Import here to avoid circular imports
@@ -268,6 +270,7 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
             live_feed=live_feed_obj,
             conformance=conformance or ConformancePipeline(),
             partial_ok=partial_ok,
+            artifact_registrar=artifact_registrar,
             **kwargs
         )
     

--- a/qmtl/runtime/sdk/backfill_engine.py
+++ b/qmtl/runtime/sdk/backfill_engine.py
@@ -42,7 +42,9 @@ class BackfillEngine:
                     node_id=node.node_id,
                     interval=node.interval,
                 )
+                metadata = getattr(self.source, "last_fetch_metadata", None)
                 if df is None:
+                    await self._process_metadata(node, metadata)
                     sdk_metrics.observe_backfill_complete(node.node_id, node.interval, end)
                     logger.info(
                         "backfill.complete",
@@ -58,6 +60,7 @@ class BackfillEngine:
                     (int(row.get("ts", 0)), row.to_dict())
                     for _, row in df.iterrows()
                 ]
+                await self._process_metadata(node, metadata)
                 node.cache.backfill_bulk(node.node_id, node.interval, items)
                 sdk_metrics.observe_backfill_complete(node.node_id, node.interval, end)
                 logger.info(
@@ -119,3 +122,104 @@ class BackfillEngine:
                 await asyncio.sleep(0.05)
         else:
             await asyncio.sleep(0)
+
+    async def _process_metadata(self, node: Node, metadata) -> None:
+        if metadata is None:
+            return
+        try:
+            node.last_fetch_metadata = metadata
+        except Exception:
+            pass
+
+        try:
+            coverage = metadata.coverage_bounds
+            if coverage is not None:
+                setattr(node, "last_coverage_bounds", coverage)
+        except Exception:
+            pass
+
+        artifact = getattr(metadata, "artifact", None)
+        try:
+            if artifact is not None:
+                node.update_compute_context(
+                    as_of=getattr(artifact, "as_of", None),
+                    dataset_fingerprint=getattr(artifact, "dataset_fingerprint", None),
+                )
+            elif getattr(metadata, "as_of", None) is not None:
+                node.update_compute_context(as_of=metadata.as_of)
+        except Exception:
+            logger.debug("failed to update node compute context from metadata", exc_info=True)
+
+        try:
+            setattr(node, "seamless_conformance_flags", dict(metadata.conformance_flags))
+        except Exception:
+            pass
+        try:
+            setattr(
+                node,
+                "seamless_conformance_warnings",
+                list(metadata.conformance_warnings or ()),
+            )
+        except Exception:
+            pass
+
+        await self._publish_metadata(node, metadata)
+
+    async def _publish_metadata(self, node: Node, metadata) -> None:
+        gateway_url = getattr(node, "gateway_url", None)
+        strategy_id = getattr(node, "strategy_id", None)
+        if not gateway_url or not strategy_id:
+            return
+
+        try:
+            from .runner import Runner
+
+            services = Runner.services()
+            client = getattr(services, "gateway_client", None)
+            if client is None:
+                return
+        except Exception:
+            logger.debug("gateway client unavailable for metadata publish", exc_info=True)
+            return
+
+        artifact = getattr(metadata, "artifact", None)
+        dataset_fp = getattr(metadata, "dataset_fingerprint", None)
+        if dataset_fp is None and artifact is not None:
+            dataset_fp = getattr(artifact, "dataset_fingerprint", None)
+        if dataset_fp is None:
+            dataset_fp = node.dataset_fingerprint
+
+        as_of_value = getattr(metadata, "as_of", None)
+        if as_of_value is None and artifact is not None:
+            as_of_value = getattr(artifact, "as_of", None)
+        if as_of_value is None:
+            as_of_value = getattr(node.compute_context, "as_of", None)
+
+        payload = {
+            "node_id": node.node_id,
+            "interval": int(getattr(node, "interval", 0) or 0),
+            "rows": getattr(metadata, "rows", 0),
+            "coverage_bounds": list(metadata.coverage_bounds) if metadata.coverage_bounds else None,
+            "conformance_flags": metadata.conformance_flags or {},
+            "conformance_warnings": list(metadata.conformance_warnings or ()),
+            "dataset_fingerprint": dataset_fp,
+            "as_of": as_of_value,
+            "world_id": getattr(node, "world_id", None),
+            "execution_domain": getattr(node, "execution_domain", None),
+        }
+        if artifact is not None:
+            payload["artifact"] = {
+                "dataset_fingerprint": getattr(artifact, "dataset_fingerprint", None),
+                "as_of": getattr(artifact, "as_of", None),
+                "rows": getattr(artifact, "rows", 0),
+                "uri": getattr(artifact, "uri", None),
+            }
+
+        try:
+            await client.post_history_metadata(
+                gateway_url=gateway_url,
+                strategy_id=strategy_id,
+                payload=payload,
+            )
+        except Exception:
+            logger.debug("failed to publish seamless metadata", exc_info=True)

--- a/qmtl/runtime/sdk/strategy_bootstrapper.py
+++ b/qmtl/runtime/sdk/strategy_bootstrapper.py
@@ -136,6 +136,19 @@ class StrategyBootstrapper:
 
         if strategy_id is not None:
             setattr(strategy, "strategy_id", strategy_id)
+            for node in strategy.nodes:
+                try:
+                    setattr(node, "strategy_id", strategy_id)
+                except Exception:
+                    pass
+
+        if gateway_url:
+            setattr(strategy, "gateway_url", gateway_url)
+            for node in strategy.nodes:
+                try:
+                    setattr(node, "gateway_url", gateway_url)
+                except Exception:
+                    pass
 
         tag_service.apply_queue_map(strategy, queue_map or {})
 

--- a/qmtl/services/gateway/api.py
+++ b/qmtl/services/gateway/api.py
@@ -90,6 +90,7 @@ def create_app(
         insert_sentinel=insert_sentinel,
         commit_log_writer=commit_log_writer_local,
         context_service=shared_context_service,
+        world_client=world_client_local,
     )
     ws_hub_local = ws_hub
     controlbus_consumer_local = controlbus_consumer

--- a/qmtl/services/gateway/models.py
+++ b/qmtl/services/gateway/models.py
@@ -85,3 +85,24 @@ class ExecutionFillEvent(BaseModel):
     else:  # pragma: no cover - legacy fallback
         class Config:  # type: ignore
             extra = 'ignore'
+
+
+class SeamlessArtifactPayload(BaseModel):
+    dataset_fingerprint: StrictStr
+    as_of: StrictStr
+    rows: StrictInt
+    uri: StrictStr | None = None
+
+
+class SeamlessHistoryReport(BaseModel):
+    node_id: StrictStr
+    interval: StrictInt
+    rows: StrictInt | None = None
+    coverage_bounds: tuple[int, int] | None = None
+    conformance_flags: dict[str, int] | None = None
+    conformance_warnings: list[str] | None = None
+    dataset_fingerprint: StrictStr | None = None
+    as_of: StrictStr | None = None
+    world_id: StrictStr | None = None
+    execution_domain: StrictStr | None = None
+    artifact: SeamlessArtifactPayload | None = None

--- a/qmtl/services/gateway/tests/test_strategy_history_metadata.py
+++ b/qmtl/services/gateway/tests/test_strategy_history_metadata.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from tests.services.gateway.helpers import gateway_app
+
+
+@pytest.mark.asyncio
+async def test_post_strategy_history_updates_context(fake_redis):
+    strategy_id = "strategy-123"
+    await fake_redis.hset(f"strategy:{strategy_id}", mapping={"dag": "{}", "hash": "abc"})
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=404)
+
+    payload = {
+        "node_id": "node-1",
+        "interval": 60,
+        "rows": 2,
+        "coverage_bounds": [0, 120],
+        "conformance_flags": {"missing": 1},
+        "conformance_warnings": ["gap"],
+        "dataset_fingerprint": "fp-abc",
+        "as_of": "2025-01-01T00:00:00Z",
+        "world_id": "world-1",
+        "execution_domain": "live",
+        "artifact": {
+            "dataset_fingerprint": "fp-abc",
+            "as_of": "2025-01-01T00:00:00Z",
+            "rows": 2,
+            "uri": "local://artifact",
+        },
+    }
+
+    async with gateway_app(handler, redis_client=fake_redis) as ctx:
+        resp = await ctx.client.post(
+            f"/strategies/{strategy_id}/history",
+            json=payload,
+        )
+        assert resp.status_code == 204
+
+    stored = await fake_redis.hgetall(f"strategy:{strategy_id}")
+    assert stored["compute_dataset_fingerprint"] == "fp-abc"
+    assert stored["compute_as_of"] == "2025-01-01T00:00:00Z"
+    assert stored["compute_world_id"] == "world-1"
+    assert stored["compute_execution_domain"] == "live"
+    meta = json.loads(stored[f"seamless:{payload['node_id']}"])
+    assert meta["dataset_fingerprint"] == "fp-abc"
+    assert meta["coverage_bounds"] == [0, 120]
+    assert meta["artifact"]["uri"] == "local://artifact"
+
+
+@pytest.mark.asyncio
+async def test_post_strategy_history_missing_strategy(fake_redis):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=404)
+
+    async with gateway_app(handler, redis_client=fake_redis) as ctx:
+        resp = await ctx.client.post(
+            "/strategies/unknown/history",
+            json={"node_id": "n1", "interval": 60},
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_post_strategy_history_forwards_to_worldservice(fake_redis):
+    strategy_id = "strategy-ws"
+    await fake_redis.hset(f"strategy:{strategy_id}", mapping={"dag": "{}", "hash": "xyz"})
+
+    calls: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(status_code=204)
+
+    payload = {
+        "node_id": "node-ws",
+        "interval": 30,
+        "rows": 1,
+        "coverage_bounds": [100, 130],
+        "dataset_fingerprint": "fp-world",
+        "as_of": "2025-02-01T00:00:00Z",
+        "world_id": "world-1",
+        "execution_domain": "live",
+    }
+
+    async with gateway_app(handler, redis_client=fake_redis) as ctx:
+        resp = await ctx.client.post(
+            f"/strategies/{strategy_id}/history",
+            json=payload,
+        )
+        assert resp.status_code == 204
+
+    assert calls
+    request = calls[0]
+    assert request.url.path.endswith("/worlds/world-1/history")
+    body = json.loads(request.content.decode())
+    assert body["strategy_id"] == strategy_id
+    assert body["dataset_fingerprint"] == "fp-world"
+    assert body["coverage_bounds"] == [100, 130]

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -320,6 +320,23 @@ class WorldServiceClient:
             json=payload,
         )
 
+    async def post_history_metadata(
+        self,
+        world_id: str,
+        payload: Any,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        resp = await self._request(
+            "POST",
+            self._build_url(f"/worlds/{world_id}/history"),
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        if resp.status_code == 204 or not resp.content:
+            return None
+        return resp.json()
+
     async def put_activation(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
         return await self._request_json(
             "PUT",

--- a/qmtl/services/worldservice/routers/bindings.py
+++ b/qmtl/services/worldservice/routers/bindings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Dict
+from typing import Any, Dict, List
 
 from fastapi import APIRouter, Response
 
@@ -34,16 +34,72 @@ def create_bindings_router(service: WorldService) -> APIRouter:
         effective_mode = 'active' if strategies else 'validate'
         reason = 'policy_evaluated' if strategies else 'no_active_strategies'
         ttl = '300s'
-        etag = f"w:{world_id}:v{version}:{int(now.timestamp())}"
+        metadata = await store.latest_history_metadata(world_id)
+        dataset_fp = metadata.get('dataset_fingerprint') if metadata else None
+        coverage_bounds: List[int] | None = None
+        conformance_flags: Dict[str, int] | None = None
+        conformance_warnings: List[str] | None = None
+        updated_at = metadata.get('updated_at') if metadata else None
+        rows = metadata.get('rows') if metadata else None
+        if rows is not None and not isinstance(rows, int):
+            try:
+                rows = int(rows)
+            except Exception:
+                rows = None
+        artifact_payload: Dict[str, Any] | None = None
+        as_of_value = metadata.get('as_of') if metadata else None
+        if metadata:
+            raw_cov = metadata.get('coverage_bounds')
+            if isinstance(raw_cov, (list, tuple)):
+                coverage_bounds = [int(v) for v in raw_cov]
+            raw_flags = metadata.get('conformance_flags')
+            if isinstance(raw_flags, dict):
+                conformance_flags = dict(raw_flags)
+            raw_warnings = metadata.get('conformance_warnings')
+            if raw_warnings is not None:
+                conformance_warnings = [str(v) for v in raw_warnings]
+            candidate_artifact = metadata.get('artifact')
+            if isinstance(candidate_artifact, dict):
+                artifact_payload = dict(candidate_artifact)
+                artifact_as_of = artifact_payload.get('as_of')
+                if artifact_as_of and not as_of_value:
+                    as_of_value = str(artifact_as_of)
+                if rows is None and 'rows' in artifact_payload:
+                    try:
+                        rows = int(artifact_payload['rows'])
+                    except Exception:
+                        rows = rows
+        if as_of_value is None:
+            as_of_value = (
+                now.replace(microsecond=0)
+                .isoformat()
+                .replace('+00:00', 'Z')
+            )
+        etag_parts = [f"w:{world_id}", f"v{version}"]
+        if dataset_fp:
+            etag_parts.append(str(dataset_fp))
+        if as_of_value:
+            etag_parts.append(as_of_value)
+        if updated_at:
+            etag_parts.append(str(updated_at))
+        etag_parts.append(str(int(now.timestamp())))
+        etag = ':'.join(etag_parts)
         response.headers['Cache-Control'] = 'max-age=300'
         return DecisionEnvelope(
             world_id=world_id,
             policy_version=version,
             effective_mode=effective_mode,
             reason=reason,
-            as_of=now.replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
+            as_of=as_of_value,
             ttl=ttl,
             etag=etag,
+            dataset_fingerprint=str(dataset_fp) if dataset_fp else None,
+            coverage_bounds=coverage_bounds,
+            conformance_flags=conformance_flags,
+            conformance_warnings=conformance_warnings,
+            history_updated_at=updated_at,
+            rows=rows,
+            artifact=artifact_payload,
         )
 
     @router.post('/worlds/{world_id}/decisions')

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -132,6 +132,13 @@ class DecisionEnvelope(BaseModel):
     as_of: str
     ttl: str
     etag: str
+    dataset_fingerprint: str | None = None
+    coverage_bounds: List[int] | None = None
+    conformance_flags: Dict[str, int] | None = None
+    conformance_warnings: List[str] | None = None
+    history_updated_at: str | None = None
+    rows: int | None = None
+    artifact: SeamlessArtifactPayload | None = None
 
 
 class ActivationEnvelope(BaseModel):
@@ -175,6 +182,28 @@ class ValidationCacheResponse(BaseModel):
     timestamp: str | None = None
 
 
+class SeamlessArtifactPayload(BaseModel):
+    dataset_fingerprint: str | None = None
+    as_of: str | None = None
+    rows: int | None = None
+    uri: str | None = None
+
+
+class SeamlessHistoryRequest(BaseModel):
+    strategy_id: str
+    node_id: str
+    interval: int
+    rows: int | None = None
+    coverage_bounds: tuple[int, int] | None = None
+    conformance_flags: Dict[str, int] | None = None
+    conformance_warnings: List[str] | None = None
+    dataset_fingerprint: str | None = None
+    as_of: str | None = None
+    execution_domain: str | None = None
+    updated_at: str | None = None
+    artifact: SeamlessArtifactPayload | None = None
+
+
 __all__ = [
     'ActivationEnvelope',
     'ActivationRequest',
@@ -196,6 +225,8 @@ __all__ = [
     'ValidationCacheLookupRequest',
     'ValidationCacheResponse',
     'ValidationCacheStoreRequest',
+    'SeamlessArtifactPayload',
+    'SeamlessHistoryRequest',
     'World',
     'WorldNodeRef',
     'WorldNodeStatusEnum',

--- a/tests/sdk/test_seamless_provider.py
+++ b/tests/sdk/test_seamless_provider.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
+from typing import Optional, Any
 
 import pandas as pd
 import pytest
@@ -22,6 +22,7 @@ from qmtl.runtime.sdk import seamless_data_provider as seamless_module
 from qmtl.runtime.sdk.sla import SLAPolicy
 from qmtl.runtime.sdk.exceptions import SeamlessSLAExceeded
 from qmtl.runtime.sdk.backfill_coordinator import Lease
+from qmtl.runtime.io.artifact import ArtifactRegistrar
 
 
 class _StaticSource:
@@ -113,6 +114,48 @@ async def test_seamless_fetch_preserves_off_grid_cache_bounds() -> None:
     assert 90 in ts  # previously dropped due to misaligned subtraction
     assert ts.count(90) == 1
     assert ts.count(95) == 1
+
+
+@pytest.mark.asyncio
+async def test_metadata_records_coverage_and_rows() -> None:
+    storage = _StaticSource([(0, 100)], DataSourcePriority.STORAGE)
+    provider = _DummyProvider(storage_source=storage)
+
+    df = await provider.fetch(0, 100, node_id="n", interval=10)
+
+    metadata = provider.last_fetch_metadata
+    assert metadata is not None
+    assert metadata.node_id == "n"
+    assert metadata.interval == 10
+    assert metadata.coverage_bounds == (0, 100)
+    assert metadata.rows == len(df)
+    assert metadata.artifact is None
+
+
+@pytest.mark.asyncio
+async def test_metadata_includes_artifact_publication() -> None:
+    storage = _StaticSource([(0, 100)], DataSourcePriority.STORAGE)
+    calls: list[tuple[pd.DataFrame, dict[str, Any]]] = []
+
+    def store(df: pd.DataFrame, manifest: dict[str, Any]) -> str:
+        calls.append((df.copy(), dict(manifest)))
+        return "local://artifact"
+
+    registrar = ArtifactRegistrar(store=store, stabilization_bars=1)
+    provider = _DummyProvider(storage_source=storage, artifact_registrar=registrar)
+
+    df = await provider.fetch(0, 100, node_id="n", interval=10)
+
+    metadata = provider.last_fetch_metadata
+    assert metadata is not None
+    assert metadata.artifact is not None
+    artifact = metadata.artifact
+    assert artifact.uri == "local://artifact"
+    assert artifact.node_id == "n"
+    assert artifact.rows == len(df) - 1  # one bar dropped for stabilization
+    assert artifact.dataset_fingerprint
+    assert artifact.manifest["conformance_version"] == registrar.conformance_version
+    assert calls, "artifact store should have been invoked"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- forward Seamless last_fetch_metadata from Gateway to WorldService
- persist history metadata in WorldService storage and surface in decision envelopes
- extend coverage across gateway and worldservice tests

## Testing
- uv run -m pytest qmtl/services/gateway/tests/test_strategy_history_metadata.py -q
- uv run -m pytest tests/services/worldservice/test_worldservice_api.py -q
