### PR TITLE
Add order book imbalance levels and depth slope indicators

### DIFF
--- a/qmtl/runtime/indicators/README.md
+++ b/qmtl/runtime/indicators/README.md
@@ -24,12 +24,37 @@ node retains in its cache. The helper also exposes
 average to the raw OBI stream for smoother downstream consumption and ensures
 the underlying OBI cache keeps ``ema_period`` samples available.
 
+For deeper liquidity cues, `order_book_imbalance_levels` computes the
+"multi-level" imbalance (also expressed as `(bid-ask)/(bid+ask)` but using a
+configurable number of tiers) while `order_book_depth_slope` estimates the
+internal depth gradient on each side of book via a simple linear regression of
+cumulative size against the level index. Empty books (or tiers with malformed
+data) safely resolve to `0.0` slopes and an `OBI_L` of `0.0`, allowing
+downstream features to remain finite. Both helpers accept a ``period`` argument
+to retain additional history in their caches.
+
+`order_book_obiL_and_slope` wraps both metrics and emits a mapping with
+``{"obi_l": float, "bid_slope": float, "ask_slope": float}`` so downstream
+nodes can subscribe to a single feed.
+
 ```python
-from qmtl.runtime.indicators import order_book_obi, order_book_obi_ema
+from qmtl.runtime.indicators import (
+    order_book_obi,
+    order_book_obi_ema,
+    order_book_imbalance_levels,
+    order_book_depth_slope,
+    order_book_obiL_and_slope,
+)
 
 obi = order_book_obi(book_snapshots, levels=3)
 smoothed = order_book_obi_ema(book_snapshots, levels=3, ema_period=10)
+obi_l = order_book_imbalance_levels(book_snapshots, levels=5)
+depth_profile = order_book_depth_slope(book_snapshots, levels=5)
+combined = order_book_obiL_and_slope(book_snapshots, levels=5)
 ```
+
+> **Note:** When the book snapshot is missing altogether the nodes emit
+> `None` to signal upstream data gaps.
 
 ## Acceptable price band alpha
 

--- a/qmtl/runtime/indicators/__init__.py
+++ b/qmtl/runtime/indicators/__init__.py
@@ -17,7 +17,13 @@ from .kalman_trend import kalman_trend
 from .rough_bergomi import rough_bergomi
 from .stoch_rsi import stoch_rsi
 from .volatility import volatility_node, volatility
-from .order_book_obi import order_book_obi, order_book_obi_ema
+from .order_book_obi import (
+    order_book_obi,
+    order_book_obi_ema,
+    order_book_imbalance_levels,
+    order_book_depth_slope,
+    order_book_obiL_and_slope,
+)
 # Optional alpha indicator; may not be available in all deployments
 try:  # pragma: no cover - fallback for missing alpha module
     from .gap_amplification_alpha import gap_amplification_node
@@ -46,6 +52,9 @@ __all__ = [
     "volatility",
     "order_book_obi",
     "order_book_obi_ema",
+    "order_book_imbalance_levels",
+    "order_book_depth_slope",
+    "order_book_obiL_and_slope",
     "alpha_indicator_with_history",
 ]
 

--- a/qmtl/runtime/indicators/order_book_obi.py
+++ b/qmtl/runtime/indicators/order_book_obi.py
@@ -10,33 +10,130 @@ from qmtl.runtime.sdk.node import Node
 
 from .ema import ema
 
-__all__ = ["order_book_obi", "order_book_obi_ema"]
+__all__ = [
+    "order_book_obi",
+    "order_book_obi_ema",
+    "order_book_imbalance_levels",
+    "order_book_depth_slope",
+    "order_book_obiL_and_slope",
+]
+
+
+def _extract_snapshot(view: CacheView, source: Node) -> Mapping[str, Any] | None:
+    """Return the latest order-book snapshot from ``source`` if available."""
+
+    series = view[source][source.interval]
+    latest = series.latest()
+    if latest is None:
+        return None
+
+    snapshot = latest[1]
+    if snapshot is None or not isinstance(snapshot, Mapping):
+        return None
+    return snapshot
+
+
+def _normalize_level_size(level: Any) -> float | None:
+    """Extract the size component from a level entry."""
+
+    if isinstance(level, (list, tuple)):
+        if not level:
+            return None
+        raw_size = level[1] if len(level) > 1 else level[0]
+    else:
+        raw_size = level
+    try:
+        return float(raw_size)
+    except (TypeError, ValueError):
+        return None
+
+
+def _iter_level_sizes(levels_data: Sequence[Any] | None, levels: int) -> list[float]:
+    """Return parsed sizes for up to ``levels`` order-book entries."""
+
+    if not levels_data or levels <= 0:
+        return []
+
+    values: list[float] = []
+    for level in levels_data:
+        if len(values) >= levels:
+            break
+        size = _normalize_level_size(level)
+        if size is None:
+            continue
+        values.append(size)
+    return values
 
 
 def _sum_levels(levels_data: Sequence[Any] | None, levels: int) -> float:
     """Return the summed depth over ``levels`` entries from ``levels_data``."""
 
