### PR TITLE
Add as_of advancement metric for Seamless live sessions

### DIFF
--- a/docs/architecture/ccxt-seamless-integrated.md
+++ b/docs/architecture/ccxt-seamless-integrated.md
@@ -518,7 +518,7 @@ This workflow keeps hot storage responsive without sacrificing the reproducibili
 | `artifact_publish_latency_ms` | Time from stabilization to manifest publish | Warn > 120 s |
 | `artifact_bytes_written` | Volume of artifact storage writes | Capacity planning |
 | `fingerprint_collisions` | Count of duplicate fingerprints | Critical if > 0 |
-| `as_of_advancement_events` | Count of monotonic `as_of` promotions | Alert if progression stalls or regresses |
+| `as_of_advancement_events` | Count of monotonic `as_of` promotions (labels: `node_id`, `world_id`) | Alert if progression stalls or regresses |
 | `domain_gate_holds` | Number of HOLD downgrades | Warn on upward trend |
 | `partial_fill_returns` | Frequency of PARTIAL_FILL outcomes | Correlate with SLA breaches |
 | `live_staleness_seconds` | Live data freshness gap | Warn if exceeds domain `max_lag` |

--- a/qmtl/runtime/sdk/metrics.py
+++ b/qmtl/runtime/sdk/metrics.py
@@ -270,6 +270,14 @@ partial_fill_returns = _counter(
     test_value_factory=dict,
 )
 
+as_of_advancement_events = _counter(
+    "as_of_advancement_events",
+    "Count of monotonic as_of promotions",
+    ["node_id", "world_id"],
+    test_value_attr="_vals",
+    test_value_factory=dict,
+)
+
 live_staleness_seconds = _gauge(
     "live_staleness_seconds",
     "Observed live data staleness for Seamless responses (seconds)",
@@ -787,6 +795,15 @@ def observe_partial_fill(*, node_id: str, interval: str | int, reason: str) -> N
     partial_fill_returns.labels(node_id=n, interval=i, world_id=world, reason=r).inc()
     partial_fill_returns._vals[(n, i, world, r)] = (  # type: ignore[attr-defined]
         partial_fill_returns._vals.get((n, i, world, r), 0) + 1
+    )
+
+
+def observe_as_of_advancement_event(*, node_id: str, world_id: str | None) -> None:
+    n = str(node_id)
+    world = str(world_id) if world_id is not None else ""
+    as_of_advancement_events.labels(node_id=n, world_id=world).inc()
+    as_of_advancement_events._vals[(n, world)] = (  # type: ignore[attr-defined]
+        as_of_advancement_events._vals.get((n, world), 0) + 1
     )
 
 


### PR DESCRIPTION
## Summary
- add the `as_of_advancement_events` Prometheus counter with node and world labels
- emit advancement events when live domain `as_of` values progress and document the metric catalog entry
- add coverage ensuring the metric only increments on monotonic promotions

## Testing
- uv run -m pytest tests/sdk/test_seamless_provider.py -k as_of_advancement

Fixes #1217

------
https://chatgpt.com/codex/tasks/task_e_68d6f9f6a68083298b9a6af23e6d6f04