### PR TITLE
Add config template profiles and generator CLI

### DIFF
--- a/qmtl/examples/templates/config/qmtl.maximal.yml
+++ b/qmtl/examples/templates/config/qmtl.maximal.yml
@@ -1,0 +1,180 @@
+# Example configuration for production-style deployments.
+# Replace placeholder endpoints and credentials with your infrastructure values.
+
+worldservice:
+  url: https://worldservice.example.com
+  timeout: 1.5
+  retries: 5
+  enable_proxy: true
+  enforce_live_guard: true
+  cache_ttl_seconds: 900
+  cache_max_entries: 2048
+  dsn: postgresql://worldsvc:CHANGE_ME@worlds-db.example.com:5432/worlds
+  redis: redis://cache.example.com:6379/4
+  bind:
+    host: 0.0.0.0
+    port: 8443
+  auth:
+    header: Authorization
+    tokens:
+      - ${WORLDSERVICE_TOKEN}
+  tls:
+    enabled: true
+    certfile: /etc/qmtl/tls/worldservice.crt
+    keyfile: /etc/qmtl/tls/worldservice.key
+
+backends:
+  redis:
+    gateway_state: redis://cache.example.com:6379/1
+    dagmanager_state: redis://cache.example.com:6379/2
+  sql:
+    gateway_dsn: postgresql://gateway:CHANGE_ME@gateway-db.example.com:5432/gateway
+    dagmanager_dsn: postgresql://dagmgr:CHANGE_ME@dag-db.example.com:5432/dagmgr
+  kafka:
+    bootstrap_servers:
+      - kafka-1.example.com:9092
+      - kafka-2.example.com:9092
+    sasl:
+      mechanism: SCRAM-SHA-512
+      username: ${KAFKA_USERNAME}
+      password: ${KAFKA_PASSWORD}
+    security_protocol: SASL_SSL
+
+secrets:
+  vault_url: https://vault.example.com
+  auth_token: ${VAULT_TOKEN}
+  gateway_event_secret: ${GATEWAY_EVENTS_SECRET}
+  dagmanager_graph_secret: ${DAGMANAGER_GRAPH_SECRET}
+
+gateway:
+  host: 0.0.0.0
+  port: 8444
+  redis_dsn: ${backends.redis.gateway_state}
+  database_backend: postgres
+  database_dsn: ${backends.sql.gateway_dsn}
+  insert_sentinel: true
+  controlbus_topics:
+    - activation
+    - policy
+    - queue
+  controlbus_group: gateway
+  commitlog_topic: gateway.prod.ingest
+  commitlog_group: gateway-prod-commit
+  commitlog_transactional_id: gateway-prod-writer
+  commitlog_bootstrap_servers: ${backends.kafka.bootstrap_servers}
+  events:
+    secret: ${secrets.gateway_event_secret}
+    ttl: 600
+    jwt_issuer: https://auth.example.com/issuer
+    jwt_audience: qmtl-gateway
+  websocket:
+    rate_limit_per_sec: 50
+    allowed_origins:
+      - https://app.example.com
+      - https://admin.example.com
+  worldservice_url: ${worldservice.url}
+  telemetry:
+    otel_endpoint: https://otel-collector.example.com:4318/v1/traces
+    prometheus_pushgateway: https://prometheus-pushgateway.example.com
+
+dagmanager:
+  memory_repo_path: null
+  neo4j_dsn: neo4j+s://neo4j.example.com:7687
+  neo4j_user: dagmanager
+  neo4j_password: ${NEO4J_PASSWORD}
+  kafka_dsn: kafka-broker.example.com:9092
+  kafka_security:
+    sasl_mechanism: SCRAM-SHA-512
+    sasl_username: ${KAFKA_USERNAME}
+    sasl_password: ${KAFKA_PASSWORD}
+    security_protocol: SASL_SSL
+  grpc_host: 0.0.0.0
+  grpc_port: 5443
+  http_host: 0.0.0.0
+  http_port: 8545
+  controlbus_dsn: kafka-control.example.com:9093
+  controlbus_queue_topic: queue
+  enable_topic_namespace: true
+  repositories:
+    neo4j:
+      tls_enabled: true
+      ca_file: /etc/qmtl/tls/neo4j-ca.pem
+  telemetry:
+    otel_endpoint: https://otel-collector.example.com:4318/v1/traces
+    prometheus_pushgateway: https://prometheus-pushgateway.example.com
+
+seamless:
+  coordinator_url: https://seamless.example.com/api
+  artifacts_enabled: true
+  artifact_dir: /var/lib/qmtl/seamless/artifacts
+  fingerprint_mode: canonical
+  publish_fingerprint: true
+  preview_fingerprint: true
+  early_fingerprint: true
+  sla_preset: enterprise
+  conformance_preset: strict-blocking
+  auth:
+    client_id: ${SEAMLESS_CLIENT_ID}
+    client_secret: ${SEAMLESS_CLIENT_SECRET}
+    token_url: https://idp.example.com/oauth/token
+
+connectors:
+  ccxt_rate_limiter_redis: ${backends.redis.gateway_state}
+  schema_registry_url: https://schema-registry.example.com
+  worker_id: worker-prod-01
+  seamless_worker_id: seam-prod-01
+  strategy_id: prod-strategy
+  execution_domain: live
+  broker_url: https://broker.example.com/api/orders
+  trade_max_retries: 10
+  trade_backoff: 0.5
+  ws_url: wss://gateway.example.com/ws
+  credentials:
+    api_key: ${BROKER_API_KEY}
+    api_secret: ${BROKER_API_SECRET}
+
+telemetry:
+  otel_exporter_endpoint: https://otel-collector.example.com:4318/v1/traces
+  enable_fastapi_otel: true
+  prometheus_url: https://prometheus.example.com
+  grafana_url: https://grafana.example.com
+
+cache:
+  arrow_cache_enabled: true
+  cache_evict_interval: 120
+  feature_artifacts_enabled: true
+  feature_artifact_dir: /var/lib/qmtl/cache/features
+  feature_artifact_versions: 20
+  feature_artifact_write_domains:
+    - equities.live
+    - futures.live
+  tagquery_cache_path: /var/lib/qmtl/cache/tagquery.json
+  snapshot_dir: /var/lib/qmtl/cache/snapshots
+  snapshot_url: s3://qmtl-snapshots/prod
+  snapshot_strict_runtime: true
+  snapshot_format: parquet
+  snapshot_auth:
+    access_key: ${SNAPSHOT_ACCESS_KEY}
+    secret_key: ${SNAPSHOT_SECRET_KEY}
+
+runtime:
+  http_timeout_seconds: 5.0
+  http_timeout_seconds_test: 2.5
+  ws_recv_timeout_seconds: 60.0
+  ws_recv_timeout_seconds_test: 15.0
+  ws_max_total_time_seconds: 600.0
+  ws_max_total_time_seconds_test: 30.0
+  poll_interval_seconds: 5.0
+  poll_interval_seconds_test: 1.0
+  retry_backoff_seconds: 2.0
+  retry_backoff_seconds_test: 0.5
+
+test:
+  test_mode: false
+  fail_on_history_gap: true
+  fixed_now: null
+  history_start: 2020-01-01T00:00:00Z
+  history_end: null
+  fixtures:
+    orders_path: /etc/qmtl/test/orders.json
+    quotes_path: /etc/qmtl/test/quotes.json

