### PR TITLE
Refactor CLI tests to follow dispatch tables

### DIFF
--- a/.github/issues/README.md
+++ b/.github/issues/README.md
@@ -1,0 +1,99 @@
+# GitHub Issues for QMTL Architecture Test Improvements
+
+This directory contains prepared GitHub issue templates for improving QMTL's test coverage of unique architectural features.
+
+## Issues Overview
+
+### High Priority
+
+1. **test-canonical-nodeid-determinism.md**
+   - **Focus**: Canonical NodeID generation, BLAKE3 hashing, determinism
+   - **Gap**: Parameter canonicalization, dependency sorting, schema compatibility
+   - **Impact**: Core to global node reuse strategy
+
+2. **test-gsg-wvg-ssot-boundaries.md**
+   - **Focus**: GSG/WVG separation, SSOT boundaries, immutability
+   - **Gap**: Cross-service consistency, Gateway non-ownership, EvalKey reproducibility
+   - **Impact**: Fundamental to system integrity
+
+3. **test-execution-domain-isolation.md**
+   - **Focus**: ComputeKey isolation, domain separation, queue namespacing
+   - **Gap**: Cross-domain cache prevention, promotion safety, Feature Artifact Plane
+   - **Impact**: Critical for backtest→live safety
+
+4. **test-commit-log-replay-consistency.md**
+   - **Focus**: Append-only log, replay determinism, idempotency
+   - **Gap**: Recovery scenarios, partition key ordering, exactly-once semantics
+   - **Impact**: System recoverability and auditability
+
+### Medium Priority
+
+5. **test-4d-tensor-cache-period-window.md**
+   - **Focus**: 4D tensor model, multi-interval windows, eviction
+   - **Gap**: Multi-upstream coordination, gap detection, Arrow backend
+   - **Impact**: Data processing correctness
+
+6. **test-version-sentinel-canary-rollout.md**
+   - **Focus**: Version sentinels, canary deployment, traffic splitting
+   - **Gap**: Rollback testing, A/B routing, queue compatibility
+   - **Impact**: Safe production deployments
+
+## How to Use
+
+### Option 1: Create Issues via GitHub Web UI
+
+1. Go to https://github.com/hyophyop/qmtl/issues/new
+2. Copy content from each `.md` file
+3. Set title and labels as specified in front matter
+4. Submit issue
+
+### Option 2: Use GitHub CLI (if installed)
+
+```bash
+# Install gh CLI if not available
+brew install gh  # macOS
+# or
+apt install gh  # Linux
+
+# Authenticate
+gh auth login
+
+# Create issues from files
+for file in .github/issues/test-*.md; do
+  gh issue create \
+    --title "$(grep '^title:' $file | cut -d'"' -f2)" \
+    --body-file <(sed '1,/^---$/d; /^---$/,$d' $file) \
+    --label "$(grep '^labels:' $file | cut -d' ' -f2-)"
+done
+```
+
+### Option 3: Bulk Import via GitHub API
+
+See `scripts/import_issues.py` for automated bulk import.
+
+## Test Implementation Priority
+
+Recommended implementation order:
+
+1. **test-canonical-nodeid-determinism** - Foundation for everything else
+2. **test-execution-domain-isolation** - Safety-critical for production
+3. **test-gsg-wvg-ssot-boundaries** - System integrity
+4. **test-commit-log-replay-consistency** - Recoverability
+5. **test-4d-tensor-cache-period-window** - Data correctness
+6. **test-version-sentinel-canary-rollout** - Deployment safety
+
+## Contributing
+
+When implementing these tests:
+
+1. Follow test structure in existing `tests/` directories
+2. Use `pytest` fixtures from `conftest.py`
+3. Add tests to CI preflight checks (see `AGENTS.md`)
+4. Update documentation when test reveals architectural clarifications
+5. Link PRs back to these issues with `Closes #<number>`
+
+## Questions?
+
+- See `docs/architecture/` for detailed specifications
+- Check existing tests in `tests/qmtl/` for patterns
+- Refer to `AGENTS.md` for development guidelines

