### PR TITLE
Avoid downcasting small integer timestamps

### DIFF
--- a/qmtl/runtime/sdk/conformance.py
+++ b/qmtl/runtime/sdk/conformance.py
@@ -318,6 +318,13 @@ class ConformancePipeline:
         if not len(non_zero):
             return 1
 
+        max_value = int(non_zero.max())
+        # Treat small magnitudes as already being in the desired resolution (seconds).
+        # This prevents arbitrary integers such as [1_000, 4_000, ...] from being
+        # interpreted as millisecond epochs and down-casted unexpectedly.
+        if max_value < 10**10:
+            return 1
+
         unique_sorted = np.unique(non_zero)
         if unique_sorted.size >= 2:
             diffs = np.diff(unique_sorted)
@@ -328,7 +335,6 @@ class ConformancePipeline:
                     if min_diff % divisor == 0:
                         return divisor
 
-        max_value = int(non_zero.max())
         if max_value >= 10**16:
             return 10**9
         if max_value >= 10**13:
@@ -339,4 +345,3 @@ class ConformancePipeline:
 
 
 __all__ = ["ConformancePipeline", "ConformanceReport"]
-


### PR DESCRIPTION
## Summary
- prevent ConformancePipeline from inferring millisecond epochs when integers are already in seconds
- guard the epoch divisor inference with a magnitude threshold so small ranges stay untouched

## Testing
- uv run -m pytest tests/runtime/sdk/test_conformance_pipeline.py::test_conformance_detects_missing_gaps
