### PR TITLE
Add order-book imbalance indicators

### DIFF
--- a/qmtl/runtime/indicators/README.md
+++ b/qmtl/runtime/indicators/README.md
@@ -18,9 +18,11 @@ from qmtl.runtime.indicators import acceptable_price_band_node
 
 `order_book_obi` consumes raw order-book snapshots containing bid and ask
 levels and returns the normalized imbalance `(bid-ask)/(bid+ask)` across the
-top ``levels`` tiers. The helper also exposes
+top ``levels`` tiers. Pass ``period`` to control how many recent outputs the
+node retains in its cache. The helper also exposes
 `order_book_obi_ema(..., ema_period=20)` which applies an exponential moving
-average to the raw OBI stream for smoother downstream consumption.
+average to the raw OBI stream for smoother downstream consumption and ensures
+the underlying OBI cache keeps ``ema_period`` samples available.
 
 ```python
 from qmtl.runtime.indicators import order_book_obi, order_book_obi_ema

--- a/qmtl/runtime/indicators/README.md
+++ b/qmtl/runtime/indicators/README.md
@@ -14,6 +14,21 @@ from qmtl.runtime.indicators import sma
 from qmtl.runtime.indicators import acceptable_price_band_node
 ```
 
+## Order-book imbalance (OBI)
+
+`order_book_obi` consumes raw order-book snapshots containing bid and ask
+levels and returns the normalized imbalance `(bid-ask)/(bid+ask)` across the
+top ``levels`` tiers. The helper also exposes
+`order_book_obi_ema(..., ema_period=20)` which applies an exponential moving
+average to the raw OBI stream for smoother downstream consumption.
+
+```python
+from qmtl.runtime.indicators import order_book_obi, order_book_obi_ema
+
+obi = order_book_obi(book_snapshots, levels=3)
+smoothed = order_book_obi_ema(book_snapshots, levels=3, ema_period=10)
+```
+
 ## Acceptable price band alpha
 
 `acceptable_price_band_node` adapts a dynamic mean and volatility band using

--- a/qmtl/runtime/indicators/__init__.py
+++ b/qmtl/runtime/indicators/__init__.py
@@ -17,6 +17,7 @@ from .kalman_trend import kalman_trend
 from .rough_bergomi import rough_bergomi
 from .stoch_rsi import stoch_rsi
 from .volatility import volatility_node, volatility
+from .order_book_obi import order_book_obi, order_book_obi_ema
 # Optional alpha indicator; may not be available in all deployments
 try:  # pragma: no cover - fallback for missing alpha module
     from .gap_amplification_alpha import gap_amplification_node
@@ -43,6 +44,8 @@ __all__ = [
     "stoch_rsi",
     "volatility_node",
     "volatility",
+    "order_book_obi",
+    "order_book_obi_ema",
     "alpha_indicator_with_history",
 ]
 

--- a/qmtl/runtime/indicators/order_book_obi.py
+++ b/qmtl/runtime/indicators/order_book_obi.py
@@ -44,6 +44,7 @@ def order_book_obi(
     *,
     levels: int = 1,
     epsilon: float = 1e-9,
+    period: int = 1,
     name: str | None = None,
 ) -> Node:
     """Return a node computing order-book imbalance from raw snapshots.
@@ -58,6 +59,8 @@ def order_book_obi(
         Number of levels from each side included in the imbalance sum.
     epsilon:
         Small constant added to the denominator to avoid division by zero.
+    period:
+        Number of recent outputs retained in the node cache. Defaults to 1.
     name:
         Optional node name. Defaults to ``"order_book_obi"``.
     """
@@ -89,7 +92,7 @@ def order_book_obi(
         compute_fn=compute,
         name=name or "order_book_obi",
         interval=source.interval,
-        period=1,
+        period=max(1, period),
     )
 
 
@@ -108,6 +111,7 @@ def order_book_obi_ema(
         source,
         levels=levels,
         epsilon=epsilon,
+        period=max(1, ema_period),
         name=f"{base_name}_obi",
     )
     return ema(obi_node, period=ema_period, name=base_name)

