### PR TITLE
feat: add logistic imbalance weights and micro-price node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added contract tests covering all registered Node Set recipes to verify chain length, descriptors, modes, and portfolio/weight injection.
 - Updated exchange Node Set architecture and CCXT guides to document the NodeSetRecipe/RecipeAdapterSpec workflow and reference the new tests.
+- Added logistic order-book imbalance weights, micro-price transforms, and supporting documentation/examples for microstructure signals.
 
 - `NodeCache.snapshot()` has been deprecated in favor of the read-only `CacheView` returned by `NodeCache.view()`. Strategy code should avoid calling the snapshot helper.
 - Added `coverage()` and `fill_missing()` interfaces for history providers and removed `start`/`end` arguments from `StreamInput`.

--- a/docs/en/guides/microstructure_signals.md
+++ b/docs/en/guides/microstructure_signals.md
@@ -1,0 +1,78 @@
+# Microstructure Signals: Top-of-Book Imbalance and Micro-Price
+
+Short-horizon liquidity bias is best captured with the combination of the
+**top-of-book imbalance** and the **micro-price**. This page explains the new
+runtime nodes shipped with QMTL and shows how to stabilise the signal using a
+logistic weighting scheme.
+
+## Top-of-Book Imbalance Node
+
+`order_book_imbalance_node` receives the best bid/ask depth and applies
+
+\[
+I = \frac{Q_{\text{bid}} - Q_{\text{ask}}}{Q_{\text{bid}} + Q_{\text{ask}}}
+\]
+
+to emit a value between -1 and +1. Large positive readings indicate bid-side
+dominance while negative readings indicate sell pressure.
+
+## Logistic Weight Node
+
+Real order books whipsaw constantly, so the linear ratio reacts too aggressively
+to fleeting depth changes. `logistic_order_book_imbalance_node` maps the
+imbalance through a sigmoid and outputs a weight `w ∈ [0, 1]`.
+
+- `slope` controls how quickly the sigmoid saturates. Higher values converge to
+  0/1 close to the origin.
+- `clamp` bounds the imbalance (by absolute value) before applying the sigmoid
+  and keeps thin-book spikes in check.
+- `offset` shifts the centre of the sigmoid when a different neutral point is
+  required.
+
+## Micro-Price Node
+
+`micro_price_node` combines the best quotes (`best_bid`, `best_ask`) with a
+weight node to compute
+
+\[
+P_{\text{micro}} = w\,P_{\text{ask}} + (1 - w)\,P_{\text{bid}}.
+\]
+
+You can supply a pre-computed weight or pass an imbalance node and select the
+`mode` (`"linear"` or `"logistic"`) to derive it on the fly.
+
+## Example Code
+
+```python
+from qmtl.runtime.sdk.node import SourceNode
+from qmtl.runtime.transforms import (
+    order_book_imbalance_node,
+    logistic_order_book_imbalance_node,
+    micro_price_node,
+)
+
+bid_volume = SourceNode(interval="1s", period=1, config={"id": "bid_volume"})
+ask_volume = SourceNode(interval="1s", period=1, config={"id": "ask_volume"})
+best_bid = SourceNode(interval="1s", period=1, config={"id": "best_bid"})
+best_ask = SourceNode(interval="1s", period=1, config={"id": "best_ask"})
+
+imbalance = order_book_imbalance_node(bid_volume, ask_volume)
+logistic_weight = logistic_order_book_imbalance_node(
+    bid_volume,
+    ask_volume,
+    slope=4.0,
+    clamp=0.8,
+)
+micro_price = micro_price_node(best_bid, best_ask, weight_node=logistic_weight)
+```
+
+## Tuning Guide
+
+- Start with **slope** between 2 and 6 and validate the predictive lift through
+  backtests.
+- Keep **clamp** near ±0.7–0.9. Lower values remove too much information, while
+  higher values reintroduce noise.
+- Choose `mode="linear"` when the raw depth ratio is desired. Logistic mode is
+  the default and performs well in high-volatility venues.
+- Reuse the logic in other alpha features by calling the shared
+  `imbalance_to_weight()` helper.

