### PR TITLE
Add SLA downgrade handling to Seamless provider

### DIFF
--- a/qmtl/runtime/sdk/sla.py
+++ b/qmtl/runtime/sdk/sla.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
+
+
+class SLAViolationMode(str, Enum):
+    """Describe how Seamless should react when an SLA budget is breached."""
+
+    FAIL_FAST = "fail_fast"
+    PARTIAL_FILL = "partial_fill"
+    HOLD = "hold"
 
 
 @dataclass
@@ -11,7 +20,17 @@ class SLAPolicy:
     retry_backoff_ms: int | None = None
     total_deadline_ms: int | None = None
     max_sync_gap_bars: int | None = None
+    on_violation: SLAViolationMode = SLAViolationMode.FAIL_FAST
+    min_coverage: float | None = None
+    max_lag_seconds: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.min_coverage is not None:
+            if not 0.0 <= self.min_coverage <= 1.0:
+                raise ValueError("min_coverage must be within [0.0, 1.0]")
+        if self.max_lag_seconds is not None and self.max_lag_seconds < 0:
+            raise ValueError("max_lag_seconds must be non-negative")
 
 
-__all__ = ["SLAPolicy"]
+__all__ = ["SLAPolicy", "SLAViolationMode"]
 


### PR DESCRIPTION
## Summary
- extend `SLAPolicy` with violation modes and compute-context thresholds for coverage and freshness
- teach `SeamlessDataProvider` to surface downgrade metadata, compute SLA decisions, and emit structured logs when policy breaches occur
- add unit tests covering partial-fill downgrades and HOLD gating driven by coverage or lag thresholds

Fixes #1173

## Testing
- uv run -m pytest tests/sdk/test_seamless_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68d61792e8108329b9bd2acc8377ba76