### PR TITLE
Refactor diff executor strategies and add CRC coverage

### DIFF
--- a/qmtl/services/gateway/strategy_submission.py
+++ b/qmtl/services/gateway/strategy_submission.py
@@ -217,7 +217,7 @@ class StrategySubmissionHelper:
     ) -> DiffOutcome:
         dag_json = json.dumps(dag)
         try:
-            sentinel_id, queue_map = await self._pipeline.run_diff(
+            outcome = await self._pipeline.run_diff(
                 strategy_id=diff_strategy_id,
                 dag_json=dag_json,
                 worlds=worlds,
@@ -228,8 +228,8 @@ class StrategySubmissionHelper:
                 expected_crc32=node_crc32,
             )
             return DiffOutcome(
-                sentinel_id=sentinel_id,
-                queue_map=queue_map,
+                sentinel_id=outcome.sentinel_id,
+                queue_map=outcome.queue_map,
                 error=False,
             )
         except Exception:

--- a/qmtl/services/gateway/submission/diff_executor.py
+++ b/qmtl/services/gateway/submission/diff_executor.py
@@ -3,7 +3,129 @@ from __future__ import annotations
 """Async wrapper for invoking DAG Manager diff operations."""
 
 import asyncio
-from typing import Any, Iterable
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Iterable, Protocol
+
+
+@dataclass(slots=True)
+class DiffOutcome:
+    """Normalized diff response containing sentinel and queue bindings."""
+
+    sentinel_id: str | None
+    queue_map: dict[str, list[dict[str, Any]]] | None
+
+
+def ensure_crc(chunk, expected_crc32: int | None) -> None:
+    """Validate that a diff chunk satisfies the negotiated CRC handshake."""
+
+    if expected_crc32 is None or chunk is None:
+        return
+    has_field = getattr(chunk, "HasField", None)
+    if callable(has_field) and not chunk.HasField("crc32"):
+        raise ValueError("diff chunk missing CRC32 handshake")
+    crc = getattr(chunk, "crc32", None)
+    if crc is None:
+        raise ValueError("diff chunk missing CRC32 handshake")
+    if int(crc) != expected_crc32:
+        raise ValueError("diff chunk CRC32 mismatch")
+
+
+class DiffRunStrategy(Protocol):
+    """Strategy protocol for running DAG diff operations."""
+
+    async def execute(self) -> DiffOutcome:
+        """Execute the diff run and normalize the outcome."""
+
+
+InvokeDiff = Callable[[str | None], Awaitable[Any]]
+
+
+class QueueMapAggregationStrategy:
+    """Aggregate queue map bindings across multiple worlds."""
+
+    def __init__(
+        self,
+        *,
+        worlds: Iterable[str],
+        invoke: InvokeDiff,
+        expected_crc32: int | None,
+        node_id_resolver: Callable[[str], str],
+    ) -> None:
+        self._worlds = list(worlds)
+        self._invoke = invoke
+        self._expected_crc32 = expected_crc32
+        self._node_id_resolver = node_id_resolver
+
+    async def execute(self) -> DiffOutcome:
+        tasks = [self._invoke(world_id) for world_id in self._worlds]
+        chunks = await asyncio.gather(*tasks, return_exceptions=True)
+
+        sentinel_id: str | None = None
+        queue_map: dict[str, list[dict[str, Any]]] = {}
+
+        for chunk in chunks:
+            if isinstance(chunk, Exception) or chunk is None:
+                continue
+            ensure_crc(chunk, self._expected_crc32)
+            if not sentinel_id:
+                sentinel_id = getattr(chunk, "sentinel_id", None)
+            for key, topic in dict(getattr(chunk, "queue_map", {})).items():
+                node_id = self._node_id_resolver(str(key))
+                entries = queue_map.setdefault(node_id, [])
+                if topic not in [d.get("queue") for d in entries]:
+                    entries.append({"queue": topic, "global": False})
+
+        return DiffOutcome(sentinel_id=sentinel_id, queue_map=queue_map)
+
+
+class SingleWorldStrategy:
+    """Execute a diff for a single world and normalize the outcome."""
+
+    def __init__(
+        self,
+        *,
+        worlds: list[str],
+        fallback_world_id: str | None,
+        invoke: InvokeDiff,
+        expected_crc32: int | None,
+        timeout: float,
+        prefer_queue_map: bool,
+        node_id_resolver: Callable[[str], str],
+    ) -> None:
+        self._worlds = worlds
+        self._fallback_world_id = fallback_world_id
+        self._invoke = invoke
+        self._expected_crc32 = expected_crc32
+        self._timeout = timeout
+        self._prefer_queue_map = prefer_queue_map
+        self._node_id_resolver = node_id_resolver
+
+    async def execute(self) -> DiffOutcome:
+        sentinel_id: str | None = None
+        queue_map: dict[str, list[dict[str, Any]]] | None = None
+
+        world = self._worlds[0] if self._worlds else self._fallback_world_id
+        if world is None and self._prefer_queue_map and not self._worlds:
+            queue_map = {}
+
+        chunk = await asyncio.wait_for(
+            self._invoke(world), timeout=self._timeout
+        )
+        if chunk is None:
+            return DiffOutcome(sentinel_id=sentinel_id, queue_map=queue_map)
+
+        ensure_crc(chunk, self._expected_crc32)
+
+        sentinel_id = getattr(chunk, "sentinel_id", None)
+        if self._prefer_queue_map:
+            queue_map = {}
+            for key, topic in dict(getattr(chunk, "queue_map", {})).items():
+                node_id = self._node_id_resolver(str(key))
+                queue_map.setdefault(node_id, []).append(
+                    {"queue": topic, "global": False}
+                )
+
+        return DiffOutcome(sentinel_id=sentinel_id, queue_map=queue_map)
 
 
 class DiffExecutor:
@@ -23,7 +145,7 @@ class DiffExecutor:
         timeout: float,
         prefer_queue_map: bool,
         expected_crc32: int | None = None,
-    ) -> tuple[str | None, dict[str, list[dict[str, Any]]] | None]:
+    ) -> DiffOutcome:
         diff_kwargs = compute_ctx.diff_kwargs()
 
         async def _invoke(world: str | None):
