### PR TITLE
Refactor NodeSetRecipe compose into helper methods

### DIFF
--- a/tests/qmtl/runtime/nodesets/test_recipes.py
+++ b/tests/qmtl/runtime/nodesets/test_recipes.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from qmtl.runtime.nodesets.recipes import NodeSetRecipe
+from qmtl.runtime.nodesets.steps import StepSpec
+from qmtl.runtime.pipeline.execution_nodes import SizingNode as RealSizingNode
+
+
+def test_merge_step_overrides_handles_default_spec():
+    recipe = NodeSetRecipe(
+        name="defaults",
+        steps={"sizing": StepSpec.from_factory(RealSizingNode, inject_portfolio=True)},
+    )
+
+    resolved = recipe._merge_step_overrides({"sizing": StepSpec.default()})
+
+    assert "sizing" not in resolved
+
+
+def test_merge_step_overrides_accepts_explicit_override():
+    recipe = NodeSetRecipe(name="explicit")
+    sizing_override = StepSpec.from_factory(RealSizingNode, inject_portfolio=True)
+
+    resolved = recipe._merge_step_overrides({"sizing": sizing_override})
+
+    assert resolved["sizing"] is sizing_override
+
+
+def test_apply_legacy_components_passthrough_function():
+    recipe = NodeSetRecipe(name="legacy")
+
+    def legacy_factory(upstream, ctx):  # pragma: no cover - signature inspected only
+        return upstream
+
+    resolved, passthrough = recipe._apply_legacy_components({}, {"sizing": legacy_factory})
+
+    assert resolved == {}
+    assert passthrough["sizing"] is legacy_factory
+
+
+def test_build_attach_kwargs_prefers_resolved_steps():
+    recipe = NodeSetRecipe(name="attach")
+    step_spec = StepSpec.from_factory(RealSizingNode, inject_portfolio=True)
+    legacy_factory = lambda upstream, ctx: upstream  # noqa: E731 - simple passthrough for test
+
+    kwargs = recipe._build_attach_kwargs(
+        {"sizing": step_spec}, {"sizing": legacy_factory}
+    )
+
+    assert kwargs["sizing"] is step_spec


### PR DESCRIPTION
## Summary
- extract helper methods that handle step overrides, legacy components, and attach kwargs inside `NodeSetRecipe`
- update `NodeSetRecipe.compose` to orchestrate helpers before attaching builders
- add focused unit tests for the new helpers covering defaults, overrides, and legacy passthrough inputs

## Testing
- uv run -m pytest tests/qmtl/runtime/nodesets/test_recipes.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915963404bc8329816c7134b93fd757)