### PR TITLE
Generate CCXT spot adapter from recipe metadata

### DIFF
--- a/qmtl/runtime/nodesets/adapters/ccxt_spot.py
+++ b/qmtl/runtime/nodesets/adapters/ccxt_spot.py
@@ -2,60 +2,12 @@ from __future__ import annotations
 
 """CCXT spot Node Set adapter."""
 
-from qmtl.runtime.sdk import Node
-from qmtl.runtime.nodesets.base import NodeSet
-from qmtl.runtime.nodesets.adapter import NodeSetAdapter, NodeSetDescriptor, PortSpec
-from qmtl.runtime.nodesets.options import NodeSetOptions
-from qmtl.runtime.nodesets.recipes import make_ccxt_spot_nodeset
+from qmtl.runtime.nodesets.adapter import NodeSetAdapter
+from qmtl.runtime.nodesets.recipes import CCXT_SPOT_ADAPTER_SPEC, build_adapter
 
 
-class CcxtSpotAdapter(NodeSetAdapter):
-    """Adapter exposing a single required input port: 'signal'."""
-
-    descriptor = NodeSetDescriptor(
-        name="ccxt_spot",
-        inputs=(PortSpec("signal", True, "Trade signal stream"),),
-        outputs=(PortSpec("orders", True, "Order stream (execution output)"),),
-    )
-
-    def __init__(
-        self,
-        *,
-        exchange_id: str,
-        sandbox: bool = False,
-        apiKey: str | None = None,
-        secret: str | None = None,
-        time_in_force: str = "GTC",
-        reduce_only: bool = False,
-    ) -> None:
-        self.exchange_id = exchange_id
-        self.sandbox = sandbox
-        self.apiKey = apiKey
-        self.secret = secret
-        self.time_in_force = time_in_force
-        self.reduce_only = reduce_only
-
-    def build(
-        self,
-        inputs: dict[str, Node],
-        *,
-        world_id: str,
-        options: NodeSetOptions | None = None,
-    ) -> NodeSet:
-        self.validate_inputs(inputs)
-        signal = inputs["signal"]
-        return make_ccxt_spot_nodeset(
-            signal,
-            world_id,
-            exchange_id=self.exchange_id,
-            sandbox=self.sandbox,
-            apiKey=self.apiKey,
-            secret=self.secret,
-            time_in_force=self.time_in_force,
-            reduce_only=self.reduce_only,
-            options=options,
-            descriptor=self.descriptor,
-        )
+CcxtSpotAdapter: type[NodeSetAdapter] = build_adapter(CCXT_SPOT_ADAPTER_SPEC)
+CcxtSpotAdapter.__module__ = __name__
 
 
 __all__ = ["CcxtSpotAdapter"]

