### PR TITLE
feat: add settings object for EnhancedQuestDBProvider

### DIFF
--- a/qmtl/runtime/io/__init__.py
+++ b/qmtl/runtime/io/__init__.py
@@ -13,7 +13,11 @@ from .ccxt_fetcher import (
     CcxtTradesFetcher,
 )
 from .ccxt_provider import CcxtQuestDBProvider
-from .seamless_provider import EnhancedQuestDBProvider
+from .seamless_provider import (
+    EnhancedQuestDBProvider,
+    EnhancedQuestDBProviderSettings,
+    FingerprintPolicy,
+)
 from .artifact import ArtifactRegistrar, ArtifactPublication
 from .ccxt_live_feed import CcxtProLiveFeed, CcxtProConfig
 
@@ -27,6 +31,8 @@ __all__ = [
     "QuestDBRecorder",
     "BinanceFetcher",
     "EnhancedQuestDBProvider",
+    "EnhancedQuestDBProviderSettings",
+    "FingerprintPolicy",
     "CcxtBackfillConfig",
     "RateLimiterConfig",
     "CcxtOHLCVFetcher",


### PR DESCRIPTION
## Summary
- add `EnhancedQuestDBProviderSettings` and `FingerprintPolicy` to capture strategy, SLA, conformance, and fingerprint configuration in one object
- update `EnhancedQuestDBProvider` to accept the settings object while preserving legacy kwargs and export the new helpers
- extend the provider tests to exercise the new configuration path and policy propagation

## Testing
- uv run -m pytest tests/runtime/io/test_enhanced_provider_nodeid.py


------
https://chatgpt.com/codex/tasks/task_e_68d7469e7ed08329855b59c0ac875a75