### PR TITLE
Fix runtime cache environment toggles and tag cache writes

### DIFF
--- a/qmtl/runtime/sdk/arrow_cache/dependencies.py
+++ b/qmtl/runtime/sdk/arrow_cache/dependencies.py
@@ -1,6 +1,8 @@
 """Optional dependency guards for Arrow cache backend."""
 from __future__ import annotations
 
+import os
+
 from .. import configuration
 
 try:  # pragma: no cover - optional dependency
@@ -16,6 +18,10 @@ except Exception:  # pragma: no cover - optional dependency
 def _resolve_enabled() -> bool:
     if pa is None:
         return False
+    env_override = os.getenv("QMTL_ARROW_CACHE")
+    if env_override is not None:
+        normalized = env_override.strip().lower()
+        return normalized not in {"", "0", "false", "no", "off"}
     unified = configuration.get_runtime_config()
     if unified is None:
         return False

--- a/qmtl/runtime/sdk/tagquery_manager.py
+++ b/qmtl/runtime/sdk/tagquery_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 import zlib
 import httpx


### PR DESCRIPTION
## Summary
- import the missing os dependency so the tag query cache writes its JSON artifact
- let the Arrow cache honour the QMTL_ARROW_CACHE environment flag when no config file is present
- allow feature artifact configuration to be driven directly by environment overrides, enabling planes when only the directory is provided

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68eb6e4ad924832993974b27aa00ae01