### PR TITLE
docs: rewrite config guidance for unified YAML workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,12 @@ Bring services up in three steps. This mirrors the detailed guidance in
    uv run qmtl config validate --config qmtl/examples/qmtl.yml --offline
    ```
 
-2. **Share the YAML with services** – either pass the path explicitly or export
-   it once for long-running processes.
+2. **Share the YAML with services** – keep the file in your workspace and pass
+   it explicitly, or copy it to `./qmtl.yml` so CLIs discover it automatically.
 
    ```bash
-   export QMTL_CONFIG_FILE=$PWD/qmtl/examples/qmtl.yml
+   # Optional: make the sample config discoverable without extra flags.
+   cp qmtl/examples/qmtl.yml ./qmtl.yml
    ```
 
 3. **Launch services** – point both Gateway and DAG Manager at the same file.
@@ -116,8 +117,9 @@ Bring services up in three steps. This mirrors the detailed guidance in
    qmtl service dagmanager server --config qmtl/examples/qmtl.yml
    ```
 
-If `QMTL_CONFIG_FILE` is invalid the services log a warning and continue with
-default settings, preventing silent misconfigurations.
+If the path is wrong or missing, the services log a warning and continue with
+default settings—keep `qmtl config validate` in your workflow to catch typos
+early.
 
 ## Trading Node Enhancements
 
@@ -239,7 +241,7 @@ stand‑alone FastAPI app and enable the Gateway proxy when needed.
 1) Start WorldService (SQLite + Redis example)
 
 ```bash
-cat > worldservice.yml <<'EOF'
+cat > qmtl.yml <<'EOF'
 worldservice:
   dsn: sqlite:///worlds.db
   redis: redis://localhost:6379/0
@@ -250,7 +252,8 @@ worldservice:
     header: Authorization
     tokens: []
 EOF
-export QMTL_CONFIG_FILE=$(pwd)/worldservice.yml
+# Validate the file once before launching the service.
+uv run qmtl config validate --config qmtl.yml --target schema --offline
 uv run uvicorn qmtl.services.worldservice.api:create_app --factory --host 0.0.0.0 --port 8080
 ```
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -36,8 +36,8 @@ See also: Architecture Glossary (architecture/glossary.md) for canonical terms s
    으로 게이트웨이/다그매니저 설정을 검증한다. 오류가 발생하면 아키텍처 설계
    문서를 참고해 빠진 요소를 보완한다.
 2. 동일한 파일을 서비스 실행 시 `--config qmtl/examples/qmtl.yml` 로 넘기거나,
-   장기 실행 환경에서는 `export QMTL_CONFIG_FILE=$PWD/qmtl/examples/qmtl.yml` 한 줄로
-   경로만 공유한다.
+   자주 실행한다면 작업 디렉터리에 `cp qmtl/examples/qmtl.yml ./qmtl.yml`로 복사해
+   자동 감지를 활용한다.
 3. `qmtl service gateway --config qmtl/examples/qmtl.yml` 와 `qmtl service dagmanager server --config qmtl/examples/qmtl.yml`
    를 실행한다. 로그에 경고가 나오면 아키텍처 상 의존하는 외부 리소스를 점검한다.
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -23,8 +23,9 @@ last_modified: 2025-09-22
 !!! tip "빠른 시작: 검증 → 기동"
     운영용 YAML을 작성했다면 `uv run qmtl config validate --config <파일> --offline`
     으로 구조를 확인하고, 동일한 파일을 `qmtl service gateway --config <파일>` 및
-    `qmtl service dagmanager server --config <파일>` 인자로 넘겨라. 장기 실행
-    프로세스에는 `export QMTL_CONFIG_FILE=<파일>` 로 경로만 공유하면 된다.
+    `qmtl service dagmanager server --config <파일>` 인자로 넘겨라. 반복 실행이
+    필요하면 파일을 작업 디렉터리의 `qmtl.yml`로 복사해 CLI가 자동으로 인식하게
+    만들 수 있다.
 
 ---
 

