### PR TITLE
Add venue-aware instrument constraints for rebalancing orders

### DIFF
--- a/qmtl/services/gateway/instrument_constraints.py
+++ b/qmtl/services/gateway/instrument_constraints.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+"""Venue and symbol normalization plus trading constraint resolution."""
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, MutableMapping
+
+
+__all__ = [
+    "ConstraintRule",
+    "InstrumentConstraint",
+    "ResolvedInstrument",
+    "ConstraintViolation",
+    "ConstraintViolationError",
+    "InstrumentConstraints",
+]
+
+
+@dataclass(frozen=True)
+class ConstraintRule:
+    """Configuration rule describing venue/symbol level constraints."""
+
+    venue: str | None = None
+    symbol: str | None = None
+    canonical_symbol: str | None = None
+    lot_size: float | None = None
+    min_notional: float | None = None
+    tick_size: float | None = None
+    aliases: Iterable[str] | None = None
+
+
+@dataclass(frozen=True)
+class InstrumentConstraint:
+    """Concrete trading limits for a normalized instrument."""
+
+    lot_size: float | None = None
+    min_notional: float | None = None
+    tick_size: float | None = None
+
+    def merge(self, override: "InstrumentConstraint") -> "InstrumentConstraint":
+        """Return a new constraint with ``override`` applied on top of ``self``."""
+
+        return InstrumentConstraint(
+            lot_size=override.lot_size if override.lot_size is not None else self.lot_size,
+            min_notional=
+                override.min_notional
+                if override.min_notional is not None
+                else self.min_notional,
+            tick_size=override.tick_size if override.tick_size is not None else self.tick_size,
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedInstrument:
+    """Result of resolving constraints for an input venue/symbol."""
+
+    venue: str | None
+    input_symbol: str
+    symbol: str
+    constraint: InstrumentConstraint
+
+
+@dataclass(frozen=True)
+class ConstraintViolation:
+    """Captured when an order cannot satisfy the configured constraints."""
+
+    venue: str | None
+    symbol: str
+    reason: str
+    details: Mapping[str, object] | None = None
+
+
+class ConstraintViolationError(RuntimeError):
+    """Raised when constraint violations are configured to be fatal."""
+
+    def __init__(self, violation: ConstraintViolation) -> None:
+        self.violation = violation
+        super().__init__(
+            f"Constraint violation for {violation.symbol} on {violation.venue or 'default'}: {violation.reason}"
+        )
+
+
+class InstrumentConstraints:
+    """Resolve venue/symbol pairs to canonical identifiers and limits."""
+
+    def __init__(self, rules: Iterable[ConstraintRule] | None = None) -> None:
+        self._rules: MutableMapping[tuple[str, str], tuple[str | None, InstrumentConstraint]] = {}
+        self._aliases: MutableMapping[tuple[str, str], str] = {}
+        if rules:
+            for rule in rules:
+                self.add_rule(rule)
+
+    @staticmethod
+    def _normalize_venue(value: str | None) -> str:
+        if value is None:
+            return ""
+        if value == "*":
+            return "*"
+        return value.lower()
+
+    @staticmethod
+    def _normalize_symbol(value: str | None) -> str:
+        if value is None or value == "*":
+            return "*"
+        return value.casefold()
+
+    def add_rule(self, rule: ConstraintRule) -> None:
+        """Register an additional constraint rule."""
+
+        venue_key = self._normalize_venue(rule.venue)
+        symbol_key = self._normalize_symbol(rule.symbol)
+        canonical = rule.canonical_symbol or (rule.symbol if rule.symbol not in (None, "*") else None)
+        constraint = InstrumentConstraint(
+            lot_size=rule.lot_size,
+            min_notional=rule.min_notional,
+            tick_size=rule.tick_size,
+        )
+        self._rules[(venue_key, symbol_key)] = (canonical, constraint)
+
+        # Register aliases for quick resolution.
+        if rule.aliases:
+            for alias in rule.aliases:
+                alias_key = self._normalize_symbol(alias)
+                self._aliases[(venue_key, alias_key)] = canonical or alias
+        if canonical and rule.symbol not in (None, "*"):
+            self._aliases.setdefault((venue_key, self._normalize_symbol(rule.symbol)), canonical)
+        if canonical:
+            self._aliases.setdefault(("*", self._normalize_symbol(canonical)), canonical)
+
+    def resolve(self, venue: str | None, symbol: str) -> ResolvedInstrument:
+        """Return the canonical symbol and merged constraints for ``(venue, symbol)``."""
+
+        venue_key = self._normalize_venue(venue)
+        symbol_key = self._normalize_symbol(symbol)
+        canonical = self._resolve_symbol_alias(venue_key, symbol_key) or symbol
+        lookup_key = self._normalize_symbol(canonical)
+
+        constraint = InstrumentConstraint()
+        canonical_override: str | None = None
+        for candidate in (
+            ("*", "*"),
+            ("*", lookup_key),
+            ("", "*"),
+            ("", lookup_key),
+            (venue_key, "*"),
+            (venue_key, lookup_key),
+        ):
+            rule = self._rules.get(candidate)
+            if not rule:
+                continue
+            rule_canonical, rule_constraint = rule
+            constraint = constraint.merge(rule_constraint)
+            if rule_canonical:
+                canonical_override = rule_canonical
+
+        resolved_symbol = canonical_override or canonical
+        return ResolvedInstrument(
+            venue=venue,
+            input_symbol=symbol,
+            symbol=resolved_symbol,
+            constraint=constraint,
+        )
+
+    def _resolve_symbol_alias(self, venue_key: str, symbol_key: str) -> str | None:
+        for candidate in ((venue_key, symbol_key), ("", symbol_key), ("*", symbol_key)):
+            alias = self._aliases.get(candidate)
+            if alias is not None:
+                return alias
+        return None

--- a/tests/qmtl/services/gateway/test_instrument_constraints.py
+++ b/tests/qmtl/services/gateway/test_instrument_constraints.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from qmtl.services.gateway.instrument_constraints import (
+    ConstraintRule,
+    InstrumentConstraints,
+)
+
+
+def test_constraint_resolution_merges_rules():
+    constraints = InstrumentConstraints(
+        [
+            ConstraintRule(symbol="*", min_notional=25.0),
+            ConstraintRule(venue="binance", symbol="*", lot_size=0.1),
+            ConstraintRule(
+                venue="binance",
+                symbol="BTCUSDT",
+                canonical_symbol="BTCUSDT",
+                lot_size=0.001,
+                min_notional=5.0,
+                aliases=["btc/usdt"],
+            ),
+        ]
+    )
+
+    resolved = constraints.resolve("binance", "btc/usdt")
+    assert resolved.symbol == "BTCUSDT"
+    assert resolved.constraint.lot_size == 0.001
+    assert resolved.constraint.min_notional == 5.0
+
+
+def test_constraint_resolution_falls_back_to_wildcard():
+    constraints = InstrumentConstraints(
+        [
+            ConstraintRule(symbol="*", min_notional=50.0),
+            ConstraintRule(symbol="ETHUSDT", lot_size=0.05),
+        ]
+    )
+
+    resolved = constraints.resolve("unknown", "ETHUSDT")
+    assert resolved.symbol == "ETHUSDT"
+    assert resolved.constraint.min_notional == 50.0
+    assert resolved.constraint.lot_size == 0.05

--- a/tests/qmtl/services/gateway/test_rebalancing_executor.py
+++ b/tests/qmtl/services/gateway/test_rebalancing_executor.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
+from qmtl.services.gateway.instrument_constraints import (
+    ConstraintRule,
+    InstrumentConstraints,
+    ConstraintViolationError,
+)
 from qmtl.services.gateway.rebalancing_executor import (
     OrderOptions,
     VenuePolicy,
@@ -66,6 +73,84 @@ def test_orders_drop_small_reduce_only_notional():
         ),
     )
     assert orders == []
