### PR TITLE
Fix docs link check workflow dependency installation

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+
       - name: Run docs link/path checks
         run: |
           python scripts/check_docs_links.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,11 @@ For general contribution and testing policies, see the repository root [AGENTS.m
 - Validate docs with `uv run mkdocs build` before committing. Ensure `mkdocs-macros-plugin`
   and `mkdocs-breadcrumbs-plugin` are installed via `uv pip install -e .[dev]`.
 - Diagrams: Use Mermaid fenced code blocks (```mermaid) for all diagrams. Avoid PlantUML/DOT or binary diagram files; prefer text-based Mermaid for reviewability and versioning.
+- When adding or modifying documentation utility scripts (e.g., `scripts/check_docs_links.py`),
+  ensure that any new Python dependencies are reflected in both the developer installation
+  instructions and the CI workflows (notably `.github/workflows/docs-link-check.yml`).
+  Add an explicit installation step or shared requirements file in the workflow so the CI job
+  installs packages such as `pyyaml` before running the script.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- add documentation guidelines to ensure doc scripts list their dependencies in CI
- install PyYAML in the docs link check workflow to fix missing module errors

## Testing
- python scripts/check_docs_links.py

------
https://chatgpt.com/codex/tasks/task_e_68f8e39ef26883298cbc8779bc2899ef