### PR TITLE
Improve diagnostics for strict history and gateway submission errors

### DIFF
--- a/qmtl/runtime/sdk/strategy_bootstrapper.py
+++ b/qmtl/runtime/sdk/strategy_bootstrapper.py
@@ -115,7 +115,12 @@ class StrategyBootstrapper:
             )
             if isinstance(ack, dict):
                 if "error" in ack:
-                    raise RuntimeError(ack["error"])
+                    error_detail = str(ack.get("error") or "unknown error")
+                    raise RuntimeError(
+                        "Gateway rejected strategy submission: "
+                        f"{error_detail} (world_id={world_id}, trade_mode={trade_mode}, "
+                        f"gateway_url={gateway_url})"
+                    )
                 if isinstance(ack.get("strategy_id"), str):
                     strategy_id = ack["strategy_id"]
                 queue_map = ack.get("queue_map", ack)

--- a/tests/qmtl/runtime/sdk/test_history_components.py
+++ b/tests/qmtl/runtime/sdk/test_history_components.py
@@ -111,5 +111,11 @@ def test_strict_history_detects_missing_points() -> None:
     timestamps = [0, 10, 30, 40]
     coverage = [(0, 40)]
 
-    with pytest.raises(RuntimeError):
-        ensure_strict_history(timestamps, interval=10, required_points=5, coverage=coverage)
+    with pytest.raises(
+        RuntimeError,
+        match=r"expected 5 points in \[0, 40\] at interval 10",
+    ) as exc:
+        ensure_strict_history(
+            timestamps, interval=10, required_points=5, coverage=coverage
+        )
+    assert "total=4" in str(exc.value)


### PR DESCRIPTION
## Summary
- add detailed context to strict history validation errors to help trace missing data
- include world and trade mode details when the gateway rejects a strategy submission
- update the strict history unit test to assert the enriched messaging

## Testing
- uv run -m pytest tests/qmtl/runtime/sdk/test_history_components.py::test_strict_history_detects_missing_points

------
https://chatgpt.com/codex/tasks/task_e_68e600676928832988d473001341ba4d