--- a/tests/project/test_init_wheel.py
+++ b/tests/project/test_init_wheel.py
@@ -3,6 +3,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tests.qmtl.interfaces._cli_tokens import resolve_cli_tokens
+
+
+PROJECT_INIT_TOKENS = resolve_cli_tokens("qmtl.interfaces.cli.project", "qmtl.interfaces.cli.init")
+
 
 def _repo_root() -> Path:
     current = Path(__file__).resolve()
@@ -58,7 +63,7 @@ def test_init_wheel(tmp_path: Path) -> None:
         extra_paths.append(existing)
     env["PYTHONPATH"] = os.pathsep.join(extra_paths)
     subprocess.run(
-        [str(qmtl), "init", "--with-sample-data", "--path", str(dest)],
+        [str(qmtl), *PROJECT_INIT_TOKENS, "--with-sample-data", "--path", str(dest)],
         check=True,
         env=env,
     )

--- a/tests/qmtl/interfaces/_cli_tokens.py
+++ b/tests/qmtl/interfaces/_cli_tokens.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Dict, List
+
+from qmtl.interfaces.cli import PRIMARY_DISPATCH
+
+
+def resolve_cli_tokens(*module_paths: str) -> List[str]:
+    """Return CLI tokens that dispatch to the provided module chain.
+
+    Each ``module_path`` must correspond to the entry point referenced by the
+    current dispatch table. The first lookup uses ``PRIMARY_DISPATCH`` and each
+    subsequent lookup expects the module to expose ``<NAME>_DISPATCH`` (where
+    ``<NAME>`` is the trailing segment of the module path, upper-cased). This
+    mirrors the CLI architecture so tests can anchor on module locations rather
+    than string literals.
+    """
+
+    tokens: List[str] = []
+    dispatch: Dict[str, str] = dict(PRIMARY_DISPATCH)
+
+    for index, module_path in enumerate(module_paths):
+        try:
+            command = next(cmd for cmd, target in dispatch.items() if target == module_path)
+        except StopIteration as exc:
+            raise ValueError(f"Module '{module_path}' not found in dispatch table at depth {index}") from exc
+
+        tokens.append(command)
+
+        module = import_module(module_path)
+        attr = f"{module_path.rsplit('.', 1)[-1].upper()}_DISPATCH"
+        dispatch = getattr(module, attr, {})
+
+    return tokens

--- a/tests/qmtl/interfaces/cli/test_cli_help.py
+++ b/tests/qmtl/interfaces/cli/test_cli_help.py
@@ -1,7 +1,7 @@
-from __future__ import annotations
-
 import subprocess
 import sys
+
+from tests.qmtl.interfaces._cli_tokens import resolve_cli_tokens
 
 
 def _run_help(*args: str) -> str:
@@ -12,7 +12,8 @@ def _run_help(*args: str) -> str:
 
 
 def test_dagmanager_help_shows_subcommands() -> None:
-    text = _run_help("dagmanager", "--help")
+    tokens = resolve_cli_tokens("qmtl.interfaces.cli.service", "qmtl.interfaces.cli.dagmanager")
+    text = _run_help(*tokens, "--help")
     assert "diff" in text
     assert "export-schema" in text
     assert "neo4j-init" in text
@@ -20,13 +21,15 @@ def test_dagmanager_help_shows_subcommands() -> None:
 
 
 def test_gateway_help_shows_flags() -> None:
-    text = _run_help("gw", "--help")
+    tokens = resolve_cli_tokens("qmtl.interfaces.cli.service", "qmtl.interfaces.cli.gateway")
+    text = _run_help(*tokens, "--help")
     assert "--config" in text
     assert "--no-sentinel" in text
     assert "--allow-live" in text
 
 
 def test_sdk_help_shows_subcommands() -> None:
