### PR TITLE
Add partitioned filesystem registrar manifest metadata

### DIFF
--- a/tests/runtime/sdk/test_artifact_registrar.py
+++ b/tests/runtime/sdk/test_artifact_registrar.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
+import json
 from pathlib import Path
+
+import pandas as pd
+import pytest
 
 from qmtl.runtime.sdk.artifacts import FileSystemArtifactRegistrar
 
@@ -29,3 +33,73 @@ def test_from_env_enabled_with_directory_only(monkeypatch, tmp_path) -> None:
 
     assert isinstance(registrar, FileSystemArtifactRegistrar)
     assert registrar.base_dir == Path(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_registrar_applies_partition_template(tmp_path) -> None:
+    frame = pd.DataFrame(
+        {
+            "ts": [0, 60, 120, 180],
+            "open": [1.0, 1.1, 1.2, 1.3],
+            "high": [1.2, 1.3, 1.4, 1.5],
+            "low": [0.9, 1.0, 1.1, 1.2],
+            "close": [1.05, 1.15, 1.25, 1.35],
+            "volume": [10, 11, 12, 13],
+        }
+    )
+
+    registrar = FileSystemArtifactRegistrar(tmp_path, stabilization_bars=1)
+    publication = await registrar.publish(
+        frame,
+        node_id="ohlcv:binance:BTC/USDT:1m",
+        interval=60,
+    )
+
+    assert publication is not None
+    manifest_path = Path(publication.manifest_uri)
+    assert manifest_path.exists()
+
+    expected_interval_dir = (
+        Path(tmp_path)
+        / "exchange=binance"
+        / "symbol=BTC_USDT"
+        / "timeframe=1m"
+        / "60"
+    )
+    assert manifest_path.parent.parent == expected_interval_dir
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["producer"]["identity"] == "seamless@qmtl"
+    assert manifest["producer"]["node_id"] == "ohlcv:binance:BTC/USDT:1m"
+    assert manifest["conformance"]["flags"] == {}
+    assert manifest["conformance"]["warnings"] == []
+    assert manifest["as_of"].endswith("Z")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_registrar_falls_back_for_unknown_node(tmp_path) -> None:
+    frame = pd.DataFrame(
+        {
+            "ts": [0, 60, 120],
+            "open": [1.0, 1.1, 1.2],
+            "high": [1.0, 1.2, 1.3],
+            "low": [0.9, 1.0, 1.1],
+            "close": [1.0, 1.1, 1.2],
+            "volume": [5, 6, 7],
+        }
+    )
+
+    registrar = FileSystemArtifactRegistrar(tmp_path)
+    publication = await registrar.publish(
+        frame,
+        node_id="custom-node",
+        interval=60,
+    )
+
+    assert publication is not None
+    manifest_path = Path(publication.manifest_uri)
+    assert manifest_path.parent.parent == Path(tmp_path) / "custom-node" / "60"
+
+    fingerprint_component = manifest_path.parent.name
+    assert ":" not in fingerprint_component
+    assert publication.dataset_fingerprint.replace(":", "-") == fingerprint_component


### PR DESCRIPTION
## Summary
- add partition template and producer identity options to the filesystem artifact registrar
- emit partitioned layouts for OHLCV nodes while enriching manifest metadata and defaults
- extend registrar tests to cover partitioning and fallback behaviors

## Testing
- uv run -m pytest tests/runtime/sdk/test_artifact_registrar.py
- uv run -m pytest tests/sdk/test_seamless_provider.py -k manifest

Fixes #1188

------
https://chatgpt.com/codex/tasks/task_e_68d639b74b008329b40b8356f1421a9f