### PR TITLE
Recompute staleness when returning cached Seamless results

### DIFF
--- a/qmtl/runtime/sdk/seamless_data_provider.py
+++ b/qmtl/runtime/sdk/seamless_data_provider.py
@@ -459,6 +459,14 @@ class SeamlessDataProvider(ABC):
     def _materialize_cached_result(self, entry: _CacheEntry) -> SeamlessFetchResult:
         frame_copy = entry.result.frame.copy(deep=True)
         metadata_copy = replace(entry.result.metadata)
+        metadata_copy.downgraded = False
+        metadata_copy.downgrade_mode = None
+        metadata_copy.downgrade_reason = None
+        metadata_copy.sla_violation = None
+        if metadata_copy.coverage_bounds is not None:
+            metadata_copy.staleness_ms = self._compute_staleness_ms(metadata_copy)
+        else:
+            metadata_copy.staleness_ms = None
         self._sync_metadata_attrs(frame_copy, metadata_copy)
         result = SeamlessFetchResult(frame_copy, metadata_copy)
         self._last_conformance_report = entry.report


### PR DESCRIPTION
## Summary
- recompute cached metadata staleness and reset downgrade state before domain gating so cached hits respect freshness limits
- extend the FakeClock test helper and add coverage that ensures cache hits refresh staleness

## Testing
- uv run -m pytest tests/sdk/test_seamless_provider.py -W error

------
https://chatgpt.com/codex/tasks/task_e_68d64d4cc9408329b0eb3371b929f909