### PR TITLE
Refactor interface scaffolding tests

### DIFF
--- a/tests/qmtl/interfaces/scaffold/test_scaffold.py
+++ b/tests/qmtl/interfaces/scaffold/test_scaffold.py
@@ -1,65 +1,128 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Iterable
 
-from qmtl.interfaces.scaffold import (
-    copy_base_files,
-    copy_dags,
-    copy_docs,
-    copy_nodes,
-    copy_pyproject,
-    copy_sample_data,
-    copy_scripts,
+import pytest
+
+from qmtl.interfaces.scaffold import create_project
+
+
+def _list_files(root: Path) -> set[str]:
+    return {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _list_dirs(root: Path) -> set[str]:
+    return {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_dir()
+    }
+
+
+def _assert_absent(paths: Iterable[str], candidates: set[str]) -> None:
+    for rel in paths:
+        assert rel not in candidates, f"{rel} unexpectedly provisioned"
+
+
+def test_create_project_provisions_core_contract(tmp_path: Path) -> None:
+    dest = tmp_path / "proj"
+    create_project(dest)
+
+    files = _list_files(dest)
+    dirs = _list_dirs(dest)
+
+    # Core files that define the scaffold contract
+    for rel in {
+        "qmtl.yml",
+        "config.example.yml",
+        ".gitignore",
+        "README.md",
+        "strategy.py",
+        "dags/example_strategy.py",
+        "tests/nodes/test_sequence_generator_node.py",
+        "templates/local_stack.example.yml",
+        "templates/backend_stack.example.yml",
+    }:
+        assert rel in files, f"Missing scaffold asset: {rel}"
+
+    # Project must expose reusable node packages for generators, indicators, transforms
+    for package in ["nodes", "nodes/generators", "nodes/indicators", "nodes/transforms"]:
+        assert package in dirs, f"Missing scaffold directory: {package}"
+        assert any(
+            candidate.startswith(f"{package}/") and candidate.endswith(".py")
+            for candidate in files
+        ), f"{package} does not contain Python templates"
+
+    # Optional assets should be opt-in and therefore absent by default
+    _assert_absent(
+        [
+            "docs/README.md",
+            "scripts/example.py",
+            "data/sample_ohlcv.csv",
+            "notebooks/strategy_analysis_example.ipynb",
+            "pyproject.toml",
+        ],
+        files,
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_artifacts",
+    [
+        (
+            {"with_docs": True, "with_scripts": True, "with_pyproject": True},
+            {
+                "docs/README.md",
+                "scripts/example.py",
+                "pyproject.toml",
+            },
+        ),
+        (
+            {"with_sample_data": True},
+            {
+                "data/sample_ohlcv.csv",
+                "notebooks/strategy_analysis_example.ipynb",
+            },
+        ),
+    ],
 )
+def test_create_project_optionals(tmp_path: Path, kwargs: dict[str, bool], expected_artifacts: set[str]) -> None:
+    dest = tmp_path / "proj_opts"
+    create_project(dest, **kwargs)
+
+    files = _list_files(dest)
+    for rel in expected_artifacts:
+        assert rel in files, f"Optional asset not provisioned: {rel}"
 
 
-def test_copy_nodes(tmp_path: Path) -> None:
-    dest = tmp_path / "proj"
-    copy_nodes(dest)
-    assert (dest / "nodes" / "generators" / "sequence.py").is_file()
-    assert (dest / "nodes" / "indicators" / "average.py").is_file()
-    assert (dest / "nodes" / "transforms" / "scale.py").is_file()
+@pytest.mark.parametrize(
+    "template, expected_snippet",
+    [
+        ("general", "qmtl.examples.strategies.general_strategy"),
+        ("branching", "class BranchingStrategy"),
+        ("single_indicator", "class SingleIndicatorStrategy"),
+        ("multi_indicator", "class MultiIndicatorStrategy"),
+        ("state_machine", "class StateMachineStrategy"),
+    ],
+)
+def test_create_project_uses_selected_template(tmp_path: Path, template: str, expected_snippet: str) -> None:
+    dest = tmp_path / template
+    create_project(dest, template=template)
+
+    dag_source = (dest / "dags" / "example_strategy.py").read_text()
+    assert expected_snippet in dag_source
 
 
-def test_copy_dags(tmp_path: Path) -> None:
-    dest = tmp_path / "proj"
-    copy_dags(dest, "general")
-    assert (dest / "dags" / "example_strategy.py").is_file()
-    assert (dest / "dags" / "example_strategy" / "config.yaml").is_file()
+def test_create_project_unknown_template(tmp_path: Path) -> None:
+    dest = tmp_path / "proj_invalid"
 
+    with pytest.raises(ValueError):
+        create_project(dest, template="does-not-exist")
 
-def test_copy_docs(tmp_path: Path) -> None:
-    dest = tmp_path / "proj"
-    copy_docs(dest)
-    assert (dest / "docs" / "README.md").is_file()
-
-
-def test_copy_scripts(tmp_path: Path) -> None:
-    dest = tmp_path / "proj"
-    copy_scripts(dest)
-    assert (dest / "scripts" / "example.py").is_file()
-
-
-def test_copy_sample_data(tmp_path: Path) -> None:
-    dest = tmp_path / "proj"
-    copy_sample_data(dest)
-    assert (dest / "data" / "sample_ohlcv.csv").is_file()
-    assert (dest / "notebooks" / "strategy_analysis_example.ipynb").is_file()
-
-
-def test_copy_pyproject(tmp_path: Path) -> None:
-    dest = tmp_path / "proj"
-    copy_pyproject(dest)
-    assert (dest / "pyproject.toml").is_file()
-
-
-def test_copy_base_files(tmp_path: Path) -> None:
-    dest = tmp_path / "proj"
-    copy_base_files(dest)
-    assert (dest / "qmtl.yml").is_file()
-    assert (dest / "config.example.yml").is_file()
-    assert (dest / ".gitignore").is_file()
-    assert (dest / "README.md").is_file()
-    assert (dest / "strategy.py").is_file()
-    assert (
-        dest / "tests" / "nodes" / "test_sequence_generator_node.py"
-    ).is_file()
-
+    # Ensure the canonical DAG entry point was not created when validation failed
+    assert not (dest / "dags" / "example_strategy.py").exists()

--- a/tests/qmtl/interfaces/test_cli_dispatch.py
+++ b/tests/qmtl/interfaces/test_cli_dispatch.py
@@ -1,20 +1,37 @@
 from __future__ import annotations
 
-from unittest import mock
+import pytest
 
 from qmtl.interfaces import cli as top_cli
 from tests.qmtl.interfaces._cli_tokens import resolve_cli_tokens
 
 
-def test_dispatch_init():
-    with mock.patch("qmtl.interfaces.cli.init.run") as run:
-        tokens = resolve_cli_tokens("qmtl.interfaces.cli.project", "qmtl.interfaces.cli.init")
-        top_cli.main([*tokens, "--path", "p"])
-        run.assert_called_once_with(["--path", "p"])
+@pytest.mark.parametrize(
+    "module_path, expected_phrase",
+    [
+        ("qmtl.interfaces.cli.project", "Project scaffolding utilities."),
+        ("qmtl.interfaces.cli.service", "Manage long-running runtime services."),
+        (
+            "qmtl.interfaces.cli.tools",
+            "Developer tooling for working with strategies and project assets.",
+        ),
+    ],
+)
+def test_main_routes_help_to_subcommand(capsys, module_path: str, expected_phrase: str) -> None:
+    tokens = resolve_cli_tokens(module_path)
+
+    top_cli.main([*tokens, "--help"])
+
+    output = capsys.readouterr().out
+    assert expected_phrase in output
 
 
-def test_dispatch_gateway():
-    with mock.patch("qmtl.interfaces.cli.gateway.run") as run:
-        tokens = resolve_cli_tokens("qmtl.interfaces.cli.service", "qmtl.interfaces.cli.gateway")
-        top_cli.main([*tokens, "arg1"])
-        run.assert_called_once_with(["arg1"])
+def test_main_reports_unknown_command(capsys) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        top_cli.main(["unknown", "--help"])
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "unknown command" in captured.err
+    # Top-level help should still be printed to guide the user
+    assert "Subcommands:" in captured.out


### PR DESCRIPTION
## Summary
- refactor scaffold interface tests to validate project creation contracts and template selection via `create_project`
- update CLI dispatch tests to assert help routing and error handling without mocking internals

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k "interfaces"
- uv run -m pytest -W error -n auto -k "interfaces"

Fixes #1375

------
https://chatgpt.com/codex/tasks/task_e_68f277ef5b008329ac98362c4dbf6a1e