### PR TITLE
Localize taglint CLI and tool

### DIFF
--- a/qmtl/interfaces/cli/taglint.py
+++ b/qmtl/interfaces/cli/taglint.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import argparse
 from typing import List
 
+from qmtl.utils.i18n import _
+
 
 def run(argv: List[str] | None = None) -> None:
     """Entry point for the ``taglint`` subcommand."""
 
-    parser = argparse.ArgumentParser(prog="qmtl tools taglint")
-    parser.add_argument("--fix", action="store_true", help="Attempt to fix issues")
+    argparse._ = _
+    parser = argparse.ArgumentParser(prog="qmtl tools taglint", description=_("Lint TAGS dictionaries"))
+    parser._ = _
+    parser.add_argument("--fix", action="store_true", help=_("Attempt to fix issues"))
     args, rest = parser.parse_known_args(argv)
 
     from qmtl.interfaces.tools.taglint import main as taglint_main

--- a/qmtl/locale/ko/LC_MESSAGES/qmtl.po
+++ b/qmtl/locale/ko/LC_MESSAGES/qmtl.po
@@ -160,3 +160,55 @@ msgstr "프로젝트 생성 위치: {path}"
 msgid "Project created at {path} using legacy template '{template}'"
 msgstr "레거시 템플릿 '{template}'으로 {path}에 프로젝트를 생성했습니다"
 
+# taglint tool
+msgid "Lint TAGS dictionaries"
+msgstr "TAGS 사전을 검사합니다"
+
+msgid "Files or directories to lint"
+msgstr "검사할 파일 또는 디렉터리"
+
+msgid "Attempt to fix issues"
+msgstr "문제를 자동으로 수정합니다"
+
+msgid "{key}: lists are not allowed"
+msgstr "{key}: 목록은 허용되지 않습니다"
+
+msgid "interval value '{value}' is invalid"
+msgstr "interval 값 '{value}'이(가) 잘못되었습니다"
+
+msgid "interval '{value}' not normalized (expected {expected})"
+msgstr "interval '{value}'이(가) 정규화되지 않았습니다 (기대값 {expected})"
+
+msgid "scope '{value}' is invalid"
+msgstr "scope '{value}'이(가) 잘못되었습니다"
+
+msgid "{key}: keys and string values must be lowercase"
+msgstr "{key}: 키와 문자열 값은 소문자여야 합니다"
+
+msgid "missing required key: {key}"
+msgstr "필수 키 누락: {key}"
+
+msgid "missing TAGS dict"
+msgstr "TAGS 사전이 없습니다"
+
+msgid "{path}: {message}"
+msgstr "{path}: {message}"
+
+msgid "{path}: error"
+msgstr "{path}: 오류"
+
+msgid "show this help message and exit"
+msgstr "이 도움말을 표시하고 종료합니다"
+
+msgid "usage: "
+msgstr "사용법: "
+
+msgid "positional arguments:"
+msgstr "위치 인수:"
+
+msgid "options:"
+msgstr "옵션:"
+
+msgid "optional arguments:"
+msgstr "선택적 인수:"
+


### PR DESCRIPTION
## Summary
- wrap taglint CLI and tool help/validation text with gettext so user messages translate and send errors to stderr
- add Korean catalogue entries for the new taglint strings and argparse help tokens
- extend the taglint tool tests to assert Korean help and error output when QMTL_LANG is set

## Testing
- uv run -m pytest tests/qmtl/interfaces/tools/test_taglint.py

Closes #1397

------
https://chatgpt.com/codex/tasks/task_e_68f8df4757a883299a3bc7609e4d38ab