### PR TITLE
Normalize effective_mode responses for world decisions

### DIFF
--- a/docs/reference/schemas/decision_envelope.schema.json
+++ b/docs/reference/schemas/decision_envelope.schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "world_id": { "type": "string" },
     "policy_version": { "type": "integer", "minimum": 0 },
-    "effective_mode": { "type": "string", "enum": ["validate", "active"] },
+    "effective_mode": { "type": "string", "enum": ["validate", "compute-only", "paper", "live"] },
     "reason": { "type": "string" },
     "as_of": { "type": "string", "format": "date-time" },
     "ttl": { "type": "string" },

--- a/docs/world/world.md
+++ b/docs/world/world.md
@@ -219,7 +219,7 @@ GET /worlds/{world}/decide?as_of=2025-08-28T09:00:00Z HTTP/1.1
 → {
   "world_id": "crypto_mom_1h",
   "policy_version": 3,
-  "effective_mode": "validate",   # validate|active
+  "effective_mode": "validate",   # validate|compute-only|paper|live (placeholder worlds default to validate)
   "reason": "data_currency_ok&gates_pass&hysteresis",
   "as_of": "2025-08-28T09:00:00Z",
   "ttl": "300s",                   # 캐시 유효 시간(권장)

--- a/qmtl/services/worldservice/routers/bindings.py
+++ b/qmtl/services/worldservice/routers/bindings.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Response
 
 from ..schemas import BindingsResponse, DecisionEnvelope, DecisionsRequest
 from ..services import WorldService
+from qmtl.foundation.common.compute_context import canonicalize_world_mode
 
 
 def create_bindings_router(service: WorldService) -> APIRouter:
@@ -31,7 +32,8 @@ def create_bindings_router(service: WorldService) -> APIRouter:
         version = await store.default_policy_version(world_id)
         now = datetime.now(timezone.utc)
         strategies = await store.get_decisions(world_id)
-        effective_mode = 'active' if strategies else 'validate'
+        candidate_mode = 'active' if strategies else 'validate'
+        effective_mode = canonicalize_world_mode(candidate_mode)
         reason = 'policy_evaluated' if strategies else 'no_active_strategies'
         ttl = '300s'
         metadata = await store.latest_history_metadata(world_id)


### PR DESCRIPTION
## Summary
- expose a canonical world-mode normalizer and reuse it in the bindings router so /decide emits validate or live instead of the legacy active token
- refresh the decision envelope schema and world docs to advertise the validate|compute-only|paper|live vocabulary with placeholder defaults
- add a regression test that covers both placeholder and active worlds to guard the canonical response payload

## Testing
- uv run -m pytest tests/qmtl/services/worldservice/test_worldservice_api.py::test_decide_effective_mode_canonicalised

------
https://chatgpt.com/codex/tasks/task_e_68e3c98ff94c8329898eef2c31cfb35a