### PR TITLE
Refocus runtime nodeset and pipeline contract tests

### DIFF
--- a/tests/qmtl/runtime/pipeline/test_pipeline.py
+++ b/tests/qmtl/runtime/pipeline/test_pipeline.py
@@ -1,7 +1,6 @@
-import pytest
-
 from qmtl.runtime.pipeline import Pipeline
 from qmtl.runtime.sdk import ProcessingNode, StreamInput
+from qmtl.runtime.sdk.runner import Runner
 
 
 class DummyProducer:
@@ -15,43 +14,91 @@ class DummyProducer:
         pass
 
 
-def test_basic_flow():
+def test_pipeline_feed_emits_contract_payloads(monkeypatch):
     src = StreamInput(interval="1s", period=1)
 
     def mul2(view):
-        ts, val = view[src][1].latest()
+        _, val = view[src][1].latest()
         return val * 2
 
     n1 = ProcessingNode(input=src, compute_fn=mul2, name="n1", interval="1s", period=1)
 
     def add1(view):
-        ts, val = view[n1][1].latest()
+        _, val = view[n1][1].latest()
         return val + 1
 
     n2 = ProcessingNode(input=n1, compute_fn=add1, name="n2", interval="1s", period=1)
 
-    prod = DummyProducer()
+    producer = DummyProducer()
     n1.kafka_topic = "n1"
     n2.kafka_topic = "n2"
 
-    pipe = Pipeline([src, n1, n2], producer=prod)
+    calls = []
+    original_feed = Runner.feed_queue_data
 
+    def spy(node, queue_id, interval, timestamp, payload, *, on_missing="skip"):
+        calls.append((node.name, queue_id, interval, timestamp, payload, on_missing))
+        return original_feed(node, queue_id, interval, timestamp, payload, on_missing=on_missing)
+
+    monkeypatch.setattr(Runner, "feed_queue_data", spy)
+
+    pipe = Pipeline([src, n1, n2], producer=producer)
     pipe.feed(src, 1, 10)
 
-    assert prod.messages[0][0] == "n1"
-    assert prod.messages[1][0] == "n2"
-    assert prod.messages[1][1]["payload"] == 21
+    assert [topic for topic, _ in producer.messages] == ["n1", "n2"]
+    assert [payload["payload"] for _, payload in producer.messages] == [20, 21]
+    assert {(call[0], call[1]) for call in calls} == {("n1", src.node_id), ("n2", n1.node_id)}
     assert n2.compute_fn(n2.cache.view()) == 21
 
 
-def test_execute_false_pass_through():
+def test_execute_false_pass_through(monkeypatch):
     src = StreamInput(interval="1s", period=1)
-    n1 = ProcessingNode(input=src, compute_fn=lambda v: None, name="n1", interval="1s", period=1)
+    n1 = ProcessingNode(input=src, compute_fn=lambda view: None, name="n1", interval="1s", period=1)
     n1.execute = False
-    n2 = ProcessingNode(input=n1, compute_fn=lambda v: v[n1][1].latest()[1] + 5, name="n2", interval="1s", period=1)
+    n2 = ProcessingNode(
+        input=n1,
+        compute_fn=lambda view: view[n1][1].latest()[1] + 5,
+        name="n2",
+        interval="1s",
+        period=1,
+    )
+
+    calls = []
+    original_feed = Runner.feed_queue_data
+
+    def spy(node, queue_id, interval, timestamp, payload, *, on_missing="skip"):
+        calls.append((node.name, payload, on_missing))
+        return original_feed(node, queue_id, interval, timestamp, payload, on_missing=on_missing)
+
+    monkeypatch.setattr(Runner, "feed_queue_data", spy)
 
     pipe = Pipeline([src, n1, n2])
-
-    # feed direct result through n1
     pipe.feed(n1, 1, 2)
+
+    assert calls == [("n2", 2, "skip")]
     assert n2.compute_fn(n2.cache.view()) == 7
+
+
+def test_pipeline_feed_passes_on_missing(monkeypatch):
+    src = StreamInput(interval="1s", period=1)
+
+    def identity(view):
+        _, val = view[src][1].latest()
+        return val
+
+    downstream = ProcessingNode(input=src, compute_fn=identity, name="down", interval="1s", period=1)
+
+    captured = []
+    original_feed = Runner.feed_queue_data
+
+    def spy(node, queue_id, interval, timestamp, payload, *, on_missing="skip"):
+        captured.append(on_missing)
+        return original_feed(node, queue_id, interval, timestamp, payload, on_missing=on_missing)
+
+    monkeypatch.setattr(Runner, "feed_queue_data", spy)
+
+    pipe = Pipeline([src, downstream])
+    pipe.feed(src, 1, 5, on_missing="fail")
+
+    assert captured == ["fail"]
+    assert downstream.compute_fn(downstream.cache.view()) == 5


### PR DESCRIPTION
## Summary
- replace runtime nodeset smoke assertions with contract-focused checks covering metadata, resource injection, and recipe overrides
- add spies around Runner propagation to validate pipeline publishing, execute passthrough, and on_missing routing behaviors

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q tests/qmtl/runtime/nodesets/test_nodeset_builder_smoke.py tests/qmtl/runtime/pipeline/test_pipeline.py --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto tests/qmtl/runtime/nodesets/test_nodeset_builder_smoke.py tests/qmtl/runtime/pipeline/test_pipeline.py`

Fixes #1377

------
https://chatgpt.com/codex/tasks/task_e_68f2780bf6508329a50bfe1d60f3cb88