### PR TITLE
Align BackfillConfig semantics with architecture

### DIFF
--- a/docs/design/seamless_data_provider.md
+++ b/docs/design/seamless_data_provider.md
@@ -307,11 +307,16 @@ seamless_data_provider:
     distributed_lease_ttl_ms: 120000
     window_bars: 900
     max_concurrent_requests: 8
-    retry_max: 6
-    retry_base_backoff_ms: 500
-    retry_jitter: true
+    max_attempts: 6
+    retry_backoff_ms: 500
+    jitter_ratio: 0.25
   cache_ttl: 3600
 ```
+
+`jitter_ratio` is expressed as a percentage of the exponentially increasing
+retry delay. A value of `0.25` means each retry waits for the deterministic
+backoff plus a random component sampled between 0 and 25% of that delay,
+ensuring concurrent workers do not stampede the upstream API.
 
 ### 3. 장애 대응
 - 자동 폴백 메커니즘


### PR DESCRIPTION
## Summary
- rename BackfillConfig fields to match the architecture contract and normalize jitter ratios
- update docs and unit tests to exercise the new retry_backoff_ms and jitter_ratio semantics

## Testing
- uv run -m pytest tests/sdk/test_seamless_provider.py -k "backfill_config_enforces_concurrency_cap or backfill_retry"

Fixes #1212

------
https://chatgpt.com/codex/tasks/task_e_68d6ff5a046883299ae5c8952cdc0e0b