### PR TITLE
Include snapshot metadata in domain gate downgrade logs

### DIFF
--- a/docs/operations/seamless_sla_dashboards.md
+++ b/docs/operations/seamless_sla_dashboards.md
@@ -111,7 +111,9 @@ non-production environments.
   on these spans.
 - **Logging**: the coordinator and SLA layers log to `seamless.backfill` and
   `seamless.sla` respectively. Use these structured logs to correlate alerts
-  with lease IDs and offending nodes.
+  with lease IDs and offending nodes. Domain gate downgrade events emit the
+  `seamless.domain_gate.downgrade` log with `dataset_fingerprint` and `as_of`
+  fields so audit trails can confirm which snapshot was served during a HOLD.
 
 ## Runbooks
 

--- a/qmtl/runtime/sdk/seamless_data_provider.py
+++ b/qmtl/runtime/sdk/seamless_data_provider.py
@@ -1013,6 +1013,14 @@ class SeamlessDataProvider(ABC):
                 )
 
             if decision is not None:
+                fingerprint = metadata.dataset_fingerprint
+                if fingerprint is None and metadata.artifact is not None:
+                    fingerprint = getattr(metadata.artifact, "dataset_fingerprint", None)
+
+                as_of_value: Any | None = metadata.as_of
+                if as_of_value is None:
+                    as_of_value = metadata.requested_as_of or context.requested_as_of
+
                 logger.warning(
                     "seamless.domain_gate.downgrade",
                     extra={
@@ -1021,6 +1029,8 @@ class SeamlessDataProvider(ABC):
                         "world_id": context.world_id,
                         "execution_domain": domain,
                         "reason": decision.reason,
+                        "dataset_fingerprint": fingerprint,
+                        "as_of": as_of_value,
                     },
                 )
             return decision


### PR DESCRIPTION
## Summary
- add dataset fingerprint and as_of context to `seamless.domain_gate.downgrade` warnings
- cover the log fields with a domain gate downgrade unit test
- document the new log schema in the seamless SLA operations guide

## Testing
- uv run -m pytest tests/sdk/test_seamless_provider.py::test_domain_gate_downgrade_includes_snapshot_metadata

Fixes #1214

------
https://chatgpt.com/codex/tasks/task_e_68d7087a3a4c83298a40b4689afcef21