--- a/docs/ko/guides/microstructure_signals.md
+++ b/docs/ko/guides/microstructure_signals.md
@@ -1,0 +1,75 @@
+# 마이크로스트럭처 신호: 탑-오브-북 불균형과 미크로-프라이스
+
+짧은 체결 주기에서 유동성 편향을 관측하려면 **탑-오브-북 불균형(top-of-book
+imbalance)**과 **미크로-프라이스(micro-price)** 조합이 가장 먼저 떠오릅니다. 이
+문서는 QMTL 런타임에 새로 추가된 노드들을 활용해 해당 신호를 계산하고, 노이즈에
+강한 로지스틱 가중치를 적용하는 방법을 정리합니다.
+
+## 탑-오브-북 불균형 노드
+
+`order_book_imbalance_node`는 최우선 매수/매도 잔량을 받아
+
+\[
+I = \frac{Q_{\text{bid}} - Q_{\text{ask}}}{Q_{\text{bid}} + Q_{\text{ask}}}
+\]
+
+공식을 그대로 계산해 -1부터 +1 사이의 균형 지표를 반환합니다. 값이 +1에 가까울수록
+매수 잔량 우위, -1이면 매도 잔량 우위를 의미합니다.
+
+## 로지스틱 가중치 노드
+
+실제 호가창에서는 잔량이 순간적으로 출렁이며 선형 지표가 과도하게 반응하는 경우가
+잦습니다. `logistic_order_book_imbalance_node`는 균형값을 시그모이드 함수로 매핑해
+가중치 `w ∈ [0, 1]`를 생성합니다.
+
+- `slope`: 포화 속도를 제어하는 기울기입니다. 값이 크면 0 근처에서도 빠르게 0 또는 1로
+  수렴합니다.
+- `clamp`: 균형값을 절댓값 기준으로 잘라 얇은 호가에서 발생하는 극단값을 완화합니다.
+- `offset`: 필요 시 균형값의 중심을 이동시켜 특정 구간을 더 민감하게 만들 수 있습니다.
+
+## 미크로-프라이스 노드
+
+`micro_price_node`는 최우선 호가(`best_bid`, `best_ask`)와 가중치 노드를 조합해
+
+\[
+P_{\text{micro}} = w\,P_{\text{ask}} + (1 - w)\,P_{\text{bid}}
+\]
+
+을 계산합니다. 이미 계산된 가중치를 입력하거나, 불균형 노드를 전달하고 `mode`를
+`"linear"` 혹은 `"logistic"`으로 지정해 자동으로 가중치를 생성할 수 있습니다.
+
+## 예제 코드
+
+```python
+from qmtl.runtime.sdk.node import SourceNode
+from qmtl.runtime.transforms import (
+    order_book_imbalance_node,
+    logistic_order_book_imbalance_node,
+    micro_price_node,
+)
+
+bid_volume = SourceNode(interval="1s", period=1, config={"id": "bid_volume"})
+ask_volume = SourceNode(interval="1s", period=1, config={"id": "ask_volume"})
+best_bid = SourceNode(interval="1s", period=1, config={"id": "best_bid"})
+best_ask = SourceNode(interval="1s", period=1, config={"id": "best_ask"})
+
+imbalance = order_book_imbalance_node(bid_volume, ask_volume)
+logistic_weight = logistic_order_book_imbalance_node(
+    bid_volume,
+    ask_volume,
+    slope=4.0,
+    clamp=0.8,
+)
+micro_price = micro_price_node(best_bid, best_ask, weight_node=logistic_weight)
+```
+
+## 튜닝 가이드
+
+- **slope** 값은 2~6 범위에서 시작해, 예측력이 가장 높은 값을 백테스트로 고르는 것이
+  일반적입니다.
+- **clamp**는 ±0.7~0.9 사이를 권장합니다. 너무 낮으면 정보 손실이, 너무 높으면 노이즈에
+  다시 민감해집니다.
+- `mode="linear"`는 잔량 비율을 그대로 활용하고 싶을 때 사용하세요. 로지스틱 모드가 기본
+  값이며, 빠르게 포화되는 암호화폐/고빈도 시장에서 특히 효과적입니다.
+- 가중치를 다른 알파와 결합할 때는 `imbalance_to_weight()` 헬퍼를 이용하면 동일한 로직을
+  재사용할 수 있습니다.

