### PR TITLE
Integrate artifact registrar with seamless provider

### DIFF
--- a/qmtl/runtime/io/seamless_provider.py
+++ b/qmtl/runtime/io/seamless_provider.py
@@ -14,7 +14,7 @@ from qmtl.runtime.sdk.seamless_data_provider import (
     LiveDataFeed,
 )
 from qmtl.runtime.sdk.conformance import ConformancePipeline
-from qmtl.runtime.io.artifact import ArtifactRegistrar
+from qmtl.runtime.sdk.artifacts import ArtifactRegistrar, FileSystemArtifactRegistrar
 
 logger = logging.getLogger(__name__)
 
@@ -243,7 +243,7 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
         strategy: DataAvailabilityStrategy = DataAvailabilityStrategy.SEAMLESS,
         conformance: ConformancePipeline | None = None,
         partial_ok: bool = False,
-        artifact_registrar: ArtifactRegistrar | None = None,
+        registrar: ArtifactRegistrar | None = None,
         **kwargs
     ):
         # Import here to avoid circular imports
@@ -262,6 +262,8 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
         # Create live feed if available (prefer explicit LiveDataFeed)
         live_feed_obj = live_feed or (LiveDataFeedImpl(live_fetcher) if live_fetcher else None)
         
+        registrar_obj = registrar if registrar is not None else FileSystemArtifactRegistrar.from_env()
+
         super().__init__(
             strategy=strategy,
             cache_source=cache_source,
@@ -270,7 +272,7 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
             live_feed=live_feed_obj,
             conformance=conformance or ConformancePipeline(),
             partial_ok=partial_ok,
-            artifact_registrar=artifact_registrar,
+            registrar=registrar_obj,
             **kwargs
         )
     

--- a/qmtl/runtime/sdk/artifacts/__init__.py
+++ b/qmtl/runtime/sdk/artifacts/__init__.py
@@ -1,0 +1,14 @@
+"""Artifact registrar interfaces used by Seamless providers."""
+
+from .registrar import (
+    ArtifactPublication,
+    ArtifactRegistrar,
+    FileSystemArtifactRegistrar,
+)
+
+__all__ = [
+    "ArtifactPublication",
+    "ArtifactRegistrar",
+    "FileSystemArtifactRegistrar",
+]
+