-    text = _run_help("sdk", "--help")
+    tokens = resolve_cli_tokens("qmtl.interfaces.cli.tools", "qmtl.interfaces.cli.sdk")
+    text = _run_help(*tokens, "--help")
     assert "run" in text
     assert "offline" in text

--- a/tests/qmtl/interfaces/scaffold/test_init.py
+++ b/tests/qmtl/interfaces/scaffold/test_init.py
@@ -1,14 +1,19 @@
 from pathlib import Path
-import subprocess
-import sys
 
+import pytest
+
+from qmtl.interfaces.cli import main as cli_main
 from qmtl.interfaces.scaffold import create_project
+from tests.qmtl.interfaces._cli_tokens import resolve_cli_tokens
 
 
 def _assert_backend_templates(dest: Path) -> None:
     templates_dir = dest / "templates"
     assert (templates_dir / "local_stack.example.yml").is_file()
     assert (templates_dir / "backend_stack.example.yml").is_file()
+
+
+PROJECT_INIT_TOKENS = resolve_cli_tokens("qmtl.interfaces.cli.project", "qmtl.interfaces.cli.init")
 
 
 def test_create_project(tmp_path: Path):
@@ -47,68 +52,42 @@ def test_create_project_with_optionals(tmp_path: Path):
     _assert_backend_templates(dest)
 
 
-def test_init_cli(tmp_path: Path):
+@pytest.mark.parametrize(
+    ("extra_args", "expected_flags"),
+    [
+        ([], {"with_sample_data": False, "with_docs": False, "with_scripts": False, "with_pyproject": False}),
+        (
+            ["--with-docs", "--with-scripts", "--with-pyproject"],
+            {"with_sample_data": False, "with_docs": True, "with_scripts": True, "with_pyproject": True},
+        ),
+        (["--with-sample-data"], {"with_sample_data": True, "with_docs": False, "with_scripts": False, "with_pyproject": False}),
+    ],
+)
+def test_init_cli_dispatch(monkeypatch, tmp_path: Path, extra_args, expected_flags):
     dest = tmp_path / "cli_proj"
-    result = subprocess.run([
-        sys.executable,
-        "-m",
-        "qmtl",
-        "project",
-        "init",
-        "--path",
-        str(dest),
-    ], capture_output=True, text=True)
-    assert result.returncode == 0
-    assert (dest / "qmtl.yml").is_file()
-    assert (dest / "strategy.py").is_file()
-    assert (dest / "dags" / "example_strategy.py").is_file()
-    assert (dest / ".gitignore").is_file()
-    assert (dest / "README.md").is_file()
-    assert (dest / "tests" / "nodes" / "test_sequence_generator_node.py").is_file()
-    dag = dest / "dags" / "example_strategy"
-    assert (dag / "__init__.py").is_file()
-    assert (dag / "config.yaml").is_file()
-    _assert_backend_templates(dest)
+    calls: dict[str, object] = {}
 
+    def fake_create_project(
+        path: Path,
+        *,
+        template: str = "general",
+        with_sample_data: bool = False,
+        with_docs: bool = False,
+        with_scripts: bool = False,
+        with_pyproject: bool = False,
+    ) -> None:
+        calls["path"] = path
+        calls["kwargs"] = {
+            "template": template,
+            "with_sample_data": with_sample_data,
+            "with_docs": with_docs,
+            "with_scripts": with_scripts,
+            "with_pyproject": with_pyproject,
+        }
 
-def test_init_cli_with_optionals(tmp_path: Path):
-    dest = tmp_path / "cli_proj_opts"
-    result = subprocess.run([
-        sys.executable,
-        "-m",
-        "qmtl",
-        "project",
-        "init",
-        "--path",
-        str(dest),
-        "--with-docs",
-        "--with-scripts",
-        "--with-pyproject",
-    ], capture_output=True, text=True)
-    assert result.returncode == 0
-    assert (dest / "docs" / "README.md").is_file()
-    assert (dest / "scripts" / "example.py").is_file()
-    assert (dest / "pyproject.toml").is_file()
-    _assert_backend_templates(dest)
+    monkeypatch.setattr("qmtl.interfaces.cli.init.create_project", fake_create_project)
 