--- a/docs/guides/sdk_tutorial.md
+++ b/docs/guides/sdk_tutorial.md
@@ -157,13 +157,6 @@ Runner.run(WorldStrategy, world_id="demo_world", gateway_url="http://gw")
 qmtl tools sdk run strategies.my:MyStrategy --world-id demo_world --gateway-url http://gw
 ```
 
-환경 변수로 값을 주입할 수도 있습니다.
-
-```bash
-export WORLD_ID=demo_world
-qmtl tools sdk run strategies.my:MyStrategy --world-id $WORLD_ID --gateway-url http://gw
-```
-
 구성 파일에서 값을 읽어오는 방법의 예시는 다음과 같습니다.
 
 ```yaml

--- a/docs/operations/backend_quickstart.md
+++ b/docs/operations/backend_quickstart.md
@@ -28,7 +28,7 @@ end-to-end tests in [E2E Testing](e2e_testing.md).
 1) Start WorldService (SQLite + Redis example)
 
 ```bash
-cat > worldservice.yml <<'EOF'
+cat > qmtl.yml <<'EOF'
 worldservice:
   dsn: sqlite:///worlds.db
   redis: redis://localhost:6379/0
@@ -39,7 +39,8 @@ worldservice:
     header: Authorization
     tokens: []
 EOF
-export QMTL_CONFIG_FILE=$(pwd)/worldservice.yml
+# Validate before starting services (schema-only for offline machines).
+uv run qmtl config validate --config qmtl.yml --target schema --offline
 uv run uvicorn qmtl.services.worldservice.api:create_app --factory --host 0.0.0.0 --port 8080
 ```
 

--- a/docs/operations/config-cli.md
+++ b/docs/operations/config-cli.md
@@ -46,7 +46,7 @@ message and exits with status code `2` before executing any validations.
 ## Launch sequence
 
 Services consume the same YAML directly. Provide the path on the command line or
-set `QMTL_CONFIG_FILE` so long-running daemons can discover it:
+copy it to `./qmtl.yml` so long-running daemons discover it automatically:
 
 ```bash
 # Validate first.
@@ -57,16 +57,7 @@ qmtl service gateway --config qmtl/examples/qmtl.yml
 qmtl service dagmanager server --config qmtl/examples/qmtl.yml
 ```
 
-If you prefer environment discovery, export the path once:
-
-```bash
-export QMTL_CONFIG_FILE=$PWD/qmtl/examples/qmtl.yml
-qmtl service gateway
-qmtl service dagmanager server
-```
-
-When `QMTL_CONFIG_FILE` points at a missing file the services log a warning and
-fall back to built-in defaults, ensuring operators can spot stale paths during
-startup.
+When the path is wrong or missing the services log a warning and fall back to
+built-in defaults, ensuring operators can spot stale files during startup.
 
 {{ nav_links() }}

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -178,14 +178,17 @@ be exported to any OTLP-compatible backend such as Jaeger or Tempo.
 
 ### Configuration
 
-Set the ``QMTL_OTEL_EXPORTER_ENDPOINT`` environment variable to the OTLP HTTP
-collector endpoint before starting services:
+Add the OTLP endpoint to your runtime configuration so every service shares the
+same destination:
 
-```bash
-export QMTL_OTEL_EXPORTER_ENDPOINT="http://localhost:4318/v1/traces"
+```yaml
+telemetry:
+  otel_exporter_endpoint: http://localhost:4318/v1/traces
 ```
 
-When unset, spans are logged to the console which is useful for development.
+Validate the change with `uv run qmtl config validate --config path/to/qmtl.yml`
+and restart services. When the field is omitted, spans fall back to console
+logging which is useful for development.
 
 ### Sample Jaeger query
 

--- a/operations/seamless/README.md
+++ b/operations/seamless/README.md
@@ -89,5 +89,16 @@ coordinator container.
    - QuestDB UI: `http://localhost:9000`
    - MinIO console: `http://localhost:${MINIO_CONSOLE_PORT}`
 
-4. Configure your QMTL runtime with the matching `QMTL_SEAMLESS_*` variables and
-   point the SDK to the coordinator URL.
+4. Update your unified configuration so runtime services match the stack, for
+   example:
+
+   ```yaml
+   seamless:
+     coordinator_url: http://localhost:8080
+
+   connectors:
+     seamless_worker_id: worker-a
+   ```
+
+   Validate with `uv run qmtl config validate --config path/to/qmtl.yml` before
+   deploying.

