### PR TITLE
Clarify ComputeKey safe-mode downgrade documentation

### DIFF
--- a/docs/architecture/dag-manager.md
+++ b/docs/architecture/dag-manager.md
@@ -132,7 +132,7 @@ qmtl service dagmanager export-schema --uri bolt://localhost:7687 --user neo4j -
   - Cross‑context cache hits (same `node_id`, different `(world_id|execution_domain|as_of|partition)`) MUST be treated as violations and reported via a metric `cross_context_cache_hit_total` and blocked by policy (SLO: 0).
   - Queue topics and NodeID remain unchanged; ComputeKey does not alter topic naming. Operators MAY additionally deploy namespace prefixes `{world_id}.{execution_domain}.<topic>` at the broker level for operational isolation (see WorldService doc).
   - Instrumentation: DAG Manager and SDK MUST emit `cross_context_cache_hit_total` and alert when >0 (critical). Promotion workflows must halt until cleared.
-  - Completeness: `as_of` MUST be non-empty for backtests/dryruns; Gateway supplies the value. When absent, ComputeKey falls back to sentinel `live` context and no reuse is permitted.
+  - Completeness: `as_of` MUST be non-empty for backtests/dryruns; Gateway supplies the value. When missing, the shared `ComputeContext.evaluate_safe_mode()` helpers (see `qmtl/foundation/common/compute_context.py`) downgrade the request to the compute-only/backtest domain, flip the safe-mode flags, and block reuse without ever emitting a "live" sentinel.
 
 Note: This design preserves NodeID stability while providing strong execution isolation across worlds and domains.
 


### PR DESCRIPTION
## Summary
- update the DAG manager docs so the ComputeKey guidance reflects the backtest safe-mode downgrade implemented in compute_context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b7ee30808329a823d96becd89849