### PR TITLE
Log radon metrics snapshot for 2025-11-14

### DIFF
--- a/docs/en/architecture/metrics/2025-11-14.md
+++ b/docs/en/architecture/metrics/2025-11-14.md
@@ -1,0 +1,23 @@
+# Radon Metrics Snapshot — 2025-11-14
+
+## Cyclomatic Complexity (CC)
+
+| File | Notable Blocks |
+| --- | --- |
+| `qmtl/runtime/sdk/trade_dispatcher.py` | `TradeOrderDispatcher.dispatch` — C (20) |
+| `qmtl/services/dagmanager/server.py` | `_KafkaAdminClient.list_topics` — D (21); `_KafkaAdminClient.create_topic` — C (11) |
+| `qmtl/services/gateway/submission/diff_executor.py` | `DiffExecutor.run` — C (18) |
+
+## Maintainability Index (MI)
+
+| File | MI Grade (Score) |
+| --- | --- |
+| `qmtl/runtime/nodesets/recipes.py` | B (18.28) |
+| `qmtl/foundation/config_validation.py` | B (18.83) |
+| `qmtl/services/worldservice/storage/persistent.py` | B (13.39) |
+| `qmtl/services/gateway/tests/test_strategy_submission_helper.py` | B (17.45) |
+
+> Reference commands:
+> - `uv run --with radon -m radon cc -s qmtl/runtime/sdk/trade_dispatcher.py qmtl/services/dagmanager/server.py qmtl/services/gateway/submission/diff_executor.py`
+> - Per-file `uv run --with radon -m radon mi -s <file>`
+

--- a/docs/ko/architecture/metrics/2025-11-14.md
+++ b/docs/ko/architecture/metrics/2025-11-14.md
@@ -1,0 +1,23 @@
+# 2025-11-14 라돈 지표 스냅샷
+
+## 순환 복잡도 (CC)
+
+| 파일 | 주목할 블록 |
+| --- | --- |
+| `qmtl/runtime/sdk/trade_dispatcher.py` | `TradeOrderDispatcher.dispatch` — C (20) |
+| `qmtl/services/dagmanager/server.py` | `_KafkaAdminClient.list_topics` — D (21); `_KafkaAdminClient.create_topic` — C (11) |
+| `qmtl/services/gateway/submission/diff_executor.py` | `DiffExecutor.run` — C (18) |
+
+## 유지보수 지수 (MI)
+
+| 파일 | MI 등급 (점수) |
+| --- | --- |
+| `qmtl/runtime/nodesets/recipes.py` | B (18.28) |
+| `qmtl/foundation/config_validation.py` | B (18.83) |
+| `qmtl/services/worldservice/storage/persistent.py` | B (13.39) |
+| `qmtl/services/gateway/tests/test_strategy_submission_helper.py` | B (17.45) |
+
+> 기준 명령:
+> - `uv run --with radon -m radon cc -s qmtl/runtime/sdk/trade_dispatcher.py qmtl/services/dagmanager/server.py qmtl/services/gateway/submission/diff_executor.py`
+> - 각 파일별 `uv run --with radon -m radon mi -s <file>`
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Seamless Data Provider Radon Plan: architecture/radon_seamless_data.md
       - History Warmup Radon Plan: architecture/radon_history_warmup.md
       - Runtime SDK Radon Plan: architecture/radon_runtime_sdk.md
+      - Radon Metrics Snapshot (2025-11-14): architecture/metrics/2025-11-14.md
   - Guides:
       - Overview: guides/README.md
       - Layered Templates Quick Start: guides/layered_templates_quickstart.md
@@ -153,6 +154,7 @@ plugins:
             "Seamless Data Provider Radon Plan": "Seamless Data Provider Radon 계획"
             "History Warmup Radon Plan": "History Warmup Radon 계획"
             "Runtime SDK Radon Plan": "런타임 SDK Radon 계획"
+            "Radon Metrics Snapshot (2025-11-14)": "라돈 지표 스냅샷 (2025-11-14)"
             "Layered Templates Quick Start": "레이어 기반 템플릿 퀵스타트"
             "Seamless Data Provider Setup": "심리스 데이터 프로바이더 구성"
             "Testing & Pytest": "테스트 & Pytest"


### PR DESCRIPTION
## Summary
- record the 2025-11-14 radon CC and MI readings in localized architecture metrics docs
- expose the new snapshot page in the MkDocs navigation for quick reference

## Testing
- uv run mkdocs build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916f3b37a0c8329bbbdccab8b6f5e98)