### PR TITLE
Add Seamless health verification tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,16 @@ jobs:
       - name: Lint DSN keys (canonical *_dsn)
         run: uv run python scripts/lint_dsn_keys.py
 
+      - name: Seamless runtime health verification
+        if: ${{ vars.RUN_SEAMLESS_HEALTH_CHECK == '1' }}
+        env:
+          QMTL_SEAMLESS_COORDINATOR_URL: ${{ secrets.QMTL_SEAMLESS_COORDINATOR_URL }}
+          QMTL_PROMETHEUS_URL: ${{ secrets.QMTL_PROMETHEUS_URL }}
+        run: |
+          uv run python scripts/seamless_health_check.py \
+            --prometheus-metric backfill_completion_ratio \
+            --prometheus-metric seamless_sla_deadline_seconds
+
       - name: Preflight – import/collection
         run: uv run -m pytest --collect-only -q
 

--- a/docs/operations/seamless_sla_dashboards.md
+++ b/docs/operations/seamless_sla_dashboards.md
@@ -82,7 +82,7 @@ alerts should page. The alert annotations link back to this runbook.
 
 ## Validation Tooling
 
-Two operational scripts now ship alongside the dashboards:
+Three operational scripts now ship alongside the dashboards:
 
 - `scripts/inject_sla_violation.py` emits synthetic SLA metrics, optionally
   writing the Prometheus exposition text to disk or serving it temporarily via
