### PR TITLE
Address review feedback: normalize early integer epochs to seconds

### DIFF
--- a/qmtl/runtime/sdk/conformance.py
+++ b/qmtl/runtime/sdk/conformance.py
@@ -317,12 +317,23 @@ class ConformancePipeline:
         non_zero = values[values > 0]
         if not len(non_zero):
             return 1
+
+        unique_sorted = np.unique(non_zero)
+        if unique_sorted.size >= 2:
+            diffs = np.diff(unique_sorted)
+            positive_diffs = diffs[diffs > 0]
+            if positive_diffs.size:
+                min_diff = int(positive_diffs.min())
+                for divisor in (10**9, 10**6, 10**3):
+                    if min_diff % divisor == 0:
+                        return divisor
+
         max_value = int(non_zero.max())
-        if max_value >= 10**17:
+        if max_value >= 10**16:
             return 10**9
-        if max_value >= 10**14:
+        if max_value >= 10**13:
             return 10**6
-        if max_value >= 10**11:
+        if max_value >= 10**10:
             return 10**3
         return 1
 

--- a/tests/runtime/sdk/test_conformance_pipeline.py
+++ b/tests/runtime/sdk/test_conformance_pipeline.py
@@ -132,3 +132,20 @@ def test_conformance_normalizes_millisecond_epoch_units():
     expected = [int(base.value // 10**9) + offset for offset in (0, 60, 120)]
     assert out["ts"].tolist() == expected
     assert report.flags_counts["ts_cast"] == 3
+
+
+def test_conformance_normalizes_microsecond_epochs_near_epoch_start():
+    base = pd.Timestamp("1971-01-01T00:00:00Z")
+    micro_values = [
+        base.value // 10**3,
+        base.value // 10**3 + 60 * 10**6,
+        base.value // 10**3 + 120 * 10**6,
+    ]
+    df = pd.DataFrame({"ts": micro_values, "price": [1.0, 2.0, 3.0]})
+
+    cp = ConformancePipeline()
+    out, report = cp.normalize(df, schema=None, interval=60)
+
+    expected = [int(base.value // 10**9) + offset for offset in (0, 60, 120)]
+    assert out["ts"].tolist() == expected
+    assert report.flags_counts["ts_cast"] == 3


### PR DESCRIPTION
## Summary
- enhance integer epoch scaling to inspect minimum deltas before falling back to relaxed magnitude thresholds, covering near-epoch microsecond data
- add a regression test confirming microsecond timestamps around 1971 normalize to epoch seconds

## Testing
- uv run -m pytest tests/runtime/sdk/test_conformance_pipeline.py -k microsecond *(fails: fakeredis is required for Redis-backed runtime tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d6361f20b88329ae583cb0542fde2a