### PR TITLE
Add declarative StepSpec DSL for node set recipes

### DIFF
--- a/qmtl/runtime/nodesets/base.py
+++ b/qmtl/runtime/nodesets/base.py
@@ -167,7 +167,12 @@ class NodeSetBuilder:
         ctx = self.context(world_id=world_id, scope=scope)
 
         def _resolve(component, upstream, default_factory: RecipeNodeFactory) -> Node:
-            if isinstance(component, Node):
+            # Import locally to avoid circular dependency during module load.
+            from .steps import StepSpec
+
+            if isinstance(component, StepSpec):
+                node = component.bind(upstream, ctx, default_factory)
+            elif isinstance(component, Node):
                 node = component
             elif callable(component):
                 node = component(upstream, ctx)

--- a/qmtl/runtime/nodesets/steps.py
+++ b/qmtl/runtime/nodesets/steps.py
@@ -8,12 +8,17 @@ pretrade → sizing → execution → order_publish → fills → portfolio → 
 
 `compose(signal, steps)` applies the provided steps left-to-right and returns a
 NodeSet. Missing trailing steps are filled with defaults; extra steps raise.
+
+The module also exposes :class:`StepSpec`, a declarative descriptor used by
+recipes to request default fallbacks or resource-aware overrides without
+writing ad-hoc wiring lambdas.
 """
 
-from typing import Any, Callable, Sequence
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal, Mapping, Sequence, TYPE_CHECKING
 
 from qmtl.runtime.sdk import Node
-from qmtl.runtime.nodesets.base import NodeSet
 from qmtl.runtime.nodesets.stubs import (
     StubPreTradeGateNode,
     StubSizingNode,
@@ -25,8 +30,179 @@ from qmtl.runtime.nodesets.stubs import (
     StubTimingGateNode,
 )
 
+if TYPE_CHECKING:
+    from qmtl.runtime.nodesets.base import NodeSetContext, NodeSet
+
 
 Step = Callable[[Node], Node]
+"""Callable that wires a node behind ``upstream``."""
+
+
+StepName = Literal[
+    "pretrade",
+    "sizing",
+    "execution",
+    "order_publish",
+    "fills",
+    "portfolio",
+    "risk",
+    "timing",
+]
+
+
+STEP_ORDER: tuple[StepName, ...] = (
+    "pretrade",
+    "sizing",
+    "execution",
+    "order_publish",
+    "fills",
+    "portfolio",
+    "risk",
+    "timing",
+)
+
+
+@dataclass(frozen=True)
+class StepSpec:
+    """Declarative description of a recipe step override."""
+
+    factory: Callable[..., Node] | None = None
+    """Callable that returns a node when supplied with ``upstream`` and kwargs."""
+
+    step: Step | None = None
+    """Pre-bound step callable (no access to a recipe context)."""
+
+    node: Node | None = None
+    """Pre-built node instance."""
+
+    kwargs: Mapping[str, Any] = field(default_factory=dict)
+    """Static keyword arguments passed to ``factory`` when invoked."""
+
+    _injections: tuple[tuple[str, Callable[["NodeSetContext"], Any]], ...] = ()
+    """Context-aware injections expressed as (argument, resolver) pairs."""
+
+    @classmethod
+    def default(cls) -> "StepSpec":
+        """Return a spec that defers to the default stub."""
+
+        return cls()
+
+    @classmethod
+    def from_step(cls, step: Step) -> "StepSpec":
+        """Wrap a pre-built :class:`Step` callable."""
+
+        return cls(step=step)
+
+    @classmethod
+    def from_node(cls, node: Node) -> "StepSpec":
+        """Wrap an already constructed node."""
+
+        return cls(node=node)
+
+    @classmethod
+    def from_factory(
+        cls,
+        factory: Callable[..., Node],
+        *,
+        kwargs: Mapping[str, Any] | None = None,
+        inject_portfolio: bool = False,
+        inject_weight_fn: bool = False,
+        inject_resources: bool = False,
+        inject_world_id: bool = False,
+    ) -> "StepSpec":
+        """Create a spec around ``factory`` with optional resource injections."""
+
+        injections: list[tuple[str, Callable[["NodeSetContext"], Any]]] = []
+        if inject_portfolio:
+            injections.append(("portfolio", lambda ctx: ctx.resources.portfolio))
+        if inject_weight_fn:
+            injections.append(("weight_fn", lambda ctx: ctx.resources.weight_fn))
+        if inject_resources:
+            injections.append(("resources", lambda ctx: ctx.resources))
+        if inject_world_id:
+            injections.append(("world_id", lambda ctx: ctx.world_id))
+
+        return cls(
+            factory=factory,
+            kwargs=dict(kwargs or {}),
+            _injections=tuple(injections),
+        )
+
+    @classmethod
+    def ensure(
+        cls,
+        component: "StepSpec | Step | Node | None",
+    ) -> "StepSpec":
+        """Normalize arbitrary step components to a :class:`StepSpec`."""
+
+        if component is None:
+            return cls.default()
+        if isinstance(component, StepSpec):
+            return component
+        if isinstance(component, Node):
+            return cls.from_node(component)
+        if callable(component):
+            try:
+                signature = inspect.signature(component)
+            except (TypeError, ValueError):
+                return cls.from_step(component)
+            if len(signature.parameters) == 1:
+                return cls.from_step(component)
+        if isinstance(component, StepSpec):  # pragma: no cover - handled above but aids mypy
+            return component
+        raise TypeError(f"Unsupported step component: {type(component)!r}")
+
+    @property
+    def is_default(self) -> bool:
+        """Return ``True`` when this spec defers to default behaviour."""
+
+        return (
+            self.factory is None
+            and self.step is None
+            and self.node is None
+            and not self.kwargs
+            and not self._injections
+        )
+
+    def with_injection(
+        self,
+        argument: str,
+        resolver: Callable[["NodeSetContext"], Any],
+    ) -> "StepSpec":
+        """Return a new spec with an additional context-driven injection."""
+
+        return StepSpec(
+            factory=self.factory,
+            step=self.step,
+            node=self.node,
+            kwargs=dict(self.kwargs),
+            _injections=self._injections + ((argument, resolver),),
+        )
+
+    def bind(
+        self,
+        upstream: Node,
+        ctx: "NodeSetContext",
+        default_factory: Callable[[Node, "NodeSetContext"], Node],
+    ) -> Node:
+        """Realize this specification into a concrete node instance."""
+
+        if self.node is not None:
+            node = self.node
+        elif self.step is not None:
+            node = self.step(upstream)
+        elif self.factory is not None:
+            kwargs = dict(self.kwargs)
+            for argument, resolver in self._injections:
+                if argument not in kwargs:
+                    kwargs[argument] = resolver(ctx)
+            node = self.factory(upstream, **kwargs)
+        else:
+            node = default_factory(upstream, ctx)
+
+        if not isinstance(node, Node):
+            raise TypeError("Step specification must resolve to a Node instance")
+        return node
 
 
 def pretrade(*, name: str | None = None) -> Step:
@@ -114,6 +290,8 @@ def compose(
     defaults in the canonical order. If more than 8 steps are provided, raises.
     """
 
+    from qmtl.runtime.nodesets.base import NodeSet
+
     default_steps: list[Step] = [
         pretrade(),
         sizing(),
@@ -152,6 +330,9 @@ def compose(
 
 __all__ = [
     "Step",
+    "StepName",
+    "STEP_ORDER",
+    "StepSpec",
     "pretrade",
     "sizing",
     "execution",


### PR DESCRIPTION
## Summary
- add a StepSpec-based DSL with resource injection helpers for node set steps
- update NodeSetRecipe to consume StepSpec overrides and refactor the CCXT spot recipe to use them
- expand node set tests to cover StepSpec bindings, resets, and error handling

## Testing
- uv run -m pytest tests/runtime/nodesets/test_nodeset_builder_smoke.py -W error

Fixes #1252

------
https://chatgpt.com/codex/tasks/task_e_68dba92043e883298d7ed43e06ee5ebc