### PR TITLE
Add tests to verify TagQuery node ID stability

### DIFF
--- a/tests/qmtl/runtime/sdk/tagquery/test_tagquery_upsert_handler.py
+++ b/tests/qmtl/runtime/sdk/tagquery/test_tagquery_upsert_handler.py
@@ -24,3 +24,47 @@ async def test_tagquery_upsert_initializes_node():
     assert node.pre_warmup
     key = (("t",), 60, MatchMode.ANY)
     assert mgr._last_queue_sets[key] == frozenset(["q1"])
+
+
+@pytest.mark.asyncio
+async def test_queue_update_preserves_node_identity():
+    node = TagQueryNode(["t1", "t2"], interval="60s", period=1)
+    original_id = node.node_id
+
+    mgr = TagQueryManager()
+    mgr.register(node)
+
+    await mgr.handle_message(
+        {
+            "type": "queue_update",
+            "data": {
+                "tags": ["t2", "t1"],
+                "interval": 60,
+                "queues": [
+                    {"queue": "q1", "global": False},
+                    {"queue": "q2", "global": False},
+                ],
+                "match_mode": "any",
+                "version": 1,
+            },
+        }
+    )
+
+    assert node.node_id == original_id
+    assert node.upstreams == ["q1", "q2"]
+
+    await mgr.handle_message(
+        {
+            "event": "queue_update",
+            "data": {
+                "tags": " t2 , t1 ",
+                "interval": 60,
+                "queues": [{"queue": "q2", "global": False}],
+                "match_mode": "any",
+                "version": 1,
+            },
+        }
+    )
+
+    assert node.node_id == original_id
+    assert node.upstreams == ["q2"]

--- a/tests/qmtl/runtime/sdk/test_tag_query_node.py
+++ b/tests/qmtl/runtime/sdk/test_tag_query_node.py
@@ -1,5 +1,6 @@
 import logging
 
+from qmtl.foundation.common.tagquery import split_tags
 from qmtl.runtime.sdk import TagQueryNode, MatchMode
 
 
@@ -31,3 +32,24 @@ def test_update_queues_logs_warning_when_empty(caplog):
 def test_tag_query_node_accepts_string_match_mode():
     node = TagQueryNode(["t"], interval="60s", period=1, match_mode="all")
     assert node.match_mode is MatchMode.ALL
+
+
+def test_tag_query_node_id_permutation_invariance():
+    node_a = TagQueryNode(["t2", "t1"], interval="60s", period=1)
+    node_b = TagQueryNode(["t1", "t2"], interval="60s", period=1)
+
+    assert sorted(node_a.query_tags) == ["t1", "t2"]
+    assert sorted(node_b.query_tags) == ["t1", "t2"]
+    assert node_a.node_id == node_b.node_id
+
+
+def test_tag_query_node_id_whitespace_normalization():
+    raw = " t1 ,\t t2 "
+    normalized = split_tags(raw)
+
+    assert normalized == ["t1", "t2"]
+
+    node_from_http = TagQueryNode(normalized, interval="60s", period=1)
+    node_reference = TagQueryNode(["t1", "t2"], interval="60s", period=1)
+
+    assert node_from_http.node_id == node_reference.node_id


### PR DESCRIPTION
## Summary
- add TagQuery node unit tests that assert node_id invariance across tag permutations and HTTP-style whitespace normalization
- extend the TagQuery manager WebSocket tests to ensure queue_update events update queues without mutating node identity

## Testing
- uv run -m pytest tests/qmtl/runtime/sdk/test_tag_query_node.py::test_tag_query_node_id_permutation_invariance tests/qmtl/runtime/sdk/test_tag_query_node.py::test_tag_query_node_id_whitespace_normalization tests/qmtl/runtime/sdk/tagquery/test_tagquery_upsert_handler.py::test_queue_update_preserves_node_identity

Fixes #1310

------
https://chatgpt.com/codex/tasks/task_e_68e70f6de7188329925e28e00312662f