### PR TITLE
Handle rebalancing plan ControlBus events in Gateway

### DIFF
--- a/docs/en/architecture/gateway.md
+++ b/docs/en/architecture/gateway.md
@@ -224,6 +224,8 @@ upstream queues execute locally.
 
 Gateway also listens (via ControlBus) for `sentinel_weight` CloudEvents emitted by DAG Manager. Upon receiving an update, the in-memory routing table is adjusted and the new weight broadcast to SDK clients via WebSocket. The effective ratio per version is exported as the Prometheus gauge `gateway_sentinel_traffic_ratio{version="<id>"}`.
 
+Rebalancing plans from WorldService are delivered on the `rebalancing_planned` ControlBus topic. Gateway deduplicates the events, broadcasts them over the WebSocket `rebalancing` topic (CloudEvent type `rebalancing.planned`), and records metrics capturing plan volume and automatic execution (`rebalance_plans_observed_total`, `rebalance_plan_last_delta_count`, `rebalance_plan_execution_attempts_total`, `rebalance_plan_execution_failures_total`).
+
 ### S5 - Reliability Checklist
 
 * **NodeID CRC pipeline** - Gateway recomputes each `node_id` and cross-checks it with the SDK value via the `crc32` field on diff requests/responses. A mismatch returns HTTP 400.

