### PR TITLE
Fix priority_index snapshot retrieval

### DIFF
--- a/qmtl/runtime/indicators/order_book_obi.py
+++ b/qmtl/runtime/indicators/order_book_obi.py
@@ -193,7 +193,7 @@ def priority_index(source: Node, *, name: str | None = None) -> Node:
     """
 
     def compute(view: CacheView) -> float | list[float | None] | None:
-        snapshot = _extract_snapshot(view, source)
+        snapshot = extract_order_book_snapshot(view, source)
         if snapshot is None:
             return None
 


### PR DESCRIPTION
## Summary
- replace the priority_index helper call with extract_order_book_snapshot to resolve the NameError

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907fb1288d88329b4a54c5b8a73087e