-    if not levels_data or levels <= 0:
+    if levels <= 0:
+        return 0.0
+    return sum(_iter_level_sizes(levels_data, levels))
+
+
+def _compute_linear_slope(values: Sequence[float]) -> float:
+    """Return the slope of a simple least-squares fit over ``values``."""
+
+    count = len(values)
+    if count == 0:
         return 0.0
 
-    total = 0.0
-    taken = 0
-    for level in levels_data:
-        if taken >= levels:
-            break
-        if isinstance(level, (list, tuple)):
-            if not level:
-                continue
-            raw_size = level[1] if len(level) > 1 else level[0]
-        else:
-            raw_size = level
-        try:
-            size = float(raw_size)
-        except (TypeError, ValueError):
-            continue
-        total += size
-        taken += 1
-    return total
+    # 1-indexed positions provide a natural depth ordering.
+    x_mean = (count + 1) / 2
+    y_mean = sum(values) / count
+
+    numerator = 0.0
+    denominator = 0.0
+    for idx, value in enumerate(values, start=1):
+        dx = idx - x_mean
+        numerator += dx * (value - y_mean)
+        denominator += dx * dx
+
+    if denominator == 0.0:
+        return 0.0
+    return numerator / denominator
+
+
+def _depth_slope(levels_data: Sequence[Any] | None, levels: int, method: str) -> float:
+    """Compute a slope describing how depth evolves across order-book levels."""
+
+    normalized_method = method.lower()
+    if normalized_method != "linear":
+        raise ValueError(
+            f"Unsupported depth slope method '{method}'. Only 'linear' is available."
+        )
+
+    sizes = _iter_level_sizes(levels_data, levels)
+    if not sizes:
+        return 0.0
+
+    cumulative: list[float] = []
+    running_total = 0.0
+    for size in sizes:
+        running_total += size
+        cumulative.append(running_total)
+
+    return _compute_linear_slope(cumulative)
+
+
+def _compute_obi(
+    bids: Sequence[Any] | None,
+    asks: Sequence[Any] | None,
+    levels: int,
+    epsilon: float,
+) -> float:
+    """Helper returning the normalized imbalance across ``levels`` tiers."""
+
+    bid_total = _sum_levels(bids, levels)
+    ask_total = _sum_levels(asks, levels)
+
+    if bid_total == 0.0 and ask_total == 0.0:
+        return 0.0
+
+    denominator = bid_total + ask_total + epsilon
+    return (bid_total - ask_total) / denominator
 
 
 def order_book_obi(
@@ -66,26 +163,14 @@ def order_book_obi(
     """
 
     def compute(view: CacheView) -> float | None:
-        series = view[source][source.interval]
-        latest = series.latest()
-        if latest is None:
-            return None
-
-        snapshot = latest[1]
-        if snapshot is None or not isinstance(snapshot, Mapping):
+        snapshot = _extract_snapshot(view, source)
+        if snapshot is None:
             return None
 
         bids = snapshot.get("bids", [])
         asks = snapshot.get("asks", [])
 
-        bid_total = _sum_levels(bids, levels)
-        ask_total = _sum_levels(asks, levels)
-
-        if bid_total == 0.0 and ask_total == 0.0:
-            return 0.0
-
-        denominator = bid_total + ask_total + epsilon
-        return (bid_total - ask_total) / denominator
+        return _compute_obi(bids, asks, levels, epsilon)
 
     return Node(
         input=source,
@@ -115,3 +200,96 @@ def order_book_obi_ema(
         name=f"{base_name}_obi",
     )
     return ema(obi_node, period=ema_period, name=base_name)
+
+
+def order_book_imbalance_levels(
+    source: Node,
+    *,
+    levels: int = 5,
+    epsilon: float = 1e-9,
+    period: int = 1,
+    name: str | None = None,
+) -> Node:
+    """Return an ``OBI_L`` node aggregating the top ``levels`` depth tiers."""
+
+    def compute(view: CacheView) -> float | None:
+        snapshot = _extract_snapshot(view, source)
+        if snapshot is None:
+            return None
+
+        return _compute_obi(snapshot.get("bids"), snapshot.get("asks"), levels, epsilon)
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "order_book_imbalance_levels",
+        interval=source.interval,
+        period=max(1, period),
+    )
+
+
+def order_book_depth_slope(
+    source: Node,
+    *,
+    levels: int = 5,
+    method: str = "linear",
+    period: int = 1,
+    name: str | None = None,
+) -> Node:
+    """Return a node emitting the bid/ask depth slope across ``levels`` tiers."""
+
+    def compute(view: CacheView) -> dict[str, float] | None:
+        snapshot = _extract_snapshot(view, source)
+        if snapshot is None:
+            return None
+
+        bids = snapshot.get("bids")
+        asks = snapshot.get("asks")
+
+        return {
+            "bid_slope": _depth_slope(bids, levels, method),
+            "ask_slope": _depth_slope(asks, levels, method),
+        }
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "order_book_depth_slope",
+        interval=source.interval,
+        period=max(1, period),
+    )
+
+
+def order_book_obiL_and_slope(
+    source: Node,
+    *,
+    levels: int = 5,
+    epsilon: float = 1e-9,
+    method: str = "linear",
+    period: int = 1,
+    name: str | None = None,
+) -> Node:
+    """Return a combined node exposing ``OBI_L`` and depth slope features."""
+
+    def compute(view: CacheView) -> dict[str, float] | None:
+        snapshot = _extract_snapshot(view, source)
+        if snapshot is None:
+            return None
+
+        bids = snapshot.get("bids")
+        asks = snapshot.get("asks")
+
+        obi_value = _compute_obi(bids, asks, levels, epsilon)
+        return {
+            "obi_l": obi_value,
+            "bid_slope": _depth_slope(bids, levels, method),
+            "ask_slope": _depth_slope(asks, levels, method),
+        }
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "order_book_obiL_and_slope",
+        interval=source.interval,
+        period=max(1, period),
+    )

--- a/tests/qmtl/runtime/indicators/test_obi.py
+++ b/tests/qmtl/runtime/indicators/test_obi.py
@@ -1,6 +1,12 @@
 import pytest
 
-from qmtl.runtime.indicators import order_book_obi, order_book_obi_ema
+from qmtl.runtime.indicators import (
+    order_book_depth_slope,
+    order_book_imbalance_levels,
+    order_book_obi,
+    order_book_obiL_and_slope,
+    order_book_obi_ema,
+)
 from qmtl.runtime.sdk.cache_view import CacheView
 from qmtl.runtime.sdk.node import SourceNode
 
@@ -92,3 +98,67 @@ def test_order_book_obi_ema_matches_manual_computation():
         expected = alpha * value + (1 - alpha) * expected
 
     assert result == pytest.approx(expected)
+
+
+def test_order_book_imbalance_levels_matches_expected_values():
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {
+        "bids": [(101, 5), (100, 3), (99, 2)],
+        "asks": [(102, 4), (103, 1), (104, 1)],
+    }
+    view = _view_for_snapshots(source, [snapshot])
+
+    obi_l1 = order_book_imbalance_levels(source, levels=1)
+    obi_l3 = order_book_imbalance_levels(source, levels=3)
+
+    epsilon = 1e-9
+    expected_lvl1 = (5 - 4) / (5 + 4 + epsilon)
+    expected_lvl3 = (10 - 6) / (10 + 6 + epsilon)
+
+    assert obi_l1.compute_fn(view) == pytest.approx(expected_lvl1)
+    assert obi_l3.compute_fn(view) == pytest.approx(expected_lvl3)
+
+
+def test_order_book_depth_slope_captures_steeper_profiles():
+    source = SourceNode(interval="1s", period=5)
+    gentle_snapshot = {
+        "bids": [(101, 5), (100, 5), (99, 5), (98, 5)],
+        "asks": [(102, 5), (103, 5), (104, 5), (105, 5)],
+    }
+    steep_snapshot = {
+        "bids": [(101, 2), (100, 5), (99, 8), (98, 12)],
+        "asks": [(102, 2), (103, 5), (104, 8), (105, 12)],
+    }
+
+    slope_node = order_book_depth_slope(source, levels=4)
+
+    gentle = slope_node.compute_fn(_view_for_snapshots(source, [gentle_snapshot]))
+    steep = slope_node.compute_fn(_view_for_snapshots(source, [steep_snapshot]))
+
+    assert gentle is not None
+    assert steep is not None
+    assert abs(steep["bid_slope"]) > abs(gentle["bid_slope"])
+    assert abs(steep["ask_slope"]) > abs(gentle["ask_slope"])
+
+
+def test_order_book_depth_slope_handles_empty_books():
+    source = SourceNode(interval="1s", period=5)
+    slope_node = order_book_depth_slope(source, levels=3)
+
+    result = slope_node.compute_fn(_view_for_snapshots(source, [{"bids": [], "asks": []}]))
+    assert result == {"bid_slope": 0.0, "ask_slope": 0.0}
+
+
+def test_order_book_obiL_and_slope_combines_metrics():
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {
+        "bids": [(101, 10), (100, 4)],
+        "asks": [(102, 3), (103, 1)],
+    }
+
+    node = order_book_obiL_and_slope(source, levels=2)
+    result = node.compute_fn(_view_for_snapshots(source, [snapshot]))
+
+    assert result is not None
+    assert set(result.keys()) == {"obi_l", "bid_slope", "ask_slope"}
+    assert result["obi_l"] == pytest.approx((14 - 4) / (14 + 4 + 1e-9))


### PR DESCRIPTION
## Summary
- add reusable helpers for multi-level order book imbalance, depth slope, and a combined node
- document the new indicators and export them through the public module
- extend the indicator test suite to cover imbalance levels, slope behaviour, and composite output

## Testing
- uv run -m pytest tests/qmtl/runtime/indicators/test_obi.py

Fixes #1265

------
https://chatgpt.com/codex/tasks/task_e_68df559717108329b6f3a0087bb8db02