### PR TITLE
Align Seamless artifact registrar with canonical pipeline

### DIFF
--- a/docs/architecture/ccxt-seamless-integrated.md
+++ b/docs/architecture/ccxt-seamless-integrated.md
@@ -100,6 +100,11 @@ flowchart LR
 
 ### Seamless Core
 - Implementation: `EnhancedQuestDBProvider` (`qmtl/runtime/io/seamless_provider.py`) paired with `ArtifactRegistrar` (`qmtl/runtime/io/artifact.py`).
+  The provider now wires the IO-layer registrar by default so every fetch emits ISO-8601
+  `as_of` values, provenance metadata, and manifest URIs even in development mode. Set
+  `QMTL_SEAMLESS_ARTIFACTS=1` (optionally combine with `QMTL_SEAMLESS_ARTIFACT_DIR`) to
+  mirror the filesystem store used in integration tests, or point `registrar=` at a custom
+  implementation when publishing to cloud storage.
 - Exposed strategies: `FAIL_FAST`, `AUTO_BACKFILL`, `PARTIAL_FILL`, `SEAMLESS`.
 - Coordinates cache, storage reads, backfills, and optional live feeds behind a `HistoryProvider` facade while delegating stabilized artifact publication to `ArtifactRegistrar`.
 

--- a/qmtl/runtime/io/artifact.py
+++ b/qmtl/runtime/io/artifact.py
@@ -30,6 +30,7 @@ class ArtifactPublication:
     end: int
     rows: int
     uri: str | None = None
+    manifest_uri: str | None = None
     manifest: dict[str, Any] = field(default_factory=dict)
 
 
@@ -128,6 +129,7 @@ class ArtifactRegistrar:
             end=end,
             rows=rows,
             uri=uri,
+            manifest_uri=manifest.get("manifest_uri"),
             manifest=manifest,
         )
 

--- a/qmtl/runtime/io/seamless_provider.py
+++ b/qmtl/runtime/io/seamless_provider.py
@@ -14,6 +14,7 @@ from qmtl.runtime.sdk.seamless_data_provider import (
     LiveDataFeed,
 )
 from qmtl.runtime.sdk.conformance import ConformancePipeline
+from qmtl.runtime.io.artifact import ArtifactRegistrar as IOArtifactRegistrar
 from qmtl.runtime.sdk.artifacts import ArtifactRegistrar, FileSystemArtifactRegistrar
 
 logger = logging.getLogger(__name__)
@@ -262,7 +263,11 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
         # Create live feed if available (prefer explicit LiveDataFeed)
         live_feed_obj = live_feed or (LiveDataFeedImpl(live_fetcher) if live_fetcher else None)
         
-        registrar_obj = registrar if registrar is not None else FileSystemArtifactRegistrar.from_env()
+        registrar_obj: ArtifactRegistrar | None = registrar
+        if registrar_obj is None:
+            registrar_obj = FileSystemArtifactRegistrar.from_env()
+        if registrar_obj is None:
+            registrar_obj = IOArtifactRegistrar(stabilization_bars=0)
 
         super().__init__(
             strategy=strategy,

--- a/qmtl/runtime/sdk/artifacts/registrar.py
+++ b/qmtl/runtime/sdk/artifacts/registrar.py
@@ -3,28 +3,42 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
-from typing import Protocol, Sequence, Tuple
-import time
+from typing import Any, MutableMapping, Protocol
 
 import pandas as pd
 
+from qmtl.runtime.io.artifact import (
+    ArtifactRegistrar as _IOArtifactRegistrar,
+    ArtifactPublication,
+)
+
 
 @dataclass(slots=True)
-class ArtifactPublication:
-    """Details about a published artifact manifest."""
+class ProducerContext:
+    """Context information recorded in manifests for provenance."""
 
-    dataset_fingerprint: str
-    as_of: int
-    coverage_bounds: tuple[int, int]
-    manifest_uri: str
-    data_uri: str | None = None
+    node_id: str
+    interval: int
+    world_id: str
+    strategy_id: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {
+            "node_id": self.node_id,
+            "interval": int(self.interval),
+            "world_id": self.world_id,
+        }
+        if self.strategy_id:
+            payload["strategy_id"] = self.strategy_id
+        return payload
 
 
 class ArtifactRegistrar(Protocol):
-    """Publish stabilized frames into an artifact catalog."""
+    """Protocol for registrars accepted by ``SeamlessDataProvider``."""
 
     def publish(
         self,
@@ -32,14 +46,15 @@ class ArtifactRegistrar(Protocol):
         *,
         node_id: str,
         interval: int,
-        coverage_bounds: tuple[int, int],
-        fingerprint: str,
-        as_of: int,
-        conformance_flags: dict[str, int] | None = None,
-        conformance_warnings: Sequence[str] | None = None,
-        request_window: tuple[int, int] | None = None,
-    ) -> ArtifactPublication:
-        """Persist ``frame`` and return publication details."""
+        conformance_report: Any | None = None,
+        requested_range: tuple[int, int] | None = None,
+    ) -> ArtifactPublication | None | Any:
+        """Publish ``frame`` and return publication metadata.
+
+        Implementations may return a coroutine that resolves to an
+        ``ArtifactPublication``. ``SeamlessDataProvider`` will await the result
+        when necessary.
+        """
 
 
 def _sanitize_component(text: str) -> str:
@@ -48,12 +63,23 @@ def _sanitize_component(text: str) -> str:
     return cleaned or "__"
 
 