--- a/qmtl/examples/docs/worldservice_gating.md
+++ b/qmtl/examples/docs/worldservice_gating.md
@@ -27,21 +27,21 @@ WorldService gating flow.
 
 1. Start Gateway and WorldService. For a local run without Docker:
    - WorldService (SQLite + Redis):
-     ```bash
-     cat > worldservice.yml <<'EOF'
-     worldservice:
-       dsn: sqlite:///worlds.db
-       redis: redis://localhost:6379/0
-       bind:
-         host: 0.0.0.0
-         port: 8080
-       auth:
-         header: Authorization
-         tokens: []
-     EOF
-     export QMTL_CONFIG_FILE=$(pwd)/worldservice.yml
-     uv run uvicorn qmtl.services.worldservice.api:create_app --factory --host 0.0.0.0 --port 8080
-     ```
+    ```bash
+    cat > qmtl.yml <<'EOF'
+    worldservice:
+      dsn: sqlite:///worlds.db
+      redis: redis://localhost:6379/0
+      bind:
+        host: 0.0.0.0
+        port: 8080
+      auth:
+        header: Authorization
+        tokens: []
+    EOF
+    uv run qmtl config validate --config qmtl.yml --target schema --offline
+    uv run uvicorn qmtl.services.worldservice.api:create_app --factory --host 0.0.0.0 --port 8080
+    ```
    - Gateway (optionally proxying WorldService):
      - In `qmtl/examples/qmtl.yml` set `gateway.worldservice_url: http://localhost:8080`
        and `gateway.enable_worldservice_proxy: true`.

--- a/qmtl/examples/templates/backend_stack.example.yml
+++ b/qmtl/examples/templates/backend_stack.example.yml
@@ -133,4 +133,4 @@ notes:
   - "Provision alerts for gateway_e2e_latency_p95, dagmanager_diff_errors_total, and worldservice_decision_stale_total."
   - "Store secrets (passwords, SASL credentials) in your secrets manager instead of committing them."
   - "Validate config before launch: uv run qmtl config validate --config /etc/qmtl/backend.yml"
-  - "Set QMTL_CONFIG_FILE=/etc/qmtl/backend.yml so qmtl service gateway/dagmanager reuse the same YAML."
+  - "Pass --config /etc/qmtl/backend.yml to qmtl service gateway/dagmanager or copy it to ./qmtl.yml for autodiscovery."

--- a/qmtl/examples/templates/local_stack.example.yml
+++ b/qmtl/examples/templates/local_stack.example.yml
@@ -92,7 +92,7 @@ qmtl:
     dagmanager.memory_repo_path: ${dagmanager.memory_repo_path}
   sample_usage:
     - "uv run qmtl config validate --config ${qmtl.foundation.config_file} --offline"
-    - "export QMTL_CONFIG_FILE=${qmtl.foundation.config_file}"
+    - "# Optional: cp ${qmtl.foundation.config_file} ./qmtl.yml for autodiscovery"
     - "qmtl service gateway --config ${qmtl.foundation.config_file}"
     - "qmtl service dagmanager server --config ${qmtl.foundation.config_file}"
     - "python -m qmtl.examples.general_strategy --gateway-url http://localhost:${gateway.port} --world-id demo"
@@ -101,4 +101,4 @@ notes:
   - "Create local state directories upfront: mkdir -p ./var/dagmanager"
   - "Set dagmanager.enable_topic_namespace: false if you need to reuse legacy topic names when testing against mocks."
   - "Install dependencies with uv pip install -e .[dev] before starting services."
-  - "Set QMTL_CONFIG_FILE to this template's YAML so service CLIs pick it up without passing --config each time."
+  - "Copy this YAML to ./qmtl.yml if you want service CLIs to discover it without passing --config each time."


### PR DESCRIPTION
## Summary
- remove environment variable exports from the quickstart, worldservice, and operations docs in favour of YAML-first configuration validated with `qmtl config`
- update architecture guides and seamless templates to explain copying unified configs to `qmtl.yml` so CLIs autodiscover them without env vars
- document telemetry and coordinator settings as YAML edits, keeping all services aligned on a shared configuration file

## Testing
- not run (documentation-only change)

Fixes #1344

------
https://chatgpt.com/codex/tasks/task_e_68eab47d4c2c832987c0511a632257a2