@@ -101,8 +101,24 @@ Two operational scripts now ship alongside the dashboards:
   uv run scripts/lease_recover.py --coordinator-url https://coordinator/v1 lease-A:deadbeef lease-B:feedface
   ```
 
-Both scripts include `--dry-run` or `--serve` modes to simplify verification in
-non-production environments.
+- `scripts/seamless_health_check.py` validates production roll-outs by checking
+  environment variables, probing the distributed coordinator, and asserting that
+  Prometheus exposes coordinator and SLA metrics. The CLI depends on
+  [`httpx`](https://www.python-httpx.org/) (already included in the dev extras)
+  and reads the `QMTL_SEAMLESS_COORDINATOR_URL` / `QMTL_PROMETHEUS_URL`
+  environment variables by default. Example:
+
+  ```bash
+  uv run python scripts/seamless_health_check.py \
+    --prometheus-metric backfill_completion_ratio \
+    --prometheus-metric seamless_sla_deadline_seconds
+  ```
+
+Override the Prometheus or coordinator endpoints by passing the
+`--prometheus-url` and `--coordinator-url` flags (or by exporting the
+environment variables before invoking the script). Combine the health check's
+`--timeout` flag with the existing `--dry-run` modes on the other scripts when
+testing in non-production environments.
 
 ## Tracing and Logging
 

--- a/scripts/seamless_health_check.py
+++ b/scripts/seamless_health_check.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Seamless runtime health verification CLI.
+
+This script validates that required environment variables are populated,
+confirms the distributed coordinator is reachable, and ensures that
+Prometheus exposes the expected metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+
+import httpx
+
+DEFAULT_REQUIRED_ENV = ("QMTL_SEAMLESS_COORDINATOR_URL",)
+DEFAULT_PROMETHEUS_METRICS = (
+    "backfill_completion_ratio",
+    "seamless_sla_deadline_seconds",
+)
+DEFAULT_COORDINATOR_HEALTH_PATH = "/health"
+
+HttpGet = Callable[[str, dict[str, str] | None, float], httpx.Response]
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a health check."""
+
+    name: str
+    success: bool
+    message: str
+
+    def format(self) -> str:
+        status = "OK" if self.success else "FAIL"
+        return f"[{status}] {self.name}: {self.message}"
+
+
+def _http_get(url: str, params: dict[str, str] | None, timeout: float) -> httpx.Response:
+    return httpx.get(url, params=params, timeout=timeout)
+
+
+def verify_required_env(
+    env_names: Sequence[str],
+    *,
+    environ: dict[str, str] | None = None,
+) -> CheckResult:
+    env = environ if environ is not None else os.environ
+    missing = [name for name in env_names if not env.get(name)]
+    if missing:
+        return CheckResult(
+            name="Environment variables",
+            success=False,
+            message=f"Missing values for: {', '.join(sorted(missing))}",
+        )
+    return CheckResult(
+        name="Environment variables",
+        success=True,
+        message=f"All {len(env_names)} required environment variables are set",
+    )
+
+
+def check_coordinator_health(
+    base_url: str | None,
+    *,
+    path: str = DEFAULT_COORDINATOR_HEALTH_PATH,
+    timeout: float = 5.0,
+    http_get: HttpGet | None = None,
+) -> CheckResult:
+    if not base_url:
+        return CheckResult(
+            name="Coordinator health",
+            success=False,
+            message="Coordinator URL not provided",
+        )
+
+    url = f"{base_url.rstrip('/')}{path}"
+    getter = http_get or _http_get
+    try:
+        response = getter(url, None, timeout)
+    except httpx.RequestError as exc:
+        return CheckResult(
+            name="Coordinator health",
+            success=False,
+            message=f"Request failed: {exc}",
+        )
+
+    if response.status_code >= 400:
+        return CheckResult(
+            name="Coordinator health",
+            success=False,
+            message=f"Received HTTP {response.status_code} from {url}",
+        )
+
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+
+    if isinstance(payload, dict):
+        status = payload.get("status") or payload.get("state")
+        if status and str(status).lower() not in {"ok", "healthy", "pass"}:
+            return CheckResult(
+                name="Coordinator health",
+                success=False,
+                message=f"Coordinator reported unhealthy status: {status}",
+            )
+
+    return CheckResult(
+        name="Coordinator health",
+        success=True,
+        message=f"Coordinator at {url} responded with HTTP {response.status_code}",
+    )
+
+
+def check_prometheus_metrics(
+    base_url: str | None,
+    metrics: Iterable[str],
+    *,
+    timeout: float = 5.0,
+    http_get: HttpGet | None = None,
+) -> CheckResult:
+    metric_list = [metric for metric in metrics if metric]
+    if not metric_list:
+        return CheckResult(
+            name="Prometheus metrics",
+            success=True,
+            message="No Prometheus metrics requested; skipping",
+        )
+
+    if not base_url:
+        return CheckResult(
+            name="Prometheus metrics",
+            success=False,
+            message="Prometheus URL not provided",
+        )
+
+    getter = http_get or _http_get
+    missing: list[str] = []
+    for metric in metric_list:
+        params = {"match[]": metric}
+        url = f"{base_url.rstrip('/')}/api/v1/series"
+        try:
+            response = getter(url, params, timeout)
+        except httpx.RequestError as exc:
+            return CheckResult(
+                name="Prometheus metrics",
+                success=False,
+                message=f"Request failed for metric '{metric}': {exc}",
+            )
+
+        if response.status_code >= 400:
+            return CheckResult(
+                name="Prometheus metrics",
+                success=False,
+                message=f"HTTP {response.status_code} querying '{metric}'",
+            )
+
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+
+        if not isinstance(payload, dict) or payload.get("status") != "success":
+            return CheckResult(
+                name="Prometheus metrics",
+                success=False,
+                message=f"Unexpected response for metric '{metric}'",
+            )
+
+        series = payload.get("data")
+        if not series:
+            missing.append(metric)
+
+    if missing:
+        return CheckResult(
+            name="Prometheus metrics",
+            success=False,
+            message="Missing series for: " + ", ".join(sorted(missing)),
+        )
+
+    return CheckResult(
+        name="Prometheus metrics",
+        success=True,
+        message=f"All {len(metric_list)} metrics returned active series",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--required-env",
+        action="append",
+        dest="required_env",
+        help="Environment variable that must be populated (can be passed multiple times)",
+    )
+    parser.add_argument(
+        "--coordinator-url",
+        default=os.getenv("QMTL_SEAMLESS_COORDINATOR_URL", ""),
+        help="Distributed coordinator base URL (default: QMTL_SEAMLESS_COORDINATOR_URL)",
+    )
+    parser.add_argument(
+        "--coordinator-health-path",
+        default=DEFAULT_COORDINATOR_HEALTH_PATH,
+        help="Path appended to the coordinator URL for the health probe (default: /health)",
+    )
+    parser.add_argument(
+        "--prometheus-url",
+        default=os.getenv("QMTL_PROMETHEUS_URL") or os.getenv("PROMETHEUS_URL", ""),
+        help="Prometheus base URL (default: QMTL_PROMETHEUS_URL or PROMETHEUS_URL)",
+    )
+    parser.add_argument(
+        "--prometheus-metric",
+        action="append",
+        dest="prometheus_metrics",
+        help="Prometheus metric to verify (can be passed multiple times)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="HTTP timeout for coordinator and Prometheus requests (seconds)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    required_env = tuple(args.required_env) if args.required_env else DEFAULT_REQUIRED_ENV
+    prometheus_metrics = (
+        tuple(args.prometheus_metrics)
+        if args.prometheus_metrics
+        else DEFAULT_PROMETHEUS_METRICS
+    )
+
+    results = [
+        verify_required_env(required_env),
+        check_coordinator_health(
+            args.coordinator_url,
+            path=args.coordinator_health_path,
+            timeout=args.timeout,
+        ),
+        check_prometheus_metrics(
+            args.prometheus_url,
+            prometheus_metrics,
+            timeout=args.timeout,
+        ),
+    ]
+
+    for result in results:
+        print(result.format())
+
+    return 0 if all(result.success for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_seamless_health_check.py
+++ b/tests/scripts/test_seamless_health_check.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts import seamless_health_check as health
+
+
+class _DummyResponse:
+    def __init__(self, status_code: int, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        if self._payload is None:
+            raise ValueError("no payload")
+        return self._payload
+
+
+def test_verify_required_env_passes_when_all_present() -> None:
+    env = {"QMTL_SEAMLESS_COORDINATOR_URL": "https://coordinator"}
+    result = health.verify_required_env(["QMTL_SEAMLESS_COORDINATOR_URL"], environ=env)
+    assert result.success
+
+
+def test_verify_required_env_fails_when_missing() -> None:
+    result = health.verify_required_env(["QMTL_SEAMLESS_COORDINATOR_URL"], environ={})
+    assert not result.success
+    assert "Missing values" in result.message
+
+
+def test_check_coordinator_health_reports_status_from_payload() -> None:
+    def fake_get(url: str, params: dict[str, str] | None, timeout: float) -> _DummyResponse:
+        assert url == "https://coordinator/health"
+        return _DummyResponse(200, {"status": "ok"})
+
+    result = health.check_coordinator_health(
+        "https://coordinator",
+        http_get=fake_get,
+    )
+    assert result.success
+
+
+@pytest.mark.parametrize(
+    "status_payload",
+    [
+        {"status": "fail"},
+        {"state": "degraded"},
+    ],
+)
+def test_check_coordinator_health_flags_unhealthy_status(status_payload: dict[str, str]) -> None:
+    def fake_get(url: str, params: dict[str, str] | None, timeout: float) -> _DummyResponse:
+        return _DummyResponse(200, status_payload)
+
+    result = health.check_coordinator_health(
+        "https://coordinator",
+        http_get=fake_get,
+    )
+    assert not result.success
+
+
+def test_check_prometheus_metrics_detects_missing_series() -> None:
+    responses = {
+        "backfill_completion_ratio": _DummyResponse(200, {"status": "success", "data": [{}]}),
+        "seamless_sla_deadline_seconds": _DummyResponse(200, {"status": "success", "data": []}),
+    }
+
+    def fake_get(url: str, params: dict[str, str] | None, timeout: float) -> _DummyResponse:
+        assert params is not None
+        metric = params["match[]"]
+        return responses[metric]
+
+    result = health.check_prometheus_metrics(
+        "https://prometheus:9090",
+        ["backfill_completion_ratio", "seamless_sla_deadline_seconds"],
+        http_get=fake_get,
+    )
+    assert not result.success
+    assert "Missing series" in result.message
+
+
+def test_check_prometheus_metrics_succeeds_with_active_series() -> None:
+    def fake_get(url: str, params: dict[str, str] | None, timeout: float) -> _DummyResponse:
+        return _DummyResponse(200, {"status": "success", "data": [{"__name__": params["match[]"]}]})
+
+    result = health.check_prometheus_metrics(
+        "https://prometheus:9090",
+        ["backfill_completion_ratio"],
+        http_get=fake_get,
+    )
+    assert result.success


### PR DESCRIPTION
## Summary
- add a Seamless runtime health verification CLI that checks environment variables, the coordinator endpoint, and Prometheus metrics
- document the workflow in the Seamless SLA dashboards runbook and add an optional CI step wired through repository variables
- cover the health verification logic with unit tests for coordinator and Prometheus failure modes

## Testing
- uv run pytest tests/scripts/test_seamless_health_check.py

------
https://chatgpt.com/codex/tasks/task_e_68d7468f898c8329b4c187fd9ac24736