### PR TITLE
docs: update execution node sdk path

### DIFF
--- a/docs/architecture/execution_nodes.md
+++ b/docs/architecture/execution_nodes.md
@@ -4,7 +4,7 @@ Wrapper nodes for pre-trade checks, order sizing, execution, fill ingestion,
 portfolio updates, risk controls and timing gates. These classes bridge
 strategy signals with exchange node sets described in
 [exchange_node_sets.md](exchange_node_sets.md) and rely on helper modules
-under `qmtl/sdk`.
+under `qmtl/runtime/sdk`.
 
 Usage note
 - In typical strategies you should attach a prebuilt Node Set (wrapper) rather than wiring these nodes one by one. The Node Set API provides a convenient, stable surface while allowing internal node composition to evolve.


### PR DESCRIPTION
## Summary
- update the execution layer node architecture doc to reference the `qmtl/runtime/sdk` helpers

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e3b7ecd2308329b5b36a37bb76fd38