@@ -34,58 +156,25 @@ class DiffExecutor:
                 **diff_kwargs,
             )
 
-        sentinel_id: str | None = None
-        queue_map: dict[str, list[dict[str, Any]]] | None = None
-
-        def _ensure_crc(chunk) -> None:
-            if expected_crc32 is None or chunk is None:
-                return
-            has_field = getattr(chunk, "HasField", None)
-            if callable(has_field):
-                if not chunk.HasField("crc32"):
-                    raise ValueError("diff chunk missing CRC32 handshake")
-            crc = getattr(chunk, "crc32", None)
-            if crc is None:
-                raise ValueError("diff chunk missing CRC32 handshake")
-            if int(crc) != expected_crc32:
-                raise ValueError("diff chunk CRC32 mismatch")
-
         if prefer_queue_map and len(worlds) > 1:
-            tasks = [_invoke(world_id) for world_id in worlds]
-            chunks = await asyncio.gather(*tasks, return_exceptions=True)
-            queue_map = {}
-            for chunk in chunks:
-                if isinstance(chunk, Exception) or chunk is None:
-                    continue
-                _ensure_crc(chunk)
-                if not sentinel_id:
-                    sentinel_id = getattr(chunk, "sentinel_id", None)
-                for key, topic in dict(getattr(chunk, "queue_map", {})).items():
-                    node_id = self._node_id_from_partition_key(str(key))
-                    lst = queue_map.setdefault(node_id, [])
-                    if topic not in [d.get("queue") for d in lst]:
-                        lst.append({"queue": topic, "global": False})
-            return sentinel_id, queue_map
+            strategy: DiffRunStrategy = QueueMapAggregationStrategy(
+                worlds=worlds,
+                invoke=_invoke,
+                expected_crc32=expected_crc32,
+                node_id_resolver=self._node_id_from_partition_key,
+            )
+        else:
+            strategy = SingleWorldStrategy(
+                worlds=worlds,
+                fallback_world_id=fallback_world_id,
+                invoke=_invoke,
+                expected_crc32=expected_crc32,
+                timeout=timeout,
+                prefer_queue_map=prefer_queue_map,
+                node_id_resolver=self._node_id_from_partition_key,
+            )
 
-        world = worlds[0] if worlds else fallback_world_id
-        if world is None and prefer_queue_map and not worlds:
-            queue_map = {}
-
-        chunk = await asyncio.wait_for(_invoke(world), timeout=timeout)
-        if chunk is None:
-            return sentinel_id, queue_map
-        _ensure_crc(chunk)
-
-        sentinel_id = getattr(chunk, "sentinel_id", None)
-        if prefer_queue_map:
-            queue_map = {}
-            for key, topic in dict(getattr(chunk, "queue_map", {})).items():
-                node_id = self._node_id_from_partition_key(str(key))
-                queue_map.setdefault(node_id, []).append(
-                    {"queue": topic, "global": False}
-                )
-
-        return sentinel_id, queue_map
+        return await strategy.execute()
 
     def _node_id_from_partition_key(self, identifier: str) -> str:
         base, _, _ = identifier.partition("#")

--- a/qmtl/services/gateway/submission/pipeline.py
+++ b/qmtl/services/gateway/submission/pipeline.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, List
 
 from .context_service import ComputeContextService, StrategyComputeContext
 from .dag_loader import DagLoader
-from .diff_executor import DiffExecutor
+from .diff_executor import DiffExecutor, DiffOutcome
 from .node_identity import NodeIdentityValidator
 from .queue_map_resolver import QueueMapResolver
 
@@ -79,7 +79,7 @@ class SubmissionPipeline:
         timeout: float,
         prefer_queue_map: bool,
         expected_crc32: int | None = None,
