### PR TITLE
Centralize OHLCV node ID handling

### DIFF
--- a/qmtl/runtime/io/ccxt_live_feed.py
+++ b/qmtl/runtime/io/ccxt_live_feed.py
@@ -22,8 +22,9 @@ import time
 
 import pandas as pd
 
+from qmtl.runtime.sdk.ohlcv_nodeid import parse as _parse_ohlcv_node_id
 from qmtl.runtime.sdk.seamless_data_provider import LiveDataFeed
-from .ccxt_fetcher import _try_parse_timeframe_s as _tf_to_seconds, _parse_symbol_from_node_id
+from .ccxt_fetcher import _try_parse_timeframe_s as _tf_to_seconds
 
 
 log = logging.getLogger(__name__)
@@ -69,7 +70,9 @@ class CcxtProLiveFeed(LiveDataFeed):
         return hasattr(ex, "watch_trades")
 
     async def subscribe(self, *, node_id: str, interval: int) -> AsyncIterator[tuple[int, pd.DataFrame]]:  # type: ignore[override]
-        symbol, tf = _parse_symbol_from_node_id(node_id)
+        parsed = _parse_ohlcv_node_id(node_id)
+        symbol = parsed[1] if parsed else None
+        tf = parsed[2] if parsed else None
         mode = self._mode_for_node(node_id)
         symbol = symbol or (self.config.symbols[0] if self.config.symbols else None)
         if not symbol:

