### PR TITLE
Allow validate activation mode in activation envelopes

### DIFF
--- a/docs/reference/schemas/activation_envelope.schema.json
+++ b/docs/reference/schemas/activation_envelope.schema.json
@@ -12,7 +12,7 @@
     "weight": { "type": "number", "minimum": 0, "maximum": 1 },
     "freeze": { "type": "boolean" },
     "drain": { "type": "boolean" },
-    "effective_mode": { "type": "string", "enum": ["compute-only", "paper", "live"] },
+    "effective_mode": { "type": "string", "enum": ["validate", "compute-only", "paper", "live"] },
     "etag": { "type": "string" },
     "run_id": { "type": "string" },
     "ts": { "type": "string", "format": "date-time" },

--- a/docs/reference/schemas/event_activation_updated.schema.json
+++ b/docs/reference/schemas/event_activation_updated.schema.json
@@ -14,7 +14,7 @@
     "weight": { "type": "number", "minimum": 0, "maximum": 1 },
     "freeze": { "type": "boolean" },
     "drain": { "type": "boolean" },
-    "effective_mode": { "type": "string", "enum": ["compute-only", "paper", "live"] },
+    "effective_mode": { "type": "string", "enum": ["validate", "compute-only", "paper", "live"] },
     "etag": { "type": "string" },
     "run_id": { "type": "string" },
     "ts": { "type": "string", "format": "date-time" },

--- a/docs/world/world.md
+++ b/docs/world/world.md
@@ -365,7 +365,7 @@ SDK는 오직 Gateway와만 통신한다. ControlBus는 내부 제어 버스이�
   - `expires_at`: 재구독 시점 안내.
   - `fallback_url`: 주 스트림 불가 시 사용. 미제공 시 HTTP 폴링 경로를 사용.
 - 이벤트 타입(요약)
-  - ActivationUpdated: `{world_id, strategy_id, side, active, weight, etag, run_id, ts}`
+  - ActivationUpdated: `{world_id, strategy_id, side, active, weight, effective_mode (validate|compute-only|paper|live), etag, run_id, ts}`
   - QueueUpdated: `{tags[], interval, queues[], etag, ts}`
   - PolicyUpdated: `{world_id, version, checksum, status, ts}`
 - 순서/중복
@@ -421,7 +421,7 @@ SDK는 오직 Gateway와만 통신한다. ControlBus는 내부 제어 버스이�
 
 ### 15.3 이벤트 타입(요약)
 
-- ActivationUpdated: `{world_id, strategy_id, side, active, weight, etag, run_id, ts}`
+- ActivationUpdated: `{world_id, strategy_id, side, active, weight, effective_mode (validate|compute-only|paper|live), etag, run_id, ts}`
 - QueueUpdated: `{tags[], interval, queues[], etag, ts}`
 - PolicyUpdated: `{world_id, version, checksum, status, ts}`
 

--- a/qmtl/runtime/reference_models/__init__.py
+++ b/qmtl/runtime/reference_models/__init__.py
@@ -19,7 +19,7 @@ class ActivationEnvelope(BaseModel):
     weight: StrictFloat
     freeze: Optional[bool] = None
     drain: Optional[bool] = None
-    effective_mode: Optional[Literal["compute-only", "paper", "live"]] = None
+    effective_mode: Optional[Literal["validate", "compute-only", "paper", "live"]] = None
     etag: StrictStr
     run_id: Optional[StrictStr] = None
     ts: StrictStr
@@ -36,7 +36,7 @@ class ActivationUpdated(BaseModel):
     weight: StrictFloat
     freeze: Optional[bool] = None
     drain: Optional[bool] = None
-    effective_mode: Optional[Literal["compute-only", "paper", "live"]] = None
+    effective_mode: Optional[Literal["validate", "compute-only", "paper", "live"]] = None
     etag: StrictStr
     run_id: Optional[StrictStr] = None
     ts: StrictStr

--- a/qmtl/services/gateway/event_models.py
+++ b/qmtl/services/gateway/event_models.py
@@ -48,7 +48,7 @@ class ActivationUpdatedData(BaseModel):
     weight: Optional[StrictFloat] = None
     freeze: Optional[bool] = None
     drain: Optional[bool] = None
-    effective_mode: Optional[Literal["compute-only", "paper", "live"]] = None
+    effective_mode: Optional[Literal["validate", "compute-only", "paper", "live"]] = None
     etag: Optional[StrictStr] = None
     run_id: Optional[StrictStr] = None
     ts: Optional[StrictStr] = None


### PR DESCRIPTION
## Summary
- allow the gateway ActivationUpdated model to accept the `validate` effective_mode token and mirror it in the runtime reference models
- extend the activation envelope JSON schemas to include the validate value
- refresh the activation event documentation to note the full set of accepted modes

## Testing
- uv run -m pytest tests/qmtl/runtime/reference_models/test_reference_models.py

------
https://chatgpt.com/codex/tasks/task_e_68e3cb00e03883298d8c1674a2abb697