### PR TITLE
Fix shared-account policy HTTP status compatibility

### DIFF
--- a/qmtl/services/gateway/routes/rebalancing.py
+++ b/qmtl/services/gateway/routes/rebalancing.py
@@ -9,6 +9,12 @@ from typing import Any, Dict, Iterable, List, Mapping, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
+
+if hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
+    HTTP_422_UNPROCESSABLE = status.HTTP_422_UNPROCESSABLE_CONTENT
+else:
+    HTTP_422_UNPROCESSABLE = status.HTTP_422_UNPROCESSABLE_ENTITY
+
 from .. import metrics as gw_metrics
 from ..database import Database
 from ..rebalancing_executor import (
@@ -153,7 +159,7 @@ def create_router(deps: GatewayDependencyProvider) -> APIRouter:
             if not evaluation.allowed:
                 message = evaluation.reason or "shared-account policy rejected execution"
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    status_code=HTTP_422_UNPROCESSABLE,
                     detail={
                         "code": "E_SHARED_ACCOUNT_POLICY",
                         "message": message,


### PR DESCRIPTION
## Summary
- use the HTTP 422 status constant that exists in the running Starlette version
- raise shared-account policy violations with the compatibility constant to avoid AttributeError in older gateways

## Testing
- uv run -m pytest tests/qmtl/services/gateway/test_rebalancing_route.py::test_rebalancing_shared_account_policy_violation -q

Fixes #1503

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158142130c8329979dbd94a65ea793)