### PR TITLE
Add IO landing page and navigation section

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,6 +13,8 @@ last_modified: 2025-09-04
 
 Tutorials and workflow guides for using QMTL.
 
+Looking for external data pipelines or storage adapters? See [IO & Integrations](../io/README.md) for specialized connectivity guides.
+
 - [SDK Tutorial](sdk_tutorial.md): Build strategies with the SDK.
 - [Strategy Workflow](strategy_workflow.md): Recommended development flow.
 - [Migration: Removing Legacy Modes](migration_bc_removal.md): Update code for Runner/CLI/Gateway changes.

--- a/docs/io/README.md
+++ b/docs/io/README.md
@@ -1,0 +1,19 @@
+---
+title: "IO & Integrations"
+tags:
+  - io
+  - integrations
+  - overview
+author: "QMTL Team"
+last_modified: 2025-09-09
+---
+
+{{ nav_links() }}
+
+# IO & Integrations
+
+Entry points for connecting QMTL to external data and storage systems. These guides focus on production-ready IO providers and integration recipes.
+
+- [CCXT × QuestDB](ccxt-questdb.md): Stream market data into QuestDB with automated backfilling using the CCXT provider stack.
+
+{{ nav_links() }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,6 @@ nav:
       - Build NodeSet (SDK): guides/build_nodeset_sdk.md
       - CCXT Spot Recipe: guides/ccxt_spot_recipe.md
       - CCXT Futures Recipe: guides/ccxt_futures_recipe.md
-      - CCXT × QuestDB (IO): io/ccxt-questdb.md
       - Node Set Adapters: guides/nodeset_adapters.md
       - Advanced:
           - Node Set Portfolio Scope: guides/nodeset_portfolio_scope.md
@@ -42,6 +41,9 @@ nav:
       - Prometheus Metric Helper: guides/prometheus_metrics_helper.md
       - HTTPX Usage: guides/httpx_usage.md
       - HTTP Health Checks: guides/http_health_checks.md
+  - IO & Integrations:
+      - Overview: io/README.md
+      - CCXT × QuestDB: io/ccxt-questdb.md
   - Operations:
       - Overview: operations/README.md
       - Backend Quickstart: operations/backend_quickstart.md


### PR DESCRIPTION
## Summary
- add an IO & Integrations landing page that highlights available connector guides
- move the CCXT × QuestDB document into a dedicated navigation section in mkdocs.yml
- link the guides overview to the new IO & Integrations landing page for discoverability

## Testing
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68f2cd25eae88329b0a347f031cba231