-class FileSystemArtifactRegistrar:
+class FileSystemArtifactRegistrar(_IOArtifactRegistrar):
     """Persist artifacts to the local filesystem for testing and development."""
 
-    def __init__(self, base_dir: str | os.PathLike[str]) -> None:
+    def __init__(
+        self,
+        base_dir: str | os.PathLike[str],
+        *,
+        stabilization_bars: int = 0,
+        conformance_version: str = "v2",
+    ) -> None:
         self.base_dir = Path(base_dir)
         self.base_dir.mkdir(parents=True, exist_ok=True)
+        super().__init__(
+            store=self._store,
+            stabilization_bars=stabilization_bars,
+            conformance_version=conformance_version,
+        )
 
     @classmethod
     def from_env(cls) -> "FileSystemArtifactRegistrar | None":
@@ -78,52 +104,53 @@ class FileSystemArtifactRegistrar:
         base = dir_override or ".qmtl_seamless_artifacts"
         return cls(base)
 
-    def _target_dir(self, node_id: str, interval: int, fingerprint: str) -> Path:
-        node_part = _sanitize_component(node_id)
-        fp_part = _sanitize_component(fingerprint)
-        return self.base_dir / node_part / str(interval) / fp_part
+    # ------------------------------------------------------------------
+    def _target_dir(self, manifest: MutableMapping[str, Any]) -> Path:
+        node_part = _sanitize_component(str(manifest.get("node_id", "unknown")))
+        interval_part = _sanitize_component(str(manifest.get("interval", "0")))
+        fingerprint_part = _sanitize_component(str(manifest.get("dataset_fingerprint", "fp")))
+        return self.base_dir / node_part / interval_part / fingerprint_part
 
-    def publish(
-        self,
-        frame: pd.DataFrame,
-        *,
-        node_id: str,
-        interval: int,
-        coverage_bounds: Tuple[int, int],
-        fingerprint: str,
-        as_of: int,
-        conformance_flags: dict[str, int] | None = None,
-        conformance_warnings: Sequence[str] | None = None,
-        request_window: tuple[int, int] | None = None,
-    ) -> ArtifactPublication:
-        target = self._target_dir(node_id, interval, fingerprint)
+    def _write_manifest(self, path: Path, manifest: MutableMapping[str, Any]) -> None:
+        path.write_text(json.dumps(manifest, sort_keys=True))
+
+    def _store(self, frame: pd.DataFrame, manifest: MutableMapping[str, Any]) -> str:
+        target = self._target_dir(manifest)
         target.mkdir(parents=True, exist_ok=True)
 
         data_path = target / "data.parquet"
-        frame.to_parquet(data_path)
+        try:
+            frame.to_parquet(data_path)
+        except (ImportError, ValueError):  # pragma: no cover - exercised in environments w/o parquet
+            data_path = target / "data.json"
+            data_path.write_text(frame.to_json(orient="records"))
 
         manifest_path = target / "manifest.json"
-        payload = {
-            "dataset_fingerprint": fingerprint,
-            "as_of": int(as_of),
-            "node_id": node_id,
-            "interval": int(interval),
-            "coverage_bounds": [int(coverage_bounds[0]), int(coverage_bounds[1])],
-            "rows": int(len(frame)),
-            "conformance_flags": dict(conformance_flags or {}),
-            "conformance_warnings": list(conformance_warnings or ()),
-            "request_window": list(request_window or ()),
-            "published_at": int(time.time()),
-        }
-        manifest_path.write_text(json.dumps(payload, sort_keys=True))
+        watermark = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        manifest["publication_watermark"] = watermark
+        start, end = manifest.get("range", [None, None])
+        if start is not None and end is not None:
+            manifest["coverage"] = {"start": int(start), "end": int(end)}
 
-        return ArtifactPublication(
-            dataset_fingerprint=fingerprint,
-            as_of=int(as_of),
-            coverage_bounds=(int(coverage_bounds[0]), int(coverage_bounds[1])),
-            manifest_uri=str(manifest_path),
-            data_uri=str(data_path),
+        dataset_fp = str(manifest.get("dataset_fingerprint", ""))
+        if dataset_fp and not dataset_fp.startswith("lake:sha256:"):
+            manifest["dataset_fingerprint"] = f"lake:sha256:{dataset_fp}"
+
+        producer = ProducerContext(
+            node_id=str(manifest.get("node_id", "unknown")),
+            interval=int(manifest.get("interval", 0)),
+            world_id=os.getenv("WORLD_ID", "default"),
+            strategy_id=os.getenv("QMTL_STRATEGY_ID"),
         )
+        manifest["producer"] = producer.as_dict()
+        manifest["storage"] = {
+            "data_uri": str(data_path),
+            "manifest_uri": str(manifest_path),
+        }
+        manifest["manifest_uri"] = str(manifest_path)
+
+        self._write_manifest(manifest_path, manifest)
+        return str(data_path)
 
 
 __all__ = [
@@ -131,4 +158,3 @@ __all__ = [
     "ArtifactRegistrar",
     "FileSystemArtifactRegistrar",
 ]
-


### PR DESCRIPTION
## Summary
- default `EnhancedQuestDBProvider` to the IO-layer `ArtifactRegistrar` and support awaitable registrars in the seamless provider
- update the filesystem registrar to emit canonical manifest metadata (ISO `as_of`, provenance, storage URIs) while handling environments without parquet engines
- refresh seamless metadata handling, unit tests, and architecture docs to reflect the new registrar contract

Fixes #1181

## Testing
- uv run -m pytest tests/sdk/test_seamless_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68d626fee8ec832989c2893112815171