### PR TITLE
Add microprice imbalance indicator and consolidate order book helpers

### DIFF
--- a/qmtl/indicators.py
+++ b/qmtl/indicators.py
@@ -1,5 +1,7 @@
-"""Indicators module alias for qmtl.runtime.indicators"""
+"""Indicators module alias for :mod:`qmtl.runtime.indicators`."""
 
 from qmtl.runtime.indicators import *  # noqa: F403,F401
+from qmtl.runtime.indicators import __all__ as _runtime_all
 
-__all__ = []  # Will be populated by the import above
+__all__ = list(_runtime_all)
+

--- a/qmtl/runtime/indicators/__init__.py
+++ b/qmtl/runtime/indicators/__init__.py
@@ -25,6 +25,7 @@ from .order_book_obi import (
     order_book_obiL_and_slope,
 )
 from .obi_regime import obi_regime_node
+from .microprice_priority import microprice_imbalance
 # Optional alpha indicator; may not be available in all deployments
 try:  # pragma: no cover - fallback for missing alpha module
     from .gap_amplification_alpha import gap_amplification_node
@@ -57,6 +58,7 @@ __all__ = [
     "order_book_depth_slope",
     "order_book_obiL_and_slope",
     "obi_regime_node",
+    "microprice_imbalance",
     "alpha_indicator_with_history",
 ]
 

--- a/qmtl/runtime/indicators/helpers.py
+++ b/qmtl/runtime/indicators/helpers.py
@@ -1,11 +1,110 @@
 """Helper utilities for indicator nodes."""
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
+from qmtl.runtime.sdk.cache_view import CacheView
 from qmtl.runtime.sdk.node import Node
 from qmtl.runtime.transforms import alpha_history_node
 