--- a/qmtl/examples/templates/config/qmtl.minimal.yml
+++ b/qmtl/examples/templates/config/qmtl.minimal.yml
@@ -1,0 +1,114 @@
+# Example unified configuration for local development.
+# Adjust endpoints and credentials to match your deployment.
+
+worldservice:
+  url: http://localhost:8080
+  timeout: 0.3
+  retries: 2
+  enable_proxy: true
+  enforce_live_guard: true
+  cache_ttl_seconds: 300
+  cache_max_entries: 128
+  dsn: sqlite:///./worlds.db
+  redis: redis://localhost:6379/0
+  bind:
+    host: 0.0.0.0
+    port: 8080
+  auth:
+    header: Authorization
+    tokens: []
+
+gateway:
+  host: 0.0.0.0
+  port: 8000
+  redis_dsn: redis://localhost:6379
+  database_backend: sqlite
+  database_dsn: ./qmtl.db
+  insert_sentinel: true
+  controlbus_topics:
+    - activation
+    - policy
+    - queue
+  controlbus_group: gateway
+  commitlog_topic: gateway.ingest
+  commitlog_group: gateway-commit
+  commitlog_transactional_id: gateway-commit-writer
+  events:
+    secret: change-me-gateway-secret
+    ttl: 300
+  websocket:
+    rate_limit_per_sec: 0
+
+# The DAG Manager can run entirely in-memory (default) or target external stores.
+dagmanager:
+  memory_repo_path: memrepo.gpickle
+  neo4j_dsn: bolt://localhost:7687
+  neo4j_user: neo4j
+  neo4j_password: neo4j
+  kafka_dsn: localhost:9092
+  grpc_host: 0.0.0.0
+  grpc_port: 50051
+  http_host: 0.0.0.0
+  http_port: 8001
+  controlbus_dsn: localhost:9092
+  controlbus_queue_topic: queue
+  enable_topic_namespace: true
+
+seamless:
+  coordinator_url: http://localhost:5010
+  artifacts_enabled: false
+  artifact_dir: ~/.qmtl_seamless_artifacts
+  fingerprint_mode: canonical
+  publish_fingerprint: true
+  preview_fingerprint: false
+  early_fingerprint: false
+  sla_preset: baseline
+  conformance_preset: strict-blocking
+
+connectors:
+  ccxt_rate_limiter_redis: redis://localhost:6379/0
+  schema_registry_url: http://localhost:8081
+  worker_id: worker-1
+  seamless_worker_id: seam-01
+  strategy_id: sample-strategy
+  execution_domain: dryrun
+  broker_url: https://broker/api/orders
+  trade_max_retries: 3
+  trade_backoff: 0.1
+  ws_url: wss://gateway/ws
+
+telemetry:
+  otel_exporter_endpoint: http://localhost:4318/v1/traces
+  enable_fastapi_otel: false
+  prometheus_url: http://localhost:9090
+
+cache:
+  arrow_cache_enabled: false
+  cache_evict_interval: 60
+  feature_artifacts_enabled: false
+  feature_artifact_dir: .qmtl_feature_artifacts
+  feature_artifact_versions: 5
+  feature_artifact_write_domains:
+    - equities.live
+  tagquery_cache_path: .qmtl_tagmap.json
+  snapshot_dir: .qmtl_snapshots
+  snapshot_url: null
+  snapshot_strict_runtime: false
+  snapshot_format: json
+
+runtime:
+  http_timeout_seconds: 2.0
+  http_timeout_seconds_test: 1.5
+  ws_recv_timeout_seconds: 30.0
+  ws_recv_timeout_seconds_test: 5.0
+  ws_max_total_time_seconds: null
+  ws_max_total_time_seconds_test: 5.0
+  poll_interval_seconds: 10.0
+  poll_interval_seconds_test: 2.0
+
+test:
+  test_mode: false
+  fail_on_history_gap: false
+  fixed_now: null
+  history_start: null
+  history_end: null

