### PR TITLE
Expand CcxtProLiveFeed configuration controls

### DIFF
--- a/docs/architecture/ccxt-seamless-hybrid.md
+++ b/docs/architecture/ccxt-seamless-hybrid.md
@@ -265,6 +265,7 @@ seamless:
       enabled: false           # true to enable ccxt.pro wrapper
       reconnect_backoff_ms: [500, 1000, 2000, 5000]
       dedupe_by: "ts"          # or ts+symbol
+      emit_building_candle: false  # emit closed bars by default
 
   metrics:
     prometheus:
@@ -302,6 +303,9 @@ exchanges:
 ```
 
 > **분리 원칙**: 교환소, SLA, 백필, 레이트리밋, 아티팩트, 도메인 정책을 **완전히 독립 파라미터**로 분리해 튜닝 가능성을 극대화한다.
+
+`emit_building_candle`가 `false`이면 라이브 피드는 완전히 마감된 캔들만 발행한다. 실시간(빌딩) 캔들이 필요할 때만 `true`로
+전환하고, 기본값은 안정적인 신호와 백필 일관성을 위해 유지한다.
 
 ---
 

--- a/tests/runtime/io/test_ccxt_live_feed.py
+++ b/tests/runtime/io/test_ccxt_live_feed.py
@@ -1,0 +1,97 @@
+import asyncio
+
+import pytest
+
+from qmtl.runtime.io import ccxt_live_feed as live_module
+from qmtl.runtime.io.ccxt_live_feed import CcxtProConfig, CcxtProLiveFeed
+
+
+class _FlakyOHLCVExchange:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def watch_ohlcv(self, symbol: str, timeframe: str):
+        self.calls += 1
+        if self.calls <= 3:
+            raise RuntimeError("boom")
+        base_ms = 1_700_000_000_000
+        return [[base_ms + (self.calls * 60_000), 100.0, 110.0, 90.0, 105.0, 12.0]]
+
+
+class _TradesExchange:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def watch_trades(self, symbol: str):
+        self.calls += 1
+        base_ms = 1_700_000_000_000
+        if self.calls == 1:
+            return [
+                {"timestamp": base_ms, "price": 100.0, "amount": 1.0, "side": "buy"},
+                {"timestamp": base_ms, "price": 100.5, "amount": 1.2, "side": "buy"},
+            ]
+        if self.calls == 2:
+            return [
+                {"timestamp": base_ms, "price": 100.25, "amount": 0.8, "side": "buy"},
+                {"timestamp": base_ms + 1000, "price": 101.0, "amount": 2.0, "side": "sell"},
+            ]
+        return []
+
+
+@pytest.mark.asyncio
+async def test_reconnect_backoff_schedule(monkeypatch):
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(delay: float):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(live_module.asyncio, "sleep", _fake_sleep)
+
+    config = CcxtProConfig(
+        exchange_id="binance",
+        symbols=["BTC/USDT"],
+        timeframe="1m",
+        reconnect_backoff_ms=[100, 250],
+        emit_building_candle=True,
+    )
+    feed = CcxtProLiveFeed(config, exchange=_FlakyOHLCVExchange())
+
+    gen = feed.subscribe(node_id="ohlcv:binance:BTC/USDT:1m", interval=60)
+    ts, frame = await asyncio.wait_for(gen.__anext__(), timeout=0.1)
+    assert not frame.empty
+    assert ts == int(frame["ts"].iloc[-1])
+
+    feed.unsubscribe(node_id="ohlcv:binance:BTC/USDT:1m", interval=60)
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(gen.__anext__(), timeout=0.05)
+
+    positive_calls = [call for call in sleep_calls if call and call > 0]
+    assert positive_calls == [0.1, 0.25, 0.25]
+
+
+@pytest.mark.asyncio
+async def test_dedupe_by_symbol():
+    config = CcxtProConfig(
+        exchange_id="binance",
+        symbols=["BTC/USDT"],
+        mode="trades",
+        dedupe_by="ts+symbol",
+    )
+    feed = CcxtProLiveFeed(config, exchange=_TradesExchange())
+
+    gen = feed.subscribe(node_id="trades:binance:BTC/USDT", interval=0)
+    first_ts, first_df = await asyncio.wait_for(gen.__anext__(), timeout=0.1)
+    assert list(first_df["ts"]) == [1_700_000_000]
+    assert list(first_df["symbol"]) == ["BTC/USDT"]
+
+    second_ts, second_df = await asyncio.wait_for(gen.__anext__(), timeout=0.1)
+    assert list(second_df["ts"]) == [1_700_000_001]
+    assert list(second_df["symbol"]) == ["BTC/USDT"]
+    assert second_ts == 1_700_000_001
+
+    feed.unsubscribe(node_id="trades:binance:BTC/USDT", interval=0)
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(gen.__anext__(), timeout=0.05)
+
+    stored_token = next(iter(feed._last_emitted_token.values()))
+    assert stored_token == (1_700_000_001, "BTC/USDT")


### PR DESCRIPTION
## Summary
- add optional reconnect_backoff_ms schedule and dedupe_by selection to `CcxtProLiveFeed`
- document the closed-candle default for the WebSocket live feed blueprint
- cover reconnect scheduling and symbol-aware dedupe with unit tests

## Testing
- uv run -m pytest tests/runtime/io/test_ccxt_live_feed.py

Closes #1189

------
https://chatgpt.com/codex/tasks/task_e_68d64cbad88c8329a0098f6ecfb47018