-    ) -> tuple[str | None, dict[str, list[dict[str, Any]]] | None]:
+    ) -> DiffOutcome:
         return await self._diff_executor.run(
             strategy_id=strategy_id,
             dag_json=dag_json,

--- a/tests/qmtl/services/gateway/submission/test_diff_executor.py
+++ b/tests/qmtl/services/gateway/submission/test_diff_executor.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from qmtl.services.gateway.submission.diff_executor import (
+    DiffExecutor,
+    DiffOutcome,
+)
+
+
+class _ComputeContext:
+    def __init__(self, **kwargs: Any) -> None:
+        self._kwargs = kwargs
+
+    def diff_kwargs(self) -> dict[str, Any]:
+        return dict(self._kwargs)
+
+
+class _Chunk:
+    def __init__(
+        self,
+        *,
+        sentinel_id: str | None,
+        queue_map: dict[str, str] | None,
+        crc32: int | None,
+    ) -> None:
+        self.sentinel_id = sentinel_id
+        self.queue_map = queue_map or {}
+        self.crc32 = crc32
+
+    def HasField(self, field: str) -> bool:  # pragma: no cover - API shim
+        return getattr(self, field, None) is not None
+
+
+@pytest.mark.asyncio
+async def test_queue_map_strategy_aggregates_unique_bindings() -> None:
+    dagmanager = AsyncMock()
+    ctx = _ComputeContext(foo="bar")
+
+    chunk_primary = _Chunk(
+        sentinel_id="sent-1",
+        queue_map={"nodeA:sub#1": "queue-A", "nodeA:sub#2": "queue-A"},
+        crc32=1234,
+    )
+    chunk_secondary = _Chunk(
+        sentinel_id=None,
+        queue_map={"nodeB#0": "queue-B"},
+        crc32=1234,
+    )
+
+    async def diff_side_effect(strategy_id, dag_json, *, world_id, **kwargs):
+        assert kwargs == {"foo": "bar"}
+        if world_id == "w1":
+            return chunk_primary
+        if world_id == "w2":
+            return chunk_secondary
+        return None
+
+    dagmanager.diff.side_effect = diff_side_effect
+
+    executor = DiffExecutor(dagmanager)
+    outcome = await executor.run(
+        strategy_id="strat",
+        dag_json="{}",
+        worlds=["w1", "w2"],
+        fallback_world_id=None,
+        compute_ctx=ctx,
+        timeout=1.0,
+        prefer_queue_map=True,
+        expected_crc32=1234,
+    )
+
+    assert outcome == DiffOutcome(
+        sentinel_id="sent-1",
+        queue_map={
+            "nodeA": [{"queue": "queue-A", "global": False}],
+            "nodeB": [{"queue": "queue-B", "global": False}],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_world_strategy_returns_sentinel_and_queue_map() -> None:
+    dagmanager = AsyncMock()
+    ctx = _ComputeContext()
+
+    dagmanager.diff.return_value = _Chunk(
+        sentinel_id="sent-2",
+        queue_map={"nodeC#0": "queue-C"},
+        crc32=555,
+    )
+
+    executor = DiffExecutor(dagmanager)
+    outcome = await executor.run(
+        strategy_id="strat",
+        dag_json="{}",
+        worlds=["w1"],
+        fallback_world_id="fallback",
+        compute_ctx=ctx,
+        timeout=1.0,
+        prefer_queue_map=True,
+        expected_crc32=555,
+    )
+
+    assert outcome == DiffOutcome(
+        sentinel_id="sent-2",
+        queue_map={"nodeC": [{"queue": "queue-C", "global": False}]},
+    )
+
+    dagmanager.diff.assert_awaited_once()
+    _args, kwargs = dagmanager.diff.await_args
+    assert kwargs["world_id"] == "w1"
+
+
+@pytest.mark.asyncio
+async def test_raises_on_crc_mismatch() -> None:
+    dagmanager = AsyncMock()
+    ctx = _ComputeContext()
+    dagmanager.diff.return_value = _Chunk(
+        sentinel_id="sent-3",
+        queue_map={},
+        crc32=1,
+    )
+
+    executor = DiffExecutor(dagmanager)
+    with pytest.raises(ValueError, match="CRC32 mismatch"):
+        await executor.run(
+            strategy_id="strat",
+            dag_json="{}",
+            worlds=["w1"],
+            fallback_world_id=None,
+            compute_ctx=ctx,
+            timeout=1.0,
+            prefer_queue_map=False,
+            expected_crc32=2,
+        )


### PR DESCRIPTION
## Summary
- introduce a strategy-driven diff executor with a shared DiffOutcome dataclass and CRC helper
- update the submission pipeline and strategy submission helper to consume the new outcome type
- add focused tests for diff executor strategies alongside the adjusted pipeline test

## Testing
- uv run -m pytest -W error -n auto tests/qmtl/services/gateway/submission/test_diff_executor.py tests/qmtl/services/gateway/test_submission_pipeline.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691809e7e7b483298453adcf583a748e)