### PR TITLE
Add extraDashboards merge support to Grafana Helm chart

### DIFF
--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -52,6 +52,8 @@ The command writes the results to `operations/monitoring/dist/` and exports reus
 - `dist/terraform/seamless_v2_observability/` contains a Terraform module that exposes the dashboards and recording rules through the Kubernetes provider alongside a `terraform.tfvars.example` file for automation.
 - `samples/` includes ready-to-commit snippets (`*.helm-values.yaml` and `*.terraform.tfvars`) that CI pipelines can mount directly without re-running the generator.
 
+The Helm chart exposes `grafanaDashboards.extraDashboards` so you can append additional dashboards without overriding the defaults baked into `values.yaml`. Only set `grafanaDashboards.dashboards` if you intend to replace the upstream list entirely.
+
 ### Deploying with Helm
 
 1. Provide Grafana connectivity by ensuring your Grafana release watches ConfigMaps with the `grafana_dashboard: "1"` label.
@@ -63,6 +65,7 @@ The command writes the results to `operations/monitoring/dist/` and exports reus
      -f operations/monitoring/dist/helm/seamless_v2_observability/values-sample.yaml
    ```
 3. Prometheus Operator users should verify that the namespace in `values-sample.yaml` matches their deployment; adjust `prometheusRule.namespace` if necessary.
+4. When adding custom dashboards, populate `grafanaDashboards.extraDashboards` in your override file so Helm merges the defaults with your additions during rendering.
 
 ### Deploying with Terraform
 

--- a/operations/monitoring/samples/seamless_v2_observability.helm-values.yaml
+++ b/operations/monitoring/samples/seamless_v2_observability.helm-values.yaml
@@ -5,13 +5,16 @@ commonLabels:
 grafanaDashboards:
   enabled: true
   folder: Seamless
-  dashboards:
-  - uid: seamless-sla-overview
-    title: Seamless SLA Overview
-  - uid: seamless-backfill-health
-    title: Backfill Coordinator Health
-  - uid: seamless-conformance-quality
-    title: Conformance Quality
+  extraDashboards: []
+  # Use extraDashboards to append additional Grafana dashboards without overriding
+  # the defaults defined in values.yaml. Provide the full dashboard JSON payload
+  # in the `json` field so Helm can render it into the ConfigMap.
+  #
+  # extraDashboards:
+  #   - uid: custom-dashboard
+  #     title: Custom Dashboard
+  #     json: |
+  #       {"annotations": [], "panels": []}
 prometheusRule:
   enabled: true
   namespace: monitoring

--- a/tests/operations/test_package_monitoring_bundle.py
+++ b/tests/operations/test_package_monitoring_bundle.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.package_monitoring_bundle import Bundle, build_helm
+
+
+def test_build_helm_appends_extra_dashboards(tmp_path: Path) -> None:
+    dashboard_payload = {
+        "uid": "base-dashboard",
+        "title": "Base Dashboard",
+        "panels": [],
+    }
+    bundle = Bundle(
+        name="demo_observability",
+        version=1,
+        dashboards=[dashboard_payload],
+        recording_rules=[],
+    )
+
+    build_helm(bundle, tmp_path)
+
+    chart_dir = tmp_path / "helm" / bundle.name
+    values = yaml.safe_load((chart_dir / "values.yaml").read_text())
+    assert values["grafanaDashboards"]["extraDashboards"] == []
+    assert len(values["grafanaDashboards"]["dashboards"]) == 1
+    rendered_json = values["grafanaDashboards"]["dashboards"][0]["json"]
+    assert json.loads(rendered_json)["uid"] == "base-dashboard"
+
+    sample = yaml.safe_load((chart_dir / "values-sample.yaml").read_text())
+    assert "dashboards" not in sample["grafanaDashboards"]
+    assert sample["grafanaDashboards"]["extraDashboards"] == []
+
+    template = (chart_dir / "templates" / "grafana-dashboards.yaml").read_text()
+    assert "concat $base $extra" in template
+    assert "Use extraDashboards" in (chart_dir / "values-sample.yaml").read_text()


### PR DESCRIPTION
## Summary
- allow Helm packaging to merge built-in dashboards with grafanaDashboards.extraDashboards instead of replacing the list
- update the sample values and documentation to steer users toward extraDashboards and add coverage for the new behaviour

## Testing
- uv run -m pytest tests/operations/test_package_monitoring_bundle.py
- uv run mkdocs build

Fixes #1242

------
https://chatgpt.com/codex/tasks/task_e_68d986899088832999e853bd31fdcdfa