### PR TITLE
Refactor ccxt fetchers to use shared base helpers

### DIFF
--- a/tests/qmtl/runtime/io/test_ccxt_trades_fetcher.py
+++ b/tests/qmtl/runtime/io/test_ccxt_trades_fetcher.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
 import pandas as pd
 import pytest
 
@@ -26,6 +28,14 @@ class _StubTradesExchange:
 
     async def close(self):  # pragma: no cover - best effort
         await asyncio.sleep(0)
+
+
+class _DummyLimiter:
+    async def __aenter__(self):  # pragma: no cover - trivial context
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):  # pragma: no cover - trivial context
+        return False
 
 
 @pytest.mark.asyncio
@@ -84,4 +94,126 @@ async def test_trades_fetcher_retries_then_succeeds():
     fetcher = CcxtTradesFetcher(cfg, exchange=ex)
     df = await fetcher.fetch(60, 60, node_id="trades:binance:BTC/USDT", interval=60)
     assert df["ts"].tolist() == [60]
+
+
+@pytest.mark.asyncio
+async def test_trades_fetcher_penalty_backoff_on_429(monkeypatch):
+    orig_sleep = asyncio.sleep
+    delays: list[float] = []
+
+    async def _fake_sleep(duration, *args, **kwargs):
+        delays.append(duration)
+        await orig_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+
+    class _RateLimitOnce(_StubTradesExchange):
+        def __init__(self, batches, *, status_code: int = 429):
+            super().__init__(batches)
+            self._status_code = status_code
+            self._fail = True
+
+        async def fetch_trades(self, symbol, since=None, limit=None):
+            if self._fail:
+                self._fail = False
+                exc = RuntimeError("too many requests")
+                setattr(exc, "status_code", self._status_code)
+                raise exc
+            return await super().fetch_trades(symbol, since=since, limit=limit)
+
+    rows = [[{"timestamp": 60_000, "price": 10.0, "amount": 0.1}]]
+    ex = _RateLimitOnce(rows)
+    cfg = CcxtTradesConfig(
+        exchange_id="binance",
+        symbols=["BTC/USDT"],
+        max_retries=2,
+        retry_backoff_s=0.1,
+        rate_limiter=RateLimiterConfig(penalty_backoff_ms=500),
+    )
+    fetcher = CcxtTradesFetcher(cfg, exchange=ex)
+
+    df = await fetcher.fetch(60, 60, node_id="trades:binance:BTC/USDT", interval=60)
+    assert df["ts"].tolist() == [60]
+    assert any(pytest.approx(0.5, rel=0.1) == d for d in delays)
+
+
+@pytest.mark.asyncio
+async def test_trades_fetcher_reuses_limiter(monkeypatch):
+    limiter_calls = 0
+    limiter = _DummyLimiter()
+
+    async def _fake_get_limiter(key: str, **kwargs):
+        nonlocal limiter_calls
+        limiter_calls += 1
+        return limiter
+
+    monkeypatch.setattr(
+        "qmtl.runtime.io.ccxt_fetcher.get_limiter", _fake_get_limiter
+    )
+
+    cfg = CcxtTradesConfig(
+        exchange_id="binance",
+        symbols=["BTC/USDT"],
+        rate_limiter=RateLimiterConfig(),
+    )
+    ex = _StubTradesExchange([[{"timestamp": 60_000, "price": 10.0, "amount": 0.1}]])
+    fetcher = CcxtTradesFetcher(cfg, exchange=ex)
+
+    await fetcher.fetch(60, 60, node_id="trades:binance:BTC/USDT", interval=60)
+    await fetcher.fetch(60, 60, node_id="trades:binance:BTC/USDT", interval=60)
+
+    assert limiter_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_trades_fetcher_reuses_cached_exchange(monkeypatch):
+    class _FakeTradesExchange:
+        instances: list["_FakeTradesExchange"] = []
+
+        def __init__(self, options):
+            self.options = options
+            self.fetch_calls = 0
+            self.close_calls = 0
+            type(self).instances.append(self)
+
+        async def fetch_trades(self, symbol, since=None, limit=None):
+            self.fetch_calls += 1
+            await asyncio.sleep(0)
+            return []
+
+        async def close(self):
+            self.close_calls += 1
+            await asyncio.sleep(0)
+
+    module = types.ModuleType("ccxt.async_support")
+    module.binance = _FakeTradesExchange
+    parent = types.ModuleType("ccxt")
+    parent.async_support = module
+    monkeypatch.setitem(sys.modules, "ccxt", parent)
+    monkeypatch.setitem(sys.modules, "ccxt.async_support", module)
+
+    limiter = _DummyLimiter()
+
+    async def _fake_get_limiter(key: str, **kwargs):
+        return limiter
+
+    monkeypatch.setattr(
+        "qmtl.runtime.io.ccxt_fetcher.get_limiter", _fake_get_limiter
+    )
+
+    _FakeTradesExchange.instances.clear()
+
+    cfg = CcxtTradesConfig(
+        exchange_id="binance",
+        symbols=["BTC/USDT"],
+    )
+    fetcher = CcxtTradesFetcher(cfg)
+
+    await fetcher.fetch(60, 60, node_id="trades:binance:BTC/USDT", interval=60)
+    await fetcher.fetch(60, 60, node_id="trades:binance:BTC/USDT", interval=60)
+
+    assert len(_FakeTradesExchange.instances) == 1
+    instance = _FakeTradesExchange.instances[0]
+    assert instance.fetch_calls >= 1
+    assert instance.close_calls == 2
 


### PR DESCRIPTION
## Summary
- add a `_BaseCcxtFetcher` that centralizes limiter management, exchange lifecycle helpers, and retry orchestration for CCXT-backed fetchers
- refactor `CcxtOHLCVFetcher` and `CcxtTradesFetcher` to derive from the shared base and delegate to its helpers
- expand unit tests to cover limiter reuse, exchange caching, and rate-limit penalty backoff scenarios for both fetchers

## Testing
- uv run -m pytest -W error tests/qmtl/runtime/io/test_ccxt_fetcher.py tests/qmtl/runtime/io/test_ccxt_trades_fetcher.py

------
https://chatgpt.com/codex/tasks/task_e_68e2608aca608329aacb308a03271ec1