--- a/qmtl/runtime/indicators/order_book_obi.py
+++ b/qmtl/runtime/indicators/order_book_obi.py
@@ -1,0 +1,113 @@
+"""Order-book imbalance indicator nodes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from qmtl.runtime.sdk.cache_view import CacheView
+from qmtl.runtime.sdk.node import Node
+
+from .ema import ema
+
+__all__ = ["order_book_obi", "order_book_obi_ema"]
+
+
+def _sum_levels(levels_data: Sequence[Any] | None, levels: int) -> float:
+    """Return the summed depth over ``levels`` entries from ``levels_data``."""
+
+    if not levels_data or levels <= 0:
+        return 0.0
+
+    total = 0.0
+    taken = 0
+    for level in levels_data:
+        if taken >= levels:
+            break
+        if isinstance(level, (list, tuple)):
+            if not level:
+                continue
+            raw_size = level[1] if len(level) > 1 else level[0]
+        else:
+            raw_size = level
+        try:
+            size = float(raw_size)
+        except (TypeError, ValueError):
+            continue
+        total += size
+        taken += 1
+    return total
+
+
+def order_book_obi(
+    source: Node,
+    *,
+    levels: int = 1,
+    epsilon: float = 1e-9,
+    name: str | None = None,
+) -> Node:
+    """Return a node computing order-book imbalance from raw snapshots.
+
+    Parameters
+    ----------
+    source:
+        Node yielding order-book snapshots containing ``"bids"`` and
+        ``"asks"`` sequences. Each level may be a ``(price, size)`` pair or a
+        raw size value.
+    levels:
+        Number of levels from each side included in the imbalance sum.
+    epsilon:
+        Small constant added to the denominator to avoid division by zero.
+    name:
+        Optional node name. Defaults to ``"order_book_obi"``.
+    """
+
+    def compute(view: CacheView) -> float | None:
+        series = view[source][source.interval]
+        latest = series.latest()
+        if latest is None:
+            return None
+
+        snapshot = latest[1]
+        if snapshot is None or not isinstance(snapshot, Mapping):
+            return None
+
+        bids = snapshot.get("bids", [])
+        asks = snapshot.get("asks", [])
+
+        bid_total = _sum_levels(bids, levels)
+        ask_total = _sum_levels(asks, levels)
+
+        if bid_total == 0.0 and ask_total == 0.0:
+            return 0.0
+
+        denominator = bid_total + ask_total + epsilon
+        return (bid_total - ask_total) / denominator
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "order_book_obi",
+        interval=source.interval,
+        period=1,
+    )
+
+
+def order_book_obi_ema(
+    source: Node,
+    *,
+    levels: int = 1,
+    ema_period: int = 20,
+    epsilon: float = 1e-9,
+    name: str | None = None,
+) -> Node:
+    """Return an EMA-smoothed order-book imbalance node."""
+
+    base_name = name or "order_book_obi_ema"
+    obi_node = order_book_obi(
+        source,
+        levels=levels,
+        epsilon=epsilon,
+        name=f"{base_name}_obi",
+    )
+    return ema(obi_node, period=ema_period, name=base_name)

--- a/tests/runtime/indicators/test_obi.py
+++ b/tests/runtime/indicators/test_obi.py
@@ -1,0 +1,92 @@
+import pytest
+
+from qmtl.runtime.indicators import order_book_obi, order_book_obi_ema
+from qmtl.runtime.sdk.cache_view import CacheView
+from qmtl.runtime.sdk.node import SourceNode
+
+
+def _view_for_snapshots(source: SourceNode, snapshots):
+    data = {
+        source.node_id: {
+            source.interval: [(idx, snapshot) for idx, snapshot in enumerate(snapshots)]
+        }
+    }
+    return CacheView(data)
+
+
+def test_order_book_obi_levels_variation():
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {
+        "bids": [(101, 10), (100, 1), (99, 1)],
+        "asks": [(102, 2), (103, 12), (104, 12)],
+    }
+    view = _view_for_snapshots(source, [snapshot])
+
+    node_lvl1 = order_book_obi(source, levels=1)
+    node_lvl3 = order_book_obi(source, levels=3)
+
+    epsilon = 1e-9
+    expected_lvl1 = (10 - 2) / (10 + 2 + epsilon)
+    expected_lvl3 = (12 - 26) / (12 + 26 + epsilon)
+
+    assert node_lvl1.compute_fn(view) == pytest.approx(expected_lvl1)
+    assert node_lvl3.compute_fn(view) == pytest.approx(expected_lvl3)
+
+
+def test_order_book_obi_accepts_scalar_levels():
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {"bids": [5, 3, 1], "asks": [5, 3, 1]}
+    view = _view_for_snapshots(source, [snapshot])
+    node = order_book_obi(source, levels=2)
+    assert node.compute_fn(view) == pytest.approx(0.0)
+
+
+def test_order_book_obi_handles_empty_and_missing_snapshots():
+    source = SourceNode(interval="1s", period=5)
+    node = order_book_obi(source)
+
+    empty_snapshot = {"bids": [], "asks": []}
+    view_with_empty = _view_for_snapshots(source, [empty_snapshot])
+    assert node.compute_fn(view_with_empty) == 0.0
+
+    empty_history = _view_for_snapshots(source, [])
+    assert node.compute_fn(empty_history) is None
+
+
+def test_order_book_obi_ema_matches_manual_computation():
+    source = SourceNode(interval="1s", period=10)
+    ema_period = 3
+    ema_node = order_book_obi_ema(source, levels=2, ema_period=ema_period)
+    obi_node = ema_node.inputs[0]
+
+    snapshots = [
+        {"bids": [(101, 8), (100, 2)], "asks": [(102, 4), (103, 1)]},
+        {"bids": [(101, 6), (100, 1)], "asks": [(102, 5), (103, 2)]},
+        {"bids": [(101, 7), (100, 3)], "asks": [(102, 2), (103, 2)]},
+        {"bids": [(101, 5), (100, 2)], "asks": [(102, 6), (103, 1)]},
+    ]
+
+    history: list[tuple[int, dict]] = []
+    obi_values: list[float] = []
+    for idx, snapshot in enumerate(snapshots):
+        history.append((idx, snapshot))
+        view = CacheView({source.node_id: {source.interval: list(history)}})
+        value = obi_node.compute_fn(view)
+        assert value is not None
+        obi_values.append(value)
+
+    base_cache = {
+        obi_node.node_id: {
+            obi_node.interval: [(idx, value) for idx, value in enumerate(obi_values)]
+        }
+    }
+    ema_view = CacheView(base_cache)
+    result = ema_node.compute_fn(ema_view)
+
+    tail = obi_values[-ema_period:]
+    alpha = 2 / (ema_period + 1)
+    expected = tail[0]
+    for value in tail[1:]:
+        expected = alpha * value + (1 - alpha) * expected
+
+    assert result == pytest.approx(expected)

--- a/tests/runtime/indicators/test_obi.py
+++ b/tests/runtime/indicators/test_obi.py
@@ -59,6 +59,8 @@ def test_order_book_obi_ema_matches_manual_computation():
     ema_node = order_book_obi_ema(source, levels=2, ema_period=ema_period)
     obi_node = ema_node.inputs[0]
 
+    assert obi_node.period == ema_period
+
     snapshots = [
         {"bids": [(101, 8), (100, 2)], "asks": [(102, 4), (103, 1)]},
         {"bids": [(101, 6), (100, 1)], "asks": [(102, 5), (103, 2)]},


### PR DESCRIPTION
## Summary
- add an order_book_obi indicator that converts raw order-book snapshots into normalized imbalance values with optional EMA smoothing
- expose the new indicators through qmtl.runtime.indicators and document usage examples
- cover the indicator behaviour with dedicated unit tests across level formats, empty books, and EMA smoothing

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'obi'
- uv run -m pytest -W error -n auto -k 'obi'

Fixes #1268

------
https://chatgpt.com/codex/tasks/task_e_68df4c1057648329bbc5d52b099dd0c1