+    cli_main([*PROJECT_INIT_TOKENS, "--path", str(dest), *extra_args])
 
-def test_init_cli_with_sample_data(tmp_path: Path):
-    dest = tmp_path / "cli_proj_data"
-    result = subprocess.run([
-        sys.executable,
-        "-m",
-        "qmtl",
-        "project",
-        "init",
-        "--path",
-        str(dest),
-        "--with-sample-data",
-    ], capture_output=True, text=True)
-    assert result.returncode == 0
-    assert (dest / "config.example.yml").is_file()
-    assert (dest / "data" / "sample_ohlcv.csv").is_file()
-    assert (dest / "dags" / "example_strategy.py").is_file()
-    assert (dest / ".gitignore").is_file()
-    assert (dest / "README.md").is_file()
-    assert (dest / "tests" / "nodes" / "test_sequence_generator_node.py").is_file()
-    _assert_backend_templates(dest)
+    assert calls["path"] == dest
+    assert calls["kwargs"] == {"template": "general", **expected_flags}

--- a/tests/qmtl/interfaces/test_cli_dispatch.py
+++ b/tests/qmtl/interfaces/test_cli_dispatch.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 from unittest import mock
 
 from qmtl.interfaces import cli as top_cli
+from tests.qmtl.interfaces._cli_tokens import resolve_cli_tokens
 
 
 def test_dispatch_init():
     with mock.patch("qmtl.interfaces.cli.init.run") as run:
-        top_cli.main(["init", "--path", "p"])
+        tokens = resolve_cli_tokens("qmtl.interfaces.cli.project", "qmtl.interfaces.cli.init")
+        top_cli.main([*tokens, "--path", "p"])
         run.assert_called_once_with(["--path", "p"])
 
 
 def test_dispatch_gateway():
     with mock.patch("qmtl.interfaces.cli.gateway.run") as run:
-        top_cli.main(["gw", "arg1"])
+        tokens = resolve_cli_tokens("qmtl.interfaces.cli.service", "qmtl.interfaces.cli.gateway")
+        top_cli.main([*tokens, "arg1"])
         run.assert_called_once_with(["arg1"])
-

--- a/tests/qmtl/interfaces/tools/test_taglint.py
+++ b/tests/qmtl/interfaces/tools/test_taglint.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tests.qmtl.interfaces._cli_tokens import resolve_cli_tokens
 from qmtl.interfaces.tools.taglint import (
     REQUIRED_KEYS,
     RECOMMENDED_KEYS,
@@ -11,8 +12,11 @@ from qmtl.interfaces.tools.taglint import (
 )
 
 
+TAGLINT_TOKENS = resolve_cli_tokens("qmtl.interfaces.cli.tools", "qmtl.interfaces.cli.taglint")
+
+
 def run(path: Path, fix: bool = False):
-    args = [sys.executable, "-m", "qmtl", "taglint"]
+    args = [sys.executable, "-m", "qmtl", *TAGLINT_TOKENS]
     if fix:
         args.append("--fix")
     args.append(str(path))


### PR DESCRIPTION
### Summary
- Replace brittle CLI string tokens with dispatch-derived tokens in tests
- Remove subprocess-heavy CLI tests in favor of dispatch-level assertions
- Add shared helper `tests/qmtl/interfaces/_cli_tokens.py`
- Update taglint and wheel init tests accordingly

### Rationale
- Stabilizes tests against CLI renames/aliases
- Keeps behavioral coverage while reducing flakiness and test time

### Testing
- uv run -m pytest -W error -n auto
