### PR TITLE
Add priority index indicator for queue metadata

### DIFF
--- a/qmtl/runtime/indicators/__init__.py
+++ b/qmtl/runtime/indicators/__init__.py
@@ -23,6 +23,7 @@ from .order_book_obi import (
     order_book_imbalance_levels,
     order_book_depth_slope,
     order_book_obiL_and_slope,
+    priority_index,
 )
 from .obi_regime import obi_regime_node
 # Optional alpha indicator; may not be available in all deployments
@@ -56,6 +57,7 @@ __all__ = [
     "order_book_imbalance_levels",
     "order_book_depth_slope",
     "order_book_obiL_and_slope",
+    "priority_index",
     "obi_regime_node",
     "alpha_indicator_with_history",
 ]

--- a/tests/qmtl/runtime/indicators/test_priority_index.py
+++ b/tests/qmtl/runtime/indicators/test_priority_index.py
@@ -1,0 +1,73 @@
+"""Tests for the ``priority_index`` indicator node."""
+
+from __future__ import annotations
+
+import pytest
+
+from qmtl.runtime.indicators import priority_index
+from qmtl.runtime.sdk.cache_view import CacheView
+from qmtl.runtime.sdk.node import SourceNode
+
+
+def _view_for_snapshots(source: SourceNode, snapshots: list[dict]) -> CacheView:
+    data = {
+        source.node_id: {
+            source.interval: [(idx, snapshot) for idx, snapshot in enumerate(snapshots)]
+        }
+    }
+    return CacheView(data)
+
+
+def test_priority_index_scalar_normalization() -> None:
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {"queue_rank": 2, "queue_size": 10}
+    node = priority_index(source)
+
+    view = _view_for_snapshots(source, [snapshot])
+
+    result = node.compute_fn(view)
+    assert result == pytest.approx(0.8)
+
+
+def test_priority_index_batched_normalization() -> None:
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {"queue_rank": [0, 5, 10], "queue_size": [10, 10, 10]}
+    node = priority_index(source)
+
+    view = _view_for_snapshots(source, [snapshot])
+
+    result = node.compute_fn(view)
+    assert result == pytest.approx([1.0, 0.5, 0.0])
+
+
+def test_priority_index_missing_queue_metadata_raises() -> None:
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {"queue_rank": 1}
+    node = priority_index(source)
+
+    view = _view_for_snapshots(source, [snapshot])
+
+    with pytest.raises(ValueError) as exc:
+        node.compute_fn(view)
+
+    assert "queue_size" in str(exc.value)
+
+
+def test_priority_index_invalid_inputs_return_none() -> None:
+    source = SourceNode(interval="1s", period=5)
+    invalid_snapshot = {"queue_rank": 1, "queue_size": 0}
+    node = priority_index(source)
+
+    view = _view_for_snapshots(source, [invalid_snapshot])
+
+    assert node.compute_fn(view) is None
+
+
+def test_priority_index_batched_invalid_entry_returns_none_marker() -> None:
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {"queue_rank": [0, 1], "queue_size": [5, 0]}
+    node = priority_index(source)
+
+    view = _view_for_snapshots(source, [snapshot])
+
+    assert node.compute_fn(view) == [1.0, None]


### PR DESCRIPTION
## Summary
- add a priority_index indicator node that normalizes queue metadata from order book snapshots
- expose the new node via the indicators package and share normalization helpers
- add unit tests covering scalar, batched, and invalid queue metadata inputs

## Testing
- uv run -m pytest tests/qmtl/runtime/indicators/test_priority_index.py

------
https://chatgpt.com/codex/tasks/task_e_6907f41721d083298d7ca0b4e1776a94