### PR TITLE
Honor min_interval_ms in CCXT provider configuration

### DIFF
--- a/docs/architecture/ccxt-seamless-integrated.md
+++ b/docs/architecture/ccxt-seamless-integrated.md
@@ -147,6 +147,10 @@ flowchart LR
 | `min_interval_ms` | Hard lower-bound between CCXT requests per worker | Provider configuration |
 | `penalty_backoff_ms` | Cooldown applied after hitting exchange-side 429s | Provider configuration |
 
+`CcxtQuestDBProvider.from_config(...)` also accepts `min_interval_s`. When both
+fields are present they must describe the same cadence; the millisecond value is
+converted to seconds for the underlying limiter configuration.
+
 ### Provider Recipes
 
 ```python


### PR DESCRIPTION
## Summary
- convert rate_limiter.min_interval_ms into seconds in `CcxtQuestDBProvider.from_config`
- validate conflicting millisecond/second values and document the precedence
- exercise the new configuration path with targeted provider tests

Fixes #1227

## Testing
- uv run -m pytest tests/runtime/io/test_ccxt_questdb_provider.py -k min_interval

------
https://chatgpt.com/codex/tasks/task_e_68d72bcaeeec8329b13936609a50b83d