### PR TITLE
Extend CCXT rate limiter configuration

### DIFF
--- a/docs/io/ccxt-questdb.md
+++ b/docs/io/ccxt-questdb.md
@@ -81,11 +81,14 @@ sequenceDiagram
 - `questdb`: `dsn`(권장) 또는 `host/port/database`와 `table`(테이블명) 또는 `table_prefix` (예: `crypto` → `crypto_ohlcv`/`crypto_trades`)
 - 레이트리밋(옵션): `rate_limiter = {max_concurrency, min_interval_s, scope}`
   - `scope`: `local`(페처별), `process`(프로세스 전역, 기본), `cluster`(분산)
-  - `cluster` 추가 옵션: `redis_dsn`, `tokens_per_sec`, `burst`, `key_suffix`
+  - `cluster` 추가 옵션: `redis_dsn`, `tokens_per_interval`, `interval_ms`, `burst_tokens`, `local_semaphore`, `key_suffix`
     - `redis_dsn`: Redis DSN (미설정 시 `QMTL_CCXT_RATE_LIMITER_REDIS` → 기본값)
-    - `tokens_per_sec`: 초당 허용 호출 수(미설정 시 `1 / min_interval_s`)
-    - `burst`: 순간 버스트 허용량(기본 1)
+    - `tokens_per_interval`: 윈도우(`interval_ms`)당 허용 토큰 수
+    - `interval_ms`: 토큰 버킷 윈도우 크기(ms)
+    - `burst_tokens`: 버스트 허용량(미설정 시 `tokens_per_interval`)
+    - `local_semaphore`: 프로세스 로컬 동시성 제한(미설정 시 `max_concurrency`)
     - `key_suffix`: 버킷 분리용 서픽스(계정/엔드포인트별 분리)
+  - `penalty_backoff_ms`: 429(Too Many Requests) 응답 이후 강제 쿨다운 시간
 - 재시도(옵션): `max_retries`, `retry_backoff_s`
 
 ## 테스트 & 검증

--- a/qmtl/runtime/io/ccxt_provider.py
+++ b/qmtl/runtime/io/ccxt_provider.py
@@ -85,6 +85,34 @@ class CcxtQuestDBProvider(QuestDBHistoryProvider):
         rate_limiter = RateLimiterConfig(
             max_concurrency=int(rl_cfg.get("max_concurrency", 1)),
             min_interval_s=float(rl_cfg.get("min_interval_s", 0.0)),
+            scope=str(rl_cfg.get("scope", "process")),
+            redis_dsn=rl_cfg.get("redis_dsn"),
+            tokens_per_interval=(
+                float(rl_cfg["tokens_per_interval"])
+                if rl_cfg.get("tokens_per_interval") is not None
+                else None
+            ),
+            interval_ms=(
+                int(rl_cfg["interval_ms"])
+                if rl_cfg.get("interval_ms") is not None
+                else None
+            ),
+            burst_tokens=(
+                int(rl_cfg["burst_tokens"])
+                if rl_cfg.get("burst_tokens") is not None
+                else None
+            ),
+            local_semaphore=(
+                int(rl_cfg["local_semaphore"])
+                if rl_cfg.get("local_semaphore") is not None
+                else None
+            ),
+            key_suffix=rl_cfg.get("key_suffix"),
+            penalty_backoff_ms=(
+                int(rl_cfg["penalty_backoff_ms"])
+                if rl_cfg.get("penalty_backoff_ms") is not None
+                else None
+            ),
         )
 
         fetcher: CcxtOHLCVFetcher | CcxtTradesFetcher

--- a/tests/runtime/io/test_ccxt_rate_limiter_cluster.py
+++ b/tests/runtime/io/test_ccxt_rate_limiter_cluster.py
@@ -63,7 +63,10 @@ async def test_cluster_rate_limit_spreads_calls_across_fetchers():
         min_interval_s=0.05,
         scope="cluster",
         redis_dsn=redis_url,
-        burst=1,
+        tokens_per_interval=2,
+        interval_ms=1000,
+        burst_tokens=1,
+        local_semaphore=1,
         key_suffix=suffix,
     )
     cfg = CcxtBackfillConfig(exchange_id="binance", symbols=["BTC/USDT"], timeframe="1m", rate_limiter=rl)


### PR DESCRIPTION
## Summary
- expose all CCXT Redis token bucket parameters and penalty cooldown through `RateLimiterConfig`
- update the Redis-backed limiter to respect interval, burst and local semaphore options
- add 429 penalty-backoff tests and refresh QuestDB CCXT documentation

## Testing
- uv run -m pytest tests/runtime/io/test_ccxt_fetcher.py tests/runtime/io/test_ccxt_rate_limiter_shared.py

Fixes #1211

------
https://chatgpt.com/codex/tasks/task_e_68d6f9e0bf0883299d270f06a7da9d8b