### PR TITLE
Fix missing compose reference in CCXT futures recipe

### DIFF
--- a/qmtl/runtime/nodesets/recipes.py
+++ b/qmtl/runtime/nodesets/recipes.py
@@ -30,7 +30,7 @@ from qmtl.runtime.nodesets.resources import get_execution_resources
 from qmtl.runtime.nodesets.steps import (
     StepSpec,
     STEP_ORDER,
-    compose,
+    compose as compose_steps,
     execution,
     pretrade,
     order_publish,
@@ -500,7 +500,7 @@ def make_ccxt_futures_nodeset(
         setattr(node, "world_id", world_id)
         return node
 
-    return compose(
+    return compose_steps(
         signal_node,
         steps=[
             pretrade(),


### PR DESCRIPTION
## Summary
- alias the compose helper import used by the CCXT futures recipe to avoid runtime NameError

## Testing
- pytest tests/qmtl/runtime/nodesets/test_nodeset_adapter_descriptor.py::test_ccxt_futures_adapter_descriptor -q

------
https://chatgpt.com/codex/tasks/task_e_68df67f1c2c083298071f83daa5d4c3e