### PR TITLE
docs: update test paths to tests/qmtl and clean caches

### DIFF
--- a/docs/architecture/exchange_node_sets.md
+++ b/docs/architecture/exchange_node_sets.md
@@ -114,7 +114,7 @@ nodeset = builder.attach(signal, world_id="demo", execution=custom_exec)
 
 - Use `NodeSetRecipe` to capture default step wiring, shared metadata (name, modes, descriptor), and adapter parameters in one place. The helper handles context creation, resource injection, and optional overrides when a recipe is invoked.
 - `RecipeAdapterSpec` + `build_adapter()` can materialise a `NodeSetAdapter` automatically from any recipe, ensuring the exposed ports, modes, and adapter parameters stay in sync.
-- Registry-backed recipes are covered by contract tests in `tests/runtime/nodesets/test_recipe_contracts.py`; add new recipes to the parametrisation to validate chain length, descriptor metadata, and portfolio/weight function injection across modes.
+- Registry-backed recipes are covered by contract tests in `tests/qmtl/runtime/nodesets/test_recipe_contracts.py`; add new recipes to the parametrisation to validate chain length, descriptor metadata, and portfolio/weight function injection across modes.
 - When extending a recipe, prefer `StepSpec.from_factory()` with the appropriate injections (`inject_portfolio`, `inject_weight_fn`, etc.) rather than wiring nodes manually. This keeps adapters and tests valid even as internals evolve.
 
 ## Node Contracts

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -335,4 +335,4 @@ See also: World API Reference (reference/api_world.md) and Schemas (reference/sc
   - Transactional commit‑log writer/consumer are implemented (`qmtl/services/gateway/commit_log.py`, `qmtl/services/gateway/commit_log_consumer.py`) with deduplication and metrics.
   - OwnershipManager coordinates Kafka ownership with Postgres advisory locks fallback (`qmtl/services/gateway/ownership.py`), and `owner_reassign_total` is recorded on handoff.
   - SDK/Gateway integration skips local execution when queues are globally owned (see `qmtl/services/gateway/worker.py`).
-  - Chaos/soak style dedup tests exist under `tests/services/gateway/test_commit_log_soak.py`.
+  - Chaos/soak style dedup tests exist under `tests/qmtl/services/gateway/test_commit_log_soak.py`.

--- a/docs/architecture/seamless_data_provider_v2.md
+++ b/docs/architecture/seamless_data_provider_v2.md
@@ -137,8 +137,8 @@ Run the suite locally or in CI with:
 
 ```
 uv run -m pytest -W error -n auto \
-  tests/runtime/sdk/test_history_coverage_property.py \
-  tests/sdk/test_seamless_provider.py
+  tests/qmtl/runtime/sdk/test_history_coverage_property.py \
+  tests/qmtl/runtime/sdk/test_seamless_provider.py
 ```
 
 The command above is also the invocation wired into the CI Seamless job so new

--- a/docs/guides/ccxt_futures_recipe.md
+++ b/docs/guides/ccxt_futures_recipe.md
@@ -4,7 +4,7 @@ This guide explains how to route trade signals through the CCXT futures Node Set
 which connects a strategy to a perpetual futures exchange (Binance USDT-M by default). The recipe
 leverages `NodeSetRecipe` for consistent composition and is registered for discovery so adapters and tests remain aligned.
 Refer to [Exchange Node Sets](../architecture/exchange_node_sets.md) for architecture context. Contract tests in
-`tests/runtime/nodesets/test_recipe_contracts.py` exercise this recipe alongside CCXT spot, ensuring the sizing/portfolio
+`tests/qmtl/runtime/nodesets/test_recipe_contracts.py` exercise this recipe alongside CCXT spot, ensuring the sizing/portfolio
 injection and node count remain stable.
 
 ## Usage
@@ -80,5 +80,5 @@ that places a Binance Futures Testnet order, see
 - Binance USDT-M symbols use the `BTC/USDT` form. Exchanges that require suffixes (e.g. `BTC/USDT:USDT`)
   should be handled in the signal/order payload and documented per strategy.
 - Fill ingestion remains a stub; integrate exchange webhooks or polling in follow-up work if needed.
-- Extending the recipe? Add your variant to `tests/runtime/nodesets/test_recipe_contracts.py` so chain length,
+- Extending the recipe? Add your variant to `tests/qmtl/runtime/nodesets/test_recipe_contracts.py` so chain length,
   modes, and portfolio injection keep their guarantees.

--- a/docs/guides/ccxt_spot_recipe.md
+++ b/docs/guides/ccxt_spot_recipe.md
@@ -4,7 +4,7 @@ This guide shows how to route trade signals through the built-in CCXT spot Node 
 which wires a strategy's signal node to a CCXT-backed spot exchange. The recipe is defined with
 `NodeSetRecipe` and registered for discovery so it inherits shared contract tests and adapter generation.
 See [Exchange Node Sets](../architecture/exchange_node_sets.md) for design details and authoring guidance.
-Contract coverage in `tests/runtime/nodesets/test_recipe_contracts.py` verifies descriptor metadata, world scoping,
+Contract coverage in `tests/qmtl/runtime/nodesets/test_recipe_contracts.py` verifies descriptor metadata, world scoping,
 and portfolio/weight injection for this recipe.
 
 ## Usage

--- a/docs/guides/nodeset_adapters.md
+++ b/docs/guides/nodeset_adapters.md
@@ -75,4 +75,4 @@ Notes
 - 어댑터는 입력 검증을 강제해 런타임 wiring 오류를 줄입니다.
 - Node Set은 여전히 블랙박스이며, 전략은 포트 스펙만 알면 충분합니다.
  - 다중 업스트림(브랜칭)은 어댑터 내부에서 합류 노드를 직접 구성하는 패턴으로 쉽게 확장할 수 있습니다.
-- `RecipeAdapterSpec`를 사용하면 새로운 레시피를 등록할 때마다 어댑터와 테스트 커버리지를 동시에 갱신할 수 있습니다. 새 레시피는 `tests/runtime/nodesets/test_recipe_contracts.py`에 추가하세요.
+- `RecipeAdapterSpec`를 사용하면 새로운 레시피를 등록할 때마다 어댑터와 테스트 커버리지를 동시에 갱신할 수 있습니다. 새 레시피는 `tests/qmtl/runtime/nodesets/test_recipe_contracts.py`에 추가하세요.

--- a/docs/guides/seamless_data_provider_setup.md
+++ b/docs/guides/seamless_data_provider_setup.md
@@ -69,8 +69,8 @@
 6. **검증 및 회귀 테스트 실행**
    ```bash
    uv run -m pytest -W error -n auto \
-     tests/runtime/sdk/test_history_coverage_property.py \
-     tests/sdk/test_seamless_provider.py
+     tests/qmtl/runtime/sdk/test_history_coverage_property.py \
+     tests/qmtl/runtime/sdk/test_seamless_provider.py
    ```
    테스트 스위트는 커버리지 연산과 실패 주입 시나리오를 포함해 SDP 구성의 안정성을 검증합니다.【F:qmtl/docs/architecture/seamless_data_provider_v2.md†L124-L139】
 

--- a/docs/operations/neo4j_migrations.md
+++ b/docs/operations/neo4j_migrations.md
@@ -56,7 +56,7 @@ Use with caution in lower environments; production rollback should follow a cont
    - For worlds that require pre-populated `backtest`/`dryrun` buckets, replay the Gateway "world node upsert" task per domain.
 4. **Validation**
    - Sample `MATCH (n:WorldNodeRef) RETURN n.execution_domain, count(*) ORDER BY n.execution_domain;` to ensure the histogram aligns with expectations.
-   - Automated coverage: `tests/services/worldservice/test_worldservice_api.py::test_world_nodes_execution_domains_and_legacy_migration` exercises the lazy conversion path via the public API.
+   - Automated coverage: `tests/qmtl/services/worldservice/test_worldservice_api.py::test_world_nodes_execution_domains_and_legacy_migration` exercises the lazy conversion path via the public API.
    - WorldService appends `world_node_bucket_normalized` audit events when legacy payloads are promoted on-demand. Monitor `GET /worlds/{id}/audit` to confirm conversions complete without manual intervention.
 
 ### Rollback
@@ -76,8 +76,8 @@ Use with caution in lower environments; production rollback should follow a cont
 1. **Deploy compatible services** that recompute EvalKeys using the new tuple `(node_id, world_id, execution_domain, contract_id, dataset_fingerprint, code_version, resource_policy)`.
 2. **Lazy invalidation**
    - During lookup the service rehashes the context; mismatched keys are dropped and the caller re-runs validation.
-   - Tests cover this path via `tests/services/worldservice/test_validation_cache.py::test_validation_cache_legacy_payloads_are_normalised_and_invalidated`.
-   - Canonical execution domain coercion is verified by `tests/services/worldservice/test_validation_cache.py::test_validation_cache_normalises_execution_domain_on_set` to prevent divergent cache buckets during the rollout.
+   - Tests cover this path via `tests/qmtl/services/worldservice/test_validation_cache.py::test_validation_cache_legacy_payloads_are_normalised_and_invalidated`.
+   - Canonical execution domain coercion is verified by `tests/qmtl/services/worldservice/test_validation_cache.py::test_validation_cache_normalises_execution_domain_on_set` to prevent divergent cache buckets during the rollout.
    - The audit log records `validation_cache_bucket_normalized` when payloads are rewritten and `validation_cache_invalidated` once stale EvalKeys are purged, providing an operational breadcrumb during rollout.
 3. **Optional proactive purge**
    - `MATCH (v:Validation) REMOVE v.eval_key_without_domain;` if a transitional property exists.

--- a/docs/reference/api/brokerage.md
+++ b/docs/reference/api/brokerage.md
@@ -186,7 +186,7 @@ eurusd_model = init.for_symbol("EURUSD")  # uses free_fee via asset-class
 
 ## Testing and Examples
 
-- See `tests/runtime/brokerage/test_brokerage_orders_tif.py` for TIF and crossing logic.
-- See `tests/runtime/brokerage/test_brokerage_extras.py` for shortable/profile usage.
+- See `tests/qmtl/runtime/brokerage/test_brokerage_orders_tif.py` for TIF and crossing logic.
+- See `tests/qmtl/runtime/brokerage/test_brokerage_extras.py` for shortable/profile usage.
 
 {{ nav_links() }}

--- a/docs/reference/enhanced_validation.md
+++ b/docs/reference/enhanced_validation.md
@@ -172,8 +172,7 @@ The validation is comprehensively tested with 50+ test cases covering:
 
 Run validation tests:
 ```bash
-pytest tests/runtime/sdk/test_enhanced_validation.py -v
+pytest tests/qmtl/runtime/sdk/test_enhanced_validation.py -v
 ```
 
 {{ nav_links() }}
-


### PR DESCRIPTION
Backport doc snippets and examples to the new tests tree aligned with qmtl/:

- Update references from tests/runtime/* and tests/sdk/* → tests/qmtl/*
- Example snippets now import from tests.qmtl.runtime.sdk.factories
- Local cleanup: removed stale __pycache__ and .pytest_cache under tests/

Docs validation:
- uv run --with mkdocs --with mkdocs-macros-plugin --with mkdocs-breadcrumbs-plugin mkdocs build → OK

This PR contains only documentation changes; no runtime code modifications.