### PR TITLE
Expose CCXT rate limiter key template support

### DIFF
--- a/docs/architecture/ccxt-seamless-integrated.md
+++ b/docs/architecture/ccxt-seamless-integrated.md
@@ -448,6 +448,14 @@ cache:
 domains:
   backtest:
     require_as_of: true
+
+The runtime honours ``rate_limit.key_template`` when wiring CCXT fetchers. The
+template supports ``{exchange}`` (lower-case), ``{exchange_id}`` (original
+case), and aliases for the optional suffix value (``{suffix}``, ``{key_suffix}``,
+``{account}``). Sections written as ``:{account?}`` are removed entirely when the
+value is missing, matching the configuration blueprint. When a template is
+provided the legacy ``key_suffix`` is not appended automatically; include the
+suffix inside the template if it should participate in the limiter key.
     source: artifact_only
   dryrun:
     require_as_of: true

--- a/docs/io/ccxt-questdb.md
+++ b/docs/io/ccxt-questdb.md
@@ -81,13 +81,17 @@ sequenceDiagram
 - `questdb`: `dsn`(권장) 또는 `host/port/database`와 `table`(테이블명) 또는 `table_prefix` (예: `crypto` → `crypto_ohlcv`/`crypto_trades`)
 - 레이트리밋(옵션): `rate_limiter = {max_concurrency, min_interval_s, scope}`
   - `scope`: `local`(페처별), `process`(프로세스 전역, 기본), `cluster`(분산)
-  - `cluster` 추가 옵션: `redis_dsn`, `tokens_per_interval`, `interval_ms`, `burst_tokens`, `local_semaphore`, `key_suffix`
+  - `cluster` 추가 옵션: `redis_dsn`, `tokens_per_interval`, `interval_ms`, `burst_tokens`, `local_semaphore`, `key_suffix`, `key_template`
     - `redis_dsn`: Redis DSN (미설정 시 `QMTL_CCXT_RATE_LIMITER_REDIS` → 기본값)
     - `tokens_per_interval`: 윈도우(`interval_ms`)당 허용 토큰 수
     - `interval_ms`: 토큰 버킷 윈도우 크기(ms)
     - `burst_tokens`: 버스트 허용량(미설정 시 `tokens_per_interval`)
     - `local_semaphore`: 프로세스 로컬 동시성 제한(미설정 시 `max_concurrency`)
     - `key_suffix`: 버킷 분리용 서픽스(계정/엔드포인트별 분리)
+    - `key_template`: 리미터 키 포맷을 직접 제어. `{exchange}`(소문자), `{exchange_id}`(원본) 및
+      `{suffix}`/`{key_suffix}`/`{account}`(서픽스 값)을 활용할 수 있으며, `:{account?}`와 같이 `?`를 붙이면
+      값이 없을 때 구분자까지 제거된다. 템플릿이 설정되면 `key_suffix`는 자동으로 덧붙지 않으므로 필요하면
+      템플릿 안에 `{suffix}`를 배치한다.
   - `penalty_backoff_ms`: 429(Too Many Requests) 응답 이후 강제 쿨다운 시간
 - 재시도(옵션): `max_retries`, `retry_backoff_s`
 

--- a/qmtl/runtime/io/ccxt_provider.py
+++ b/qmtl/runtime/io/ccxt_provider.py
@@ -123,6 +123,7 @@ class CcxtQuestDBProvider(QuestDBHistoryProvider):
                 else None
             ),
             key_suffix=rl_cfg.get("key_suffix"),
+            key_template=rl_cfg.get("key_template"),
             penalty_backoff_ms=(
                 int(rl_cfg["penalty_backoff_ms"])
                 if rl_cfg.get("penalty_backoff_ms") is not None

--- a/tests/runtime/io/test_ccxt_questdb_provider.py
+++ b/tests/runtime/io/test_ccxt_questdb_provider.py
@@ -111,3 +111,16 @@ def test_from_config_rejects_conflicting_min_interval_fields():
     with pytest.raises(ValueError):
         CcxtQuestDBProvider.from_config(cfg)
 
+
+def test_from_config_propagates_key_template():
+    cfg = _base_provider_config(
+        key_suffix="acct42",
+        key_template="ccxt:{exchange}:{suffix}",
+    )
+    provider = CcxtQuestDBProvider.from_config(cfg)
+    fetcher = provider.fetcher
+    assert fetcher is not None
+    rl = fetcher.config.rate_limiter  # type: ignore[union-attr]
+    assert rl.key_template == "ccxt:{exchange}:{suffix}"
+    assert rl.key_suffix == "acct42"
+


### PR DESCRIPTION
## Summary
- allow RateLimiterConfig to accept key_template and render optional placeholders before calling get_limiter
- pass rate limiter templates through CcxtQuestDBProvider and document template usage with new tests

## Testing
- uv run -m pytest tests/runtime/io/test_ccxt_fetcher.py tests/runtime/io/test_ccxt_questdb_provider.py

Fixes #1228

------
https://chatgpt.com/codex/tasks/task_e_68d72f1405dc83299d914cc217fd33c3