--- a/qmtl/runtime/io/ccxt_provider.py
+++ b/qmtl/runtime/io/ccxt_provider.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from qmtl.runtime.sdk.auto_backfill import FetcherBackfillStrategy
+from qmtl.runtime.sdk.ohlcv_nodeid import build as _build_ohlcv_node_id
 from qmtl.runtime.io.historyprovider import QuestDBHistoryProvider
 from .ccxt_fetcher import (
     CcxtBackfillConfig,
@@ -135,7 +136,7 @@ class CcxtQuestDBProvider(QuestDBHistoryProvider):
         if mode == "trades":
             return f"trades:{exchange_id}:{symbol}"
         tf = timeframe or "1m"
-        return f"ohlcv:{exchange_id}:{symbol}:{tf}"
+        return _build_ohlcv_node_id(exchange_id, symbol, tf)
 
     # ------------------------------------------------------------------
     @classmethod

--- a/qmtl/runtime/sdk/ohlcv_nodeid.py
+++ b/qmtl/runtime/sdk/ohlcv_nodeid.py
@@ -1,0 +1,148 @@
+"""Utilities for working with canonical OHLCV node identifiers.
+
+The SDK treats OHLCV history nodes as having the conventional identity
+``ohlcv:{exchange}:{symbol}:{timeframe}``.  Several code paths need to build,
+inspect, or validate these identifiers.  Centralising the logic in this module
+helps us avoid subtle drift between components and provides a single place to
+enforce the documented schema.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+_PREFIX: Final = "ohlcv"
+
+# ``TIMEFRAME_SECONDS`` mirrors the static fallback table used by the CCXT
+# fetcher when ``ccxt.parse_timeframe`` is unavailable.  The mapping is exposed
+# so consumers can share a consistent view of supported timeframe tokens.
+TIMEFRAME_SECONDS: Final[dict[str, int]] = {
+    "1s": 1,
+    "5s": 5,
+    "10s": 10,
+    "15s": 15,
+    "30s": 30,
+    "1m": 60,
+    "3m": 180,
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "2h": 7200,
+    "4h": 14400,
+    "6h": 21600,
+    "8h": 28800,
+    "12h": 43200,
+    "1d": 86400,
+    "3d": 259200,
+    "1w": 604800,
+}
+
+SUPPORTED_TIMEFRAMES: Final[frozenset[str]] = frozenset(TIMEFRAME_SECONDS)
+
+
+def build(exchange: str, symbol: str, timeframe: str) -> str:
+    """Construct an OHLCV node identifier.
+
+    Raises
+    ------
+    ValueError
+        If any component is blank, contains a colon, or the timeframe token is
+        not recognised.
+    """
+
+    exchange_norm = _normalise_component("exchange", exchange)
+    symbol_norm = _normalise_component("symbol", symbol)
+    timeframe_norm = _normalise_timeframe(timeframe)
+    return f"{_PREFIX}:{exchange_norm}:{symbol_norm}:{timeframe_norm}"
+
+
+def parse(node_id: str) -> tuple[str, str, str] | None:
+    """Parse a canonical OHLCV node identifier.
+
+    Returns ``None`` when ``node_id`` is not an OHLCV identifier in the
+    expected ``ohlcv:{exchange}:{symbol}:{timeframe}`` format.
+    """
+
+    if not isinstance(node_id, str):  # defensive guard; mirrors ``split`` API
+        return None
+
+    trimmed = node_id.strip()
+    if not trimmed:
+        return None
+
+    parts = trimmed.split(":")
+    if len(parts) != 4 or parts[0] != _PREFIX:
+        return None
+
+    exchange, symbol, timeframe = parts[1], parts[2], parts[3]
+    if not exchange or not symbol or not timeframe:
+        return None
+    return exchange, symbol, timeframe
+
+
+def validate(node_id: str) -> None:
+    """Validate that ``node_id`` follows the canonical OHLCV schema.
+
+    Raises
+    ------
+    ValueError
+        If the identifier is malformed or includes unsupported components.
+    """
+
+    parsed = parse(node_id)
+    if not parsed:
+        raise ValueError(
+            f"Invalid OHLCV node_id {node_id!r}; expected 'ohlcv:{{exchange}}:{{symbol}}:{{timeframe}}'"
+        )
+
+    exchange, symbol, timeframe = parsed
+    for name, value in ("exchange", exchange), ("symbol", symbol):
+        if not value.strip():
+            raise ValueError(f"OHLCV node_id {node_id!r} missing {name} component")
+        if ":" in value:
+            raise ValueError(
+                f"OHLCV node_id {node_id!r} contains ':' in the {name} component"
+            )
+
+    timeframe_norm = timeframe.strip()
+    if not timeframe_norm:
+        raise ValueError(f"OHLCV node_id {node_id!r} missing timeframe component")
+    if timeframe_norm not in SUPPORTED_TIMEFRAMES:
+        raise ValueError(
+            f"Unsupported OHLCV timeframe '{timeframe_norm}' in node_id {node_id!r}"
+        )
+
+
+def _normalise_component(name: str, value: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string, got {type(value).__name__}")
+    trimmed = value.strip()
+    if not trimmed:
+        raise ValueError(f"{name} component cannot be empty")
+    if ":" in trimmed:
+        raise ValueError(f"{name} component cannot contain ':'")
+    return trimmed
+
+
+def _normalise_timeframe(timeframe: str) -> str:
+    if not isinstance(timeframe, str):
+        raise TypeError(
+            f"timeframe must be a string, got {type(timeframe).__name__}"
+        )
+    trimmed = timeframe.strip()
+    if not trimmed:
+        raise ValueError("timeframe component cannot be empty")
+    if trimmed not in SUPPORTED_TIMEFRAMES:
+        raise ValueError(f"Unsupported timeframe token: {trimmed}")
+    return trimmed
+
+
+__all__ = [
+    "TIMEFRAME_SECONDS",
+    "SUPPORTED_TIMEFRAMES",
+    "build",
+    "parse",
+    "validate",
+]
+

--- a/qmtl/runtime/sdk/seamless_data_provider.py
+++ b/qmtl/runtime/sdk/seamless_data_provider.py
@@ -260,6 +260,11 @@ class SeamlessDataProvider(ABC):
             self._create_fingerprint_window
         )
 
+    def _validate_node_id(self, node_id: str) -> None:
+        """Hook for subclasses to validate node identifiers."""
+
+        return None
+
     @property
     def last_conformance_report(self) -> Optional[ConformanceReport]:
         """Return the most recent conformance report emitted by ``fetch``."""
@@ -294,9 +299,10 @@ class SeamlessDataProvider(ABC):
     ) -> pd.DataFrame:
         """
         Fetch data transparently from available sources.
-        
+
         Implementation follows the priority order and strategy configuration.
         """
+        self._validate_node_id(node_id)
         self._last_conformance_report = None
         self._last_fetch_metadata = None
         tracker = self._build_sla_tracker(node_id, interval)
@@ -345,6 +351,7 @@ class SeamlessDataProvider(ABC):
         self, *, node_id: str, interval: int
     ) -> list[tuple[int, int]]:
         """Return combined coverage from all sources."""
+        self._validate_node_id(node_id)
         all_ranges: list[tuple[int, int]] = []
         
         # Collect coverage from all available sources
@@ -376,10 +383,11 @@ class SeamlessDataProvider(ABC):
     ) -> bool:
         """
         Ensure data is available for the given range.
-        
+
         If data is missing and auto-backfill is enabled, trigger backfill.
         Returns True if data will be available after this call.
         """
+        self._validate_node_id(node_id)
         tracker = sla_tracker or self._build_sla_tracker(node_id, interval)
 
         # Check current availability

--- a/tests/runtime/io/test_enhanced_provider_nodeid.py
+++ b/tests/runtime/io/test_enhanced_provider_nodeid.py
@@ -1,0 +1,49 @@
+import pandas as pd
+import pytest
+
+from qmtl.runtime.io.seamless_provider import EnhancedQuestDBProvider
+from qmtl.runtime.sdk.seamless_data_provider import DataAvailabilityStrategy
+
+
+class _QuestDBLoaderStub:
+    def __init__(self, dsn, table=None, fetcher=None):
+        self.dsn = dsn
+        self.table = table
+        self.fetcher = fetcher
+
+    async def fetch(self, start, end, *, node_id: str, interval: int) -> pd.DataFrame:
+        return pd.DataFrame({"ts": [start]})
+
+    async def coverage(self, *, node_id: str, interval: int) -> list[tuple[int, int]]:
+        return [(0, 10_000_000)]
+
+    def bind_stream(self, stream) -> None:  # pragma: no cover - not used in tests
+        self._stream = stream
+
+
+class _RegistrarStub:
+    def publish(self, *args, **kwargs):  # pragma: no cover - publication not awaited in tests
+        return None
+
+
+@pytest.mark.asyncio
+async def test_enhanced_provider_validates_node_ids(monkeypatch):
+    monkeypatch.setattr(
+        "qmtl.runtime.io.historyprovider.QuestDBLoader",
+        _QuestDBLoaderStub,
+    )
+
+    provider = EnhancedQuestDBProvider(
+        "memory://",
+        registrar=_RegistrarStub(),
+        node_id_format="ohlcv:{exchange}:{symbol}:{timeframe}",
+        strategy=DataAvailabilityStrategy.FAIL_FAST,
+    )
+
+    # Invalid OHLCV identifier should fail fast before hitting storage.
+    with pytest.raises(ValueError):
+        await provider.fetch(0, 60, node_id="ohlcv:binance:BTC/USDT", interval=60)
+
+    # Well-formed identifier is accepted.
+    df = await provider.fetch(0, 60, node_id="ohlcv:binance:BTC/USDT:1m", interval=60)
+    assert df.empty or "ts" in df.columns

--- a/tests/runtime/sdk/test_ohlcv_nodeid.py
+++ b/tests/runtime/sdk/test_ohlcv_nodeid.py
@@ -1,0 +1,32 @@
+import pytest
+
+from qmtl.runtime.sdk.ohlcv_nodeid import build, parse, validate
+
+
+def test_build_round_trip_and_validate():
+    node_id = build("binance", "BTC/USDT", "1m")
+    assert node_id == "ohlcv:binance:BTC/USDT:1m"
+    parsed = parse(node_id)
+    assert parsed == ("binance", "BTC/USDT", "1m")
+    validate(node_id)  # should not raise
+
+
+@pytest.mark.parametrize(
+    "bad_timeframe",
+    ["", "  ", "2x", "100m"],
+)
+def test_validate_rejects_unknown_timeframes(bad_timeframe: str):
+    node_id = f"ohlcv:binance:BTC/USDT:{bad_timeframe}"
+    with pytest.raises(ValueError):
+        validate(node_id)
+
+
+def test_parse_returns_none_for_non_ohlcv_prefix():
+    assert parse("trades:binance:BTC/USDT") is None
+
+
+def test_build_rejects_colon_components():
+    with pytest.raises(ValueError):
+        build("binance:us", "BTC/USDT", "1m")
+    with pytest.raises(ValueError):
+        build("binance", "BTC:USDT", "1m")


### PR DESCRIPTION
## Summary
- add shared helpers in `qmtl.runtime.sdk.ohlcv_nodeid` to build, parse, and validate canonical OHLCV node identifiers
- update CCXT fetchers, live feed, and provider utilities to consume the shared schema helpers and reuse the supported timeframe map
- enable optional node ID validation in `EnhancedQuestDBProvider` when `node_id_format` is configured and add regression tests

## Testing
- uv run -m pytest tests/runtime/sdk/test_ohlcv_nodeid.py tests/runtime/io/test_ccxt_fetcher.py tests/runtime/io/test_enhanced_provider_nodeid.py

Fixes #1190

------
https://chatgpt.com/codex/tasks/task_e_68d632c7b7dc8329a064f0d25ad6e39d