### PR TITLE
Read SDK CLI history bounds from unified config

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -170,6 +170,11 @@ Sample configurations for common environments live under
 | `history_start` | string or null | `null` | `QMTL_HISTORY_START` | No |
 | `history_end` | string or null | `null` | `QMTL_HISTORY_END` | No |
 
+> **Note:** `qmtl tools sdk run` now reads history boundaries exclusively from
+> the `test.history_start` and `test.history_end` keys in `qmtl.yml`. The legacy
+> `QMTL_HISTORY_START` and `QMTL_HISTORY_END` environment variable overrides are
+> ignored during command execution.
+
 ## Validation summary
 
 * `qmtl config validate --target schema` checks structural types only.

--- a/tests/qmtl/runtime/sdk/test_cli.py
+++ b/tests/qmtl/runtime/sdk/test_cli.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from qmtl.foundation.config import TestConfig, UnifiedConfig
+from qmtl.runtime.sdk.configuration import runtime_config_override
 from qmtl.runtime.sdk import cli as sdk_cli, runtime
 
 STRATEGY_PATH = "tests.sample_strategy:SampleStrategy"
@@ -55,3 +57,84 @@ async def test_cli_sets_no_ray(monkeypatch):
         "--no-ray",
     ])
     assert runtime.NO_RAY
+
+
+@pytest.mark.asyncio
+async def test_cli_run_uses_config_history(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_run_async(
+        strategy_cls,
+        *,
+        world_id,
+        gateway_url,
+        history_start,
+        history_end,
+        **kwargs,
+    ):
+        captured.update(
+            {
+                "world_id": world_id,
+                "gateway_url": gateway_url,
+                "history_start": history_start,
+                "history_end": history_end,
+            }
+        )
+
+    monkeypatch.setattr(sdk_cli.Runner, "run_async", staticmethod(_fake_run_async))
+
+    config = UnifiedConfig(test=TestConfig(history_start="7", history_end="19"))
+    with runtime_config_override(config):
+        await sdk_cli._main(
+            [
+                "run",
+                STRATEGY_PATH,
+                "--world-id",
+                "world-123",
+                "--gateway-url",
+                "http://gateway",
+            ]
+        )
+
+    assert captured["world_id"] == "world-123"
+    assert captured["gateway_url"] == "http://gateway"
+    assert captured["history_start"] == 7
+    assert captured["history_end"] == 19
+
+
+@pytest.mark.asyncio
+async def test_cli_run_defaults_history_when_test_mode(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_run_async(
+        strategy_cls,
+        *,
+        world_id,
+        gateway_url,
+        history_start,
+        history_end,
+        **kwargs,
+    ):
+        captured.update({"history_start": history_start, "history_end": history_end})
+
+    monkeypatch.setattr(sdk_cli.Runner, "run_async", staticmethod(_fake_run_async))
+
+    previous_test_mode = runtime.TEST_MODE
+    runtime.TEST_MODE = True
+    try:
+        with runtime_config_override(UnifiedConfig()):
+            await sdk_cli._main(
+                [
+                    "run",
+                    STRATEGY_PATH,
+                    "--world-id",
+                    "world-test",
+                    "--gateway-url",
+                    "http://gateway",
+                ]
+            )
+    finally:
+        runtime.TEST_MODE = previous_test_mode
+
+    assert captured["history_start"] == 1
+    assert captured["history_end"] == 2


### PR DESCRIPTION
## Summary
- resolve `qmtl tools sdk run` history bounds from the unified YAML configuration instead of environment overrides
- add regression tests that exercise config-driven history propagation and the deterministic test-mode fallback
- document the YAML-only source of history boundaries for the SDK CLI

## Testing
- uv run -m pytest tests/qmtl/runtime/sdk/test_cli.py

Refs #1337

------
https://chatgpt.com/codex/tasks/task_e_68eb99a5ce508329a845856fd45f0467