### PR TITLE
Refactor project CLI listing into dedicated subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ uv pip install -e .[io]
 
 Create a new working directory with `qmtl project init`. The command generates a
 project scaffold containing extension packages and a sample strategy.
-Use `--strategy` to select from the built-in templates, `--list-templates` to
-see the choices and `--with-sample-data` to copy an example OHLCV CSV and
-notebook:
+Use `--strategy` to select from the built-in templates, `qmtl project
+list-presets --show-legacy-templates` to see the preset and legacy template
+options, and `--with-sample-data` to copy an example OHLCV CSV and notebook:
 
 ```bash
 qmtl project init --path my_qmtl_project
-# list available templates
-qmtl project init --list-templates
+# list available presets and legacy templates
+qmtl project list-presets --show-legacy-templates
 
 # create project with the branching template
 qmtl project init --path my_qmtl_project --strategy branching

--- a/docs/en/architecture/layered_template_system.md
+++ b/docs/en/architecture/layered_template_system.md
@@ -84,8 +84,6 @@ qmtl project
   +--- init                  # Create a new project
   |   +--- --preset          # Select a preset (fast start)
   |   +--- --layers          # Choose layers explicitly
-  |   +--- --list-presets    # Show available presets
-  |   +--- --list-layers     # Show available layers
   |   `--- --path            # Target project path
   +--- add-layer             # Add a layer to an existing project
   |   +--- <layer>           # Layer to add (positional)
@@ -94,6 +92,8 @@ qmtl project
   +--- list-layers           # Print layer and template metadata
   |   +--- --show-templates  # Display template list
   |   `--- --show-requires   # Display template dependencies
+  +--- list-presets          # Print preset descriptions
+  |   `--- --show-legacy-templates  # Include deprecated template names
   `--- validate              # Validate project structure
       `--- --path            # Project path (defaults to CWD)
 ```
@@ -104,7 +104,7 @@ qmtl project
 
 ```bash
 # Discover available presets
-qmtl project init --list-presets
+qmtl project list-presets
 
 # Minimal backtesting strategy
 qmtl project init --path my_backtest --preset minimal

--- a/docs/en/guides/layered_templates_quickstart.md
+++ b/docs/en/guides/layered_templates_quickstart.md
@@ -49,7 +49,7 @@ needed.
 
 ```bash
 # List available presets
-qmtl project init --list-presets
+qmtl project list-presets
 
 # Create a minimal project
 qmtl project init --path my_strategy --preset minimal
@@ -268,7 +268,7 @@ qmtl project init --path my_exec --layers execution
 ### 2. List available layers
 
 ```bash
-qmtl project init --list-layers
+qmtl project list-layers
 ```
 
 ### 3. Validate the project

--- a/docs/en/guides/strategy_workflow.md
+++ b/docs/en/guides/strategy_workflow.md
@@ -41,11 +41,11 @@ uv pip install -e .[dev]
 ## 1. Initialize a Project
 
 Create a dedicated directory for your strategy and generate the scaffold. List
-available templates, then initialize the project with a chosen template and
-optional sample data:
+available presets (include legacy templates if needed), then initialize the
+project with a chosen template and optional sample data:
 
 ```bash
-qmtl project init --list-templates
+qmtl project list-presets --show-legacy-templates
 qmtl project init --path my_qmtl_project --strategy branching --with-sample-data
 cd my_qmtl_project
 ```

--- a/docs/en/reference/templates.md
+++ b/docs/en/reference/templates.md
@@ -17,7 +17,7 @@ For a step-by-step introduction and a minimal working example, see the
 List them with:
 
 ```bash
-qmtl project init --list-templates
+qmtl project list-presets --show-legacy-templates
 ```
 
 Add sample data and an analysis notebook with `--with-sample-data`:

--- a/docs/ko/architecture/layered_template_system.md
+++ b/docs/ko/architecture/layered_template_system.md
@@ -81,8 +81,6 @@ qmtl project
   ├── init                  # 새 프로젝트 생성
   │   ├── --preset          # 프리셋 선택 (빠른 시작)
   │   ├── --layers          # 레이어 직접 선택
-  │   ├── --list-presets    # 사용 가능한 프리셋 목록
-  │   ├── --list-layers     # 사용 가능한 레이어 목록
   │   └── --path            # 프로젝트 경로
   ├── add-layer             # 기존 프로젝트에 레이어 추가
   │   ├── <layer>           # 추가할 레이어 (위치 인자)
@@ -91,6 +89,8 @@ qmtl project
   ├── list-layers           # 레이어 및 템플릿 메타데이터 출력
   │   ├── --show-templates  # 템플릿 목록 표시
   │   └── --show-requires   # 템플릿 의존 패키지 표시
+  ├── list-presets          # 프리셋 설명 출력
+  │   └── --show-legacy-templates  # 폐기 예정 템플릿 이름 포함
   └── validate              # 프로젝트 구조 검증
       └── --path            # 검증할 프로젝트 경로 (기본값: 현재 디렉터리)
 ```
