### PR TITLE
Include Seamless presets in packaged examples

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include qmtl/examples *.yml *.py *.md *.csv *.ipynb
+recursive-include qmtl/examples *.yml *.yaml *.py *.md *.csv *.ipynb
 recursive-include qmtl/examples/data *.csv

--- a/docs/operations/seamless_stack.md
+++ b/docs/operations/seamless_stack.md
@@ -11,8 +11,10 @@ The repository ships the following artifacts:
   the Seamless backfill coordinator, QuestDB, Redis, and MinIO.
 - `operations/seamless/.env.example` – Baseline environment variables for the
   Compose stack and Seamless SDK.
-- `operations/seamless/presets.yaml` – SLA and conformance presets aligned with
-  the QMTL SDK defaults.
+- `qmtl/examples/seamless/presets.yaml` – SLA and conformance presets aligned
+  with the QMTL SDK defaults. A convenience copy remains under
+  `operations/seamless/presets.yaml` for operators working from the repository
+  checkout.
 - `operations/seamless/README.md` – Detailed documentation of services and
   configuration options.
 

--- a/operations/seamless/README.md
+++ b/operations/seamless/README.md
@@ -12,7 +12,11 @@ artifact bucket) together with opinionated SLA and conformance presets.
 | `.env.example` | Seed environment variables that the Seamless runtime and Compose stack expect. Copy it to `.env` before launching containers. |
 | `.gitignore` | Prevents accidental commits of local `.env` overrides. |
 | `docker-compose.seamless.yml` | Compose bundle for the coordinator, QuestDB, Redis, and MinIO services. |
-| `presets.yaml` | Reference SLA and conformance presets that align with the provider defaults. |
+| `presets.yaml` | Reference SLA and conformance presets that align with the provider defaults. Packaged copy lives in `qmtl/examples/seamless/presets.yaml`. |
+
+> **Note:** The packaged copy is distributed with the `qmtl.examples`
+> module so SDK consumers can load presets without checking out the operations
+> assets.
 
 ## Services
 
@@ -84,7 +88,9 @@ from qmtl.runtime.sdk.sla import SLAPolicy
 from qmtl.runtime.sdk.seamless_data_provider import SeamlessDataProvider
 from qmtl.runtime.sdk.conformance import ConformancePipeline
 
-with open("operations/seamless/presets.yaml", "r", encoding="utf-8") as handle:
+from qmtl.examples.seamless import open_presets
+
+with open_presets() as handle:
     presets = yaml.safe_load(handle)
 
 sla_config = presets["sla_presets"]["baseline"]["policy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,11 +69,14 @@ include = ["qmtl*"]
 "qmtl.examples" = [
   "*.py",
   "*.yml",
+  "*.yaml",
   "templates/*.yml",
   "gitignore",
   "README.md",
   "data/*.csv",
   "*.csv",
+  "seamless/*.yaml",
+  "seamless/*.yml",
   "notebooks/*.ipynb",
 ]
 "qmtl.foundation.schema" = [

--- a/qmtl/examples/seamless/__init__.py
+++ b/qmtl/examples/seamless/__init__.py
@@ -1,0 +1,15 @@
+"""Seamless stack presets and helpers shipped with the QMTL examples package."""
+
+from importlib import resources as _resources
+
+__all__ = ["get_presets_path", "open_presets"]
+
+
+def get_presets_path() -> str:
+    """Return the filesystem path to the packaged Seamless presets file."""
+    return str(_resources.files(__package__).joinpath("presets.yaml"))
+
+
+def open_presets():
+    """Open a text stream for the packaged Seamless presets."""
+    return _resources.files(__package__).joinpath("presets.yaml").open("r", encoding="utf-8")

--- a/qmtl/examples/seamless/presets.yaml
+++ b/qmtl/examples/seamless/presets.yaml
@@ -1,0 +1,54 @@
+version: 1
+sla_presets:
+  baseline:
+    description: >-
+      Balanced SLA for ccxt polling workloads. Blocks responses when storage, backfill,
+      or live waits exceed their budget so gaps surface quickly in staging.
+    policy:
+      total_deadline_ms: 60000
+      max_wait_storage_ms: 3000
+      max_wait_backfill_ms: 45000
+      max_wait_live_ms: 5000
+      retry_backoff_ms: 500
+      min_coverage: 0.98
+      max_lag_seconds: 45
+      on_violation: fail_fast
+  tolerant-partial:
+    description: >-
+      Allows partial fills for exploratory notebooks while still bounding latency.
+    policy:
+      total_deadline_ms: 90000
+      max_wait_storage_ms: 5000
+      max_wait_backfill_ms: 75000
+      max_wait_live_ms: 7000
+      retry_backoff_ms: 1000
+      min_coverage: 0.9
+      max_lag_seconds: 90
+      on_violation: partial_fill
+conformance_presets:
+  strict-blocking:
+    description: >-
+      Enforces schema rollups and rejects frames that raise any conformance warnings.
+    partial_ok: false
+    interval_ms: 60000
+    schema:
+      fields:
+        - name: ts
+          dtype: datetime64[ns]
+        - name: open
+          dtype: float64
+        - name: high
+          dtype: float64
+        - name: low
+          dtype: float64
+        - name: close
+          dtype: float64
+        - name: volume
+          dtype: float64
+  permissive-dev:
+    description: >-
+      Keeps the conformance pipeline enabled but allows responses to pass with warnings.
+      Useful for local development and dataset audits.
+    partial_ok: true
+    interval_ms: null
+    schema: {}


### PR DESCRIPTION
## Summary
- package the Seamless presets alongside the examples module and expose helper utilities for loading them
- document the new presets location in the Seamless operations guide and README while keeping a convenience copy for operators
- update packaging configuration so YAML presets ship with wheels and sdists

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3b799f57083299c66a31bab69c1dc