### PR TITLE
Unify canonical dataset fingerprinting across artifact pipelines

### DIFF
--- a/qmtl/runtime/sdk/artifacts/fingerprint.py
+++ b/qmtl/runtime/sdk/artifacts/fingerprint.py
@@ -1,0 +1,112 @@
+"""Canonical dataset fingerprint helpers for artifact publication."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+import hashlib
+import json
+
+import pandas as pd
+
+__all__ = [
+    "compute_artifact_fingerprint",
+    "compute_legacy_artifact_fingerprint",
+]
+
+
+_CANONICAL_PREFIX = "sha256:"
+_LEGACY_PREFIX = "lake:sha256:"
+
+
+def _canonicalize_value(value: Any) -> Any:
+    if isinstance(value, (int, float, str, bool)):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, pd.Timestamp):
+        return int(value.value // 10**9)
+    if isinstance(value, pd.Timedelta):
+        return int(value.value // 10**9)
+    if pd.isna(value):
+        return None
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except Exception:  # pragma: no cover - defensive fallback
+            pass
+    return str(value)
+
+
+def _iter_metadata_items(metadata: Mapping[str, Any], *, sort_keys: bool) -> Iterable[tuple[str, Any]]:
+    if sort_keys:
+        return ((key, metadata[key]) for key in sorted(metadata))
+    return metadata.items()
+
+
+def _normalize_metadata(metadata: Mapping[str, Any], *, sort_keys: bool) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    for key, value in _iter_metadata_items(metadata, sort_keys=sort_keys):
+        if isinstance(value, Mapping):
+            normalized[key] = _normalize_metadata(value, sort_keys=sort_keys)
+        elif isinstance(value, (list, tuple, set)):
+            normalized[key] = [_canonicalize_value(v) for v in value]
+        else:
+            normalized[key] = _canonicalize_value(value)
+    return normalized
+
+
+def _canonicalize_columns(columns: Sequence[str]) -> list[str]:
+    if "ts" in columns:
+        remainder = [col for col in columns if col != "ts"]
+        remainder.sort()
+        return ["ts", *remainder]
+    ordered = list(columns)
+    ordered.sort()
+    return ordered
+
+
+def _canonicalize_frame(frame: pd.DataFrame) -> list[dict[str, Any]]:
+    if frame.empty:
+        return []
+
+    working = frame.copy()
+    if "ts" in working.columns:
+        working["ts"] = pd.to_numeric(working["ts"], errors="coerce").astype("Int64")
+        working.dropna(subset=["ts"], inplace=True)
+        working["ts"] = working["ts"].astype("int64")
+        working.sort_values("ts", inplace=True)
+    else:
+        working.sort_index(inplace=True)
+    working.reset_index(drop=True, inplace=True)
+
+    columns = _canonicalize_columns(list(working.columns))
+    records: list[dict[str, Any]] = []
+    for _, row in working[columns].iterrows():
+        record = {col: _canonicalize_value(row[col]) for col in columns}
+        records.append(record)
+    return records
+
+
+def _serialize_payload(frame: pd.DataFrame, metadata: Mapping[str, Any], *, sort_metadata: bool) -> bytes:
+    payload = {
+        "frame": _canonicalize_frame(frame),
+        "metadata": _normalize_metadata(metadata, sort_keys=sort_metadata),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def compute_artifact_fingerprint(frame: pd.DataFrame, metadata: Mapping[str, Any]) -> str:
+    """Return the canonical ``sha256:<digest>`` fingerprint for *frame* and *metadata*."""
+
+    serialized = _serialize_payload(frame, metadata, sort_metadata=True)
+    digest = hashlib.sha256(serialized).hexdigest()
+    return f"{_CANONICAL_PREFIX}{digest}"
+
+
+def compute_legacy_artifact_fingerprint(frame: pd.DataFrame, metadata: Mapping[str, Any]) -> str:
+    """Return the legacy ``lake:sha256:<digest>`` fingerprint for compatibility."""
+
+    serialized = _serialize_payload(frame, metadata, sort_metadata=False)
+    digest = hashlib.sha256(serialized).hexdigest()
+    return f"{_LEGACY_PREFIX}{digest}"
+

--- a/qmtl/runtime/sdk/artifacts/registrar.py
+++ b/qmtl/runtime/sdk/artifacts/registrar.py
@@ -133,8 +133,8 @@ class FileSystemArtifactRegistrar(_IOArtifactRegistrar):
             manifest["coverage"] = {"start": int(start), "end": int(end)}
 
         dataset_fp = str(manifest.get("dataset_fingerprint", ""))
-        if dataset_fp and not dataset_fp.startswith("lake:sha256:"):
-            manifest["dataset_fingerprint"] = f"lake:sha256:{dataset_fp}"
+        if dataset_fp.startswith("lake:sha256:"):
+            manifest["dataset_fingerprint"] = dataset_fp.replace("lake:", "", 1)
 
         producer = ProducerContext(
             node_id=str(manifest.get("node_id", "unknown")),


### PR DESCRIPTION
## Summary
- add a shared qmtl.runtime.sdk.artifacts.fingerprint helper to compute canonical and legacy dataset fingerprints
- update the IO and filesystem registrars plus the seamless provider to consume the helper, honor a canonical/legacy env flag, and normalize returned fingerprints
- refresh seamless provider tests to expect sha256-prefixed fingerprints and align the recording registrar stub with the canonical helper

## Testing
- uv run -m pytest tests/sdk/test_seamless_provider.py

Fixes #1184

------
https://chatgpt.com/codex/tasks/task_e_68d63597a7548329a1854d2a9138dc07