### PR TITLE
Refactor tests to load YAML config fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,11 @@ def _default_runner_context():
 def configure_sdk(tmp_path, monkeypatch):
     """Write a temporary qmtl.yml and reload runtime/config caches."""
 
-    def _apply(data: dict) -> str:
-        cfg_path = tmp_path / "qmtl.yml"
+    def _apply(data: dict, *, filename: str = "qmtl.yml") -> str:
+        cfg_path = tmp_path / filename
         cfg_path.write_text(yaml.safe_dump(data))
-        monkeypatch.setenv("QMTL_CONFIG_FILE", str(cfg_path))
-        sdk_configuration.reload()
+        monkeypatch.chdir(tmp_path)
+        sdk_configuration.reset_runtime_config_cache()
         runtime.reload()
         reload_arrow_cache()
         return str(cfg_path)
@@ -54,7 +54,6 @@ def configure_sdk(tmp_path, monkeypatch):
     try:
         yield _apply
     finally:
-        monkeypatch.delenv("QMTL_CONFIG_FILE", raising=False)
-        sdk_configuration.reload()
+        sdk_configuration.reset_runtime_config_cache()
         runtime.reload()
         reload_arrow_cache()


### PR DESCRIPTION
## Summary
- update the configure_sdk test fixture to load runtime settings from temporary YAML files instead of environment variables
- expand qmtl config validate tests to exercise the new seamless coordinator and presets fields
- add seamless provider tests that read coordinator and preset settings from YAML fixtures

## Testing
- pytest tests/qmtl/interfaces/cli/test_config_validate.py
- pytest tests/qmtl/runtime/sdk/test_seamless_provider.py::test_legacy_mode_allows_publish_override tests/qmtl/runtime/sdk/test_seamless_provider.py::test_coordinator_url_loaded_from_yaml tests/qmtl/runtime/sdk/test_seamless_provider.py::test_presets_file_loaded_from_yaml

Fixes #1346

------
https://chatgpt.com/codex/tasks/task_e_68eb6e6a04408329a6258f5eeb3db771