### PR TITLE
Automate nodeset recipe registration

### DIFF
--- a/docs/architecture/exchange_node_sets.md
+++ b/docs/architecture/exchange_node_sets.md
@@ -85,6 +85,23 @@ from qmtl.runtime.nodesets.registry import make
 nodeset = make("ccxt_spot", signal, "demo-world", exchange_id="binance")
 ```
 
+- Registering a new recipe is handled by a decorator. Recipes register
+  themselves when their module is imported, keeping the registry in sync with
+  available builders:
+
+```python
+from qmtl.runtime.nodesets.registry import nodeset_recipe
+
+
+@nodeset_recipe("my_adapter")
+def make_my_adapter(signal, world_id, **kwargs):
+    # construct and return a NodeSet instance
+    ...
+```
+
+If another callable tries to reuse an existing recipe name the registry raises
+``ValueError`` to prevent silent shadowing.
+
 Branching inside
 - Node Sets may contain internal branching/join nodes when needed (e.g., execution step joining sized orders with market data). Keep the Node Set a black box to the strategy; expose multi-input needs via an Adapter’s port specs.
 

--- a/qmtl/runtime/nodesets/recipes.py
+++ b/qmtl/runtime/nodesets/recipes.py
@@ -26,12 +26,15 @@ from qmtl.runtime.nodesets.resources import get_execution_resources
 from qmtl.runtime.nodesets.steps import (
     StepSpec,
     STEP_ORDER,
+    compose,
     execution,
+    pretrade,
     order_publish,
     fills,
     risk,
     timing,
 )
+from qmtl.runtime.nodesets.registry import nodeset_recipe
 from qmtl.runtime.pipeline.execution_nodes import (
     SizingNode as RealSizingNode,
     PortfolioNode as RealPortfolioNode,
@@ -129,6 +132,7 @@ class NodeSetRecipe:
         return normalized
 
 
+@nodeset_recipe("ccxt_spot")
 def make_ccxt_spot_nodeset(
     signal_node: Node,
     world_id: str,
@@ -211,6 +215,7 @@ def make_ccxt_spot_nodeset(
     )
 
 
+@nodeset_recipe("ccxt_futures")
 def make_ccxt_futures_nodeset(
     signal_node: Node,
     world_id: str,

--- a/qmtl/runtime/nodesets/registry.py
+++ b/qmtl/runtime/nodesets/registry.py
@@ -2,21 +2,66 @@ from __future__ import annotations
 
 """Lightweight Node Set registry for discoverability and extension."""
 
-from typing import Callable, Dict
+from importlib import import_module
+from typing import Callable, Dict, Iterable, TypeVar
 
 from .base import NodeSet
 
 
-_REGISTRY: Dict[str, Callable[..., NodeSet]] = {}
+RecipeBuilder = Callable[..., NodeSet]
+_REGISTRY: Dict[str, RecipeBuilder] = {}
+_DISCOVERED = False
+_AUTO_IMPORTS: tuple[str, ...] = ("qmtl.runtime.nodesets.recipes",)
+_T = TypeVar("_T", bound=RecipeBuilder)
 
 
-def register(name: str, builder: Callable[..., NodeSet]) -> None:
+def register(name: str, builder: RecipeBuilder) -> None:
+    """Register ``builder`` under ``name``.
+
+    Duplicate registrations for different callables are rejected to avoid
+    accidentally shadowing an existing recipe. Re-registering the same callable
+    is treated as a no-op to support module reloads in development.
+    """
+
     if not isinstance(name, str) or not name:
         raise ValueError("registry name must be a non-empty string")
+
+    existing = _REGISTRY.get(name)
+    if existing is not None and existing is not builder:
+        raise ValueError(f"nodeset recipe '{name}' is already registered")
     _REGISTRY[name] = builder
 
 
+def nodeset_recipe(name: str) -> Callable[[_T], _T]:
+    """Decorator that registers a Node Set recipe for discovery."""
+
+    def decorator(builder: _T) -> _T:
+        register(name, builder)
+        return builder
+
+    return decorator
+
+
+def _ensure_discovered() -> None:
+    global _DISCOVERED
+    if _DISCOVERED:
+        return
+
+    for module_name in _AUTO_IMPORTS:
+        import_module(module_name)
+
+    _DISCOVERED = True
+
+
+def discover(modules: Iterable[str]) -> None:
+    """Explicitly import additional modules to trigger recipe registration."""
+
+    for module_name in modules:
+        import_module(module_name)
+
+
 def make(name: str, *args, **kwargs) -> NodeSet:
+    _ensure_discovered()
     try:
         builder = _REGISTRY[name]
     except KeyError as e:
@@ -25,19 +70,9 @@ def make(name: str, *args, **kwargs) -> NodeSet:
 
 
 def list_registered() -> list[str]:
+    _ensure_discovered()
     return sorted(_REGISTRY.keys())
 
 
-def _register_builtins() -> None:
-    # Local import to avoid cycles
-    from .recipes import make_ccxt_spot_nodeset, make_ccxt_futures_nodeset
-
-    register("ccxt_spot", make_ccxt_spot_nodeset)
-    register("ccxt_futures", make_ccxt_futures_nodeset)
-
-
-_register_builtins()
-
-
-__all__ = ["register", "make", "list_registered"]
+__all__ = ["discover", "nodeset_recipe", "register", "make", "list_registered"]
 

--- a/tests/runtime/nodesets/test_nodeset_registry_basic.py
+++ b/tests/runtime/nodesets/test_nodeset_registry_basic.py
@@ -1,4 +1,7 @@
+import pytest
+
 from qmtl.runtime.sdk import Node, StreamInput
+from qmtl.runtime.nodesets import registry as registry_module
 from qmtl.runtime.nodesets.registry import make, list_registered
 
 
@@ -26,3 +29,34 @@ def test_nodeset_registry_make_ccxt_futures_simulate():
     nodes = list(ns)
     assert ns.head is nodes[0] and ns.tail is nodes[-1]
     assert len(nodes) == 8
+
+
+def test_nodeset_recipe_decorator_registers(monkeypatch):
+    monkeypatch.setattr(registry_module, "_REGISTRY", {}, raising=False)
+    monkeypatch.setattr(registry_module, "_DISCOVERED", True, raising=False)
+
+    @registry_module.nodeset_recipe("test_recipe")
+    def _builder(*_args, **_kwargs):
+        return "sentinel"
+
+    assert list_registered() == ["test_recipe"]
+    assert make("test_recipe") == "sentinel"
+    assert registry_module._REGISTRY["test_recipe"] is _builder
+
+
+def test_nodeset_recipe_duplicate_name(monkeypatch):
+    monkeypatch.setattr(registry_module, "_REGISTRY", {}, raising=False)
+    monkeypatch.setattr(registry_module, "_DISCOVERED", True, raising=False)
+
+    @registry_module.nodeset_recipe("test_recipe")
+    def _builder(*_args, **_kwargs):
+        return "sentinel"
+
+    with pytest.raises(ValueError):
+
+        @registry_module.nodeset_recipe("test_recipe")
+        def _other_builder():
+            return "other"
+
+    # Re-registering the same callable should be a no-op.
+    registry_module.register("test_recipe", _builder)


### PR DESCRIPTION
## Summary
- add a decorator-based registration mechanism with lazy discovery for node set recipes
- convert the built-in CCXT recipes to self-register and document the pattern for new recipes
- expand registry coverage to exercise the decorator path and duplicate-name protection

## Testing
- uv run -m pytest -W error tests/runtime/nodesets/test_nodeset_registry_basic.py

Fixes #1253

------
https://chatgpt.com/codex/tasks/task_e_68de31addc948329abdfeb033f5fad40