@@ -101,7 +101,7 @@ qmtl project
 
 ```bash
 # 사용 가능한 프리셋 확인
-qmtl project init --list-presets
+qmtl project list-presets
 
 # 간단한 백테스팅 전략
 qmtl project init --path my_backtest --preset minimal

--- a/docs/ko/guides/layered_templates_quickstart.md
+++ b/docs/ko/guides/layered_templates_quickstart.md
@@ -46,7 +46,7 @@ last_modified: 2025-10-18
 
 ```bash
 # 사용 가능한 프리셋 확인
-qmtl project init --list-presets
+qmtl project list-presets
 
 # 최소 구성으로 프로젝트 생성
 qmtl project init --path my_strategy --preset minimal
@@ -265,7 +265,7 @@ qmtl project init --path my_exec --layers execution
 ### 2. 사용 가능한 레이어 확인
 
 ```bash
-qmtl project init --list-layers
+qmtl project list-layers
 ```
 
 ### 3. 프로젝트 검증

--- a/docs/ko/guides/strategy_workflow.md
+++ b/docs/ko/guides/strategy_workflow.md
@@ -39,11 +39,12 @@ uv pip install -e .[dev]
 
 ## 1. 프로젝트 초기화
 
-전략을 위한 디렉터리를 만들고 스캐폴드를 생성합니다. 사용 가능한 템플릿을 조회한 후,
-선택한 템플릿과 선택적 샘플 데이터를 사용해 프로젝트를 초기화합니다:
+전략을 위한 디렉터리를 만들고 스캐폴드를 생성합니다. 사용 가능한 프리셋(필요하면 레거시
+템플릿 포함)을 조회한 후, 선택한 템플릿과 선택적 샘플 데이터를 사용해 프로젝트를
+초기화합니다:
 
 ```bash
-qmtl project init --list-templates
+qmtl project list-presets --show-legacy-templates
 qmtl project init --path my_qmtl_project --strategy branching --with-sample-data
 cd my_qmtl_project
 ```

--- a/docs/ko/reference/templates.md
+++ b/docs/ko/reference/templates.md
@@ -17,7 +17,7 @@ last_modified: 2025-08-21
 사용 가능한 템플릿 목록 보기:
 
 ```bash
-qmtl project init --list-templates
+qmtl project list-presets --show-legacy-templates
 ```
 
 `--with-sample-data` 옵션으로 샘플 데이터와 분석 노트북을 함께 추가할 수 있습니다:

--- a/qmtl/interfaces/cli/init.py
+++ b/qmtl/interfaces/cli/init.py
@@ -6,14 +6,7 @@ from pathlib import Path
 from typing import List
 from qmtl.utils.i18n import _
 
-from ..scaffold import (
-    TEMPLATES,
-    copy_docs,
-    copy_pyproject,
-    copy_sample_data,
-    copy_scripts,
-    create_project,
-)
+from ..scaffold import copy_docs, copy_pyproject, copy_sample_data, copy_scripts, create_project
 from ..layers import Layer, LayerComposer, PresetLoader, LayerValidator
 from ..config_templates import available_profiles
 
@@ -43,12 +36,12 @@ def run(argv: List[str] | None = None) -> None:
     parser.add_argument(
         "--list-presets",
         action="store_true",
-        help=_("List available presets and exit"),
+        help=_("(Deprecated: use 'qmtl project list-presets') List available presets and exit"),
     )
     parser.add_argument(
         "--list-layers",
         action="store_true",
-        help=_("List available layers and exit"),
+        help=_("(Deprecated: use 'qmtl project list-layers') List available layers and exit"),
     )
 
     # Legacy options (deprecated)
@@ -86,25 +79,32 @@ def run(argv: List[str] | None = None) -> None:
     composer = LayerComposer()
     validator = LayerValidator()
 
