### PR TITLE
Refine architecture docs navigation and API grouping

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -20,11 +20,10 @@ last_modified: 2025-09-22
 - [ControlBus](controlbus.md)
 - [Exchange Node Sets](exchange_node_sets.md)
 
-!!! tip "빠른 시작: 검증 → 기동"
-    운영용 YAML을 작성했다면 `uv run qmtl config validate --config <파일> --offline`
-    으로 구조를 확인하고, 동일한 파일을 `qmtl service gateway --config <파일>` 및
-    `qmtl service dagmanager server --config <파일>` 인자로 넘겨라. 장기 실행
-    프로세스에서는 작업 디렉터리에 `qmtl.yml` 이름으로 복사해 자동으로 읽게 할 수 있다.
+---
+
+운영 환경에서의 초기 부트스트랩 절차와 실행 방법은 [Backend Quickstart](../operations/backend_quickstart.md#fast-start-validate-and-launch)
+문서에서 다룬다.
 
 ---
 

--- a/docs/operations/backend_quickstart.md
+++ b/docs/operations/backend_quickstart.md
@@ -23,6 +23,31 @@ end-to-end tests in [E2E Testing](e2e_testing.md).
 - Python environment managed by uv: `uv venv && uv pip install -e .[dev]`
 - Optional: Docker/Compose for infra services
 
+## Fast start: validate and launch
+
+Follow this quick validation and launch loop when an operations YAML is ready:
+
+1. **Static validation** – confirm the structure before booting services.
+
+   ```bash
+   uv run qmtl config validate --config <path-to-config> --offline
+   ```
+
+2. **Gateway** – start the public entrypoint with the validated config.
+
+   ```bash
+   qmtl service gateway --config <path-to-config>
+   ```
+
+3. **DAG Manager** – launch orchestration services with the same settings.
+
+   ```bash
+   qmtl service dagmanager server --config <path-to-config>
+   ```
+
+For long-lived processes, copy the file to `qmtl.yml` in the working directory so the
+service commands auto-discover it.
+
 ## Option A — Run locally (no Docker)
 
 1) Start WorldService (SQLite + Redis example)

--- a/docs/reference/apis.md
+++ b/docs/reference/apis.md
@@ -1,0 +1,23 @@
+---
+title: "API Reference Overview"
+tags:
+  - reference
+  - api
+author: "QMTL Team"
+last_modified: 2025-09-23
+---
+
+{{ nav_links() }}
+
+# API Reference Overview
+
+Key service APIs are grouped here for quick discovery:
+
+- [World API](api_world.md): Manage worlds, decisions, and activation lifecycles.
+- [Brokerage API](api/brokerage.md): Submit orders, configure fees, and manage execution hooks.
+- [Live & Brokerage Connectors](api/connectors.md): Integrate third-party broker connections and event relays.
+- [Portfolio & Position API](api/portfolio.md): Query account equity, holdings, and exposure snapshots.
+- [Order & Fill Events](api/order_events.md): Understand the message schema for executions and fills.
+- [Fills Webhook](api/fills_webhook.md): Deliver fill notifications to downstream systems.
+
+{{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,9 +17,6 @@ nav:
       - Exchange Node Sets: architecture/exchange_node_sets.md
       - Execution Nodes: architecture/execution_nodes.md
       - Execution State: architecture/execution_state.md
-      - Brokerage API: reference/api/brokerage.md
-      - Live & Brokerage Connectors: reference/api/connectors.md
-      - Portfolio & Position API: reference/api/portfolio.md
   - Guides:
       - Overview: guides/README.md
       - Layered Templates Quick Start: guides/layered_templates_quickstart.md
@@ -78,7 +75,6 @@ nav:
       - Schema Registry: reference/schema_registry.md
       - Schemas: reference/schemas.md
       - Templates: reference/templates.md
-      - World API: reference/api_world.md
       - Enhanced Validation: reference/enhanced_validation.md
       - Node Schema Validation: reference/node_schema_validation.md
       - Node Identity Validation: reference/node_validation.md
@@ -86,12 +82,16 @@ nav:
       - Report CLI: reference/report_cli.md
       - Lean-like Features: reference/lean_like_features.md
       - Commit Log: reference/commit_log.md
-      - Brokerage API: reference/api/brokerage.md
       - Brokerage Assumptions: reference/brokerage_assumptions.md
-      - Order & Fill Events: reference/api/order_events.md
-      - Fills Webhook: reference/api/fills_webhook.md
       - Bracket Order Helper: reference/bracket_order.md
-      - Portfolio & Position API: reference/api/portfolio.md
+      - APIs:
+          - Overview: reference/apis.md
+          - World API: reference/api_world.md
+          - Brokerage API: reference/api/brokerage.md
+          - Live & Brokerage Connectors: reference/api/connectors.md
+          - Portfolio & Position API: reference/api/portfolio.md
+          - Order & Fill Events: reference/api/order_events.md
+          - Fills Webhook: reference/api/fills_webhook.md
       - Inventory: reference/_inventory.md
       - Changelog: reference/CHANGELOG.md
   - World:


### PR DESCRIPTION
## Summary
- remove API documents from the Architecture nav group and nest them under a new Reference > APIs section
- add an API reference overview landing page to guide readers to the individual API docs
- move bootstrap runbook guidance into the backend quickstart doc and link to it from the architecture overview

## Testing
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68f2a7741cb08329ad8a0f104772cc22