### PR TITLE
Document full world apply acknowledgement payload

### DIFF
--- a/docs/reference/api_world.md
+++ b/docs/reference/api_world.md
@@ -132,8 +132,17 @@ Request
 
 Response
 ```json
-{ "ok": true, "run_id": "..." }
+{
+  "ok": true,
+  "run_id": "...",
+  "active": ["s1", "s2"],
+  "phase": "completed"
+}
 ```
+
+- `ok` defaults to `true` and only flips to `false` if the apply run aborts.
+- `active` always echoes the persisted strategy list after the apply completes (empty when nothing is active).
+- `phase` is optional; when present it reflects the final stage (`completed`, `rolled_back`, etc.). Intermediate polling may observe `phase` transitions such as `freeze` or `switch`.
 
 ### POST /events/subscribe
 Returns an opaque event stream descriptor for real‑time control updates (activation/queues/policy).

--- a/docs/world/policy_engine.md
+++ b/docs/world/policy_engine.md
@@ -36,3 +36,14 @@ curl -X POST /worlds/alpha/apply \
 ```
 
 The response contains the active strategies after evaluation.
+
+```json
+{
+  "ok": true,
+  "run_id": "...",
+  "active": ["alpha-core", "alpha-hedge"],
+  "phase": "completed"
+}
+```
+
+`ok` defaults to `true`, `active` mirrors the persisted strategy roster (empty when nothing is active), and `phase` is optional—`completed` for successful runs, or another stage while the 2‑Phase apply is still progressing.

--- a/docs/world/world.md
+++ b/docs/world/world.md
@@ -256,8 +256,17 @@ POST /worlds/{world}/evaluate HTTP/1.1
 ```http
 POST /worlds/{world}/apply HTTP/1.1
 { "run_id": "...", "plan": { ... } }
-→ { "ok": true, "run_id": "..." }
+→ {
+  "ok": true,
+  "run_id": "...",
+  "active": ["s1", "s2"],
+  "phase": "completed"
+}
 ```
+
+- `ok` 기본값은 `true`이며 적용(run) 중단 시에만 `false`로 내려간다.
+- `active`는 적용 이후 월드에 남아 있는 활성 전략 ID 목록을 그대로 반환한다(없으면 빈 배열).
+- `phase`는 옵션 필드이며 `freeze` → `switch` → `unfreeze` → `completed` 등 2‑Phase 진행 단계를 나타낸다. 롤백이 발생하면 `rolled_back`으로 종료된다.
 
 이벤트 구독(은닉 ControlBus 핸드오버)
 

--- a/tests/e2e/world_smoke/servers/worldservice_stub.py
+++ b/tests/e2e/world_smoke/servers/worldservice_stub.py
@@ -125,7 +125,9 @@ class ApplyRequest(BaseModel):
 
 @app.post("/worlds/{wid}/apply")
 async def apply(wid: str, req: ApplyRequest) -> dict:
-    return {"ok": True, "run_id": req.run_id}
+    plan = req.plan or {}
+    active = list(plan.get("activate", [])) if isinstance(plan, dict) else []
+    return {"ok": True, "run_id": req.run_id, "active": active, "phase": "completed"}
 
 
 def main() -> None:

--- a/tests/e2e/world_smoke/test_service_checks.py
+++ b/tests/e2e/world_smoke/test_service_checks.py
@@ -162,7 +162,10 @@ def test_service_mode_evaluate_apply_roundtrip():
         pytest.skip("/worlds/{id}/apply not available")
 
     assert apply_js.get("run_id", run_id) == run_id
-    assert apply_js.get("ok") in (True, 1, "true")
+    assert apply_js.get("ok", True) in (True, 1, "true")
+    assert isinstance(apply_js.get("active"), list)
+    if "phase" in apply_js:
+        assert isinstance(apply_js["phase"], str) and apply_js["phase"]
 
 
 @pytest.mark.order(8)


### PR DESCRIPTION
## Summary
- document the full 2-phase apply acknowledgement envelope, including the `active` roster and optional `phase`
- refresh world policy docs and samples to note default semantics for `ok`, `active`, and `phase`
- align smoke tests and stub service so they assert the complete acknowledgement payload

## Testing
- pytest tests/qmtl/services/worldservice/test_apply_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68e3cd11d828832984f5b4793c772c32