### PR TITLE
Avoid advancing live as_of state for unknown domains

### DIFF
--- a/qmtl/runtime/sdk/seamless_data_provider.py
+++ b/qmtl/runtime/sdk/seamless_data_provider.py
@@ -626,9 +626,7 @@ class SeamlessDataProvider(ABC):
                 )
             return decision
 
-        # Unknown domain: still track the most recent as_of per world
-        if context.requested_as_of:
-            self._live_as_of_state[(context.world_id, node_id)] = context.requested_as_of
+        # Unknown domain: do not advance live/shadow monotonic tracking
         return None
 
     async def fetch(


### PR DESCRIPTION
## Summary
- avoid mutating the live/shadow monotonic as_of tracker when handling unknown execution domains in `SeamlessDataProvider`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d640a4dbb08329ac1890089483c1bb