-    # Handle list commands
-    if args.list_presets or args.list_templates:
-        if args.list_templates:
-            print(_("Warning: --list-templates is deprecated, use --list-presets instead"), file=sys.stderr)
-            print(_("Available templates:"))
-            for template_name in sorted(TEMPLATES):
-                print(template_name)
-        if args.list_presets:
-            print(_("Available presets:"))
-        for preset_name in preset_loader.list_presets():
-            preset = preset_loader.get_preset(preset_name)
-            if preset:
-                print(_("  {name:15} - {desc}").format(name=preset_name, desc=preset.description))
+    # Handle list commands via dedicated subcommands
+    if args.list_templates:
+        print(_("Warning: --list-templates is deprecated, use --list-presets instead"), file=sys.stderr)
+        from . import presets as presets_cli  # Local import to avoid circular dependency
+
+        presets_cli.run(["--show-legacy-templates"])
+        return
+
+    if args.list_presets:
+        print(
+            _("Warning: --list-presets is deprecated, use 'qmtl project list-presets'"),
+            file=sys.stderr,
+        )
+        from . import presets as presets_cli  # Local import to avoid circular dependency
+
+        presets_cli.run([])
         return
 
     if args.list_layers:
-        print(_("Available layers:"))
-        for layer in Layer:
-            print(_("  {value:15} - {name}").format(value=layer.value, name=layer.name))
+        print(
+            _("Warning: --list-layers is deprecated, use 'qmtl project list-layers'"),
+            file=sys.stderr,
+        )
+        from . import list_layers as list_layers_cli  # Local import to avoid circular dependency
+
+        list_layers_cli.run([])
         return
 
     # Check that --path is provided for actual project creation

--- a/qmtl/interfaces/cli/presets.py
+++ b/qmtl/interfaces/cli/presets.py
@@ -1,0 +1,47 @@
+"""List available project presets."""
+
+from __future__ import annotations
+
+import argparse
+
+from qmtl.utils.i18n import _
+
+from ..layers import PresetLoader
+from ..scaffold import TEMPLATES
+
+
+def run(argv: list[str] | None = None) -> None:
+    """Entry point for the ``list-presets`` subcommand."""
+
+    parser = argparse.ArgumentParser(
+        prog="qmtl project list-presets",
+        description=_("List available presets for layered project scaffolds"),
+    )
+    parser.add_argument(
+        "--show-legacy-templates",
+        action="store_true",
+        help=_("Include deprecated template names (from qmtl.interfaces.scaffold.TEMPLATES)"),
+    )
+    args = parser.parse_args(argv)
+
+    loader = PresetLoader()
+    print(_("Available presets:"))
+    for preset_name in loader.list_presets():
+        preset = loader.get_preset(preset_name)
+        if not preset:
+            continue
+        print(
+            _("  {name:15} - {desc}").format(
+                name=preset_name,
+                desc=preset.description,
+            )
+        )
+
+    if args.show_legacy_templates:
+        print(_("\nAvailable legacy templates:"))
+        for template_name in sorted(TEMPLATES):
+            print(template_name)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/qmtl/interfaces/cli/project.py
+++ b/qmtl/interfaces/cli/project.py
@@ -11,6 +11,7 @@ PROJECT_DISPATCH = {
     "init": "qmtl.interfaces.cli.init",
     "add-layer": "qmtl.interfaces.cli.add_layer",
     "list-layers": "qmtl.interfaces.cli.list_layers",
+    "list-presets": "qmtl.interfaces.cli.presets",
     "validate": "qmtl.interfaces.cli.validate",
 }
 
@@ -23,10 +24,11 @@ def _build_help_parser() -> argparse.ArgumentParser:
             Project scaffolding utilities.
 
             Available commands:
-              init         Create a new strategy project from templates or presets.
-              add-layer    Add a layer to an existing project.
-              list-layers  List available layers and metadata.
-              validate     Validate an existing layered project.
+              init          Create a new strategy project from templates or presets.
+              add-layer     Add a layer to an existing project.
+              list-layers   List available layers and metadata.
+              list-presets  List available presets (and optional legacy templates).
+              validate      Validate an existing layered project.
             """
         )
     ).strip()

--- a/qmtl/locale/ko/LC_MESSAGES/qmtl.po
+++ b/qmtl/locale/ko/LC_MESSAGES/qmtl.po
@@ -85,19 +85,21 @@ msgid """
             Project scaffolding utilities.
 
             Available commands:
-              init         Create a new strategy project from templates or presets.
-              add-layer    Add a layer to an existing project.
-              list-layers  List available layers and metadata.
-              validate     Validate an existing layered project.
+              init          Create a new strategy project from templates or presets.
+              add-layer     Add a layer to an existing project.
+              list-layers   List available layers and metadata.
+              list-presets  List available presets (and optional legacy templates).
+              validate      Validate an existing layered project.
             """
 msgstr """
             프로젝트 스캐폴딩 유틸리티.
 
             사용 가능한 명령:
