### PR TITLE
Localize gateway CLI help and errors

### DIFF
--- a/qmtl/locale/ko/LC_MESSAGES/qmtl.po
+++ b/qmtl/locale/ko/LC_MESSAGES/qmtl.po
@@ -15,6 +15,40 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+# gateway cli
+msgid "Gateway configuration loaded from %(path)s (--config)"
+msgstr "Gateway 구성은 %(path)s (--config)에서 로드되었습니다"
+
+msgid "Gateway configuration loaded from %(path)s"
+msgstr "Gateway 구성은 %(path)s에서 로드되었습니다"
+
+msgid "Gateway configuration file not provided; using built-in defaults"
+msgstr "Gateway 구성 파일이 제공되지 않았습니다. 내장 기본값을 사용합니다"
+
+msgid "Run the Gateway HTTP server."
+msgstr "Gateway HTTP 서버를 실행합니다."
+
+msgid "Path to configuration file"
+msgstr "구성 파일 경로"
+
+msgid "Disable automatic VersionSentinel insertion"
+msgstr "자동 VersionSentinel 삽입 비활성화"
+
+msgid "Disable live trading guard requiring X-Allow-Live header"
+msgstr "X-Allow-Live 헤더가 필요한 라이브 트레이딩 가드를 비활성화"
+
+msgid "Gateway configuration file {path} does not define the 'gateway' section."
+msgstr "Gateway 구성 파일 {path}에 'gateway' 섹션이 없습니다."
+
+msgid "Commit-log writer is disabled; production deployments must set commitlog_bootstrap and commitlog_topic to record gateway.ingest events."
+msgstr "커밋 로그 기록기가 비활성화되었습니다. 운영 배포에서는 gateway.ingest 이벤트를 기록하려면 commitlog_bootstrap과 commitlog_topic을 설정해야 합니다."
+
+msgid "Failed to connect to database"
+msgstr "데이터베이스 연결에 실패했습니다"
+
+msgid "Failed to close database connection"
+msgstr "데이터베이스 연결을 닫지 못했습니다"
+
 # CLI top-level
 msgid "Subcommand to run"
 msgstr "실행할 하위 명령"

--- a/tests/qmtl/services/gateway/test_cli_config_fallback.py
+++ b/tests/qmtl/services/gateway/test_cli_config_fallback.py
@@ -86,7 +86,9 @@ def test_gateway_cli_discovers_default_file(tmp_path, monkeypatch, caplog, gatew
     )
 
 
-def test_gateway_cli_errors_when_section_missing(tmp_path, monkeypatch, caplog, gateway_testbed):
+def test_gateway_cli_errors_when_section_missing(
+    tmp_path, monkeypatch, caplog, capfd, gateway_testbed
+):
     config_path = tmp_path / "no_gateway.yml"
     config_path.write_text("dagmanager:\n  grpc_port: 1234\n")
 
@@ -98,3 +100,6 @@ def test_gateway_cli_errors_when_section_missing(tmp_path, monkeypatch, caplog, 
     assert any(
         "does not define the 'gateway' section" in record.message for record in caplog.records
     )
+    stderr = capfd.readouterr().err
+    assert "error:" in stderr
+    assert "does not define the 'gateway' section" in stderr

--- a/tests/qmtl/services/gateway/test_gateway_cli.py
+++ b/tests/qmtl/services/gateway/test_gateway_cli.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 
 import pytest
+from qmtl.utils.i18n import set_language
 
 
 @pytest.mark.parametrize(
@@ -47,6 +48,21 @@ def test_removed_top_level_aliases_show_top_level_usage(cmd):
     assert result.stdout.splitlines()[0].startswith("usage: qmtl")
     assert "error: unknown command" in result.stderr
     assert cmd in result.stderr
+
+
+def test_gateway_cli_help_respects_locale(monkeypatch, capsys):
+    from qmtl.services.gateway import cli
+
+    monkeypatch.setenv("QMTL_LANG", "ko")
+
+    try:
+        with pytest.raises(SystemExit):
+            cli.main(["--help"])
+        captured = capsys.readouterr()
+    finally:
+        set_language("en")
+
+    assert "구성 파일 경로" in captured.out
 
 
 def test_gateway_cli_config_file(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- localize the gateway service CLI help output, logging, and error handling through the shared i18n helpers
- extend the i18n utilities and Korean catalog to support the new gateway strings and reliable Unicode parsing
- add regression tests covering stderr error emission and Korean help output for the gateway CLI

## Testing
- uv run -m pytest -W error tests/qmtl/services/gateway/test_cli_config_fallback.py tests/qmtl/services/gateway/test_gateway_cli.py

Fixes #1398

------
https://chatgpt.com/codex/tasks/task_e_68f8e6fc2eb88329896c78c04448d7a4