### PR TITLE
Refactor seamless history data sources

### DIFF
--- a/qmtl/runtime/io/seamless_presets.py
+++ b/qmtl/runtime/io/seamless_presets.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, Mapping, MutableMapping, Sequence
 
 from qmtl.runtime.sdk.seamless import SeamlessPresetRegistry
+from qmtl.runtime.sdk.seamless_data_provider import DataSourcePriority
 from qmtl.runtime.io.historyprovider import QuestDBLoader
 from qmtl.runtime.io.seamless_provider import (
-    CacheDataSource,
     DataFetcherAutoBackfiller,
     LiveDataFeedImpl,
-    StorageDataSource,
+    HistoryProviderDataSource,
 )
 from qmtl.runtime.io.ccxt_fetcher import (
     CcxtBackfillConfig,
@@ -141,7 +141,7 @@ def _register_ccxt_questdb_preset() -> None:
         def storage_factory():
             fetcher = make_fetcher()
             provider = QuestDBLoader(dsn, table=table, fetcher=fetcher)
-            return StorageDataSource(provider)
+            return HistoryProviderDataSource(provider, DataSourcePriority.STORAGE)
 
         def backfill_factory():
             return DataFetcherAutoBackfiller(make_fetcher())
@@ -152,7 +152,7 @@ def _register_ccxt_questdb_preset() -> None:
                 provider = cache_provider_factory()
                 if provider is None:
                     raise RuntimeError("cache_provider factory returned None")
-                return CacheDataSource(provider)
+                return HistoryProviderDataSource(provider, DataSourcePriority.CACHE)
 
             builder.with_cache(cache_factory)
         builder.with_backfill(backfill_factory)
@@ -203,7 +203,7 @@ def _register_ccxt_trades_preset() -> None:
         def storage_factory():
             fetcher = make_fetcher()
             provider = QuestDBLoader(dsn, table=table, fetcher=fetcher)
-            return StorageDataSource(provider)
+            return HistoryProviderDataSource(provider, DataSourcePriority.STORAGE)
 
         builder.with_storage(storage_factory)
         builder.with_backfill(lambda: DataFetcherAutoBackfiller(make_fetcher()))

--- a/qmtl/runtime/io/seamless_provider.py
+++ b/qmtl/runtime/io/seamless_provider.py
@@ -71,66 +71,40 @@ class EnhancedQuestDBProviderSettings:
     fingerprint: FingerprintPolicy = field(default_factory=FingerprintPolicy)
 
 
-class CacheDataSource:
-    """In-memory cache data source implementation."""
-    
-    def __init__(self, cache_provider: HistoryProvider):
-        self.cache_provider = cache_provider
-        self.priority = DataSourcePriority.CACHE
-    
+class HistoryProviderDataSource:
+    """HistoryProvider-backed :class:`DataSource` with configurable priority."""
+
+    def __init__(self, provider: HistoryProvider, priority: DataSourcePriority):
+        self.provider = provider
+        self.priority = priority
+
+        # Preserve legacy attribute names for downstream compatibility.
+        if priority is DataSourcePriority.CACHE:
+            self.cache_provider = provider
+        elif priority is DataSourcePriority.STORAGE:
+            self.storage_provider = provider
+
     async def is_available(
         self, start: int, end: int, *, node_id: str, interval: int
     ) -> bool:
         try:
-            coverage = await self.cache_provider.coverage(node_id=node_id, interval=interval)
-            # Check if requested range is fully covered
+            coverage = await self.provider.coverage(node_id=node_id, interval=interval)
             for range_start, range_end in coverage:
                 if range_start <= start and end <= range_end:
                     return True
             return False
         except Exception:
             return False
-    
+
     async def fetch(
         self, start: int, end: int, *, node_id: str, interval: int
     ) -> pd.DataFrame:
-        return await self.cache_provider.fetch(start, end, node_id=node_id, interval=interval)
-    
+        return await self.provider.fetch(start, end, node_id=node_id, interval=interval)
+
     async def coverage(
         self, *, node_id: str, interval: int
     ) -> list[tuple[int, int]]:
-        return await self.cache_provider.coverage(node_id=node_id, interval=interval)
-
-
-class StorageDataSource:
-    """Historical storage data source implementation."""
-    
-    def __init__(self, storage_provider: HistoryProvider):
-        self.storage_provider = storage_provider
-        self.priority = DataSourcePriority.STORAGE
-    
-    async def is_available(
-        self, start: int, end: int, *, node_id: str, interval: int
-    ) -> bool:
-        try:
-            coverage = await self.storage_provider.coverage(node_id=node_id, interval=interval)
-            # Check if requested range is fully covered
-            for range_start, range_end in coverage:
-                if range_start <= start and end <= range_end:
-                    return True
-            return False
-        except Exception:
-            return False
-    
-    async def fetch(
-        self, start: int, end: int, *, node_id: str, interval: int
-    ) -> pd.DataFrame:
-        return await self.storage_provider.fetch(start, end, node_id=node_id, interval=interval)
-    
-    async def coverage(
-        self, *, node_id: str, interval: int
-    ) -> list[tuple[int, int]]:
-        return await self.storage_provider.coverage(node_id=node_id, interval=interval)
+        return await self.provider.coverage(node_id=node_id, interval=interval)
 
 
 class DataFetcherAutoBackfiller:
@@ -201,11 +175,11 @@ class DataFetcherAutoBackfiller:
         batch_identifier = self._build_batch_id(
             batch_id=batch_id, node_id=node_id, interval=interval, start=start, end=end
         )
-        planned_source = (
-            "storage"
-            if target_storage and hasattr(target_storage, "storage_provider")
-            else "fetcher"
+        is_storage_target = (
+            target_storage is not None
+            and getattr(target_storage, "priority", None) is DataSourcePriority.STORAGE
         )
+        planned_source = "storage" if is_storage_target else "fetcher"
         logger.info(
             "seamless.backfill.attempt",
             extra=self._build_log_extra(
@@ -220,9 +194,11 @@ class DataFetcherAutoBackfiller:
         )
 
         # Prefer materializing directly into storage to avoid double-fetch
-        if target_storage and hasattr(target_storage, "storage_provider"):
-            storage_provider = target_storage.storage_provider
-            if hasattr(storage_provider, "fill_missing") and hasattr(storage_provider, "fetch"):
+        if is_storage_target:
+            storage_provider = getattr(target_storage, "provider", None) if target_storage else None
+            if storage_provider is None and target_storage is not None:
+                storage_provider = getattr(target_storage, "storage_provider", None)
+            if storage_provider and hasattr(storage_provider, "fill_missing") and hasattr(storage_provider, "fetch"):
                 try:
                     await storage_provider.fill_missing(
                         start, end, node_id=node_id, interval=interval
@@ -450,9 +426,11 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
         )
 
         # Create data sources via builder to support future adapter swaps
-        storage_source = StorageDataSource(self.storage_provider)
+        storage_source = HistoryProviderDataSource(
+            self.storage_provider, DataSourcePriority.STORAGE
+        )
         cache_source = (
-            CacheDataSource(resolved_cache_provider)
+            HistoryProviderDataSource(resolved_cache_provider, DataSourcePriority.CACHE)
             if resolved_cache_provider
             else None
         )
@@ -514,8 +492,12 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
         self.storage_provider.bind_stream(stream)
 
         # Also bind cache if available
-        if self.cache_source and hasattr(self.cache_source.cache_provider, 'bind_stream'):
-            self.cache_source.cache_provider.bind_stream(stream)
+        if self.cache_source:
+            cache_provider = getattr(self.cache_source, "provider", None)
+            if cache_provider is None:
+                cache_provider = getattr(self.cache_source, "cache_provider", None)
+            if cache_provider and hasattr(cache_provider, "bind_stream"):
+                cache_provider.bind_stream(stream)
 
     def _validate_node_id(self, node_id: str) -> None:
         super()._validate_node_id(node_id)
@@ -539,8 +521,7 @@ class EnhancedQuestDBProvider(SeamlessDataProvider):
 
 
 __all__ = [
-    "CacheDataSource",
-    "StorageDataSource",
+    "HistoryProviderDataSource",
     "DataFetcherAutoBackfiller",
     "LiveDataFeedImpl",
     "FingerprintPolicy",

--- a/tests/qmtl/runtime/sdk/test_seamless_config.py
+++ b/tests/qmtl/runtime/sdk/test_seamless_config.py
@@ -5,8 +5,9 @@ import pytest
 import pandas as pd
 
 from qmtl.runtime.sdk import build_seamless_assembly, hydrate_builder
+from qmtl.runtime.sdk.seamless_data_provider import DataSourcePriority
 from qmtl.runtime.io.seamless_provider import (
-    StorageDataSource,
+    HistoryProviderDataSource,
     DataFetcherAutoBackfiller,
 )
 
@@ -29,7 +30,8 @@ def _ccxt_preset_config() -> dict:
 def test_build_seamless_assembly_from_single_preset() -> None:
     assembly = build_seamless_assembly(_ccxt_preset_config())
 
-    assert isinstance(assembly.storage_source, StorageDataSource)
+    assert isinstance(assembly.storage_source, HistoryProviderDataSource)
+    assert assembly.storage_source.priority is DataSourcePriority.STORAGE
     assert isinstance(assembly.backfiller, DataFetcherAutoBackfiller)
     assert assembly.cache_source is None
     assert assembly.live_feed is None
@@ -49,7 +51,8 @@ def test_hydrate_builder_supports_presets_sequence() -> None:
     builder = hydrate_builder(config)
     assembly = builder.build()
 
-    assert isinstance(assembly.storage_source, StorageDataSource)
+    assert isinstance(assembly.storage_source, HistoryProviderDataSource)
+    assert assembly.storage_source.priority is DataSourcePriority.STORAGE
     assert isinstance(assembly.backfiller, DataFetcherAutoBackfiller)
 
 
@@ -93,7 +96,8 @@ def test_preset_assembly_uses_loader_and_fetcher(monkeypatch) -> None:
 
     assembly = build_seamless_assembly(_ccxt_preset_config())
 
-    assert isinstance(assembly.storage_source, StorageDataSource)
+    assert isinstance(assembly.storage_source, HistoryProviderDataSource)
+    assert assembly.storage_source.priority is DataSourcePriority.STORAGE
     assert isinstance(assembly.backfiller, DataFetcherAutoBackfiller)
     assert "loader_args" in created
     assert created["loader_args"]["dsn"] == "postgresql://localhost:8812/qdb"

--- a/tests/qmtl/runtime/sdk/test_seamless_provider.py
+++ b/tests/qmtl/runtime/sdk/test_seamless_provider.py
@@ -21,7 +21,7 @@ from qmtl.runtime.sdk.seamless_data_provider import (
     BackfillConfig,
 )
 from qmtl.runtime.io.seamless_provider import (
-    StorageDataSource,
+    HistoryProviderDataSource,
     DataFetcherAutoBackfiller,
 )
 from qmtl.foundation.common.compute_context import ComputeContext
@@ -1027,20 +1027,9 @@ async def test_storage_backfill_materializes_and_reads_back() -> None:
     sdk_metrics.reset_metrics()
     storage_provider = _FakeStorageProvider()
 
-    class _StorageDS(StorageDataSource):
-        # Expose required attribute to satisfy DataFetcherAutoBackfiller contract
+    class _StorageDS(HistoryProviderDataSource):
         def __init__(self, sp):
-            self.storage_provider = sp
-            self.priority = DataSourcePriority.STORAGE
-
-        async def is_available(self, *args, **kwargs):  # pragma: no cover
-            return False
-
-        async def fetch(self, *args, **kwargs):  # pragma: no cover
-            return pd.DataFrame()
-
-        async def coverage(self, *args, **kwargs):  # pragma: no cover
-            return []
+            super().__init__(sp, DataSourcePriority.STORAGE)
 
     storage_ds = _StorageDS(storage_provider)
     fetcher = _FakeFetcher()
@@ -1059,19 +1048,9 @@ async def test_storage_backfill_materializes_and_reads_back() -> None:
 async def test_data_fetcher_backfiller_logs_structured_success(caplog) -> None:
     storage_provider = _FakeStorageProvider()
 
-    class _StorageDS(StorageDataSource):
+    class _StorageDS(HistoryProviderDataSource):
         def __init__(self, sp):
-            self.storage_provider = sp
-            self.priority = DataSourcePriority.STORAGE
-
-        async def is_available(self, *args, **kwargs):  # pragma: no cover
-            return False
-
-        async def fetch(self, *args, **kwargs):  # pragma: no cover
-            return pd.DataFrame()
-
-        async def coverage(self, *args, **kwargs):  # pragma: no cover
-            return []
+            super().__init__(sp, DataSourcePriority.STORAGE)
 
     storage_ds = _StorageDS(storage_provider)
     fetcher = _FakeFetcher()


### PR DESCRIPTION
## Summary
- replace the cache and storage data source wrappers with a single configurable `HistoryProviderDataSource`
- update seamless provider setup and presets to construct priority-aware history data sources
- refresh seamless configuration and provider tests to assert the new data source priority wiring

## Testing
- uv run -m pytest tests/qmtl/runtime/sdk/test_seamless_config.py tests/qmtl/runtime/sdk/test_seamless_provider.py::test_storage_backfill_materializes_and_reads_back tests/qmtl/runtime/sdk/test_seamless_provider.py::test_data_fetcher_backfiller_logs_structured_success

------
https://chatgpt.com/codex/tasks/task_e_68e2609ef7188329896d9a2e604217ae