### PR TITLE
Ensure taglint tool loads locale before parsing

### DIFF
--- a/qmtl/interfaces/tools/taglint.py
+++ b/qmtl/interfaces/tools/taglint.py
@@ -11,7 +11,7 @@ import sys
 from collections import OrderedDict
 from typing import Any, Dict, List, Tuple
 
-from qmtl.utils.i18n import _
+from qmtl.utils.i18n import _, language_source, set_language
 
 REQUIRED_KEYS = ["scope", "family", "interval", "asset"]
 RECOMMENDED_KEYS = ["window", "price", "side", "target_horizon", "label"]
@@ -164,6 +164,8 @@ def iter_py_files(path: str):
 
 
 def main(argv: list[str] | None = None):
+    if language_source() is None:
+        set_language(None)
     argparse._ = _
     parser = argparse.ArgumentParser(description=_("Lint TAGS dictionaries"))
     parser._ = _

--- a/tests/qmtl/interfaces/tools/test_taglint.py
+++ b/tests/qmtl/interfaces/tools/test_taglint.py
@@ -111,8 +111,7 @@ def test_taglint_help_respects_language_env():
     assert "Attempt to fix issues" in res_en.stdout
     assert "Attempt to fix issues" not in res_ko.stdout
     assert "문제를 자동으로 수정합니다" not in res_en.stdout
-    encoded = res_ko.stdout.encode("unicode_escape").decode()
-    assert "\\xeb\\xac\\xb8\\xec\\xa0\\x9c" in encoded
+    assert "문제를 자동으로 수정합니다" in res_ko.stdout
 
 
 def test_taglint_errors_localized(tmp_path):
@@ -126,5 +125,4 @@ def test_taglint_errors_localized(tmp_path):
     assert res_ko.returncode != 0
     assert "missing required key: scope" in res_en.stderr
     assert "missing required key: scope" not in res_ko.stderr
-    encoded = res_ko.stderr.encode("unicode_escape").decode()
-    assert "\\xed\\x95\\x84\\xec\\x88\\x98" in encoded
+    assert "필수 키 누락" in res_ko.stderr


### PR DESCRIPTION
## Summary
- ensure the taglint tool installs the configured locale when invoked directly so help text is localized
- update the taglint CLI tests to assert on the Korean translations directly

## Testing
- uv run -m pytest tests/qmtl/interfaces/tools/test_taglint.py

------
https://chatgpt.com/codex/tasks/task_e_68f91a3eedd4832980bbc5c26e07c076