### PR TITLE
Ensure artifact manifests include provenance metadata

### DIFF
--- a/docs/architecture/ccxt-seamless-integrated.md
+++ b/docs/architecture/ccxt-seamless-integrated.md
@@ -241,7 +241,7 @@ flowchart LR
 #### Dataset Identity
 - **Runtime key**: `node_id` as defined above.
 - **Version key**: `dataset_fingerprint` (SHA-256 over canonicalized frame + metadata) and `as_of` (snapshot or commit instant).
-- Artifact manifests record `{fingerprint, as_of, node_id, range, conformance_version, producer, publication_watermark}` and live alongside Parquet data in object storage.
+- Artifact manifests record `{fingerprint, as_of, node_id, range, conformance_version, producer, publication_watermark}` and live alongside Parquet data in object storage. The default registrar stamps manifests with a `producer.identity` of `seamless@qmtl`, the originating `node_id`/`interval`, and a UTC `publication_watermark` indicating when the stabilized dataset was sealed.
 - Fingerprints must be calculated after tail-bar stabilization and dtype normalization to guarantee idempotent replay. Workers may compute a "preview" fingerprint for debugging, but only the post-stabilization value is authoritative.
 
 #### Publication Workflow

--- a/qmtl/runtime/io/artifact.py
+++ b/qmtl/runtime/io/artifact.py
@@ -45,6 +45,7 @@ class ArtifactRegistrar:
         stabilization_bars: int = 2,
         conformance_version: str = "v2",
         float_format: str = "%.10f",
+        producer_identity: str | None = "seamless@qmtl",
     ) -> None:
         if stabilization_bars < 0:
             raise ValueError("stabilization_bars must be >= 0")
@@ -52,6 +53,8 @@ class ArtifactRegistrar:
         self._stabilization_bars = int(stabilization_bars)
         self._conformance_version = str(conformance_version)
         self._float_format = float_format
+        identity = (producer_identity or "").strip()
+        self._producer_identity = identity or "seamless@qmtl"
 
     @property
     def stabilization_bars(self) -> int:
@@ -111,6 +114,12 @@ class ArtifactRegistrar:
             "as_of": as_of,
             "conformance_version": self._conformance_version,
             "stabilization_bars": self._stabilization_bars,
+        }
+        manifest["publication_watermark"] = self._now_iso()
+        manifest["producer"] = {
+            "identity": self._producer_identity,
+            "node_id": node_id,
+            "interval": int(interval),
         }
         if requested_range is not None:
             manifest["requested_range"] = [int(requested_range[0]), int(requested_range[1])]

--- a/qmtl/runtime/io/seamless_provider.py
+++ b/qmtl/runtime/io/seamless_provider.py
@@ -377,7 +377,7 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
         if registrar_obj is None:
             registrar_obj = FileSystemArtifactRegistrar.from_env()
         if registrar_obj is None:
-            registrar_obj = IOArtifactRegistrar(stabilization_bars=0)
+            registrar_obj = IOArtifactRegistrar(stabilization_bars=2)
 
         fmt = node_id_format.strip() if node_id_format else None
         self._node_id_format = fmt

--- a/qmtl/runtime/sdk/artifacts/registrar.py
+++ b/qmtl/runtime/sdk/artifacts/registrar.py
@@ -85,6 +85,7 @@ class FileSystemArtifactRegistrar(_IOArtifactRegistrar):
             store=self._store,
             stabilization_bars=stabilization_bars,
             conformance_version=conformance_version,
+            producer_identity=producer,
         )
 
     @classmethod


### PR DESCRIPTION
## Summary
- teach the core Seamless artifact registrar to stamp manifests with a publication watermark and producer identity
- wire the provenance defaults through the filesystem registrar and document the identity semantics
- align the EnhancedQuestDBProvider fallback registrar with the documented two-bar tail-drop behaviour and add coverage for provenance metadata

## Testing
- `uv run -m pytest -W error tests/runtime/sdk/test_artifact_registrar.py tests/runtime/io/test_enhanced_provider_nodeid.py` *(fails early because fakeredis is unavailable in the test environment)*

Fixes #1215

------
https://chatgpt.com/codex/tasks/task_e_68d710d71cd08329b10681a52168f1c9