### PR TITLE
Add TWAP indicator and shared weighting helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added a time-weighted average price (TWAP) indicator to the runtime
+  indicator suite.
 - Added contract tests covering all registered Node Set recipes to verify chain length, descriptors, modes, and portfolio/weight injection.
 - Updated exchange Node Set architecture and CCXT guides to document the NodeSetRecipe/RecipeAdapterSpec workflow and reference the new tests.
 - Added logistic order-book imbalance weights, micro-price transforms, and supporting documentation/examples for microstructure signals.

--- a/qmtl/runtime/indicators/README.md
+++ b/qmtl/runtime/indicators/README.md
@@ -14,6 +14,23 @@ from qmtl.runtime.indicators import sma
 from qmtl.runtime.indicators import acceptable_price_band_node
 ```
 
+## Time Weighted Average Price (TWAP)
+
+`twap` computes the time-weighted average of a price stream by pairing each
+sample with the elapsed time until the next observation. The node emits `None`
+when history is too short or all time gaps collapse to zero.
+
+```python
+from qmtl.runtime.sdk.node import SourceNode
+from qmtl.runtime.indicators import twap
+
+price_node = SourceNode(interval="1s", period=10)
+twap_node = twap(price_node, period=5)
+```
+
+The node respects the interval of its price input and retains ``period + 1``
+observations to cover the trailing ``period`` time spans.
+
 ## Order-book imbalance (OBI)
 
 `order_book_obi` consumes raw order-book snapshots containing bid and ask

--- a/qmtl/runtime/indicators/__init__.py
+++ b/qmtl/runtime/indicators/__init__.py
@@ -13,6 +13,7 @@ from .keltner_channel import keltner_channel
 from .obv import obv
 from .vwap import vwap
 from .anchored_vwap import anchored_vwap
+from .twap import twap
 from .kalman_trend import kalman_trend
 from .rough_bergomi import rough_bergomi
 from .stoch_rsi import stoch_rsi
@@ -47,6 +48,7 @@ __all__ = [
     "keltner_channel",
     "obv",
     "vwap",
+    "twap",
     "anchored_vwap",
     "kalman_trend",
     "rough_bergomi",

--- a/qmtl/runtime/indicators/twap.py
+++ b/qmtl/runtime/indicators/twap.py
@@ -1,0 +1,35 @@
+"""Time Weighted Average Price indicator."""
+
+from qmtl.runtime.sdk.cache_view import CacheView
+from qmtl.runtime.sdk.node import Node
+
+from .helpers import timestamp_weighted_average
+
+
+def twap(price: Node, period: int, *, name: str | None = None) -> Node:
+    """Return a Node computing the Time Weighted Average Price.
+
+    The indicator samples the most recent ``period`` intervals, weighting each
+    price by the elapsed time until the next observation. When the cache lacks
+    sufficient data or the cumulative weight is zero the node emits ``None``.
+    """
+
+    window = max(period, 0) + 1
+
+    def compute(view: CacheView):
+        if period <= 0:
+            return None
+
+        series = view[price][price.interval][-window:]
+        if len(series) < window:
+            return None
+        return timestamp_weighted_average(series)
+
+    return Node(
+        input=[price],
+        compute_fn=compute,
+        name=name or "twap",
+        interval=price.interval,
+        period=window,
+    )
+

--- a/qmtl/runtime/indicators/vwap.py
+++ b/qmtl/runtime/indicators/vwap.py
@@ -3,6 +3,8 @@
 from qmtl.runtime.sdk.node import Node
 from qmtl.runtime.sdk.cache_view import CacheView
 
+from .helpers import weighted_average
+
 
 def vwap(price: Node, volume: Node, period: int, *, name: str | None = None) -> Node:
     """Return a Node computing VWAP."""
@@ -12,11 +14,8 @@ def vwap(price: Node, volume: Node, period: int, *, name: str | None = None) -> 
         vols = view[volume][volume.interval][-period:]
         if len(prices) < period or len(vols) < period:
             return None
-        num = sum(p[1] * v[1] for p, v in zip(prices, vols))
-        den = sum(v[1] for v in vols)
-        if den == 0:
-            return None
-        return num / den
+        weights = [entry[1] for entry in vols]
+        return weighted_average(prices, weights)
 
     return Node(
         input=[price, volume],


### PR DESCRIPTION
## Summary
- add timestamp-weighted average helper utilities and reuse them in the VWAP indicator
- implement a TWAP node, expose it through the runtime indicator package, and cover edge cases with tests
- document the new indicator and record the addition in the changelog

## Testing
- uv run -m pytest -W error -n auto tests/qmtl/runtime/indicators/test_indicators.py

------
https://chatgpt.com/codex/tasks/task_e_6907fc879be88329b0be9b4289cac5b9