### PR TITLE
Avoid returning null execution domain in activation payloads

### DIFF
--- a/qmtl/services/gateway/world_payloads.py
+++ b/qmtl/services/gateway/world_payloads.py
@@ -44,7 +44,10 @@ def augment_activation_payload(payload: Any) -> Any:
         return payload
 
     domain = resolve_execution_domain(payload.get("effective_mode"))
-    payload["execution_domain"] = domain
+    if domain is not None:
+        payload["execution_domain"] = domain
+    else:
+        payload.pop("execution_domain", None)
     return payload
 
 


### PR DESCRIPTION
## Summary
- avoid setting the activation payload execution_domain field when the derived value is null

## Testing
- uv run -m pytest tests/qmtl/services/gateway/test_world_proxy_activation.py

------
https://chatgpt.com/codex/tasks/task_e_68e3cdbff4e88329a7fcd2207ad6373c