### PR TITLE
Generalized Seamless builder + CCXT preset integration

### DIFF
--- a/examples/seamless_data_provider_examples.py
+++ b/examples/seamless_data_provider_examples.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from qmtl.runtime.io.seamless_provider import EnhancedQuestDBProvider
 from qmtl.runtime.sdk.seamless_data_provider import DataAvailabilityStrategy
+from qmtl.runtime.sdk import build_seamless_assembly
 
 
 # Example DataFetcher implementation for demonstration
@@ -227,9 +228,36 @@ async def example_stream_input_integration():
     # and will transparently handle all data requirements
 
 
+async def example_preset_config_usage():
+    """Example 5: Build components via preset-driven config."""
+    print("\n=== Example 5: Preset Config Usage ===")
+
+    config = {
+        "preset": "ccxt.questdb.ohlcv",
+        "options": {
+            "exchange_id": "binance",
+            "symbols": ["BTC/USDT"],
+            "timeframe": "1m",
+            "questdb": {
+                "dsn": "postgresql://localhost:8812/qmtl",
+                "table": "crypto_ohlcv",
+            },
+        },
+    }
+
+    assembly = build_seamless_assembly(config)
+
+    print("Storage source:", type(assembly.storage_source).__name__ if assembly.storage_source else None)
+    print("Backfiller:", type(assembly.backfiller).__name__ if assembly.backfiller else None)
+    print("Cache source:", assembly.cache_source)
+    print("Live feed:", assembly.live_feed)
+
+    print("The assembly can now be passed into Seamless providers (e.g., EnhancedQuestDBProvider)")
+
+
 async def example_custom_backfiller():
-    """Example 5: Custom backfiller implementation."""
-    print("\n=== Example 5: Custom Backfiller ===")
+    """Example 6: Custom backfiller implementation."""
+    print("\n=== Example 6: Custom Backfiller ===")
     
     class CustomMarketDataBackfiller:
         """Custom backfiller with specific business logic."""
@@ -317,6 +345,7 @@ async def main():
     await example_strategy_comparison()
     await example_migration_from_existing()
     await example_stream_input_integration()
+    await example_preset_config_usage()
     await example_custom_backfiller()
     
     print("\n=== Summary ===")
@@ -324,8 +353,9 @@ async def main():
     print("1. Transparent auto-backfill of missing historical data")
     print("2. Seamless integration of live and historical data")
     print("3. Multiple strategies for handling data availability")
-    print("4. Background processing capabilities")
-    print("5. Full compatibility with existing QMTL components")
+    print("4. Preset-driven configuration for rapid assembly")
+    print("5. Background processing capabilities")
+    print("6. Full compatibility with existing QMTL components")
     print("\nUsers can migrate gradually and customize behavior as needed.")
 
 

--- a/qmtl/runtime/io/__init__.py
+++ b/qmtl/runtime/io/__init__.py
@@ -20,6 +20,7 @@ from .seamless_provider import (
 )
 from .artifact import ArtifactRegistrar, ArtifactPublication
 from .ccxt_live_feed import CcxtProLiveFeed, CcxtProConfig