--- a/qmtl/interfaces/cli/init.py
+++ b/qmtl/interfaces/cli/init.py
@@ -14,6 +14,7 @@ from ..scaffold import (
     create_project,
 )
 from ..layers import Layer, LayerComposer, PresetLoader, LayerValidator
+from ..config_templates import available_profiles
 
 
 def run(argv: List[str] | None = None) -> None:
@@ -70,6 +71,12 @@ def run(argv: List[str] | None = None) -> None:
     parser.add_argument("--with-scripts", action="store_true", help="Include scripts/ directory template")
     parser.add_argument("--with-pyproject", action="store_true", help="Include pyproject.toml template")
     parser.add_argument("--force", action="store_true", help="Overwrite existing directory")
+    parser.add_argument(
+        "--config-profile",
+        choices=sorted(available_profiles()),
+        default="minimal",
+        help="Select configuration template for qmtl.yml",
+    )
 
     args = parser.parse_args(argv)
 
@@ -149,6 +156,7 @@ def _run_legacy(args) -> None:
         with_docs=args.with_docs,
         with_scripts=args.with_scripts,
         with_pyproject=args.with_pyproject,
+        config_profile=args.config_profile,
     )
     print(f"Project created at {args.path} using legacy template '{args.strategy or 'general'}'")
 
@@ -171,6 +179,7 @@ def _run_with_preset(args, preset_loader: PresetLoader, composer: LayerComposer)
         dest=Path(args.path),
         template_choices=preset.template_choices,
         force=args.force,
+        config_profile=args.config_profile,
     )
 
     if not result.valid:
@@ -205,6 +214,7 @@ def _run_with_layers(args, composer: LayerComposer, validator: LayerValidator) -
         layers=layers,
         dest=Path(args.path),
         force=args.force,
+        config_profile=args.config_profile,
     )
 
     if not result.valid:

--- a/qmtl/interfaces/config_templates.py
+++ b/qmtl/interfaces/config_templates.py
@@ -1,0 +1,62 @@
+"""Helpers for accessing packaged configuration templates."""
+
+from __future__ import annotations
+
+import importlib.resources as resources
+from pathlib import Path
+from typing import Iterable
+
+__all__ = [
+    "CONFIG_TEMPLATE_FILES",
+    "available_profiles",
+    "resolve_template",
+    "write_template",
+]
+
+CONFIG_TEMPLATE_FILES = {
+    "minimal": "qmtl.minimal.yml",
+    "maximal": "qmtl.maximal.yml",
+}
+
+
+def available_profiles() -> Iterable[str]:
+    """Return the supported configuration template profiles."""
+
+    return CONFIG_TEMPLATE_FILES.keys()
+
+
+def resolve_template(profile: str):
+    """Return a package resource handle for the requested profile."""
+
+    try:
+        filename = CONFIG_TEMPLATE_FILES[profile]
+    except KeyError as exc:  # pragma: no cover - argparse prevents invalid choices
+        raise ValueError(f"Unknown configuration profile: {profile}") from exc
+
+    base = resources.files("qmtl.examples").joinpath("templates", "config")
+    template = base.joinpath(filename)
+    if not template.is_file():  # pragma: no cover - defensive guard
+        raise FileNotFoundError(f"Template for profile '{profile}' not found")
+    return template
+
+
+def write_template(profile: str, output: Path, *, force: bool = False) -> Path:
+    """Write the requested configuration template to *output*.
+
+    Args:
+        profile: Template profile name to write.
+        output: Destination path for the rendered template.
+        force: Allow overwriting an existing file when ``True``.
+
+    Returns:
+        The path that was written.
+    """
+
+    output = Path(output)
+    if output.exists() and not force:
+        raise FileExistsError(f"{output} already exists")
+
+    template = resolve_template(profile)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(template.read_bytes())
+    return output

