### PR TITLE
Add pipeline contract tests for runtime components

### DIFF
--- a/tests/qmtl/runtime/generators/test_generators.py
+++ b/tests/qmtl/runtime/generators/test_generators.py
@@ -1,22 +1,54 @@
+import pandas as pd
+import pytest
+
 from qmtl.runtime.generators import GarchInput, HestonInput, RoughBergomiInput
+from qmtl.runtime.pipeline.pipeline import Pipeline
+from qmtl.runtime.sdk.node import Node
+from qmtl.runtime.transforms import identity_transform_node
+from qmtl.runtime.sdk.util import parse_interval
 
 
-def _test_stream(cls):
-    stream = cls(interval="1s", period=2, seed=42)
-    data = stream.generate(5)
-    assert len(data) == 5
-    assert all(ts == i + 1 for i, (ts, _) in enumerate(data))
-    assert all("price" in payload for _, payload in data)
+@pytest.mark.parametrize(
+    "generator_cls",
+    [GarchInput, HestonInput, RoughBergomiInput],
+)
+def test_synthetic_generators_stream_through_pipeline(generator_cls):
+    """Generators should honour StreamInput contracts when wired into a DAG."""
 
+    generator = generator_cls(interval="1s", period=3, seed=7)
+    outputs: list[pd.DataFrame] = []
 
-def test_garch_input():
-    _test_stream(GarchInput)
+    def collecting_transform(view):
+        frame = identity_transform_node(view)
+        outputs.append(frame)
+        return frame
 
+    sink = Node(
+        input=generator,
+        compute_fn=collecting_transform,
+        interval="1s",
+        period=3,
+    )
+    pipeline = Pipeline([generator, sink])
 
-def test_heston_input():
-    _test_stream(HestonInput)
+    timestamps: list[int] = []
+    payloads: list[dict[str, float]] = []
 
+    for _ in range(3):
+        ts, payload = generator.step()
+        timestamps.append(ts)
+        payloads.append(payload)
+        pipeline.feed(generator, ts, payload)
 
-def test_rough_bergomi_input():
-    _test_stream(RoughBergomiInput)
+    assert timestamps == [parse_interval("1s"), 2 * parse_interval("1s"), 3 * parse_interval("1s")]
+    assert all("price" in payload for payload in payloads)
 
+    # Warm-up should finish once the cache has the configured period of data.
+    assert sink.pre_warmup is False
+    assert sink.cache.ready()
+
+    assert len(outputs) == 1
+    latest = outputs[-1]
+    assert list(latest.columns) == ["price"]
+    assert latest.shape == (3, 1)
+    assert latest.iloc[-1]["price"] == pytest.approx(payloads[-1]["price"])

--- a/tests/qmtl/runtime/io/test_artifact_registrar.py
+++ b/tests/qmtl/runtime/io/test_artifact_registrar.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import pytest
+
+from qmtl.runtime.io.artifact import ArtifactRegistrar
+
+
+@pytest.mark.asyncio
+async def test_publish_stabilizes_frame_and_records_manifest():
+    captured: dict[str, object] = {}
+
+    def fake_store(frame: pd.DataFrame, manifest: dict):
+        captured["frame"] = frame.copy(deep=True)
+        captured["manifest"] = dict(manifest)
+        return "memory://artifact"
+
+    registrar = ArtifactRegistrar(store=fake_store, stabilization_bars=1, producer_identity=" tester ")
+    frame = pd.DataFrame(
+        [
+            {"ts": 10, "open": 100, "close": 101, "volume": 1.5},
+            {"ts": 20, "open": 102, "close": 103, "volume": 1.7},
+        ]
+    )
+
+    publication = await registrar.publish(
+        frame,
+        node_id="alpha.node",
+        interval=60,
+        requested_range=(10, 20),
+    )
+
+    assert publication is not None
+    assert publication.uri == "memory://artifact"
+    assert publication.rows == 1
+    assert publication.start == 10
+    assert publication.end == 10
+    assert publication.manifest["producer"]["identity"] == "tester"
+    assert captured["frame"].shape == (1, 4)
+    assert captured["manifest"]["requested_range"] == [10, 20]
+
+
+@pytest.mark.asyncio
+async def test_publish_returns_none_when_frame_missing_timestamp():
+    registrar = ArtifactRegistrar()
+    frame = pd.DataFrame([{"open": 100, "close": 101}])
+
+    result = await registrar.publish(frame, node_id="alpha.node", interval=60)
+
+    assert result is None

--- a/tests/qmtl/runtime/transforms/test_stream_pipeline_contracts.py
+++ b/tests/qmtl/runtime/transforms/test_stream_pipeline_contracts.py
@@ -1,0 +1,61 @@
+import math
+
+import pytest
+
+from qmtl.runtime.pipeline.pipeline import Pipeline
+from qmtl.runtime.sdk.node import Node, SourceNode
+from qmtl.runtime.transforms import volume_features
+
+
+@pytest.mark.parametrize(
+    "samples, expected",
+    [
+        (
+            [
+                (1, 10.0),
+                (2, 12.0),
+                (3, 8.0),
+                (4, 14.0),
+            ],
+            [
+                {"volume_hat": 10.0, "volume_std": math.sqrt(8 / 3)},
+                {
+                    "volume_hat": pytest.approx(34 / 3),
+                    "volume_std": pytest.approx(math.sqrt(56 / 9)),
+                },
+            ],
+        ),
+    ],
+)
+def test_volume_features_pipeline_contract(samples, expected):
+    """Volume features should emit aggregates once the cache is primed."""
+
+    source = SourceNode(interval="1s", period=3, config={"id": "vol"})
+    features = volume_features(source, period=3)
+
+    collected: list[dict[str, float]] = []
+
+    def capture(view):
+        records = view[features][features.interval]
+        latest = records.latest()
+        assert latest is not None
+        collected.append(latest[1])
+        return latest[1]
+
+    sink = Node(
+        input=features,
+        compute_fn=capture,
+        interval="1s",
+        period=1,
+    )
+    pipeline = Pipeline([source, features, sink])
+
+    for ts, volume in samples:
+        pipeline.feed(source, ts, volume)
+
+    assert len(collected) == len(expected)
+    for actual, expected_payload in zip(collected, expected, strict=True):
+        assert actual["volume_hat"] == pytest.approx(expected_payload["volume_hat"])
+        assert actual["volume_std"] == pytest.approx(expected_payload["volume_std"])
+
+    assert features.cache.missing_flags()[source.node_id][features.interval] is False


### PR DESCRIPTION
## Summary
- add generator pipeline contract tests to validate stream behaviour end-to-end
- cover volume feature transforms within a pipeline to assert aggregated outputs
- add artifact registrar guardrail coverage for stabilized publications

## Testing
- uv run -m pytest tests/qmtl/runtime/generators/test_generators.py tests/qmtl/runtime/transforms/test_stream_pipeline_contracts.py tests/qmtl/runtime/io/test_artifact_registrar.py

Closes #1378

------
https://chatgpt.com/codex/tasks/task_e_68f2780fed508329999e5221fb6e8626