-__all__ = ["alpha_indicator_with_history"]
+__all__ = [
+    "alpha_indicator_with_history",
+    "extract_order_book_snapshot",
+    "normalize_order_book_level_size",
+    "iter_order_book_level_sizes",
+    "sum_order_book_levels",
+    "best_order_book_level",
+]
+
+
+def extract_order_book_snapshot(view: CacheView, source: Node) -> Mapping[str, Any] | None:
+    """Return the latest order-book snapshot emitted by ``source`` if available."""
+
+    series = view[source][source.interval]
+    latest = series.latest()
+    if latest is None:
+        return None
+
+    snapshot = latest[1]
+    if snapshot is None or not isinstance(snapshot, Mapping):
+        return None
+    return snapshot
+
+
+def _to_float(value: Any) -> float | None:
+    """Safely convert ``value`` to ``float`` when possible."""
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_order_book_level_size(level: Any) -> float | None:
+    """Extract the size component from a level entry."""
+
+    if isinstance(level, Mapping):
+        raw_size = level.get("size")
+    elif isinstance(level, (list, tuple)):
+        if not level:
+            return None
+        raw_size = level[1] if len(level) > 1 else level[0]
+    else:
+        raw_size = level
+    return _to_float(raw_size)
+
+
+def _normalize_order_book_level_price(level: Any) -> float | None:
+    """Extract the price component from a level entry."""
+
+    if isinstance(level, Mapping):
+        raw_price = level.get("price")
+    elif isinstance(level, (list, tuple)):
+        if not level:
+            return None
+        raw_price = level[0]
+    else:
+        return None
+    return _to_float(raw_price)
+
+
+def best_order_book_level(
+    levels_data: Sequence[Any] | None,
+) -> tuple[float | None, float | None]:
+    """Return the price and size of the best level in ``levels_data``."""
+
+    if not levels_data:
+        return None, None
+
+    level = levels_data[0]
+    price = _normalize_order_book_level_price(level)
+    size = normalize_order_book_level_size(level)
+    return price, size
+
+
+def iter_order_book_level_sizes(levels_data: Sequence[Any] | None, levels: int) -> list[float]:
+    """Return parsed sizes for up to ``levels`` order-book entries."""
+
+    if not levels_data or levels <= 0:
+        return []
+
+    values: list[float] = []
+    for level in levels_data:
+        if len(values) >= levels:
+            break
+        size = normalize_order_book_level_size(level)
+        if size is None:
+            continue
+        values.append(size)
+    return values
+
+
+def sum_order_book_levels(levels_data: Sequence[Any] | None, levels: int) -> float:
+    """Return the summed depth over ``levels`` entries from ``levels_data``."""
+
+    if levels <= 0:
+        return 0.0
+    return sum(iter_order_book_level_sizes(levels_data, levels))
 
 
 def alpha_indicator_with_history(

--- a/qmtl/runtime/indicators/microprice_priority.py
+++ b/qmtl/runtime/indicators/microprice_priority.py
@@ -1,0 +1,96 @@
+"""Microprice and order-book imbalance indicators with priority weighting."""
+
+from __future__ import annotations
+
+from qmtl.runtime.sdk.cache_view import CacheView
+from qmtl.runtime.sdk.node import Node
+
+from .helpers import (
+    best_order_book_level,
+    extract_order_book_snapshot,
+    sum_order_book_levels,
+)
+
+__all__ = ["microprice_imbalance"]
+
+
+def _compute_microprice(
+    bid_price: float | None,
+    bid_size: float | None,
+    ask_price: float | None,
+    ask_size: float | None,
+    epsilon: float,
+) -> float | None:
+    """Return the microprice using top-of-book price and size information."""
+
+    if bid_price is None or ask_price is None:
+        return None
+
+    bid_depth = bid_size or 0.0
+    ask_depth = ask_size or 0.0
+
+    denominator = bid_depth + ask_depth + epsilon
+    if denominator == 0.0:
+        return 0.0
+
+    numerator = ask_price * bid_depth + bid_price * ask_depth
+    return numerator / denominator
+
+
+def microprice_imbalance(
+    source: Node,
+    *,
+    top_levels: int = 1,
+    epsilon: float = 1e-9,
+    name: str | None = None,
+) -> Node:
+    """Return a node computing microprice and depth imbalance metrics.
+
+    Parameters
+    ----------
+    source:
+        Node yielding order-book snapshots containing ``"bids"`` and
+        ``"asks"`` sequences. Each level may be a ``(price, size)`` pair, a
+        mapping with ``price``/``size`` keys, or a raw size value.
+    top_levels:
+        Number of levels from each side included in the imbalance sum.
+    epsilon:
+        Small constant added to denominators to avoid division by zero.
+    name:
+        Optional node name. Defaults to ``"microprice_imbalance"``.
+    """
+
+    def compute(view: CacheView) -> dict[str, float | None] | None:
+        snapshot = extract_order_book_snapshot(view, source)
+        if snapshot is None:
+            return None
+
+        bids = snapshot.get("bids")
+        asks = snapshot.get("asks")
+
+        bid_price, bid_size = best_order_book_level(bids)
+        ask_price, ask_size = best_order_book_level(asks)
+
+        microprice = _compute_microprice(bid_price, bid_size, ask_price, ask_size, epsilon)
+
+        bid_total = sum_order_book_levels(bids, top_levels)
+        ask_total = sum_order_book_levels(asks, top_levels)
+
+        if bid_total == 0.0 and ask_total == 0.0:
+            imbalance = 0.0
+        else:
+            denominator = bid_total + ask_total + epsilon
+            imbalance = (bid_total - ask_total) / denominator
+
+        return {
+            "microprice": microprice,
+            "imbalance": imbalance,
+        }
+
+    return Node(
+        input=source,
+        compute_fn=compute,
+        name=name or "microprice_imbalance",
+        interval=source.interval,
+        period=source.period,
+    )

--- a/tests/qmtl/runtime/indicators/test_microprice_priority.py
+++ b/tests/qmtl/runtime/indicators/test_microprice_priority.py
@@ -1,0 +1,69 @@
+import pytest
+
+from qmtl.runtime.indicators import microprice_imbalance
+from qmtl.runtime.sdk.cache_view import CacheView
+from qmtl.runtime.sdk.node import SourceNode
+
+
+def _view_for_snapshots(source: SourceNode, snapshots):
+    data = {
+        source.node_id: {
+            source.interval: [(idx, snapshot) for idx, snapshot in enumerate(snapshots)]
+        }
+    }
+    return CacheView(data)
+
+
+def test_microprice_imbalance_computes_expected_values():
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {
+        "bids": [(100.0, 4.0), (99.5, 3.0), (99.0, 2.0)],
+        "asks": [(101.0, 3.0), (101.5, 2.0), (102.0, 1.0)],
+    }
+
+    node = microprice_imbalance(source, top_levels=2)
+    result = node.compute_fn(_view_for_snapshots(source, [snapshot]))
+
+    assert result is not None
+
+    bid_price, bid_size = snapshot["bids"][0]
+    ask_price, ask_size = snapshot["asks"][0]
+    epsilon = 1e-9
+    expected_microprice = (
+        ask_price * bid_size + bid_price * ask_size
+    ) / (bid_size + ask_size + epsilon)
+
+    bid_total = snapshot["bids"][0][1] + snapshot["bids"][1][1]
+    ask_total = snapshot["asks"][0][1] + snapshot["asks"][1][1]
+    expected_imbalance = (bid_total - ask_total) / (bid_total + ask_total + epsilon)
+
+    assert result["microprice"] == pytest.approx(expected_microprice)
+    assert result["imbalance"] == pytest.approx(expected_imbalance)
+
+
+def test_microprice_imbalance_handles_missing_levels():
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {"bids": [], "asks": [(101.0, 5.0), (101.5, 1.0)]}
+
+    node = microprice_imbalance(source, top_levels=3)
+    result = node.compute_fn(_view_for_snapshots(source, [snapshot]))
+
+    assert result is not None
+    assert result["microprice"] is None
+
+    epsilon = 1e-9
+    ask_total = snapshot["asks"][0][1] + snapshot["asks"][1][1]
+    expected_imbalance = (0.0 - ask_total) / (ask_total + epsilon)
+    assert result["imbalance"] == pytest.approx(expected_imbalance)
+
+
+def test_microprice_imbalance_zero_depth_returns_zero_metrics():
+    source = SourceNode(interval="1s", period=5)
+    snapshot = {"bids": [(100.0, 0.0)], "asks": [(101.0, 0.0)]}
+
+    node = microprice_imbalance(source)
+    result = node.compute_fn(_view_for_snapshots(source, [snapshot]))
+
+    assert result is not None
+    assert result["microprice"] == pytest.approx(0.0)
+    assert result["imbalance"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- move snapshot and depth parsing helpers into the shared indicators helpers module
- add a microprice_imbalance runtime node that reuses the helpers and exposes microprice plus top-level imbalance
- register the new indicator in the runtime exports and add focused unit tests for missing levels and zero depth

## Testing
- pytest tests/qmtl/runtime/indicators/test_microprice_priority.py

------
https://chatgpt.com/codex/tasks/task_e_6907f3fcec48832988a4561133ccc7ff