### PR TITLE
Archive CCXT × Seamless legacy audit doc

### DIFF
--- a/docs/architecture/ccxt-seamless-integrated.md
+++ b/docs/architecture/ccxt-seamless-integrated.md
@@ -7,7 +7,7 @@
 - [CCXT × QuestDB IO Recipe](../io/ccxt-questdb.md)
 - Historical governance notes formerly published as `ccxt-seamless-gpt5codex.md` were retired after their guidance landed in this blueprint.
 - Historical runtime notes previously published as `ccxt-seamless-gpt5high.md` were retired after their coverage guidance landed in this blueprint.
-- [CCXT × Seamless Legacy Audit](ccxt-seamless-legacy-audit.md) captures the migration record and external link inventory.
+- [CCXT × Seamless Legacy Audit](../archive/ccxt-seamless-legacy-audit.md) captures the migration record and external link inventory.
 
 ## Scope and Status
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -4,6 +4,6 @@
 
 | Version | Status |
 |--------|--------|
-| _None yet_ | - |
+| [CCXT × Seamless Legacy Audit](ccxt-seamless-legacy-audit.md) | Historical migration log confirming retirement of GPT5-era drafts (Fixes #1167). |
 
 {{ nav_links() }}

--- a/docs/archive/ccxt-seamless-legacy-audit.md
+++ b/docs/archive/ccxt-seamless-legacy-audit.md
@@ -1,7 +1,7 @@
 # CCXT × Seamless Legacy Audit
 
 ## Summary
-This inventory supports the migration tracked in [#1162](https://github.com/hyophyop/qmtl/issues/1162) by cataloging the remaining content inside the legacy CCXT × Seamless design notes. The audit compares each document against the consolidated [`ccxt-seamless-integrated.md`](ccxt-seamless-integrated.md) blueprint and highlights external links that still point at the deprecated files. With the legacy drafts now removed from the repository, the tables below remain as a historical record of what was merged where.
+This inventory supports the migration tracked in [#1162](https://github.com/hyophyop/qmtl/issues/1162) by cataloging the remaining content inside the legacy CCXT × Seamless design notes. The audit compares each document against the consolidated [`ccxt-seamless-integrated.md`](../architecture/ccxt-seamless-integrated.md) blueprint and highlights external links that still point at the deprecated files. With the legacy drafts now removed from the repository, the tables below remain as a historical record of what was merged where.
 
 ## Outstanding Content by Source Document
 The following tables list sections, diagrams, or code samples that have no equivalent in the integrated specification. Each row includes migration guidance so that the legacy files can be retired once their content is ported.
@@ -39,7 +39,7 @@ The following tables list sections, diagrams, or code samples that have no equiv
 
 ## External Links that Depend on the Legacy Docs
 - ✅ `mkdocs.yml` navigation now routes readers directly to the integrated blueprint (the GPT5-High entry was removed).
-- ✅ [`ccxt-seamless-integrated.md`](ccxt-seamless-integrated.md) inlines the former GPT5-High material and no longer links out to the archived file.
+- ✅ [`ccxt-seamless-integrated.md`](../architecture/ccxt-seamless-integrated.md) inlines the former GPT5-High material and no longer links out to the archived file.
 - Historical `ccxt-seamless-hybrid.md` references have been excised from the tree; consumers should link directly to the integrated blueprint going forward.
 
 ## Recommended Follow-Up

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,6 @@ nav:
       - Architecture & World ID Flow: architecture/architecture.md
       - Seamless Data Provider v2: architecture/seamless_data_provider_v2.md
       - CCXT × Seamless Integrated (High + Codex): architecture/ccxt-seamless-integrated.md
-      - CCXT × Seamless Legacy Audit: architecture/ccxt-seamless-legacy-audit.md
       - Glossary: architecture/glossary.md
       - DAG Manager: architecture/dag-manager.md
       - Gateway: architecture/gateway.md
@@ -88,7 +87,9 @@ nav:
       - Spec: world/world.md
       - Realm Terminology Evaluation: world/realm_rename_eval.md
       - Policy Engine: world/policy_engine.md
-  - Archive: archive/README.md
+  - Archive:
+      - Overview: archive/README.md
+      - CCXT × Seamless Legacy Audit: archive/ccxt-seamless-legacy-audit.md
   - Tags: tags.md
   - Templates:
       - Index: templates/index.md


### PR DESCRIPTION
## Summary
- move the CCXT × Seamless legacy audit document into the archive section and update cross-links
- refresh the archive index and navigation so the audit remains discoverable outside the main architecture tree

Fixes #1167

## Testing
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d6513f76208329a9112e20a67111f1