+from . import seamless_presets as _seamless_presets  # noqa: F401 - ensure preset registration
 
 __all__ = [
     "DataFetcher",

--- a/qmtl/runtime/io/seamless_presets.py
+++ b/qmtl/runtime/io/seamless_presets.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+"""Preset registrations for Seamless builder integrations."""
+
+from typing import Any, Callable, Mapping, MutableMapping, Sequence
+
+from qmtl.runtime.sdk.seamless import SeamlessPresetRegistry
+from qmtl.runtime.io.historyprovider import QuestDBLoader
+from qmtl.runtime.io.seamless_provider import (
+    CacheDataSource,
+    DataFetcherAutoBackfiller,
+    LiveDataFeedImpl,
+    StorageDataSource,
+)
+from qmtl.runtime.io.ccxt_fetcher import (
+    CcxtBackfillConfig,
+    CcxtOHLCVFetcher,
+    RateLimiterConfig,
+)
+
+
+def _ensure_str(value: Any, *, field: str) -> str:
+    if value is None:
+        raise KeyError(f"ccxt.questdb.ohlcv preset requires '{field}'")
+    return str(value)
+
+
+def _ensure_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    return int(value)
+
+
+def _ensure_float(value: Any, default: float) -> float:
+    if value is None:
+        return default
+    return float(value)
+
+
+def _normalize_symbols(value: Any) -> list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence):
+        return [str(item) for item in value]
+    raise TypeError("symbols must be string or sequence of strings")
+
+
+def _pull_questdb_config(config: Mapping[str, Any]) -> tuple[str, str | None]:
+    questdb_cfg = config.get("questdb")
+    if isinstance(questdb_cfg, Mapping):
+        dsn = questdb_cfg.get("dsn")
+        table = questdb_cfg.get("table")
+    else:
+        dsn = config.get("dsn")
+        table = config.get("table")
+    return _ensure_str(dsn, field="questdb.dsn"), str(table) if table else None
+
+
+def _pull_rate_limiter(config: Mapping[str, Any]) -> RateLimiterConfig:
+    raw = config.get("rate_limiter")
+    if not isinstance(raw, MutableMapping):
+        raw = {}
+    return RateLimiterConfig(
+        max_concurrency=_ensure_int(raw.get("max_concurrency"), 1),
+        min_interval_s=_ensure_float(raw.get("min_interval_s"), 0.0),
+        scope=str(raw.get("scope", "process")),
+        redis_dsn=raw.get("redis_dsn"),
+        tokens_per_interval=(
+            float(raw["tokens_per_interval"])
+            if raw.get("tokens_per_interval") is not None
+            else None
+        ),
+        interval_ms=(
+            int(raw["interval_ms"])
+            if raw.get("interval_ms") is not None
+            else None
+        ),
+        burst_tokens=(
+            int(raw["burst_tokens"])
+            if raw.get("burst_tokens") is not None
+            else None
+        ),
+        local_semaphore=(
+            int(raw["local_semaphore"])
+            if raw.get("local_semaphore") is not None
+            else None
+        ),
+        key_suffix=raw.get("key_suffix"),
+        penalty_backoff_ms=(
+            int(raw["penalty_backoff_ms"])
+            if raw.get("penalty_backoff_ms") is not None
+            else None
+        ),
+    )
+
+
+def _resolve_callable(value: Any) -> Callable[[], Any] | None:
+    if value is None:
+        return None
+    if callable(value):
+        return value
+    return lambda value=value: value
+
+
+def _register_ccxt_questdb_preset() -> None:
+    def _apply(builder, config: Mapping[str, Any]):
+        dsn, table = _pull_questdb_config(config)
+        exchange_id = _ensure_str(
+            config.get("exchange_id") or config.get("exchange"),
+            field="exchange_id",
+        )
+        symbols = _normalize_symbols(config.get("symbols"))
+        timeframe = str(config.get("timeframe", "1m"))
+        window_size = _ensure_int(config.get("window_size"), 1000)
+        max_retries = _ensure_int(config.get("max_retries"), 3)
+        retry_backoff_s = _ensure_float(config.get("retry_backoff_s"), 0.5)
+        rate_limiter = _pull_rate_limiter(config)
+
+        def make_fetcher() -> CcxtOHLCVFetcher:
+            backfill_cfg = CcxtBackfillConfig(
+                exchange_id=exchange_id,
+                symbols=symbols,
+                timeframe=timeframe,
+                window_size=window_size,
+                max_retries=max_retries,
+                retry_backoff_s=retry_backoff_s,
+                rate_limiter=rate_limiter,
+            )
+            return CcxtOHLCVFetcher(backfill_cfg)
+
+        cache_provider_factory = _resolve_callable(config.get("cache_provider"))
+        registrar_factory = _resolve_callable(config.get("registrar"))
+        live_fetcher_factory = _resolve_callable(config.get("live_fetcher"))
+
+        def storage_factory():
+            fetcher = make_fetcher()
+            provider = QuestDBLoader(dsn, table=table, fetcher=fetcher)
+            return StorageDataSource(provider)
+
+        def backfill_factory():
+            return DataFetcherAutoBackfiller(make_fetcher())
+
+        builder.with_storage(storage_factory)
+        if cache_provider_factory is not None:
+            def cache_factory():
+                provider = cache_provider_factory()
+                if provider is None:
+                    raise RuntimeError("cache_provider factory returned None")
+                return CacheDataSource(provider)
+
+            builder.with_cache(cache_factory)
+        builder.with_backfill(backfill_factory)
+        if live_fetcher_factory is not None:
+            def live_factory():
+                fetcher = live_fetcher_factory()
+                if fetcher is None:
+                    raise RuntimeError("live_fetcher factory returned None")
+                return LiveDataFeedImpl(fetcher)
+
+            builder.with_live(live_factory)
+        if registrar_factory is not None:
+            builder.with_registrar(registrar_factory)
+        return builder
+
+    SeamlessPresetRegistry.register("ccxt.questdb.ohlcv", _apply)
+
+
+_register_ccxt_questdb_preset()
+
+
+__all__ = ["_register_ccxt_questdb_preset"]