--- a/docs/en/operations/rebalancing_execution.md
+++ b/docs/en/operations/rebalancing_execution.md
@@ -54,6 +54,7 @@ Use `per_world` for execution unless running in a shared-account mode; treat `gl
 - **Live guard:** when `submit=true` the request must include header `X-Allow-Live: true` (unless `enforce_live_guard` is disabled in configuration). Requests without the header are rejected with HTTP 403.
 - **Venue policies:** lot sizes, minimum trade notional and venue capabilities are applied before submission. Reduce-only flags are omitted for venues that do not support them and venues that require IOC will have `time_in_force="IOC"` set automatically.
 - **Metrics:** each submitted batch increments Prometheus counters/gauges (`rebalance_batches_submitted_total`, `rebalance_last_batch_size`, `rebalance_reduce_only_ratio`) labelled by `world_id` and `scope`.
+- **ControlBus fan-out:** WorldService publishes `rebalancing_planned` events that Gateway relays via the WebSocket `rebalancing` topic (`rebalancing.planned`) while updating plan-level metrics (`rebalance_plans_observed_total`, `rebalance_plan_last_delta_count`, `rebalance_plan_execution_attempts_total`, `rebalance_plan_execution_failures_total`).
 - **Audit trail:** the Gateway records an `append_event` entry under `rebalance:<world_id>` summarising order counts and reduce-only ratios for each batch.
 - **Commit log:** submitted batches are written to the commit log as `("gateway.rebalance", timestamp_ms, batch_id, payload)` where `payload` contains the batch scope, orders and metadata (shared-account flag, reduce-only ratio, mode).
 

--- a/docs/ko/architecture/gateway.md
+++ b/docs/ko/architecture/gateway.md
@@ -224,6 +224,8 @@ upstream queues execute locally.
 
 Gateway also listens (via ControlBus) for `sentinel_weight` CloudEvents emitted by DAG Manager. Upon receiving an update, the in-memory routing table is adjusted and the new weight broadcast to SDK clients via WebSocket. The effective ratio per version is exported as the Prometheus gauge `gateway_sentinel_traffic_ratio{version="<id>"}`.
 
+WorldService에서 발행하는 `rebalancing_planned` ControlBus 이벤트 역시 Gateway가 중복을 제거한 뒤 WebSocket `rebalancing` 토픽(CloudEvent 타입 `rebalancing.planned`)으로 중계하며, 계획 건수와 자동 실행 시도를 나타내는 지표(`rebalance_plans_observed_total`, `rebalance_plan_last_delta_count`, `rebalance_plan_execution_attempts_total`, `rebalance_plan_execution_failures_total`)를 기록한다.
+
 ### S5 · Reliability Checklist
 
 * **NodeID CRC 파이프라인** – SDK가 전송한 `node_id`와 Gateway가 재계산한 값이

--- a/docs/ko/operations/rebalancing_execution.md
+++ b/docs/ko/operations/rebalancing_execution.md
@@ -59,6 +59,7 @@ for payload in orders:
 - **라이브 가드:** `submit=true` 요청은 `X-Allow-Live: true` 헤더가 필요합니다(`enforce_live_guard` 비활성화 시 제외). 헤더가 없으면 403 응답을 반환합니다.
 - **거래소 정책:** 로트 사이즈, 최소 거래 노미널, 거래소별 지원 여부를 고려해 주문을 보정합니다. reduce-only를 지원하지 않는 거래소에는 플래그를 제거하고, IOC가 필요한 거래소에는 `time_in_force="IOC"`가 자동으로 지정됩니다.
 - **메트릭:** 제출된 각 배치는 `rebalance_batches_submitted_total`, `rebalance_last_batch_size`, `rebalance_reduce_only_ratio` Prometheus 지표(world_id, scope 라벨)를 갱신합니다.
+- **ControlBus 팬아웃:** WorldService가 발행하는 `rebalancing_planned` 이벤트는 Gateway가 WebSocket `rebalancing` 토픽(`rebalancing.planned`)으로 전달하며, 계획 수준 지표(`rebalance_plans_observed_total`, `rebalance_plan_last_delta_count`, `rebalance_plan_execution_attempts_total`, `rebalance_plan_execution_failures_total`)를 함께 갱신합니다.
 - **감사 로그:** 각 배치는 `rebalance:<world_id>` 키로 `append_event`에 기록되어 주문 수와 reduce-only 비율을 남깁니다.
 - **Commit Log:** 배치는 `("gateway.rebalance", timestamp_ms, batch_id, payload)` 형태로 Commit Log에 기록되며 `payload`에는 scope, 주문 목록, 공유 계정 여부, reduce-only 비율, 모드 등이 포함됩니다.
 

--- a/qmtl/services/gateway/event_models.py
+++ b/qmtl/services/gateway/event_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 # Priority: gpt5pro
 
 from datetime import datetime
-from typing import Any, Generic, List, Literal, Optional, TypeVar
+from typing import Any, Dict, Generic, List, Literal, Optional, TypeVar
 
 from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
 
@@ -64,6 +64,26 @@ class PolicyUpdatedData(BaseModel):
     ts: Optional[StrictStr] = None
 
 
+class RebalancingPlanDelta(BaseModel):
+    symbol: StrictStr
+    delta_qty: StrictFloat
+    venue: Optional[StrictStr] = None
+
+
+class RebalancingPlanPayload(BaseModel):
+    scale_world: StrictFloat
+    scale_by_strategy: Dict[StrictStr, StrictFloat]
+    deltas: List[RebalancingPlanDelta]
+
+
+class RebalancingPlannedData(BaseModel):
+    world_id: StrictStr
+    plan: RebalancingPlanPayload
+    version: StrictInt
+    policy: Optional[StrictStr] = None
+    run_id: Optional[StrictStr] = None
+
+
 T = TypeVar("T", bound=BaseModel)
 
 
@@ -88,5 +108,8 @@ __all__ = [
     "SentinelWeightData",
     "ActivationUpdatedData",
     "PolicyUpdatedData",
+    "RebalancingPlanDelta",
+    "RebalancingPlanPayload",
+    "RebalancingPlannedData",
     "CloudEvent",
 ]

--- a/qmtl/services/gateway/ws/hub.py
+++ b/qmtl/services/gateway/ws/hub.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
-from typing import Any, Optional, Set
+from typing import Any, Mapping, Optional, Set
 
 from fastapi import WebSocket
 
@@ -189,6 +189,26 @@ class WebSocketHub:
     async def send_policy_updated(self, payload: dict) -> None:
         payload.setdefault("version", 1)
         await self._send_event("policy_updated", payload, topic="policy")
+
+    async def send_rebalancing_planned(
+        self,
+        *,
+        world_id: str,
+        plan: Mapping[str, Any],
+        version: int,
+        policy: str | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "world_id": world_id,
+            "plan": dict(plan),
+            "version": version,
+        }
+        if policy:
+            payload["policy"] = policy
+        if run_id:
+            payload["run_id"] = run_id
+        await self._send_event("rebalancing.planned", payload, topic="rebalancing")
 
     async def send_deprecation_notice(self, payload: dict) -> None:
         payload.setdefault("version", 1)


### PR DESCRIPTION
## Summary
- extend the ControlBus consumer to process `rebalancing_planned` messages, dedupe them, and call an optional execution policy hook
- add WebSocket fan-out helpers and Prometheus counters/gauges for rebalancing plans and automatic execution attempts
- document the new `rebalancing.planned` WebSocket topic/metrics and cover the flow with consumer unit tests

## Testing
- pytest tests/qmtl/services/gateway/test_controlbus_consumer.py

Fixes #1424

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911034294088329adad82c1b70c7b2b)