### PR TITLE
feat(i18n): CLI English/Korean foundation + docs i18n guide

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,9 @@
+[python: **.py]
+encoding = utf-8
+silent = true
+keywords = _
+exclude = 
+  tests/**
+  qmtl/examples/**
+  **/__pycache__/**
+

--- a/docs/en/guides/docs_internationalization.md
+++ b/docs/en/guides/docs_internationalization.md
@@ -1,0 +1,53 @@
+# Documentation Internationalization
+
+This project publishes multilingual docs using MkDocs Material and the `mkdocs-static-i18n` plugin.
+
+- Default locale: `en`
+- Additional locales: `ko`
+- Structure: `docs/<locale>/...` (e.g., `docs/en/guides/...`)
+
+## Add or Update a Translation
+
+1) Add files under the target locale folder
+
+- Mirror the English file path: for `docs/en/guides/foo.md`, add `docs/ko/guides/foo.md`.
+- Keep headings consistent and use relative links.
+
+2) Update navigation titles (optional)
+
+- If the page appears in the MkDocs nav, ensure its title has a localized label.
+- Add entries to `nav_translations` (under the `ko` config) when introducing new nav item titles.
+
+3) Validate the docs build
+
+- Run a full build locally:
+  - `uv run mkdocs build`
+- This validates both locales and catches missing or incorrect links.
+
+4) Manage message catalogs (CLI translations)
+
+- Install dev deps: `uv pip install -e .[dev]`
+- Extract messages: `uv run pybabel extract -F babel.cfg -o qmtl/locale/qmtl.pot .`
+- Initialize/update KO: `uv run pybabel init -l ko -i qmtl/locale/qmtl.pot -d qmtl/locale` (first time)
+- Or update catalogs: `uv run pybabel update -l ko -i qmtl/locale/qmtl.pot -d qmtl/locale`
+- Compile catalogs: `uv run pybabel compile -d qmtl/locale`
+
+## Link Checking Policy
+
+Our static link checker intentionally validates only the canonical (default) locale to avoid false positives from in‑progress translations:
+
+- It reads the i18n configuration from `mkdocs.yml` and skips non‑default locales.
+- Archived docs are also skipped.
+
+Run it locally:
+
+- `python scripts/check_docs_links.py`
+
+## CLI Language Override
+
+The CLI supports a language hint for user‑facing messages:
+
+- Global option: `--lang {en,ko}` (e.g., `qmtl --lang ko project --help`)
+- Environment variable: `QMTL_LANG=ko`
+
+When no override is provided, the CLI attempts to detect a language from common locale environment variables and falls back to English.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Layered Templates Quick Start: guides/layered_templates_quickstart.md
       - SDK Tutorial & World ID: guides/sdk_tutorial.md
       - Strategy Workflow: guides/strategy_workflow.md
+      - Docs Internationalization: guides/docs_internationalization.md
       - Seamless Data Provider Setup: guides/seamless_data_provider_setup.md
       - Seamless Migration to v2: guides/seamless_migration_v2.md
       - CCXT Seamless Data Provider: guides/ccxt_seamless_usage.md
@@ -125,6 +126,7 @@ plugins:
             Maintenance Schedule: 유지보수 일정
             Architecture: 아키텍처
             Guides: 가이드
+            Docs Internationalization: 문서 국제화
             "IO & Integrations": "IO & 통합"
             Operations: 운영
             Design: 설계

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "mkdocs-breadcrumbs-plugin",
     "mkdocs-static-i18n",
     "websocket-client",
+    "Babel>=2.13",
 ]
 
 ray = ["ray"]
@@ -69,6 +70,7 @@ dev = [
     "mkdocs-breadcrumbs-plugin",
     "mkdocs-static-i18n",
     "websocket-client",
+    "Babel>=2.13",
 ]
 
 [project.scripts]
@@ -102,4 +104,8 @@ include = ["qmtl*"]
 ]
 "qmtl.foundation.schema" = [
   "schemas/*.json",
+]
+"qmtl" = [
+  "locale/*/LC_MESSAGES/*.mo",
+  "locale/*/LC_MESSAGES/*.po",
 ]

--- a/qmtl/interfaces/cli/add_layer.py
+++ b/qmtl/interfaces/cli/add_layer.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 from typing import List
+from qmtl.utils.i18n import _
 
 from ..layers import Layer, LayerComposer
 
@@ -14,25 +16,25 @@ def run(argv: List[str] | None = None) -> None:
 
     parser = argparse.ArgumentParser(
         prog="qmtl project add-layer",
-        description="Add a layer to an existing project",
+        description=_("Add a layer to an existing project"),
     )
     parser.add_argument(
         "--path",
         default=".",
-        help="Project directory (default: current directory)",
+        help=_("Project directory (default: current directory)"),
     )
     parser.add_argument(
         "layer",
-        help="Layer to add (data, signal, execution, brokerage, monitoring)",
+        help=_("Layer to add (data, signal, execution, brokerage, monitoring)"),
     )
     parser.add_argument(
         "--template",
-        help="Specific template to use for this layer",
+        help=_("Specific template to use for this layer"),
     )
     parser.add_argument(
         "--force",
         action="store_true",
-        help="Force overwrite if layer already exists",
+        help=_("Force overwrite if layer already exists"),
     )
 
     args = parser.parse_args(argv)
@@ -41,10 +43,10 @@ def run(argv: List[str] | None = None) -> None:
     try:
         layer = Layer(args.layer)
     except ValueError:
-        print(f"Error: Invalid layer '{args.layer}'")
-        print("\nAvailable layers:")
+        print(_("Error: Invalid layer '{layer}'").format(layer=args.layer), file=sys.stderr)
+        print(_("\nAvailable layers:"), file=sys.stderr)
         for layer_option in Layer:
-            print(f"  {layer_option.value}")
+            print(_("  {value}").format(value=layer_option.value), file=sys.stderr)
         raise SystemExit(1)
 
     # Add layer
@@ -57,11 +59,11 @@ def run(argv: List[str] | None = None) -> None:
     )
 
     if not result.valid:
-        print("Error adding layer:")
+        print(_("Error adding layer:"), file=sys.stderr)
         for error in result.errors:
-            print(f"  - {error}")
+            print(_("  - {error}").format(error=error), file=sys.stderr)
         raise SystemExit(1)
 
-    print(f"Layer '{layer.value}' added to project at {args.path}")
+    print(_("Layer '{name}' added to project at {path}").format(name=layer.value, path=args.path))
     if args.template:
-        print(f"Using template: {args.template}")
+        print(_("Using template: {template}").format(template=args.template))

--- a/qmtl/interfaces/cli/init.py
+++ b/qmtl/interfaces/cli/init.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 from typing import List
+from qmtl.utils.i18n import _
 
 from ..scaffold import (
     TEMPLATES,
@@ -22,60 +23,60 @@ def run(argv: List[str] | None = None) -> None:
 
     parser = argparse.ArgumentParser(
         prog="qmtl project init",
-        description="Initialize new project (see docs/guides/strategy_workflow.md)",
+        description=_("Initialize new project (see docs/guides/strategy_workflow.md)"),
     )
-    parser.epilog = "More docs: docs/reference/templates.md"
+    parser.epilog = _("More docs: docs/reference/templates.md")
     parser.add_argument(
         "--path",
-        help="Project directory to create scaffolding",
+        help=_("Project directory to create scaffolding"),
     )
 
     # Preset/layer options (new system)
     parser.add_argument(
         "--preset",
-        help="Preset configuration to use (see docs/architecture/layered_template_system.md)",
+        help=_("Preset configuration to use (see docs/architecture/layered_template_system.md)"),
     )
     parser.add_argument(
         "--layers",
-        help="Comma-separated list of layers to include (e.g., data,signal)",
+        help=_("Comma-separated list of layers to include (e.g., data,signal)"),
     )
     parser.add_argument(
         "--list-presets",
         action="store_true",
-        help="List available presets and exit",
+        help=_("List available presets and exit"),
     )
     parser.add_argument(
         "--list-layers",
         action="store_true",
-        help="List available layers and exit",
+        help=_("List available layers and exit"),
     )
 
     # Legacy options (deprecated)
     parser.add_argument(
         "--strategy",
-        help="(Deprecated: use --preset) Strategy template to use",
+        help=_("(Deprecated: use --preset) Strategy template to use"),
     )
     parser.add_argument(
         "--list-templates",
         action="store_true",
-        help="(Deprecated: use --list-presets) List available templates and exit",
+        help=_("(Deprecated: use --list-presets) List available templates and exit"),
     )
 
     # Additional options
     parser.add_argument(
         "--with-sample-data",
         action="store_true",
-        help="Include sample OHLCV CSV and notebook",
+        help=_("Include sample OHLCV CSV and notebook"),
     )
-    parser.add_argument("--with-docs", action="store_true", help="Include docs/ directory template")
-    parser.add_argument("--with-scripts", action="store_true", help="Include scripts/ directory template")
-    parser.add_argument("--with-pyproject", action="store_true", help="Include pyproject.toml template")
-    parser.add_argument("--force", action="store_true", help="Overwrite existing directory")
+    parser.add_argument("--with-docs", action="store_true", help=_("Include docs/ directory template"))
+    parser.add_argument("--with-scripts", action="store_true", help=_("Include scripts/ directory template"))
+    parser.add_argument("--with-pyproject", action="store_true", help=_("Include pyproject.toml template"))
+    parser.add_argument("--force", action="store_true", help=_("Overwrite existing directory"))
     parser.add_argument(
         "--config-profile",
         choices=sorted(available_profiles()),
         default="minimal",
-        help="Select configuration template for qmtl.yml",
+        help=_("Select configuration template for qmtl.yml"),
     )
 
     args = parser.parse_args(argv)
@@ -88,25 +89,22 @@ def run(argv: List[str] | None = None) -> None:
     # Handle list commands
     if args.list_presets or args.list_templates:
         if args.list_templates:
-            print(
-                "Warning: --list-templates is deprecated, use --list-presets instead",
-                file=sys.stderr,
-            )
-            print("Available templates:")
+            print(_("Warning: --list-templates is deprecated, use --list-presets instead"), file=sys.stderr)
+            print(_("Available templates:"))
             for template_name in sorted(TEMPLATES):
                 print(template_name)
         if args.list_presets:
-            print("Available presets:")
+            print(_("Available presets:"))
         for preset_name in preset_loader.list_presets():
             preset = preset_loader.get_preset(preset_name)
             if preset:
-                print(f"  {preset_name:15} - {preset.description}")
+                print(_("  {name:15} - {desc}").format(name=preset_name, desc=preset.description))
         return
 
     if args.list_layers:
-        print("Available layers:")
+        print(_("Available layers:"))
         for layer in Layer:
-            print(f"  {layer.value:15} - {layer.name}")
+            print(_("  {value:15} - {name}").format(value=layer.value, name=layer.name))
         return
 
     # Check that --path is provided for actual project creation
@@ -117,10 +115,7 @@ def run(argv: List[str] | None = None) -> None:
     use_legacy = False
 
     if args.strategy:
-        print(
-            "Warning: --strategy is deprecated, use --preset instead",
-            file=sys.stderr,
-        )
+        print(_("Warning: --strategy is deprecated, use --preset instead"), file=sys.stderr)
         use_legacy = True
 
     # Use legacy system when no layer/preset selection is provided
@@ -158,19 +153,19 @@ def _run_legacy(args) -> None:
         with_pyproject=args.with_pyproject,
         config_profile=args.config_profile,
     )
-    print(f"Project created at {args.path} using legacy template '{args.strategy or 'general'}'")
+    print(_("Project created at {path} using legacy template '{template}'").format(path=args.path, template=(args.strategy or 'general')))
 
 
 def _run_with_preset(args, preset_loader: PresetLoader, composer: LayerComposer) -> None:
     """Run using preset configuration."""
     preset = preset_loader.get_preset(args.preset)
     if not preset:
-        print(f"Error: Unknown preset '{args.preset}'")
-        print("\nAvailable presets:")
+        print(_("Error: Unknown preset '{preset}'").format(preset=args.preset))
+        print(_("\nAvailable presets:"))
         for name in preset_loader.list_presets():
             p = preset_loader.get_preset(name)
             if p:
-                print(f"  {name:15} - {p.description}")
+                print(_("  {name:15} - {desc}").format(name=name, desc=p.description))
         raise SystemExit(1)
 
     # Compose project from preset
@@ -183,13 +178,13 @@ def _run_with_preset(args, preset_loader: PresetLoader, composer: LayerComposer)
     )
 
     if not result.valid:
-        print(f"Error creating project:")
+        print(_("Error creating project:"))
         for error in result.errors:
-            print(f"  - {error}")
+            print(_("  - {error}").format(error=error))
         raise SystemExit(1)
 
-    print(f"Project created at {args.path} using preset '{preset.name}'")
-    print(f"Layers included: {', '.join(layer.value for layer in preset.layers)}")
+    print(_("Project created at {path} using preset '{preset}'").format(path=args.path, preset=preset.name))
+    print(_("Layers included: {layers}").format(layers=', '.join(layer.value for layer in preset.layers)))
     _apply_optional_components(Path(args.path), args)
 
 
@@ -200,10 +195,10 @@ def _run_with_layers(args, composer: LayerComposer, validator: LayerValidator) -
     try:
         layers = [Layer(name) for name in layer_names]
     except ValueError as e:
-        print(f"Error: Invalid layer name - {e}")
-        print("\nAvailable layers:")
+        print(_("Error: Invalid layer name - {error}").format(error=e))
+        print(_("\nAvailable layers:"))
         for layer in Layer:
-            print(f"  {layer.value}")
+            print(_("  {value}").format(value=layer.value))
         raise SystemExit(1)
 
     # Get minimal layer set with dependencies
@@ -218,11 +213,11 @@ def _run_with_layers(args, composer: LayerComposer, validator: LayerValidator) -
     )
 
     if not result.valid:
-        print("Error creating project:")
+        print(_("Error creating project:"))
         for error in result.errors:
-            print(f"  - {error}")
+            print(_("  - {error}").format(error=error))
         raise SystemExit(1)
 
-    print(f"Project created at {args.path}")
-    print(f"Layers included: {', '.join(layer.value for layer in layers)}")
+    print(_("Project created at {path}").format(path=args.path))
+    print(_("Layers included: {layers}").format(layers=', '.join(layer.value for layer in layers)))
     _apply_optional_components(Path(args.path), args)

--- a/qmtl/interfaces/cli/list_layers.py
+++ b/qmtl/interfaces/cli/list_layers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from ..layers import Layer, load_layer_metadata
+from qmtl.utils.i18n import _
 
 
 def run(argv: list[str] | None = None) -> None:
@@ -12,27 +13,27 @@ def run(argv: list[str] | None = None) -> None:
 
     parser = argparse.ArgumentParser(
         prog="qmtl project list-layers",
-        description="List available layers and their metadata",
+        description=_("List available layers and their metadata"),
     )
     parser.add_argument(
         "--show-templates",
         action="store_true",
-        help="Include template names for each layer",
+        help=_("Include template names for each layer"),
     )
     parser.add_argument(
         "--show-requires",
         action="store_true",
-        help="Include dependency information for templates",
+        help=_("Include dependency information for templates"),
     )
     args = parser.parse_args(argv)
 
-    print("Available layers:")
+    print(_("Available layers:"))
     for layer in Layer:
         metadata = load_layer_metadata(layer)
-        print(f"  {layer.value:12} - {metadata.description}")
+        print(_("  {value:12} - {desc}").format(value=layer.value, desc=metadata.description))
         if args.show_templates and metadata.templates:
             for template in metadata.templates:
                 requires = ""
                 if args.show_requires and template.requires:
-                    requires = f" (requires: {', '.join(template.requires)})"
-                print(f"    • {template.name}{requires} - {template.description}")
+                    requires = _(" (requires: {req})").format(req=', '.join(template.requires))
+                print(_("    • {name}{req} - {desc}").format(name=template.name, req=requires, desc=template.description))

--- a/qmtl/interfaces/cli/project.py
+++ b/qmtl/interfaces/cli/project.py
@@ -4,6 +4,7 @@ import argparse
 import textwrap
 from importlib import import_module
 from typing import List
+from qmtl.utils.i18n import _
 
 
 PROJECT_DISPATCH = {
@@ -17,21 +18,23 @@ PROJECT_DISPATCH = {
 def _build_help_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="qmtl project", add_help=True)
     parser.description = textwrap.dedent(
-        """
-        Project scaffolding utilities.
+        _(
+            """
+            Project scaffolding utilities.
 
-        Available commands:
-          init         Create a new strategy project from templates or presets.
-          add-layer    Add a layer to an existing project.
-          list-layers  List available layers and metadata.
-          validate     Validate an existing layered project.
-        """
+            Available commands:
+              init         Create a new strategy project from templates or presets.
+              add-layer    Add a layer to an existing project.
+              list-layers  List available layers and metadata.
+              validate     Validate an existing layered project.
+            """
+        )
     ).strip()
     parser.add_argument(
         "cmd",
         nargs="?",
         choices=sorted(PROJECT_DISPATCH.keys()),
-        help="Project command to run",
+        help=_("Project command to run"),
     )
     return parser
 

--- a/qmtl/interfaces/cli/report.py
+++ b/qmtl/interfaces/cli/report.py
@@ -5,13 +5,14 @@ import json
 from pathlib import Path
 from typing import List
 import sys
+from qmtl.utils.i18n import _
 
 from qmtl.runtime.transforms.alpha_performance import alpha_performance_node
 
 
 def _build_report(metrics: dict[str, float]) -> str:
     """Build a markdown report from metrics."""
-    lines = ["# Backtest Report", ""]
+    lines = [_("# Backtest Report"), ""]
     for key, value in metrics.items():
         pretty = key.replace("_", " ").title()
         if isinstance(value, float):
@@ -24,28 +25,28 @@ def _build_report(metrics: dict[str, float]) -> str:
 
 def run(argv: List[str] | None = None) -> None:
     """Entrypoint for ``qmtl tools report`` subcommand."""
-    parser = argparse.ArgumentParser(prog="qmtl tools report", description="Generate performance report from results.json")
-    parser.add_argument("--from", dest="input", required=True, help="Path to results JSON containing a 'returns' array")
-    parser.add_argument("--out", dest="output", default="report.md", help="Output markdown file path")
-    parser.add_argument("--risk-free", dest="risk_free", type=float, default=0.0, help="Risk free rate")
-    parser.add_argument("--transaction-cost", dest="transaction_cost", type=float, default=0.0, help="Transaction cost per period")
+    parser = argparse.ArgumentParser(prog="qmtl tools report", description=_("Generate performance report from results.json"))
+    parser.add_argument("--from", dest="input", required=True, help=_("Path to results JSON containing a 'returns' array"))
+    parser.add_argument("--out", dest="output", default="report.md", help=_("Output markdown file path"))
+    parser.add_argument("--risk-free", dest="risk_free", type=float, default=0.0, help=_("Risk free rate"))
+    parser.add_argument("--transaction-cost", dest="transaction_cost", type=float, default=0.0, help=_("Transaction cost per period"))
     args = parser.parse_args(argv)
 
     try:
         text = Path(args.input).read_text()
     except OSError as e:
-        print(f"Failed to read input file '{args.input}': {e}", file=sys.stderr)
+        print(_("Failed to read input file '{path}': {exc}").format(path=args.input, exc=e), file=sys.stderr)
         raise SystemExit(1)
 
     try:
         data = json.loads(text)
     except json.JSONDecodeError as e:
-        print(f"Invalid JSON in '{args.input}': {e}", file=sys.stderr)
+        print(_("Invalid JSON in '{path}': {exc}").format(path=args.input, exc=e), file=sys.stderr)
         raise SystemExit(1)
 
     returns = data.get("returns")
     if returns is None:
-        print("Input JSON must contain a 'returns' key", file=sys.stderr)
+        print(_("Input JSON must contain a 'returns' key"), file=sys.stderr)
         raise SystemExit(1)
 
     metrics = alpha_performance_node(returns, risk_free_rate=args.risk_free, transaction_cost=args.transaction_cost)

--- a/qmtl/interfaces/cli/service.py
+++ b/qmtl/interfaces/cli/service.py
@@ -4,6 +4,7 @@ import argparse
 import textwrap
 from importlib import import_module
 from typing import List
+from qmtl.utils.i18n import _
 
 
 SERVICE_DISPATCH = {
@@ -15,19 +16,21 @@ SERVICE_DISPATCH = {
 def _build_help_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="qmtl service", add_help=True)
     parser.description = textwrap.dedent(
-        """
-        Manage long-running runtime services.
+        _(
+            """
+            Manage long-running runtime services.
 
-        Available services:
-          gateway     Run the Gateway HTTP API.
-          dagmanager  Operate DAG Manager utilities and daemons.
-        """
+            Available services:
+              gateway     Run the Gateway HTTP API.
+              dagmanager  Operate DAG Manager utilities and daemons.
+            """
+        )
     ).strip()
     parser.add_argument(
         "cmd",
         nargs="?",
         choices=sorted(SERVICE_DISPATCH.keys()),
-        help="Service to manage",
+        help=_("Service to manage"),
     )
     return parser
 

--- a/qmtl/interfaces/cli/tools.py
+++ b/qmtl/interfaces/cli/tools.py
@@ -4,6 +4,7 @@ import argparse
 import textwrap
 from importlib import import_module
 from typing import List
+from qmtl.utils.i18n import _
 
 
 TOOLS_DISPATCH = {
@@ -16,20 +17,22 @@ TOOLS_DISPATCH = {
 def _build_help_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="qmtl tools", add_help=True)
     parser.description = textwrap.dedent(
-        """
-        Developer tooling for working with strategies and project assets.
+        _(
+            """
+            Developer tooling for working with strategies and project assets.
 
-        Available tools:
-          sdk      Execute strategies in run/offline modes.
-          taglint  Validate TAGS dictionaries in project code.
-          report   Generate performance reports from JSON returns.
-        """
+            Available tools:
+              sdk      Execute strategies in run/offline modes.
+              taglint  Validate TAGS dictionaries in project code.
+              report   Generate performance reports from JSON returns.
+            """
+        )
     ).strip()
     parser.add_argument(
         "cmd",
         nargs="?",
         choices=sorted(TOOLS_DISPATCH.keys()),
-        help="Tool to invoke",
+        help=_("Tool to invoke"),
     )
     return parser
 

--- a/qmtl/interfaces/cli/validate.py
+++ b/qmtl/interfaces/cli/validate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from typing import List
+from qmtl.utils.i18n import _
 
 from ..layers import LayerComposer
 
@@ -14,12 +15,12 @@ def run(argv: List[str] | None = None) -> None:
 
     parser = argparse.ArgumentParser(
         prog="qmtl project validate",
-        description="Validate a project created with layered templates",
+        description=_("Validate a project created with layered templates"),
     )
     parser.add_argument(
         "--path",
         default=".",
-        help="Project directory to validate (default: current directory)",
+        help=_("Project directory to validate (default: current directory)"),
     )
     args = parser.parse_args(argv)
 
@@ -27,14 +28,14 @@ def run(argv: List[str] | None = None) -> None:
     result = composer.validate_project(Path(args.path))
 
     if result.valid:
-        print(f"Project at {args.path} is valid.")
+        print(_("Project at {path} is valid.").format(path=args.path))
         return
 
-    print(f"Validation failed for project at {args.path}:")
+    print(_("Validation failed for project at {path}:").format(path=args.path))
     for error in result.errors:
-        print(f"  - {error}")
+        print(_("  - {error}").format(error=error))
     if result.warnings:
-        print("Warnings:")
+        print(_("Warnings:"))
         for warning in result.warnings:
-            print(f"  - {warning}")
+            print(_("  - {warning}").format(warning=warning))
     raise SystemExit(1)

--- a/qmtl/locale/ko/LC_MESSAGES/qmtl.po
+++ b/qmtl/locale/ko/LC_MESSAGES/qmtl.po
@@ -1,0 +1,162 @@
+# Korean translations for qmtl.
+# Copyright (C)
+# This file is distributed under the same license as the qmtl project.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: qmtl\n"
+"POT-Creation-Date: 2025-10-22 00:00+0000\n"
+"PO-Revision-Date: 2025-10-22 00:00+0000\n"
+"Last-Translator: qmtl\n"
+"Language-Team: Korean\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+# CLI top-level
+msgid "Subcommand to run"
+msgstr "실행할 하위 명령"
+
+msgid "\nerror: unknown command '{cmd}'"
+msgstr "\n오류: 알 수 없는 명령 '{cmd}'"
+
+msgid """
+            Subcommands:
+              config    Validate gateway and DAG Manager configuration files.
+              service   Manage long-running services such as Gateway and DAG Manager.
+              tools     Developer tooling including SDK runners and linters.
+              project   Project scaffolding and template helpers.
+
+            Global options:
+              --lang {en,ko}  Override CLI language (default: auto)
+            """
+msgstr """
+            하위 명령:
+              config    Gateway 및 DAG Manager 설정 파일을 검증합니다.
+              service   Gateway/DAG Manager 등 장기 실행 서비스를 관리합니다.
+              tools     SDK 실행기와 린터 등 개발자 도구입니다.
+              project   프로젝트 스캐폴딩과 템플릿 도우미입니다.
+
+            전역 옵션:
+              --lang {en,ko}  CLI 언어를 지정합니다 (기본: 자동)
+            """
+
+# project.py
+msgid "Project command to run"
+msgstr "프로젝트 명령 선택"
+
+msgid """
+            Project scaffolding utilities.
+
+            Available commands:
+              init         Create a new strategy project from templates or presets.
+              add-layer    Add a layer to an existing project.
+              list-layers  List available layers and metadata.
+              validate     Validate an existing layered project.
+            """
+msgstr """
+            프로젝트 스캐폴딩 유틸리티.
+
+            사용 가능한 명령:
+              init         템플릿 또는 프리셋으로 새 프로젝트를 생성합니다.
+              add-layer    기존 프로젝트에 레이어를 추가합니다.
+              list-layers  사용 가능한 레이어와 메타데이터를 표시합니다.
+              validate     기존 레이어드 프로젝트를 검증합니다.
+            """
+
+# init.py options
+msgid "Initialize new project (see docs/guides/strategy_workflow.md)"
+msgstr "새 프로젝트를 초기화합니다 (docs/guides/strategy_workflow.md 참조)"
+
+msgid "More docs: docs/reference/templates.md"
+msgstr "추가 문서: docs/reference/templates.md"
+
+msgid "Project directory to create scaffolding"
+msgstr "스캐폴딩을 생성할 프로젝트 디렉터리"
+
+msgid "Preset configuration to use (see docs/architecture/layered_template_system.md)"
+msgstr "사용할 프리셋 구성 (docs/architecture/layered_template_system.md 참조)"
+
+msgid "Comma-separated list of layers to include (e.g., data,signal)"
+msgstr "포함할 레이어의 쉼표-구분 목록 (예: data,signal)"
+
+msgid "List available presets and exit"
+msgstr "사용 가능한 프리셋을 표시하고 종료"
+
+msgid "List available layers and exit"
+msgstr "사용 가능한 레이어를 표시하고 종료"
+
+msgid "(Deprecated: use --preset) Strategy template to use"
+msgstr "(폐기 예정: --preset 사용) 사용할 전략 템플릿"
+
+msgid "(Deprecated: use --list-presets) List available templates and exit"
+msgstr "(폐기 예정: --list-presets 사용) 템플릿 목록을 표시하고 종료"
+
+msgid "Include sample OHLCV CSV and notebook"
+msgstr "샘플 OHLCV CSV 및 노트북 포함"
+
+msgid "Include docs/ directory template"
+msgstr "docs/ 디렉터리 템플릿 포함"
+
+msgid "Include scripts/ directory template"
+msgstr "scripts/ 디렉터리 템플릿 포함"
+
+msgid "Include pyproject.toml template"
+msgstr "pyproject.toml 템플릿 포함"
+
+msgid "Overwrite existing directory"
+msgstr "기존 디렉터리 덮어쓰기"
+
+msgid "Select configuration template for qmtl.yml"
+msgstr "qmtl.yml에 사용할 구성 템플릿 선택"
+
+msgid "Warning: --list-templates is deprecated, use --list-presets instead"
+msgstr "경고: --list-templates는 폐기 예정입니다. 대신 --list-presets를 사용하세요."
+
+msgid "Available templates:"
+msgstr "사용 가능한 템플릿:"
+
+msgid "Available presets:"
+msgstr "사용 가능한 프리셋:"
+
+msgid "  {name:15} - {desc}"
+msgstr "  {name:15} - {desc}"
+
+msgid "Available layers:"
+msgstr "사용 가능한 레이어:"
+
+msgid "  {value:15} - {name}"
+msgstr "  {value:15} - {name}"
+
+msgid "Warning: --strategy is deprecated, use --preset instead"
+msgstr "경고: --strategy는 폐기 예정입니다. 대신 --preset를 사용하세요."
+
+msgid "Error: Unknown preset '{preset}'"
+msgstr "오류: 알 수 없는 프리셋 '{preset}'"
+
+msgid "Error creating project:"
+msgstr "프로젝트 생성 오류:"
+
+msgid "  - {error}"
+msgstr "  - {error}"
+
+msgid "Project created at {path} using preset '{preset}'"
+msgstr "'{preset}' 프리셋으로 {path}에 프로젝트를 생성했습니다"
+
+msgid "Layers included: {layers}"
+msgstr "포함된 레이어: {layers}"
+
+msgid "Error: Invalid layer name - {error}"
+msgstr "오류: 잘못된 레이어 이름 - {error}"
+
+msgid "  {value}"
+msgstr "  {value}"
+
+msgid "Project created at {path}"
+msgstr "프로젝트 생성 위치: {path}"
+
+msgid "Project created at {path} using legacy template '{template}'"
+msgstr "레거시 템플릿 '{template}'으로 {path}에 프로젝트를 생성했습니다"
+

--- a/qmtl/utils/__init__.py
+++ b/qmtl/utils/__init__.py
@@ -1,0 +1,2 @@
+# Utility subpackage
+

--- a/qmtl/utils/i18n.py
+++ b/qmtl/utils/i18n.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import gettext
+import os
+from pathlib import Path
+from typing import Optional
+
+
+_translator: object = gettext.NullTranslations()
+
+
+def _locale_dir() -> str:
+    # qmtl/utils/i18n.py -> qmtl/locale
+    return str(Path(__file__).resolve().parents[1] / "locale")
+
+
+class _PoTranslations:
+    def __init__(self, catalog: dict[str, str]):
+        self._catalog = catalog
+
+    def gettext(self, message: str) -> str:
+        return self._catalog.get(message, message)
+
+
+def _try_load_po(domain: str, localedir: str, lang: str | None) -> Optional[_PoTranslations]:
+    if not lang:
+        return None
+    po_path = Path(localedir) / lang / "LC_MESSAGES" / f"{domain}.po"
+    if not po_path.exists():
+        return None
+
+    catalog: dict[str, str] = {}
+    current_id: Optional[str] = None
+    current_str: Optional[str] = None
+    collecting: Optional[str] = None  # "id" or "str"
+
+    def _finish_pair():
+        nonlocal current_id, current_str
+        if current_id is not None and current_str is not None:
+            catalog[current_id] = current_str
+        current_id = None
+        current_str = None
+
+    def _unquote(s: str) -> str:
+        if s.startswith('"') and s.endswith('"'):
+            s = s[1:-1]
+        return s.encode('utf-8').decode('unicode_escape')
+
+    for raw in po_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith('#'):
+            continue
+        if line.startswith('msgid '):
+            _finish_pair()
+            collecting = "id"
+            current_id = _unquote(line[6:].strip())
+            current_str = None
+            continue
+        if line.startswith('msgstr '):
+            collecting = "str"
+            current_str = _unquote(line[7:].strip())
+            continue
+        if line.startswith('"'):
+            frag = _unquote(line)
+            if collecting == "id" and current_id is not None:
+                current_id += frag
+            elif collecting == "str" and current_str is not None:
+                current_str += frag
+            continue
+        # ignore other directives (plural, context) for simplicity
+
+    _finish_pair()
+    return _PoTranslations(catalog)
+
+
+def set_language(lang: Optional[str]) -> None:
+    """Install the language for CLI messages.
+
+    If ``lang`` is None, detect from env. Falls back to English.
+    """
+    global _translator
+
+    if not lang:
+        lang = detect_language()
+
+    try:
+        t = gettext.translation(
+            domain="qmtl",
+            localedir=_locale_dir(),
+            languages=[lang] if lang else None,
+            fallback=True,
+        )
+        # If .mo not available, provide .po fallback
+        if isinstance(t, gettext.NullTranslations):
+            po_fallback = _try_load_po("qmtl", _locale_dir(), lang)
+            _translator = po_fallback or t
+        else:
+            _translator = t
+    except Exception:
+        # Be resilient; always provide a translator
+        po_fallback = _try_load_po("qmtl", _locale_dir(), lang)
+        _translator = po_fallback or gettext.NullTranslations()
+
+
+def _(message: str) -> str:
+    """Translate a message using the currently installed translator."""
+    return _translator.gettext(message)
+
+
+def detect_language() -> str:
+    """Return preferred language code.
+
+    Priority:
+    - QMTL_LANG
+    - LANGUAGE / LC_ALL / LC_MESSAGES / LANG (first two-letter code)
+    - "en"
+    """
+    # Explicit override
+    lang = os.environ.get("QMTL_LANG")
+    if lang:
+        return _normalize_lang(lang)
+
+    for key in ("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"):
+        val = os.environ.get(key)
+        if val:
+            return _normalize_lang(val)
+    return "en"
+
+
+def _normalize_lang(value: str) -> str:
+    # e.g., "ko_KR.UTF-8:en_US" -> "ko"
+    token = value.split(":", 1)[0]
+    token = token.split(".", 1)[0]
+    token = token.replace("-", "_")
+    return token.split("_", 1)[0].lower() or "en"


### PR DESCRIPTION
Summary\n- Introduces CLI i18n foundation with English/Korean; adds docs i18n guide; makes link checker locale-aware.\n\nKey changes\n- Global --lang for CLI (also QMTL_LANG env) with safe gettext + .po fallback loader.\n- Localized user-facing help/messages in project/config/tools/service/report CLIs.\n- Added babel.cfg and seeded ko catalog.\n- Docs: added Guides/Docs Internationalization and nav translation; link checker now skips non-default locales via mkdocs.yml.\n\nWhy\n- Enable bilingual UX and set up a scalable path for more locales.\n\nValidation\n- Default English behavior unchanged; tests referring to English strings remain valid.\n- Docs link checker passes locally; mkdocs build recommended in CI.\n\nRefs\n- Refs #1397\n- Refs #1398\n- Refs #1399\n- Refs #1400\n