--- a/qmtl/runtime/nodesets/recipes.py
+++ b/qmtl/runtime/nodesets/recipes.py
@@ -7,6 +7,9 @@ for constructing exchange-backed execution pipelines. Treat the returned
 NodeSet as a black box; its internal composition may change between versions.
 """
 
+from dataclasses import dataclass
+from inspect import Parameter, Signature
+from types import MappingProxyType
 from typing import Any, Callable, Literal, Mapping, Sequence
 
 from qmtl.runtime.sdk import Node
@@ -21,6 +24,7 @@ from qmtl.runtime.nodesets.base import (
     NodeSetBuilder,
     NodeSetContext,
 )
+from qmtl.runtime.nodesets.adapter import NodeSetAdapter, NodeSetDescriptor, PortSpec
 from qmtl.runtime.nodesets.options import NodeSetOptions
 from qmtl.runtime.nodesets.resources import get_execution_resources
 from qmtl.runtime.nodesets.steps import (
@@ -41,6 +45,41 @@ from qmtl.runtime.pipeline.execution_nodes import (
 )
 
 
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class AdapterParameter:
+    """Declarative description of an adapter configuration parameter."""
+
+    name: str
+    annotation: Any = Any
+    default: Any = _MISSING
+    required: bool = True
+    description: str | None = None
+
+    def has_default(self) -> bool:
+        return self.default is not _MISSING
+
+
+@dataclass(frozen=True)
+class RecipeAdapterSpec:
+    """Specification describing how to build an adapter from a recipe."""
+
+    compose: Callable[..., NodeSet]
+    descriptor: NodeSetDescriptor
+    parameters: Sequence[AdapterParameter] = ()
+    name: str | None = None
+    doc: str | None = None
+    input_port: str = "signal"
+    class_name: str | None = None
+    modes: Sequence[str] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.input_port:
+            raise ValueError("input_port must be a non-empty string")
+
+
 RecipeComponent = Node | Callable[[Node, NodeSetContext], Node] | StepSpec | None
 
 
@@ -55,12 +94,19 @@ class NodeSetRecipe:
         modes: Sequence[str] | None = None,
         descriptor: Any | None = None,
         steps: Mapping[str, StepSpec | Callable[[Node], Node] | Node | None] | None = None,
+        adapter_parameters: Sequence[AdapterParameter] | None = None,
     ) -> None:
-        self.builder = builder or NodeSetBuilder()
+        template = builder or NodeSetBuilder()
+        self.builder = template
+        self._builder_template = template
+        self._builder_cls = type(template)
+        base_options = getattr(template, "options", None)
+        self._builder_options = base_options if base_options is not None else NodeSetOptions()
         self.name = name
         self._modes = tuple(modes) if modes is not None else None
         self._descriptor = descriptor
         self._steps = self._normalize_steps(steps or {}, drop_defaults=True)
+        self._adapter_parameters = tuple(adapter_parameters or ())
 
     def compose(
         self,
@@ -70,6 +116,7 @@ class NodeSetRecipe:
         scope: Literal["strategy", "world"] | None = None,
         descriptor: Any | None = None,
         steps: Mapping[str, StepSpec | Callable[[Node], Node] | Node | None] | None = None,
+        options: NodeSetOptions | None = None,
         **legacy_components: RecipeComponent,
     ) -> NodeSet:
         resolved_steps = dict(self._steps)
@@ -105,7 +152,9 @@ class NodeSetRecipe:
             elif name in legacy_passthrough:
                 attach_kwargs[name] = legacy_passthrough[name]
 
-        return self.builder.attach(
+        builder = self._make_builder(options)
+
+        return builder.attach(
             signal,
             world_id=world_id,
             scope=scope,
@@ -114,6 +163,27 @@ class NodeSetRecipe:
             descriptor=descriptor if descriptor is not None else self._descriptor,
             **attach_kwargs,
         )
+
+    def _make_builder(self, options: NodeSetOptions | None) -> NodeSetBuilder:
+        opts = options or self._builder_options
+        try:
+            return self._builder_cls(options=opts)
+        except TypeError:
+            if options is None:
+                return self._builder_template
+            raise
+
+    @property
+    def descriptor(self) -> Any | None:
+        return self._descriptor
+
+    @property
+    def default_modes(self) -> tuple[str, ...] | None:
+        return self._modes
+
+    @property
+    def adapter_parameters(self) -> tuple[AdapterParameter, ...]:
+        return self._adapter_parameters
 
     @staticmethod
     def _normalize_steps(
@@ -130,6 +200,130 @@ class NodeSetRecipe:
                 continue
             normalized[name] = spec
         return normalized
+
+
+def build_adapter(spec: RecipeAdapterSpec) -> type[NodeSetAdapter]:
+    """Return a concrete :class:`NodeSetAdapter` for ``spec``."""
+
+    parameters = tuple(spec.parameters)
+    descriptor_value = spec.descriptor
+    compose = spec.compose
+    input_port = spec.input_port
+    name_hint = spec.name or descriptor.name
+    class_name = spec.class_name or (
+        f"{''.join(part.capitalize() for part in (name_hint or 'nodeset').split('_'))}Adapter"
+    )
+    doc = spec.doc or f"Adapter generated for recipe '{name_hint}'."
+    modes = tuple(spec.modes) if spec.modes is not None else None
+
+    slots = tuple(param.name for param in parameters) + ("_config",)
+
+    class GeneratedAdapter(NodeSetAdapter):
+        __slots__ = slots
+        descriptor = descriptor_value
+        recipe_name = name_hint
+        default_modes = modes
+        adapter_parameters = parameters
+        __doc__ = doc
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__()
+            values: dict[str, Any] = {}
+            for param in parameters:
+                if param.name in kwargs:
+                    value = kwargs.pop(param.name)
+                elif param.has_default():
+                    value = param.default
+                elif param.required:
+                    raise TypeError(f"missing required adapter parameter: {param.name}")
+                else:
+                    value = None
+                setattr(self, param.name, value)
+                values[param.name] = value
+
+            if kwargs:
+                unexpected = ", ".join(sorted(kwargs))
+                raise TypeError(f"unexpected adapter parameter(s): {unexpected}")
+
+            object.__setattr__(self, "_config", MappingProxyType(dict(values)))
+
+        def build(
+            self,
+            inputs: Mapping[str, Node],
+            *,
+            world_id: str,
+            options: NodeSetOptions | None = None,
+        ) -> NodeSet:
+            self.validate_inputs(inputs)
+            if input_port not in inputs:
+                raise KeyError(f"Missing required input port: {input_port}")
+
+            compose_kwargs = {param.name: getattr(self, param.name) for param in parameters}
+            return compose(
+                inputs,
+                world_id,
+                options=options,
+                descriptor=descriptor_value,
+                **compose_kwargs,
+            )
+
+        @property
+        def config(self) -> Mapping[str, Any]:
+            return self._config
+
+    init_parameters = [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
+    for param in parameters:
+        default = param.default if param.has_default() else Parameter.empty
+        annotation = param.annotation if param.annotation is not None else Parameter.empty
+        init_parameters.append(
+            Parameter(
+                param.name,
+                kind=Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=annotation,
+            )
+        )
+    GeneratedAdapter.__init__.__signature__ = Signature(init_parameters)
+
+    GeneratedAdapter.__name__ = class_name
+    GeneratedAdapter.__qualname__ = class_name
+    GeneratedAdapter.__module__ = compose.__module__
+
+    return GeneratedAdapter
+
+
+CCXT_SPOT_DESCRIPTOR = NodeSetDescriptor(
+    name="ccxt_spot",
+    inputs=(PortSpec("signal", True, "Trade signal stream"),),
+    outputs=(PortSpec("orders", True, "Order stream (execution output)"),),
+)
+
+CCXT_SPOT_ADAPTER_PARAMETERS = (
+    AdapterParameter("exchange_id", annotation=str),
+    AdapterParameter("sandbox", annotation=bool, default=False, required=False),
+    AdapterParameter("apiKey", annotation=str | None, default=None, required=False),
+    AdapterParameter("secret", annotation=str | None, default=None, required=False),
+    AdapterParameter("time_in_force", annotation=str, default="GTC", required=False),
+    AdapterParameter("reduce_only", annotation=bool, default=False, required=False),
+)
+
+_CCXT_SPOT_RECIPE = NodeSetRecipe(
+    name="ccxt_spot",
+    modes=("simulate", "paper", "live"),
+    descriptor=CCXT_SPOT_DESCRIPTOR,
+    steps={
+        "sizing": StepSpec.from_factory(
+            RealSizingNode,
+            inject_portfolio=True,
+            inject_weight_fn=True,
+        ),
+        "portfolio": StepSpec.from_factory(
+            RealPortfolioNode,
+            inject_portfolio=True,
+        ),
+    },
+    adapter_parameters=CCXT_SPOT_ADAPTER_PARAMETERS,
+)
 
 
 @nodeset_recipe("ccxt_spot")
@@ -166,8 +360,7 @@ def make_ccxt_spot_nodeset(
     else:
         client = FakeBrokerageClient()
 
-    # Execution with CCXT client; applies default opts inline
-    def _exec(view: CacheView, upstream: Node) -> dict | None:  # capture time_in_force/reduce_only
+    def _exec(view: CacheView, upstream: Node) -> dict | None:
         data = view[upstream][upstream.interval]
         if not data:
             return None
@@ -178,7 +371,7 @@ def make_ccxt_spot_nodeset(
             order["reduce_only"] = True
         return order
 
-    def _publish(view: CacheView, upstream: Node) -> dict | None:  # capture client
+    def _publish(view: CacheView, upstream: Node) -> dict | None:
         data = view[upstream][upstream.interval]
         if not data:
             return None
@@ -186,33 +379,49 @@ def make_ccxt_spot_nodeset(
         client.post_order(order)
         return order
 
-    opts = options or NodeSetOptions()
-    recipe = NodeSetRecipe(
-        name="ccxt_spot",
-        builder=NodeSetBuilder(options=opts),
-        modes=("simulate", "paper", "live"),
-    )
-
+    resolved_options = options or NodeSetOptions()
     step_overrides = {
-        "sizing": StepSpec.from_factory(
-            RealSizingNode,
-            inject_portfolio=True,
-            inject_weight_fn=True,
-        ),
         "execution": StepSpec.from_step(execution(compute_fn=_exec)),
         "order_publish": StepSpec.from_step(order_publish(compute_fn=_publish)),
-        "portfolio": StepSpec.from_factory(
-            RealPortfolioNode,
-            inject_portfolio=True,
-        ),
     }
 
-    return recipe.compose(
+    return _CCXT_SPOT_RECIPE.compose(
         signal_node,
         world_id,
         descriptor=descriptor,
         steps=step_overrides,
+        options=resolved_options,
     )
+
+
+def _compose_ccxt_spot_adapter(
+    inputs: Mapping[str, Node],
+    world_id: str,
+    *,
+    options: NodeSetOptions | None = None,
+    descriptor: Any | None = None,
+    **config: Any,
+) -> NodeSet:
+    signal = inputs["signal"]
+    return make_ccxt_spot_nodeset(
+        signal,
+        world_id,
+        descriptor=descriptor,
+        options=options,
+        **config,
+    )
+
+
+CCXT_SPOT_ADAPTER_SPEC = RecipeAdapterSpec(
+    compose=_compose_ccxt_spot_adapter,
+    descriptor=CCXT_SPOT_DESCRIPTOR,
+    parameters=_CCXT_SPOT_RECIPE.adapter_parameters,
+    name="ccxt_spot",
+    class_name="CcxtSpotAdapter",
+    doc="Adapter exposing a single required input port: 'signal'.",
+    input_port="signal",
+    modes=_CCXT_SPOT_RECIPE.default_modes,
+)
 
 
 @nodeset_recipe("ccxt_futures")
@@ -310,4 +519,13 @@ def make_ccxt_futures_nodeset(
     )
 
 
-__all__ = ["NodeSetRecipe", "make_ccxt_spot_nodeset", "make_ccxt_futures_nodeset"]
+__all__ = [
+    "AdapterParameter",
+    "RecipeAdapterSpec",
+    "NodeSetRecipe",
+    "build_adapter",
+    "CCXT_SPOT_DESCRIPTOR",
+    "CCXT_SPOT_ADAPTER_SPEC",
+    "make_ccxt_spot_nodeset",
+    "make_ccxt_futures_nodeset",
+]

--- a/qmtl/runtime/nodesets/recipes.py
+++ b/qmtl/runtime/nodesets/recipes.py
@@ -209,7 +209,7 @@ def build_adapter(spec: RecipeAdapterSpec) -> type[NodeSetAdapter]:
     descriptor_value = spec.descriptor
     compose = spec.compose
     input_port = spec.input_port
-    name_hint = spec.name or descriptor.name
+    name_hint = spec.name or getattr(descriptor_value, "name", None)
     class_name = spec.class_name or (
         f"{''.join(part.capitalize() for part in (name_hint or 'nodeset').split('_'))}Adapter"
     )


### PR DESCRIPTION
## Summary
- extend recipe utilities with adapter parameter metadata and a `build_adapter` helper
- generate the CCXT spot adapter from the shared recipe specification while preserving its API

## Testing
- uv run -m pytest tests/runtime/nodesets/test_nodeset_adapter_descriptor.py

Fixes #1254

------
https://chatgpt.com/codex/tasks/task_e_68de48af9b9c8329a35d9daf33111e33