--- a/qmtl/interfaces/scaffold.py
+++ b/qmtl/interfaces/scaffold.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 import importlib.resources as resources
 
+from .config_templates import write_template
+
 
 _EXAMPLES_PKG = "qmtl.examples"
 
@@ -129,11 +131,11 @@ def copy_backend_templates(dest: Path) -> None:
             (templates_dest / name).write_bytes(src.read_bytes())
 
 
-def copy_base_files(dest: Path) -> None:
+def copy_base_files(dest: Path, *, config_profile: str = "minimal") -> None:
     dest = Path(dest)
     dest.mkdir(parents=True, exist_ok=True)
     examples = resources.files(_EXAMPLES_PKG)
-    (dest / "qmtl.yml").write_bytes(examples.joinpath("qmtl.yml").read_bytes())
+    write_template(config_profile, dest / "qmtl.yml", force=True)
     (dest / "config.example.yml").write_bytes(
         examples.joinpath("config.example.yml").read_bytes()
     )
@@ -164,6 +166,8 @@ def create_project(
     with_docs: bool = False,
     with_scripts: bool = False,
     with_pyproject: bool = False,
+    *,
+    config_profile: str = "minimal",
 ) -> None:
     """Create a new project scaffold under *path*.
 
@@ -177,7 +181,7 @@ def create_project(
 
     copy_nodes(dest)
     copy_dags(dest, template)
-    copy_base_files(dest)
+    copy_base_files(dest, config_profile=config_profile)
     if with_docs:
         copy_docs(dest)
     if with_scripts:

--- a/tests/qmtl/interfaces/cli/test_config_generate.py
+++ b/tests/qmtl/interfaces/cli/test_config_generate.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qmtl.interfaces.cli import config as config_cli
+from qmtl.interfaces.config_templates import CONFIG_TEMPLATE_FILES, resolve_template
+
+
+@pytest.mark.parametrize("profile", sorted(CONFIG_TEMPLATE_FILES))
+def test_generate_writes_expected_template(tmp_path: Path, profile: str) -> None:
+    output = tmp_path / "generated.yml"
+
+    config_cli.run([
+        "generate",
+        "--profile",
+        profile,
+        "--output",
+        str(output),
+    ])
+
+    expected = resolve_template(profile).read_text()
+    assert output.read_text() == expected
+
+
+def test_generate_refuses_to_overwrite(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    output = tmp_path / "qmtl.yml"
+    output.write_text("existing")
+
+    with pytest.raises(SystemExit) as exc:
+        config_cli.run([
+            "generate",
+            "--profile",
+            "minimal",
+            "--output",
+            str(output),
+        ])
+
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "already exists" in captured.err
+    assert output.read_text() == "existing"
+
+
+def test_generate_force_overwrites(tmp_path: Path) -> None:
+    output = tmp_path / "qmtl.yml"
+    output.write_text("existing")
+
+    config_cli.run([
+        "generate",
+        "--profile",
+        "maximal",
+        "--output",
+        str(output),
+        "--force",
+    ])
+
+    expected = resolve_template("maximal").read_text()
+    assert output.read_text() == expected
+
+
+def test_generate_defaults_to_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    config_cli.run(["generate", "--profile", "minimal"])
+
+    expected = resolve_template("minimal").read_text()
+    assert Path("qmtl.yml").read_text() == expected


### PR DESCRIPTION
## Summary
- package minimal and maximal configuration templates for reuse
- add a `qmtl config generate` command and expose config profile selection during project init
- update scaffolding utilities to seed projects from the packaged templates and cover the flow with tests

## Testing
- uv run -m pytest tests/qmtl/interfaces/cli/test_config_generate.py -q
- uv run -m pytest tests/qmtl/interfaces/cli/test_config_validate.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f75fb824f88329a31ecab21c2b9c51