--- a/qmtl/runtime/sdk/artifacts/registrar.py
+++ b/qmtl/runtime/sdk/artifacts/registrar.py
@@ -1,0 +1,124 @@
+"""Artifact registrar implementations for Seamless providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from typing import Protocol, Sequence, Tuple
+import time
+
+import pandas as pd
+
+
+@dataclass(slots=True)
+class ArtifactPublication:
+    """Details about a published artifact manifest."""
+
+    dataset_fingerprint: str
+    as_of: int
+    coverage_bounds: tuple[int, int]
+    manifest_uri: str
+    data_uri: str | None = None
+
+
+class ArtifactRegistrar(Protocol):
+    """Publish stabilized frames into an artifact catalog."""
+
+    def publish(
+        self,
+        frame: pd.DataFrame,
+        *,
+        node_id: str,
+        interval: int,
+        coverage_bounds: tuple[int, int],
+        fingerprint: str,
+        as_of: int,
+        conformance_flags: dict[str, int] | None = None,
+        conformance_warnings: Sequence[str] | None = None,
+        request_window: tuple[int, int] | None = None,
+    ) -> ArtifactPublication:
+        """Persist ``frame`` and return publication details."""
+
+
+def _sanitize_component(text: str) -> str:
+    cleaned = text.replace("/", "_").replace("..", "")
+    cleaned = cleaned.replace(":", "-")
+    return cleaned or "__"
+
+
+class FileSystemArtifactRegistrar:
+    """Persist artifacts to the local filesystem for testing and development."""
+
+    def __init__(self, base_dir: str | os.PathLike[str]) -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def from_env(cls) -> "FileSystemArtifactRegistrar | None":
+        disabled = str(os.getenv("QMTL_SEAMLESS_ARTIFACTS", "")).strip().lower() in {
+            "0",
+            "false",
+            "off",
+            "no",
+        }
+        if disabled:
+            return None
+        base = os.getenv("QMTL_SEAMLESS_ARTIFACT_DIR", ".qmtl_seamless_artifacts")
+        return cls(base)
+
+    def _target_dir(self, node_id: str, interval: int, fingerprint: str) -> Path:
+        node_part = _sanitize_component(node_id)
+        fp_part = _sanitize_component(fingerprint)
+        return self.base_dir / node_part / str(interval) / fp_part
+
+    def publish(
+        self,
+        frame: pd.DataFrame,
+        *,
+        node_id: str,
+        interval: int,
+        coverage_bounds: Tuple[int, int],
+        fingerprint: str,
+        as_of: int,
+        conformance_flags: dict[str, int] | None = None,
+        conformance_warnings: Sequence[str] | None = None,
+        request_window: tuple[int, int] | None = None,
+    ) -> ArtifactPublication:
+        target = self._target_dir(node_id, interval, fingerprint)
+        target.mkdir(parents=True, exist_ok=True)
+
+        data_path = target / "data.parquet"
+        frame.to_parquet(data_path)
+
+        manifest_path = target / "manifest.json"
+        payload = {
+            "dataset_fingerprint": fingerprint,
+            "as_of": int(as_of),
+            "node_id": node_id,
+            "interval": int(interval),
+            "coverage_bounds": [int(coverage_bounds[0]), int(coverage_bounds[1])],
+            "rows": int(len(frame)),
+            "conformance_flags": dict(conformance_flags or {}),
+            "conformance_warnings": list(conformance_warnings or ()),
+            "request_window": list(request_window or ()),
+            "published_at": int(time.time()),
+        }
+        manifest_path.write_text(json.dumps(payload, sort_keys=True))
+
+        return ArtifactPublication(
+            dataset_fingerprint=fingerprint,
+            as_of=int(as_of),
+            coverage_bounds=(int(coverage_bounds[0]), int(coverage_bounds[1])),
+            manifest_uri=str(manifest_path),
+            data_uri=str(data_path),
+        )
+
+
+__all__ = [
+    "ArtifactPublication",
+    "ArtifactRegistrar",
+    "FileSystemArtifactRegistrar",
+]
+

--- a/tests/runtime/sdk/test_artifact_registrar.py
+++ b/tests/runtime/sdk/test_artifact_registrar.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from pathlib import Path
+
+from qmtl.runtime.sdk.artifacts import FileSystemArtifactRegistrar
+
+
+def test_from_env_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("QMTL_SEAMLESS_ARTIFACTS", raising=False)
+    monkeypatch.delenv("QMTL_SEAMLESS_ARTIFACT_DIR", raising=False)
+
+    assert FileSystemArtifactRegistrar.from_env() is None
+
+
+def test_from_env_enabled_with_flag_and_dir(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("QMTL_SEAMLESS_ARTIFACTS", "1")
+    monkeypatch.setenv("QMTL_SEAMLESS_ARTIFACT_DIR", str(tmp_path))
+
+    registrar = FileSystemArtifactRegistrar.from_env()
+
+    assert isinstance(registrar, FileSystemArtifactRegistrar)
+    assert registrar.base_dir == Path(tmp_path)
+
+
+def test_from_env_enabled_with_directory_only(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("QMTL_SEAMLESS_ARTIFACTS", raising=False)
+    monkeypatch.setenv("QMTL_SEAMLESS_ARTIFACT_DIR", str(tmp_path))
+
+    registrar = FileSystemArtifactRegistrar.from_env()
+
+    assert isinstance(registrar, FileSystemArtifactRegistrar)
+    assert registrar.base_dir == Path(tmp_path)

--- a/tests/sdk/test_seamless_provider.py
+++ b/tests/sdk/test_seamless_provider.py
@@ -5,6 +5,8 @@ from typing import Optional, Any
 
 import pandas as pd
 import pytest
+import json
+from pathlib import Path
 
 from qmtl.runtime.sdk.seamless_data_provider import (
     SeamlessDataProvider,
@@ -18,6 +20,7 @@ from qmtl.runtime.io.seamless_provider import (
 )
 from qmtl.runtime.sdk import metrics as sdk_metrics
 from qmtl.runtime.sdk.conformance import ConformancePipeline
+from qmtl.runtime.sdk.artifacts import ArtifactPublication, FileSystemArtifactRegistrar
 from qmtl.runtime.sdk import seamless_data_provider as seamless_module
 from qmtl.runtime.sdk.sla import SLAPolicy
 from qmtl.runtime.sdk.exceptions import SeamlessSLAExceeded
@@ -65,7 +68,9 @@ class _DuplicateSource(_StaticSource):
 class _DummyProvider(SeamlessDataProvider):
     """Concrete instance of SeamlessDataProvider using injected sources/backfiller."""
 
-    pass
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("stabilization_bars", 0)
+        super().__init__(*args, **kwargs)
 
 
 class _FakeClock:
@@ -173,6 +178,64 @@ async def test_find_missing_ranges_uses_interval_math() -> None:
     assert gaps == [(110, 200)]
 
 
+@pytest.mark.asyncio
+async def test_fetch_response_includes_metadata() -> None:
+    storage = _StaticSource([(0, 100)], DataSourcePriority.STORAGE)
+    registrar = _RecordingRegistrar()
+    provider = _DummyProvider(
+        storage_source=storage,
+        registrar=registrar,
+        stabilization_bars=1,
+    )
+
+    result = await provider.fetch(0, 100, node_id="node", interval=10)
+
+    assert isinstance(result.metadata.dataset_fingerprint, str)
+    assert result.metadata.dataset_fingerprint.startswith("lake:sha256:")
+    assert result.metadata.coverage_bounds == (0, 90)
+    assert isinstance(result.metadata.as_of, int)
+    assert registrar.calls and registrar.calls[0]["rows"] == len(result.frame)
+    assert result.frame.attrs["dataset_fingerprint"] == result.metadata.dataset_fingerprint
+    assert result.metadata.manifest_uri == "mem://manifest"
+
+
+@pytest.mark.asyncio
+async def test_fetch_fingerprint_stable_across_calls() -> None:
+    storage = _StaticSource([(0, 100)], DataSourcePriority.STORAGE)
+    registrar = _RecordingRegistrar()
+    provider = _DummyProvider(
+        storage_source=storage,
+        registrar=registrar,
+        stabilization_bars=1,
+    )
+
+    first = await provider.fetch(0, 100, node_id="node", interval=10)
+    second = await provider.fetch(0, 100, node_id="node", interval=10)
+
+    assert first.metadata.dataset_fingerprint == second.metadata.dataset_fingerprint
+    assert len(registrar.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_filesystem_registrar_writes_manifest(tmp_path) -> None:
+    storage = _StaticSource([(0, 100)], DataSourcePriority.STORAGE)
+    registrar = FileSystemArtifactRegistrar(tmp_path)
+    provider = _DummyProvider(
+        storage_source=storage,
+        registrar=registrar,
+        stabilization_bars=1,
+    )
+
+    result = await provider.fetch(0, 100, node_id="node", interval=10)
+
+    manifest_path = Path(result.metadata.manifest_uri)
+    assert manifest_path.exists()
+    content = json.loads(manifest_path.read_text())
+    assert content["dataset_fingerprint"] == result.metadata.dataset_fingerprint
+    data_path = manifest_path.parent / "data.parquet"
+    assert data_path.exists()
+
+
 class _CountingBackfiller:
     """AutoBackfiller-like stub that records calls and updates storage coverage."""
 
@@ -250,6 +313,44 @@ class _FailingBackfiller(_RecordingBackfiller):
             target_storage=target_storage,
         )
         raise self._error
+
+
+class _RecordingRegistrar:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def publish(
+        self,
+        frame: pd.DataFrame,
+        *,
+        node_id: str,
+        interval: int,
+        coverage_bounds: tuple[int, int],
+        fingerprint: str,
+        as_of: int,
+        conformance_flags: dict[str, int] | None = None,
+        conformance_warnings: tuple[str, ...] | list[str] | None = None,
+        request_window: tuple[int, int] | None = None,
+    ) -> ArtifactPublication:
+        record = {
+            "node_id": node_id,
+            "interval": interval,
+            "coverage_bounds": coverage_bounds,
+            "fingerprint": fingerprint,
+            "as_of": as_of,
+            "conformance_flags": dict(conformance_flags or {}),
+            "conformance_warnings": tuple(conformance_warnings or ()),
+            "request_window": request_window,
+            "rows": len(frame),
+        }
+        self.calls.append(record)
+        return ArtifactPublication(
+            dataset_fingerprint=fingerprint,
+            as_of=as_of,
+            coverage_bounds=coverage_bounds,
+            manifest_uri="mem://manifest",
+            data_uri="mem://data",
+        )
 
 
 class _FlakyCoordinator:
@@ -447,8 +548,8 @@ async def test_fetch_seamless_records_metrics_on_backfill() -> None:
     backfiller = _CountingBackfiller(storage)
     provider = _DummyProvider(storage_source=storage, backfiller=backfiller)
 
-    df = await provider.fetch(0, 100, node_id="n", interval=10)
-    assert isinstance(df, pd.DataFrame)
+    result = await provider.fetch(0, 100, node_id="n", interval=10)
+    assert isinstance(result.frame, pd.DataFrame)
     key = ("n", "10")
     assert sdk_metrics.backfill_last_timestamp._vals.get(key) == 100  # type: ignore[attr-defined]
 


### PR DESCRIPTION
## Summary
- add a filesystem-backed artifact registrar and expose its interface to seamless providers
- extend SeamlessDataProvider fetch responses with stabilization, metadata, and publication hooks
- cover fingerprint stability, manifest publication, and metadata echoing in seamless provider tests

## Testing
- pytest tests/sdk/test_seamless_provider.py *(skipped: fakeredis is required for Redis-backed runtime tests)*

Fixes #1172

------
https://chatgpt.com/codex/tasks/task_e_68d608b814f88329a30baa4a399122dc