### PR TITLE
docs(reference): fix inventory link (link checker)

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -19,7 +19,6 @@ Reference materials and inventories for QMTL.
 - [FAQ](faq.md): Frequently asked questions.
 - [Lean-like Features](lean_like_features.md): Proposed feature alignment with Lean.
 - [Templates](templates.md): Document templates.
-- [Inventory](\_inventory.md): Documentation index.
+- [Inventory](_inventory.md): Documentation index.
 
 {{ nav_links() }}
-


### PR DESCRIPTION
Remove backslash escape in docs/reference/README.md for the Inventory link.

- Before: [Inventory](\_inventory.md) → resolved as literal '\_inventory.md' and failed link check
- After:  [Inventory](_inventory.md) → passes scripts/check_docs_links.py

Validation:
- python scripts/check_docs_links.py → passed
- mkdocs build (optional): uv run --with mkdocs mkdocs build