+
+
+def test_orders_normalize_symbol_via_constraints():
+    plan = RebalancePlan(
+        world_id="w",
+        scale_world=1.0,
+        scale_by_strategy={},
+        deltas=[SymbolDelta(symbol="btc/usdt", delta_qty=1.0, venue="binance")],
+    )
+    constraints = InstrumentConstraints(
+        [
+            ConstraintRule(
+                venue="binance",
+                symbol="BTCUSDT",
+                canonical_symbol="BTCUSDT",
+                lot_size=0.1,
+                aliases=["btc/usdt"],
+            )
+        ]
+    )
+    orders = orders_from_world_plan(
+        plan,
+        options=OrderOptions(
+            instrument_constraints=constraints,
+        ),
+    )
+    assert len(orders) == 1
+    order = orders[0]
+    assert order["symbol"] == "BTCUSDT"
+    assert order["quantity"] == 1.0
+
+
+def test_orders_collect_constraint_violations():
+    plan = RebalancePlan(
+        world_id="w",
+        scale_world=1.0,
+        scale_by_strategy={},
+        deltas=[SymbolDelta(symbol="BTCUSDT", delta_qty=0.0004, venue="binance")],
+    )
+    constraints = InstrumentConstraints(
+        [ConstraintRule(venue="binance", symbol="BTCUSDT", lot_size=0.001)]
+    )
+    sink: list = []
+    orders = orders_from_world_plan(
+        plan,
+        options=OrderOptions(
+            instrument_constraints=constraints,
+            constraint_violation_sink=sink,
+        ),
+    )
+    assert orders == []
+    assert len(sink) == 1
+    violation = sink[0]
+    assert violation.reason == "lot-size"
+    assert violation.symbol == "BTCUSDT"
+
+
+def test_orders_raise_on_constraint_violation():
+    plan = RebalancePlan(
+        world_id="w",
+        scale_world=1.0,
+        scale_by_strategy={},
+        deltas=[SymbolDelta(symbol="BTCUSDT", delta_qty=0.0004, venue="binance")],
+    )
+    constraints = InstrumentConstraints(
+        [ConstraintRule(venue="binance", symbol="BTCUSDT", lot_size=0.001)]
+    )
+    with pytest.raises(ConstraintViolationError) as excinfo:
+        orders_from_world_plan(
+            plan,
+            options=OrderOptions(
+                instrument_constraints=constraints,
+                raise_on_violation=True,
+            ),
+        )
+
+    assert excinfo.value.violation.symbol == "BTCUSDT"
+    assert excinfo.value.violation.reason == "lot-size"
 
 
 def test_orders_respect_venue_policies():


### PR DESCRIPTION
## Summary
- add a reusable instrument constraint resolver that normalizes venue/symbol pairs and merges lot/min-notional/tick rules
- update the rebalancing executor to enforce normalized constraints, collect violations, and expose stricter order options
- document constraint configuration patterns in both English and Korean rebalancing guides with supporting tests

## Testing
- uv run -m pytest -W error tests/qmtl/services/gateway/test_instrument_constraints.py tests/qmtl/services/gateway/test_rebalancing_executor.py

Fixes #1425

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110cc74ee48329afb7cbd60b41c56a)