### PR TITLE
Return HTTP 501 for overlay rebalancing modes

### DIFF
--- a/qmtl/services/worldservice/routers/rebalancing.py
+++ b/qmtl/services/worldservice/routers/rebalancing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 from ..rebalancing import (
     MultiWorldProportionalRebalancer,
@@ -77,8 +77,9 @@ def create_rebalancing_router(service: WorldService) -> APIRouter:
         ]
         mode = (payload.mode or 'scaling').lower()
         if mode in ('overlay', 'hybrid'):
-            raise NotImplementedError(
-                "Overlay mode is not implemented yet. Use mode='scaling'."
+            raise HTTPException(
+                status_code=501,
+                detail="Overlay mode is not implemented yet. Use mode='scaling'.",
             )
         return MultiWorldRebalanceResponse(per_world=per_world, global_deltas=global_deltas)
 
@@ -108,8 +109,9 @@ def create_rebalancing_router(service: WorldService) -> APIRouter:
 
         mode = (payload.mode or 'scaling').lower()
         if mode in ('overlay', 'hybrid'):
-            raise NotImplementedError(
-                "Overlay mode is not implemented yet. Use mode='scaling'."
+            raise HTTPException(
+                status_code=501,
+                detail="Overlay mode is not implemented yet. Use mode='scaling'.",
             )
 
         # Persist a compact audit entry per world (and a summary)


### PR DESCRIPTION
## Summary
- return HTTP 501 from the rebalancing plan and apply endpoints when overlay or hybrid modes are requested, avoiding server errors
- add a regression test that exercises the scaling path and ensures overlay mode requests are rejected with the documented message

## Testing
- uv run -m pytest tests/qmtl/services/worldservice/test_worldservice_api.py -k "rebalancing_apply" -W error

Fixes #1427

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b5ac2eb88329810f37019450d42b)