--- a/qmtl/runtime/sdk/__init__.py
+++ b/qmtl/runtime/sdk/__init__.py
@@ -68,6 +68,13 @@ from .portfolio import (
     order_value,
 )
 from .exchanges import CcxtExchange, normalize_exchange_id, ensure_ccxt_exchange
+from .seamless import (
+    SeamlessAssembly,
+    SeamlessBuilder,
+    SeamlessPresetRegistry,
+    hydrate_builder,
+    build_assembly as build_seamless_assembly,
+)
 
 __all__ = [
     "Node",
@@ -131,4 +138,9 @@ __all__ = [
     "InvalidPeriodError",
     "InvalidNameError",
     "_cli",
+    "SeamlessBuilder",
+    "SeamlessAssembly",
+    "SeamlessPresetRegistry",
+    "hydrate_builder",
+    "build_seamless_assembly",
 ]

--- a/qmtl/runtime/sdk/seamless/__init__.py
+++ b/qmtl/runtime/sdk/seamless/__init__.py
@@ -1,0 +1,16 @@
+from .builder import (
+    ComponentFactory,
+    SeamlessAssembly,
+    SeamlessBuilder,
+    SeamlessPresetRegistry,
+)
+from .config import build_assembly, hydrate_builder
+
+__all__ = [
+    "ComponentFactory",
+    "SeamlessAssembly",
+    "SeamlessBuilder",
+    "SeamlessPresetRegistry",
+    "hydrate_builder",
+    "build_assembly",
+]

--- a/qmtl/runtime/sdk/seamless/builder.py
+++ b/qmtl/runtime/sdk/seamless/builder.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+"""Composable builder utilities for Seamless data providers.
+
+The goal is to let concrete integrations (CCXT, equities, etc.) assemble
+Seamless providers by wiring storage, backfill, live, and governance
+components without hard-coding those decisions inside provider subclasses.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Generic, Mapping, Optional, Protocol, TypeVar
+
+from qmtl.runtime.sdk.artifacts import ArtifactRegistrar
+from qmtl.runtime.sdk.seamless_data_provider import (
+    AutoBackfiller,
+    DataSource,
+    LiveDataFeed,
+)
+
+T_co = TypeVar("T_co")
+
+
+class ComponentFactory(Protocol, Generic[T_co]):
+    """Callable that produces a component instance when invoked."""
+
+    def __call__(self) -> T_co:  # pragma: no cover - interface definition
+        ...
+
+
+def _normalize_factory(value: Optional[Callable[[], T_co] | T_co]) -> Optional[ComponentFactory[T_co]]:
+    if value is None:
+        return None
+    if callable(value):
+        return value  # type: ignore[return-value]
+    return lambda: value  # type: ignore[return-value]
+
+
+def _instantiate(name: str, factory: Optional[ComponentFactory[T_co]]) -> Optional[T_co]:
+    if factory is None:
+        return None
+    try:
+        return factory()
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError(f"failed to build seamless component '{name}'") from exc
+
+
+@dataclass(slots=True)
+class SeamlessAssembly:
+    """Concrete component instances ready to feed into SeamlessDataProvider."""
+
+    cache_source: Optional[DataSource] = None
+    storage_source: Optional[DataSource] = None
+    backfiller: Optional[AutoBackfiller] = None
+    live_feed: Optional[LiveDataFeed] = None
+    registrar: Optional[ArtifactRegistrar] = None
+
+
+@dataclass(slots=True)
+class SeamlessBuilder:
+    """Builder used to assemble Seamless providers from pluggable parts."""
+
+    cache: Optional[ComponentFactory[DataSource]] = field(default=None)
+    storage: Optional[ComponentFactory[DataSource]] = field(default=None)
+    backfill: Optional[ComponentFactory[AutoBackfiller]] = field(default=None)
+    live: Optional[ComponentFactory[LiveDataFeed]] = field(default=None)
+    registrar: Optional[ComponentFactory[ArtifactRegistrar]] = field(default=None)
+
+    def with_cache(self, component: Optional[Callable[[], DataSource] | DataSource]) -> "SeamlessBuilder":
+        self.cache = _normalize_factory(component)
+        return self
+
+    def with_storage(self, component: Optional[Callable[[], DataSource] | DataSource]) -> "SeamlessBuilder":
+        self.storage = _normalize_factory(component)
+        return self
+
+    def with_backfill(self, component: Optional[Callable[[], AutoBackfiller] | AutoBackfiller]) -> "SeamlessBuilder":
+        self.backfill = _normalize_factory(component)
+        return self
+
+    def with_live(self, component: Optional[Callable[[], LiveDataFeed] | LiveDataFeed]) -> "SeamlessBuilder":
+        self.live = _normalize_factory(component)
+        return self
+
+    def with_registrar(
+        self,
+        component: Optional[Callable[[], ArtifactRegistrar] | ArtifactRegistrar],
+    ) -> "SeamlessBuilder":
+        self.registrar = _normalize_factory(component)
+        return self
+
+    def build(self) -> SeamlessAssembly:
+        """Materialize the configured components into concrete instances."""
+
+        return SeamlessAssembly(
+            cache_source=_instantiate("cache", self.cache),
+            storage_source=_instantiate("storage", self.storage),
+            backfiller=_instantiate("backfill", self.backfill),
+            live_feed=_instantiate("live", self.live),
+            registrar=_instantiate("registrar", self.registrar),
+        )
+
+
+PresetFactory = Callable[["SeamlessBuilder", Mapping[str, object]], "SeamlessBuilder"]
+
+
+class SeamlessPresetRegistry:
+    """Global registry mapping preset names to builder customisations."""
+
+    _presets: Dict[str, PresetFactory] = {}
+
+    @classmethod
+    def register(cls, name: str, factory: PresetFactory) -> None:
+        cls._presets[name] = factory
+
+    @classmethod
+    def apply(
+        cls,
+        name: str,
+        *,
+        builder: Optional["SeamlessBuilder"] = None,
+        config: Optional[Mapping[str, object]] = None,
+    ) -> "SeamlessBuilder":
+        if name not in cls._presets:
+            raise KeyError(f"unknown seamless preset: {name}")
+        base = builder or SeamlessBuilder()
+        cfg = config or {}
+        return cls._presets[name](base, cfg)
+
+
+__all__ = [
+    "ComponentFactory",
+    "SeamlessAssembly",
+    "SeamlessBuilder",
+    "SeamlessPresetRegistry",
+]

--- a/qmtl/runtime/sdk/seamless/config.py
+++ b/qmtl/runtime/sdk/seamless/config.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+"""Helpers to hydrate Seamless builders from configuration mappings."""
+
+from typing import Any, Mapping, Optional, Sequence
+
+from .builder import SeamlessBuilder, SeamlessPresetRegistry
+
+
+def _as_mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return value
+    raise TypeError(f"expected mapping for '{field}', got {type(value)!r}")
+
+
+def hydrate_builder(
+    config: Mapping[str, Any],
+    *,
+    builder: Optional[SeamlessBuilder] = None,
+) -> SeamlessBuilder:
+    """Apply presets described by ``config`` to a :class:`SeamlessBuilder`.
+
+    Supported keys (all optional):
+        ``preset``: single preset name (string).
+        ``options``: mapping of options for the single preset.
+        ``presets``: sequence of preset entries. Each entry may be a string name or a
+            mapping with ``name``/``preset`` and optional ``config``/``options``.
+
+    Returns the updated builder (creating a new one when not provided).
+    """
+
+    if not isinstance(config, Mapping):
+        raise TypeError("config must be a mapping")
+
+    result = builder or SeamlessBuilder()
+    entries: list[tuple[str, Mapping[str, Any]]] = []
+
+    if "preset" in config:
+        name = config["preset"]
+        if not isinstance(name, str):
+            raise TypeError("'preset' must be a string")
+        options = _as_mapping(config.get("options"), "options")
+        entries.append((name, options))
+
+    if "presets" in config:
+        raw_presets = config["presets"]
+        if isinstance(raw_presets, str):
+            entries.append((raw_presets, {}))
+        elif isinstance(raw_presets, Mapping):
+            # single mapping entry
+            preset_name = raw_presets.get("name") or raw_presets.get("preset")
+            if not isinstance(preset_name, str):
+                raise KeyError("preset mapping requires 'name' or 'preset'")
+            options = _as_mapping(
+                raw_presets.get("config") or raw_presets.get("options"),
+                "presets.options",
+            )
+            entries.append((preset_name, options))
+        elif isinstance(raw_presets, Sequence):
+            for idx, entry in enumerate(raw_presets):
+                if isinstance(entry, str):
+                    entries.append((entry, {}))
+                    continue
+                if isinstance(entry, Mapping):
+                    preset_name = entry.get("name") or entry.get("preset")
+                    if not isinstance(preset_name, str):
+                        raise KeyError(
+                            f"presets[{idx}] mapping requires 'name' or 'preset'"
+                        )
+                    options = _as_mapping(
+                        entry.get("config") or entry.get("options"),
+                        f"presets[{idx}].options",
+                    )
+                    entries.append((preset_name, options))
+                    continue
+                raise TypeError(
+                    f"unsupported presets[{idx}] entry type: {type(entry)!r}"
+                )
+        elif raw_presets is not None:
+            raise TypeError("'presets' must be string, mapping, or sequence")
+
+    for name, options in entries:
+        result = SeamlessPresetRegistry.apply(name, builder=result, config=options)
+
+    return result
+
+
+def build_assembly(
+    config: Mapping[str, Any],
+    *,
+    builder: Optional[SeamlessBuilder] = None,
+):
+    """Hydrate a builder using ``config`` and return the resulting assembly."""
+
+    updated = hydrate_builder(config, builder=builder)
+    return updated.build()
+
+
+__all__ = ["hydrate_builder", "build_assembly"]

--- a/tests/sdk/test_seamless_config.py
+++ b/tests/sdk/test_seamless_config.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+
+import pandas as pd
+
+from qmtl.runtime.sdk import build_seamless_assembly, hydrate_builder
+from qmtl.runtime.io.seamless_provider import (
+    StorageDataSource,
+    DataFetcherAutoBackfiller,
+)
+
+
+def _ccxt_preset_config() -> dict:
+    return {
+        "preset": "ccxt.questdb.ohlcv",
+        "options": {
+            "exchange_id": "binance",
+            "symbols": ["BTC/USDT"],
+            "timeframe": "1m",
+            "questdb": {
+                "dsn": "postgresql://localhost:8812/qdb",
+                "table": "crypto_ohlcv",
+            },
+        },
+    }
+
+
+def test_build_seamless_assembly_from_single_preset() -> None:
+    assembly = build_seamless_assembly(_ccxt_preset_config())
+
+    assert isinstance(assembly.storage_source, StorageDataSource)
+    assert isinstance(assembly.backfiller, DataFetcherAutoBackfiller)
+    assert assembly.cache_source is None
+    assert assembly.live_feed is None
+    assert assembly.registrar is None
+
+
+def test_hydrate_builder_supports_presets_sequence() -> None:
+    config = {
+        "presets": [
+            {
+                "name": "ccxt.questdb.ohlcv",
+                "options": _ccxt_preset_config()["options"],
+            }
+        ]
+    }
+
+    builder = hydrate_builder(config)
+    assembly = builder.build()
+
+    assert isinstance(assembly.storage_source, StorageDataSource)
+    assert isinstance(assembly.backfiller, DataFetcherAutoBackfiller)
+
+
+def test_unknown_preset_raises_key_error() -> None:
+    with pytest.raises(KeyError):
+        build_seamless_assembly({"preset": "unknown.preset"})
+
+
+def test_preset_assembly_uses_loader_and_fetcher(monkeypatch) -> None:
+    created = {}
+
+    class FakeFetcher:
+        def __init__(self, config):
+            created["fetcher_config"] = config
+
+    class FakeLoader:
+        def __init__(self, dsn, *, table=None, fetcher=None):
+            created["loader_args"] = {
+                "dsn": dsn,
+                "table": table,
+                "fetcher": fetcher,
+            }
+
+        async def fetch(self, start, end, *, node_id, interval):
+            return pd.DataFrame()
+
+        async def coverage(self, *, node_id, interval):
+            return []
+
+        async def fill_missing(self, start, end, *, node_id, interval):
+            return None
+
+    monkeypatch.setattr(
+        "qmtl.runtime.io.seamless_presets.CcxtOHLCVFetcher",
+        FakeFetcher,
+    )
+    monkeypatch.setattr(
+        "qmtl.runtime.io.seamless_presets.QuestDBLoader",
+        FakeLoader,
+    )
+
+    assembly = build_seamless_assembly(_ccxt_preset_config())
+
+    assert isinstance(assembly.storage_source, StorageDataSource)
+    assert isinstance(assembly.backfiller, DataFetcherAutoBackfiller)
+    assert "loader_args" in created
+    assert created["loader_args"]["dsn"] == "postgresql://localhost:8812/qdb"
+    assert created["loader_args"]["table"] == "crypto_ohlcv"
+    assert isinstance(created["loader_args"]["fetcher"], FakeFetcher)
+    assert created["fetcher_config"].exchange_id == "binance"


### PR DESCRIPTION
This PR introduces a generalized Seamless assembly layer and migrates CCXT integration to use it.\n\nKey changes\n- Add SeamlessBuilder + SeamlessPresetRegistry + config helpers (hydrate_builder, build_seamless_assembly) under qmtl/runtime/sdk/seamless/\n- Register ccxt.questdb.ohlcv preset (QuestDB storage + CCXT OHLCV backfill), auto-loaded via io package\n- Rewire EnhancedQuestDBProvider to assemble via the builder while preserving new settings paths\n- Documentation: architecture guide section for config-driven usage; example updated with preset demo\n- Tests: new  covering hydration paths and factory invocation\n\nNotes\n- Backwards compatible: existing providers continue to work; the builder is additive.\n- Follow-ups: additional presets, YAML loader examples, and extended E2E tests.