### PR TITLE
Guard legacy registrar fallback exceptions

### DIFF
--- a/qmtl/runtime/sdk/seamless_data_provider.py
+++ b/qmtl/runtime/sdk/seamless_data_provider.py
@@ -819,17 +819,20 @@ class SeamlessDataProvider(ABC):
                 )
             except TypeError:
                 if coverage_bounds is not None:
-                    publish_call = self._registrar.publish(  # type: ignore[misc]
-                        stabilized,
-                        node_id=node_id,
-                        interval=interval,
-                        coverage_bounds=coverage_bounds,
-                        fingerprint=fingerprint,
-                        as_of=as_of,
-                        conformance_flags=report.flags_counts,
-                        conformance_warnings=report.warnings,
-                        request_window=(int(start), int(end)),
-                    )
+                    try:
+                        publish_call = self._registrar.publish(  # type: ignore[misc]
+                            stabilized,
+                            node_id=node_id,
+                            interval=interval,
+                            coverage_bounds=coverage_bounds,
+                            fingerprint=fingerprint,
+                            as_of=as_of,
+                            conformance_flags=report.flags_counts,
+                            conformance_warnings=report.warnings,
+                            request_window=(int(start), int(end)),
+                        )
+                    except Exception:  # pragma: no cover - publication failures shouldn't crash
+                        publish_call = None
             except Exception:  # pragma: no cover - publication failures shouldn't crash
                 publish_call = None
 


### PR DESCRIPTION
## Summary
- default `EnhancedQuestDBProvider` to the IO-layer `ArtifactRegistrar` and support awaitable registrars in the seamless provider
- update the filesystem registrar to emit canonical manifest metadata (ISO `as_of`, provenance, storage URIs) while handling environments without parquet engines
- refresh seamless metadata handling, unit tests, and architecture docs to reflect the new registrar contract
- guard the legacy seamless registrar fallback so publication failures remain non-fatal

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d62e4d5cac8329b1a9f8f7c4aca6c7