-              init         템플릿 또는 프리셋으로 새 프로젝트를 생성합니다.
-              add-layer    기존 프로젝트에 레이어를 추가합니다.
-              list-layers  사용 가능한 레이어와 메타데이터를 표시합니다.
-              validate     기존 레이어드 프로젝트를 검증합니다.
+              init          템플릿 또는 프리셋으로 새 프로젝트를 생성합니다.
+              add-layer     기존 프로젝트에 레이어를 추가합니다.
+              list-layers   사용 가능한 레이어와 메타데이터를 표시합니다.
+              list-presets  사용 가능한 프리셋(및 선택적 레거시 템플릿)을 표시합니다.
+              validate      기존 레이어드 프로젝트를 검증합니다.
             """
 
 # init.py options
@@ -116,11 +118,11 @@ msgstr "사용할 프리셋 구성 (docs/architecture/layered_template_system.md
 msgid "Comma-separated list of layers to include (e.g., data,signal)"
 msgstr "포함할 레이어의 쉼표-구분 목록 (예: data,signal)"
 
-msgid "List available presets and exit"
-msgstr "사용 가능한 프리셋을 표시하고 종료"
+msgid "(Deprecated: use 'qmtl project list-presets') List available presets and exit"
+msgstr "(폐기 예정: 'qmtl project list-presets' 사용) 사용 가능한 프리셋을 표시하고 종료"
 
-msgid "List available layers and exit"
-msgstr "사용 가능한 레이어를 표시하고 종료"
+msgid "(Deprecated: use 'qmtl project list-layers') List available layers and exit"
+msgstr "(폐기 예정: 'qmtl project list-layers' 사용) 사용 가능한 레이어를 표시하고 종료"
 
 msgid "(Deprecated: use --preset) Strategy template to use"
 msgstr "(폐기 예정: --preset 사용) 사용할 전략 템플릿"
@@ -148,6 +150,21 @@ msgstr "qmtl.yml에 사용할 구성 템플릿 선택"
 
 msgid "Warning: --list-templates is deprecated, use --list-presets instead"
 msgstr "경고: --list-templates는 폐기 예정입니다. 대신 --list-presets를 사용하세요."
+
+msgid "Warning: --list-presets is deprecated, use 'qmtl project list-presets'"
+msgstr "경고: --list-presets는 폐기 예정입니다. 'qmtl project list-presets'를 사용하세요."
+
+msgid "Warning: --list-layers is deprecated, use 'qmtl project list-layers'"
+msgstr "경고: --list-layers는 폐기 예정입니다. 'qmtl project list-layers'를 사용하세요."
+
+msgid "List available presets for layered project scaffolds"
+msgstr "레이어드 프로젝트 스캐폴드를 위한 사용 가능한 프리셋을 표시"
+
+msgid "Include deprecated template names (from qmtl.interfaces.scaffold.TEMPLATES)"
+msgstr "폐기 예정 템플릿 이름 포함 (qmtl.interfaces.scaffold.TEMPLATES)"
+
+msgid "Available legacy templates:"
+msgstr "사용 가능한 레거시 템플릿:"
 
 msgid "Available templates:"
 msgstr "사용 가능한 템플릿:"

--- a/tests/qmtl/interfaces/cli/test_cli_init.py
+++ b/tests/qmtl/interfaces/cli/test_cli_init.py
@@ -21,11 +21,30 @@ def test_cli_init_with_template(tmp_path):
     assert "BranchingStrategy" in contents
 
 
-def test_cli_list_templates(capsys):
-    init_cli.run(["--list-templates", "--path", "foo"])
-    out = capsys.readouterr().out.strip().splitlines()
-    assert "branching" in out
-    assert "general" in out
+def test_cli_list_presets_shim(monkeypatch):
+    captured: dict[str, list[str] | None] = {}
+
+    def fake_run(argv=None):
+        captured["argv"] = argv
+
+    monkeypatch.setattr("qmtl.interfaces.cli.presets.run", fake_run)
+
+    init_cli.run(["--list-presets"])
+
+    assert captured["argv"] == []
+
+
+def test_cli_list_templates_shim(monkeypatch):
+    captured: dict[str, list[str] | None] = {}
+
+    def fake_run(argv=None):
+        captured["argv"] = argv
+
+    monkeypatch.setattr("qmtl.interfaces.cli.presets.run", fake_run)
+
+    init_cli.run(["--list-templates"])
+
+    assert captured["argv"] == ["--show-legacy-templates"]
 
 
 def test_cli_help_contains_doc_links(capsys):


### PR DESCRIPTION
## Summary
- add a standalone `qmtl project list-presets` entry point and route deprecated init flags through it
- update project CLI help/docs to highlight the new list-presets command and remove list handlers from init
- refresh CLI tests and Korean/English docs to reference the new subcommands

## Testing
- uv run -m pytest -W error tests/qmtl/interfaces/cli/test_cli_init.py tests/qmtl/interfaces/scaffold/test_init.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142d10cadc8329b11ddb19b9ebe08e)