--- a/examples/microstructure_signals.py
+++ b/examples/microstructure_signals.py
@@ -1,0 +1,97 @@
+"""Example pipeline for microstructure signals."""
+
+from __future__ import annotations
+
+from qmtl.runtime.sdk.cache_view import CacheView
+from qmtl.runtime.sdk.node import SourceNode
+from qmtl.runtime.transforms import (
+    order_book_imbalance_node,
+    logistic_order_book_imbalance_node,
+    micro_price_node,
+)
+
+
+def build_example_nodes():
+    """Create nodes for imbalance, logistic weight, and micro-price."""
+
+    bid_volume = SourceNode(interval="1s", period=1, config={"id": "bid_volume"})
+    ask_volume = SourceNode(interval="1s", period=1, config={"id": "ask_volume"})
+    best_bid = SourceNode(interval="1s", period=1, config={"id": "best_bid"})
+    best_ask = SourceNode(interval="1s", period=1, config={"id": "best_ask"})
+
+    imbalance = order_book_imbalance_node(bid_volume, ask_volume)
+    logistic_weight = logistic_order_book_imbalance_node(
+        bid_volume,
+        ask_volume,
+        slope=4.0,
+        clamp=0.8,
+    )
+    micro_price = micro_price_node(
+        best_bid,
+        best_ask,
+        weight_node=logistic_weight,
+    )
+
+    return {
+        "bid_volume": bid_volume,
+        "ask_volume": ask_volume,
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "imbalance": imbalance,
+        "logistic_weight": logistic_weight,
+        "micro_price": micro_price,
+    }
+
+
+def compute_example_snapshot():
+    """Compute the nodes using a single synthetic snapshot."""
+
+    nodes = build_example_nodes()
+    bid_volume = nodes["bid_volume"]
+    ask_volume = nodes["ask_volume"]
+    best_bid = nodes["best_bid"]
+    best_ask = nodes["best_ask"]
+    imbalance = nodes["imbalance"]
+    logistic_weight = nodes["logistic_weight"]
+    micro_price = nodes["micro_price"]
+
+    cache = CacheView(
+        {
+            bid_volume.node_id: {1: [(0, 120.0)]},
+            ask_volume.node_id: {1: [(0, 80.0)]},
+            best_bid.node_id: {1: [(0, 99.5)]},
+            best_ask.node_id: {1: [(0, 100.0)]},
+        }
+    )
+
+    imbalance_value = imbalance.compute_fn(cache)
+    logistic_value = logistic_weight.compute_fn(cache)
+
+    weight_cache = CacheView(
+        {
+            bid_volume.node_id: {1: [(0, 120.0)]},
+            ask_volume.node_id: {1: [(0, 80.0)]},
+            best_bid.node_id: {1: [(0, 99.5)]},
+            best_ask.node_id: {1: [(0, 100.0)]},
+            logistic_weight.node_id: {1: [(0, logistic_value)]},
+        }
+    )
+    micro_price_value = micro_price.compute_fn(weight_cache)
+
+    return {
+        "imbalance": imbalance_value,
+        "logistic_weight": logistic_value,
+        "micro_price": micro_price_value,
+    }
+
+
+def main() -> None:
+    """Print example outputs for quick verification."""
+
+    snapshot = compute_example_snapshot()
+    for key, value in snapshot.items():
+        print(f"{key}: {value:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Layered Templates Quick Start: guides/layered_templates_quickstart.md
       - SDK Tutorial & World ID: guides/sdk_tutorial.md
       - Strategy Workflow: guides/strategy_workflow.md
+      - Microstructure Signals: guides/microstructure_signals.md
       - Docs Internationalization: guides/docs_internationalization.md
       - Seamless Data Provider Setup: guides/seamless_data_provider_setup.md
       - Seamless Migration to v2: guides/seamless_migration_v2.md
@@ -138,6 +139,7 @@ plugins:
             "Testing & Pytest": "테스트 & Pytest"
             "Python Environment": "Python 환경"
             "CCXT Seamless Data Provider": "CCXT 심리스 데이터 프로바이더"
+            "Microstructure Signals": "마이크로스트럭처 신호"
             "IO & Integrations": "IO & 통합"
             Operations: 운영
             Design: 설계

--- a/qmtl/runtime/transforms/README.md
+++ b/qmtl/runtime/transforms/README.md
@@ -17,13 +17,17 @@ from qmtl.runtime.transforms import (
     stochastic,
     angle,
     order_book_imbalance_node,
+    logistic_order_book_imbalance_node,
+    micro_price_node,
     execution_imbalance_node,
     scale_transform_node,
 )
 
 obi = order_book_imbalance_node(bid_volume_node, ask_volume_node)
+obi_sigmoid = logistic_order_book_imbalance_node(bid_volume_node, ask_volume_node)
 obi_derivative = rate_of_change(obi, period=2)
 exec_imbalance = execution_imbalance_node(buy_volume, sell_volume)
 exec_imbalance_deriv = rate_of_change(exec_imbalance)
+micro_price = micro_price_node(best_bid, best_ask, weight_node=obi_sigmoid)
 scaled_metric = scale_transform_node({"average": 2}, factor=3)
 ```

--- a/qmtl/runtime/transforms/__init__.py
+++ b/qmtl/runtime/transforms/__init__.py
@@ -5,7 +5,13 @@ from .stochastic import stochastic
 from .angle import angle
 from .order_book_depth import depth_change_node, depth_node
 from .price_change import price_change, price_delta
-from .order_book_imbalance import order_book_imbalance_node, order_book_imbalance
+from .order_book_imbalance import (
+    order_book_imbalance_node,
+    order_book_imbalance,
+    logistic_order_book_imbalance_node,
+    logistic_order_book_weight,
+    imbalance_to_weight,
+)
 from .volume_features import volume_features, avg_volume_node, volume_stats
 from .execution_imbalance import execution_imbalance_node, execution_imbalance
 from .alpha_history import alpha_history_node
@@ -26,6 +32,11 @@ from .microstructure import (
     order_flow_imbalance_node,
     spread_zscore_node,
     hazard_node,
+)
+from .micro_price import (
+    micro_price,
+    micro_price_from_imbalance,
+    micro_price_node,
 )
 from .acceptable_price_band import estimate_band, overshoot, volume_surprise
 from .hazard_utils import direction_signal, execution_cost
@@ -67,6 +78,9 @@ __all__ = [
     "price_delta",
     "order_book_imbalance_node",
     "order_book_imbalance",
+    "logistic_order_book_imbalance_node",
+    "logistic_order_book_weight",
+    "imbalance_to_weight",
     "execution_imbalance_node",
     "execution_imbalance",
     "alpha_history_node",
@@ -87,6 +101,9 @@ __all__ = [
     "order_flow_imbalance_node",
     "spread_zscore_node",
     "hazard_node",
+    "micro_price",
+    "micro_price_from_imbalance",
+    "micro_price_node",
     "hazard_probability",
     "direction_gating",
     "execution_cost",

--- a/qmtl/runtime/transforms/micro_price.py
+++ b/qmtl/runtime/transforms/micro_price.py
@@ -1,0 +1,138 @@
+"""Micro-price transformation node."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from qmtl.runtime.sdk.cache_view import CacheView
+from qmtl.runtime.sdk.node import Node
+
+from .order_book_imbalance import imbalance_to_weight
+
+
+def _latest_price(view: CacheView, node: Node, interval: int | str) -> float | None:
+    data = view[node][interval]
+    sequence = getattr(data, "_data", data)
+    if not sequence:
+        return None
+    price = sequence[-1][1]
+    if not isinstance(price, (int, float)) or math.isnan(price):
+        return None
+    return float(price)
+
+
+def _latest_scalar(view: CacheView, node: Node, interval: int | str) -> float | None:
+    data = view[node][interval]
+    sequence = getattr(data, "_data", data)
+    if not sequence:
+        return None
+    value = sequence[-1][1]
+    if not isinstance(value, (int, float)) or math.isnan(value):
+        return None
+    return float(value)
+
+
+def micro_price(
+    bid_price: float,
+    ask_price: float,
+    weight: float,
+) -> float:
+    """Return micro-price from bid/ask quotes and a mixing weight."""
+
+    return weight * ask_price + (1.0 - weight) * bid_price
+
+
+def micro_price_from_imbalance(
+    bid_price: float,
+    ask_price: float,
+    imbalance: float,
+    *,
+    mode: Literal["linear", "logistic"] = "linear",
+    slope: float = 5.0,
+    offset: float = 0.0,
+    clamp: float | None = 0.9,
+) -> float:
+    weight = imbalance_to_weight(
+        imbalance,
+        mode=mode,
+        slope=slope,
+        offset=offset,
+        clamp=clamp,
+    )
+    return micro_price(bid_price, ask_price, weight)
+
+
+def micro_price_node(
+    bid_price: Node,
+    ask_price: Node,
+    *,
+    weight_node: Node | None = None,
+    imbalance_node: Node | None = None,
+    mode: Literal["linear", "logistic"] = "logistic",
+    slope: float = 5.0,
+    offset: float = 0.0,
+    clamp: float | None = 0.9,
+    interval: int | None = None,
+    name: str | None = None,
+) -> Node:
+    """Return a node computing micro-price from best quotes.
+
+    Provide ``weight_node`` when pre-computed weights are available. Otherwise
+    supply ``imbalance_node`` and specify how the imbalance should be mapped to a
+    weight through ``mode`` (``"linear"`` or ``"logistic"``) and the optional
+    logistic parameters ``slope``/``offset``/``clamp``.
+    """
+
+    if weight_node is None and imbalance_node is None:
+        raise ValueError("Either weight_node or imbalance_node must be provided")
+
+    if weight_node is not None and imbalance_node is not None:
+        raise ValueError("Provide only one of weight_node or imbalance_node")
+
+    interval = interval or bid_price.interval
+
+    def compute(view: CacheView):
+        bid = _latest_price(view, bid_price, interval)
+        ask = _latest_price(view, ask_price, interval)
+        if bid is None or ask is None:
+            return None
+
+        if weight_node is not None:
+            weight = _latest_scalar(view, weight_node, interval)
+            if weight is None:
+                return None
+        else:
+            imbalance = _latest_scalar(view, imbalance_node, interval)  # type: ignore[arg-type]
+            if imbalance is None:
+                return None
+            weight = imbalance_to_weight(
+                imbalance,
+                mode=mode,
+                slope=slope,
+                offset=offset,
+                clamp=clamp,
+            )
+
+        weight = max(0.0, min(1.0, weight))
+        return micro_price(bid, ask, weight)
+
+    inputs = [bid_price, ask_price]
+    if weight_node is not None:
+        inputs.append(weight_node)
+    else:
+        inputs.append(imbalance_node)  # type: ignore[arg-type]
+
+    return Node(
+        input=inputs,
+        compute_fn=compute,
+        name=name or "micro_price",
+        interval=interval,
+    )
+
+
+__all__ = [
+    "micro_price",
+    "micro_price_from_imbalance",
+    "micro_price_node",
+]

--- a/qmtl/runtime/transforms/order_book_imbalance.py
+++ b/qmtl/runtime/transforms/order_book_imbalance.py
@@ -1,7 +1,24 @@
-"""Order book imbalance transformation node."""
+"""Order book imbalance transformation nodes and helpers."""
+
+from __future__ import annotations
+
+import math
+from typing import Callable
 
 from qmtl.runtime.sdk.node import Node
 from qmtl.runtime.sdk.cache_view import CacheView
+
+
+def _latest(view: CacheView, node: Node, interval: int | str) -> float | None:
+    """Return the most recent scalar payload for *node* at *interval*."""
+
+    data = view[node][interval]
+    if not data:
+        return None
+    value = data[-1][1]
+    if not isinstance(value, (int, float)) or math.isnan(value):
+        return None
+    return float(value)
 
 
 def order_book_imbalance_node(
@@ -19,12 +36,10 @@ def order_book_imbalance_node(
     interval = interval or bid_volume.interval
 
     def compute(view: CacheView):
-        bid_data = view[bid_volume][interval]
-        ask_data = view[ask_volume][interval]
-        if not bid_data or not ask_data:
+        b = _latest(view, bid_volume, interval)
+        a = _latest(view, ask_volume, interval)
+        if b is None or a is None:
             return None
-        b = bid_data[-1][1]
-        a = ask_data[-1][1]
         total = b + a
         if total == 0:
             return None
@@ -46,4 +61,154 @@ def order_book_imbalance(bid_volume: float, ask_volume: float) -> float:
     return (bid_volume - ask_volume) / total
 
 
-__all__ = ["order_book_imbalance_node", "order_book_imbalance"]
+def _sigmoid(z: float) -> float:
+    """Numerically stable logistic function."""
+
+    if z >= 0:
+        exp_neg = math.exp(-z)
+        return 1.0 / (1.0 + exp_neg)
+    exp_pos = math.exp(z)
+    return exp_pos / (1.0 + exp_pos)
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(value, maximum))
+
+
+def imbalance_to_weight(
+    imbalance: float,
+    *,
+    mode: str = "linear",
+    slope: float = 5.0,
+    offset: float = 0.0,
+    clamp: float | None = None,
+    floor: float = 0.0,
+    ceiling: float = 1.0,
+) -> float:
+    """Convert an imbalance in ``[-1, 1]`` into a mixing weight ``[0, 1]``.
+
+    Parameters
+    ----------
+    imbalance:
+        Raw imbalance value.
+    mode:
+        ``"linear"`` (default) maps via ``(1 + imbalance) / 2`` while
+        ``"logistic"`` applies a sigmoid with the provided ``slope`` and
+        ``offset``.
+    clamp:
+        Optional absolute cap applied to the imbalance before the mapping is
+        evaluated. This helps avoid excessive saturation from thin-book noise.
+    floor, ceiling:
+        Clamp the resulting weight into the inclusive range ``[floor, ceiling]``.
+    """
+
+    if clamp is not None:
+        clamp = max(0.0, float(clamp))
+        imbalance = _clamp(imbalance, -clamp, clamp)
+
+    if mode == "linear":
+        weight = 0.5 * (1.0 + imbalance)
+    elif mode == "logistic":
+        slope = float(slope)
+        if slope == 0:
+            weight = 0.5
+        else:
+            z = slope * (imbalance - offset)
+            weight = _sigmoid(z)
+    else:
+        raise ValueError(f"Unsupported imbalance weight mode: {mode!r}")
+
+    return _clamp(weight, floor, ceiling)
+
+
+def logistic_order_book_weight(
+    bid_volume: float,
+    ask_volume: float,
+    *,
+    slope: float = 5.0,
+    offset: float = 0.0,
+    clamp: float | None = 0.9,
+    floor: float = 0.0,
+    ceiling: float = 1.0,
+) -> float:
+    """Return a logistic weight derived from raw order-book volumes."""
+
+    imbalance = order_book_imbalance(bid_volume, ask_volume)
+    return imbalance_to_weight(
+        imbalance,
+        mode="logistic",
+        slope=slope,
+        offset=offset,
+        clamp=clamp,
+        floor=floor,
+        ceiling=ceiling,
+    )
+
+
+def _imbalance_node_compute(
+    bid_volume: Node,
+    ask_volume: Node,
+    *,
+    interval: int | str,
+    mapper: Callable[[float], float | None],
+) -> Callable[[CacheView], float | None]:
+    def compute(view: CacheView):
+        b = _latest(view, bid_volume, interval)
+        a = _latest(view, ask_volume, interval)
+        if b is None or a is None:
+            return None
+        total = b + a
+        if total == 0:
+            return None
+        return mapper((b - a) / total)
+
+    return compute
+
+
+def logistic_order_book_imbalance_node(
+    bid_volume: Node,
+    ask_volume: Node,
+    *,
+    slope: float = 5.0,
+    offset: float = 0.0,
+    clamp: float | None = 0.9,
+    floor: float = 0.0,
+    ceiling: float = 1.0,
+    interval: int | None = None,
+    name: str | None = None,
+) -> Node:
+    """Return a node computing a logistic weight from order-book imbalance."""
+
+    interval = interval or bid_volume.interval
+
+    def mapper(imbalance: float) -> float:
+        return imbalance_to_weight(
+            imbalance,
+            mode="logistic",
+            slope=slope,
+            offset=offset,
+            clamp=clamp,
+            floor=floor,
+            ceiling=ceiling,
+        )
+
+    return Node(
+        input=[bid_volume, ask_volume],
+        compute_fn=_imbalance_node_compute(
+            bid_volume,
+            ask_volume,
+            interval=interval,
+            mapper=mapper,
+        ),
+        name=name or "logistic_order_book_weight",
+        interval=interval,
+    )
+
+
+__all__ = [
+    "order_book_imbalance_node",
+    "order_book_imbalance",
+    "logistic_order_book_weight",
+    "logistic_order_book_imbalance_node",
+    "imbalance_to_weight",
+]

--- a/tests/qmtl/runtime/transforms/test_micro_price.py
+++ b/tests/qmtl/runtime/transforms/test_micro_price.py
@@ -1,0 +1,80 @@
+import math
+
+from qmtl.runtime.transforms import (
+    micro_price,
+    micro_price_from_imbalance,
+    micro_price_node,
+    imbalance_to_weight,
+)
+from qmtl.runtime.sdk.node import SourceNode
+from qmtl.runtime.sdk.cache_view import CacheView
+
+
+def test_micro_price_function():
+    assert micro_price(99.0, 101.0, 0.25) == 0.25 * 101.0 + 0.75 * 99.0
+
+
+def test_micro_price_from_imbalance_linear():
+    result = micro_price_from_imbalance(99.0, 101.0, 0.0, mode="linear")
+    assert result == 100.0
+
+
+def test_micro_price_node_with_weight():
+    bid = SourceNode(interval="1s", period=1, config={"id": "bid"})
+    ask = SourceNode(interval="1s", period=1, config={"id": "ask"})
+    weight = SourceNode(interval="1s", period=1, config={"id": "w"})
+    node = micro_price_node(bid, ask, weight_node=weight)
+    data = {
+        bid.node_id: {1: [(0, 99.0)]},
+        ask.node_id: {1: [(0, 101.0)]},
+        weight.node_id: {1: [(0, 0.75)]},
+    }
+    view = CacheView(data)
+    assert node.compute_fn(view) == micro_price(99.0, 101.0, 0.75)
+
+
+def test_micro_price_node_with_linear_imbalance():
+    bid = SourceNode(interval="1s", period=1, config={"id": "bid"})
+    ask = SourceNode(interval="1s", period=1, config={"id": "ask"})
+    imbalance = SourceNode(interval="1s", period=1, config={"id": "imb"})
+    node = micro_price_node(bid, ask, imbalance_node=imbalance, mode="linear")
+    data = {
+        bid.node_id: {1: [(0, 99.0)]},
+        ask.node_id: {1: [(0, 101.0)]},
+        imbalance.node_id: {1: [(0, 0.2)]},
+    }
+    view = CacheView(data)
+    weight = imbalance_to_weight(0.2, mode="linear")
+    expected = micro_price(99.0, 101.0, weight)
+    assert view is not None
+    assert node.compute_fn(view) == expected
+
+
+def test_micro_price_node_with_logistic_imbalance():
+    bid = SourceNode(interval="1s", period=1, config={"id": "bid"})
+    ask = SourceNode(interval="1s", period=1, config={"id": "ask"})
+    imbalance = SourceNode(interval="1s", period=1, config={"id": "imb"})
+    node = micro_price_node(bid, ask, imbalance_node=imbalance, slope=4.0, clamp=0.8)
+    data = {
+        bid.node_id: {1: [(0, 100.0)]},
+        ask.node_id: {1: [(0, 100.5)]},
+        imbalance.node_id: {1: [(0, 0.6)]},
+    }
+    view = CacheView(data)
+    weight = imbalance_to_weight(0.6, mode="logistic", slope=4.0, clamp=0.8)
+    expected = micro_price(100.0, 100.5, weight)
+    assert math.isclose(node.compute_fn(view), expected)
+
+
+def test_micro_price_node_missing_weight():
+    bid = SourceNode(interval="1s", period=1, config={"id": "bid"})
+    ask = SourceNode(interval="1s", period=1, config={"id": "ask"})
+    weight = SourceNode(interval="1s", period=1, config={"id": "w"})
+    node = micro_price_node(bid, ask, weight_node=weight)
+    data = {
+        bid.node_id: {1: [(0, 99.0)]},
+        ask.node_id: {1: [(0, 101.0)]},
+        weight.node_id: {1: []},
+    }
+    view = CacheView(data)
+    assert node.compute_fn(view) is None


### PR DESCRIPTION
## Summary
- add logistic order-book imbalance weighting helpers and expose a dedicated micro-price transform
- extend transform tests, add an executable example, and document microstructure signals in both Korean and English
- update MkDocs navigation so the new guide ships with the documentation set

## Testing
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1`
- `uv run -m pytest -W error -n auto`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6900ad0b5b248329a61c452047c566d9