### PR TITLE
docs: clarify design intent across architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ Resolved mappings are cached to `.qmtl_tagmap.json` (override with
 reproduce the live mapping deterministically. `resolve_tags(offline=True)`
 hydrates nodes from this snapshot when the Gateway is unavailable.
 
+Purpose & guidance
+- The snapshot exists to make offline runs reproducible. When a snapshot is stale or its CRC no longer matches, prefer re‑resolving via Gateway when online, or fail fast/skip according to your policy when offline. `resolve_tags(offline=True)` SHOULD rely only on the snapshot and MUST NOT invent mappings.
+
 `ProcessingNode` instances accept either a single upstream `Node` or a list of nodes via the `input` parameter. Dictionary inputs are no longer supported.
 
 See [docs/reference/faq.md](docs/reference/faq.md) for common questions such as using `TagQueryNode` during backtesting.

--- a/docs/architecture/controlbus.md
+++ b/docs/architecture/controlbus.md
@@ -22,6 +22,9 @@ Non‑Goals
 - Not a source of truth (SSOT); decisions/activation live in WorldService, queues in DAG Manager
 - Not a general data bus; market/indicator/trade data remain on data topics managed by DAG Manager
 
+!!! note "Design intent"
+- ControlBus is opaque to SDKs by default. Clients consume control events only via the Gateway’s tokenized WebSocket bridge (`/events/subscribe`). This keeps the bus private, centralizes authN/Z, and allows initial snapshot/state_hash reconciliation without exposing internal topics.
+
 ---
 
 ## 1. Topology & Semantics

--- a/docs/architecture/exchange_node_sets.md
+++ b/docs/architecture/exchange_node_sets.md
@@ -182,6 +182,9 @@ Both options are compatible with the Commit‑Log design; they do not change DM�
 
 ## Execution Semantics (Enhancements)
 
+!!! note "Design intent"
+- Preserve DAG acyclicity and determinism by consuming feedback at `t−1` only and advancing bucket processing behind an upstream watermark. Watermark gating is disabled for simulate/backtest and enabled for paper/live by default.
+
 - DelayedEdge Contract
   - Nodes consuming portfolio/risk must declare an explicit time offset (e.g., `lag=1`) and only read snapshots from the previous bucket. This guarantees deterministic evaluation order at bucket barriers and prevents hidden cycles.
   - Scheduler Watermarks: Bucket processing advances only after upstream state topics commit up to a watermark for `t−1`. This can be implemented as a soft rule at the node/scheduler interface without changing DM invariants.

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -209,6 +209,11 @@ Clarifications
 
 Immediately after ingest, Gateway inserts a `VersionSentinel` node into the DAG so that rollbacks and canary traffic control can be orchestrated without strategy code changes. This behaviour is enabled by default and controlled by the ``insert_sentinel`` configuration field; it may be disabled with the ``--no-sentinel`` CLI flag.
 
+!!! note "Design intent"
+- TagQuery canonicalization keeps `NodeID` stable; dynamic queue discovery is a runtime concern (ControlBus → SDK TagQueryManager), not part of canonical hashing.
+- Execution domains are derived centrally by Gateway from WorldService decisions (see §S0) and propagated via the shared `ComputeContext`; SDK treats the result as input only.
+- VersionSentinel is default-on to enable rollout/rollback/traffic-split without strategy changes; disable only in low‑risk, low‑frequency environments.
+
 Gateway persists its FSM in Redis with AOF enabled and mirrors crucial events in PostgreSQL's Write-Ahead Log. This mitigates the Redis failure scenario described in the architecture (§2).
 
 When resolving `TagQueryNode` dependencies, the Runner's **TagQueryManager**

--- a/docs/architecture/worldservice.md
+++ b/docs/architecture/worldservice.md
@@ -20,6 +20,9 @@ WorldService is the system of record (SSOT) for Worlds. It owns:
 - Audit & RBAC: every policy/update/decision/apply event is logged and authorized
 - Events: emits activation/policy updates to the internal ControlBus
 
+!!! note "Design intent"
+- WS produces `effective_mode` (policy string); Gateway maps it to `execution_domain` and propagates via a shared compute context. SDK/Runner do not choose modes and treat the mapped domain as input only. Stale/unknown decisions default to compute‑only with order gates OFF.
+
 Non-goals: Strategy ingest, DAG diff, queue/tag discovery (owned by Gateway/DAG Manager). Order I/O is not handled here.
 
 ---
@@ -76,6 +79,9 @@ Policies
 Bindings
 - POST /worlds/{id}/bindings        (upsert WSB: bind `strategy_id` to world)
 - GET  /worlds/{id}/bindings        (list; filter by `strategy_id`)
+
+Purpose
+- WSB ensures a `(world_id, strategy_id)` root exists in the WVG for each submission. For operational isolation and resource control, running separate processes per world is recommended when strategies target multiple worlds.
 
 Decisions & Control
 - GET /worlds/{id}/decide?as_of=... → DecisionEnvelope


### PR DESCRIPTION
Summary: Clarify ambiguous design intents to reduce implementation confusion.

Changes
- Feature Artifact Plane: explicit purpose vs. runtime cache; cross-domain sharing rules
- Key boundaries: NodeID (global), ComputeKey (runtime/domain), EvalKey (WS validation)
- VersionSentinel: rollout/rollback/traffic-split purpose; default-on guidance
- Gateway: TagQuery canonicalization; execution-domain mapping responsibility
- ControlBus: opaque to SDK; WS snapshot/state_hash reconciliation via Gateway WS
- Exchange Node Sets: delayed-edge and watermark purpose for acyclic determinism
- README: TagQuery snapshot usage and policy

Validation
- mkdocs build passed
- pytest collection-only passed (1327 tests collected)

No runtime code changes; docs-only.
