### PR TITLE
Add workflow orchestration radon plan doc

### DIFF
--- a/docs/en/architecture/radon_workflow_orchestration.md
+++ b/docs/en/architecture/radon_workflow_orchestration.md
@@ -1,0 +1,98 @@
+# Workflow Orchestration Radon Plan
+
+## Scope
+- Target modules:
+  - `qmtl/services/dagmanager/diff_service.py`, `kafka_admin.py`
+  - `qmtl/services/gateway/strategy_submission.py`, `dagmanager_client.py`, `worker.py`
+  - `qmtl/runtime/sdk/gateway_client.py`, `tag_manager_service.py`, `backfill_engine.py`, `activation_manager.py`
+- Related issues:
+  - #1549 Workflow orchestration complexity review (meta)
+  - #1563 DiffService queue/sentinel orchestration refactor
+  - #1564 KafkaAdmin topic verification/creation orchestration cleanup
+  - #1565 Gateway strategy submission context/queue-map/world binding pipeline refactor
+  - #1566 Gateway DAG diff worker and gRPC client orchestration cleanup
+  - #1567 Runtime SDK Gateway/tag/backfill/activation orchestration cleanup
+
+This document summarizes the outcome of the workflow orchestration complexity work tracked in the issues above and captures reusable design patterns for future changes.
+
+## Baseline radon snapshot (at plan time)
+
+The following functions had C/D-level cyclomatic complexity in the radon report while sitting on critical orchestration paths for DAG diff, topic orchestration, strategy submission and Runtime SDK flows.
+
+| File | Function | CC grade / score | Notes |
+| --- | --- | --- | --- |
+| `services/dagmanager/server.py` | `_KafkaAdminClient.list_topics` | D / 21 | Topic metadata lookup, validation and error handling combined. |
+| `services/dagmanager/diff_service.py` | `DiffService._hash_compare` | C / 20 | Queue binding, cross-context validation, sentinel/CRC/metrics in a single method. |
+| `services/dagmanager/kafka_admin.py` | `KafkaAdmin._verify_topic` | C / 13 | Topic existence/collision/parameter checks mixed with error flow. |
+| `services/gateway/strategy_submission.py` | `StrategySubmissionHelper._build_queue_outputs` | C / 14 | Diff call, fallback queue map and CRC sentinel handled in one orchestration method. |
+| `services/gateway/strategy_submission.py` | `StrategySubmissionHelper._persist_world_bindings` | C / 12 | DB and WorldService bindings and error handling intertwined. |
+| `services/gateway/dagmanager_client.py` | `DagManagerClient.diff` | C / 11 | Builds the request, collects the gRPC stream, validates CRC, handles retries/breaker and applies namespaces. |
+| `services/gateway/worker.py` | `StrategyWorker._process` | C / 14 | Redis state loading, diff call, FSM transitions, WS broadcasting and alerts in one function. |
+| `runtime/sdk/trade_dispatcher.py` | `TradeOrderDispatcher.dispatch` | C / 20 | Validation, gating, dedup and HTTP/Kafka submission handled together. |
+| `runtime/sdk/gateway_client.py` | `GatewayClient.post_strategy` | C / 14 | HTTP request construction, breaker, status-code mapping and pydantic validation combined. |
+| `runtime/sdk/tag_manager_service.py` | `TagManagerService.apply_queue_map` | C / 16 | Queue-map application, logging and state updates tightly coupled. |
+| `runtime/sdk/backfill_engine.py` | `BackfillEngine._publish_metadata` | C / 17 | Metadata construction, validation and Gateway call in one method. |
+| `runtime/sdk/activation_manager.py` | `ActivationManager.start` | C / 14 | Activation start, event stream subscription and initial state orchestration in a single method. |
+
+## Outcome summary (as of 2025-11-16)
+
+After merging the work from #1563–#1567, the CC grades for the paths above improved as follows.
+
+- DAG Manager
+  - `_KafkaAdminClient.list_topics` (D / 21) → **A / 2** (#1563).
+  - `DiffService._hash_compare` (C / 20) → **A / 1** (#1563) — topic binding planning/execution split with result types.
+  - `KafkaAdmin._verify_topic` (C / 13) → **A / 1** (#1564) — introduced `TopicVerificationPolicy` and `TopicEnsureResult`.
+- Gateway
+  - `StrategySubmissionHelper._build_queue_outputs` (C / 14) → **A / 3** (#1565) — refactored around `QueueResolution` and `_resolve_queue_map`.
+  - `StrategySubmissionHelper._persist_world_bindings` (C / 12) → **A / 3** (#1565) — separated binding target discovery from WorldService sync.
+  - `DagManagerClient.diff` (C / 11) → **A / 3** (#1566) — delegated stream collection, CRC checks and namespace application to `DiffStreamClient`.
+  - `StrategyWorker._process` (C / 14) → **A / 4** (#1566) — split into smaller steps for locking, context loading, diff execution, broadcasting and FSM transitions.
+- Runtime SDK
+  - `TradeOrderDispatcher.dispatch` (C / 20) → **A / 3** — now a pipeline of `DispatchStep` implementations.
+  - `GatewayClient.post_strategy` (C / 14) → **A / 1** (#1567) — introduced `GatewayCallResult` and split `_post` / `_parse_strategy_response`.
+  - `TagManagerService.apply_queue_map` (C / 16) → **A / 3** (#1567) — separated match collection, application and logging helpers.
+  - `BackfillEngine._publish_metadata` (C / 17) → **A / 5** (#1567) — split metadata construction and Gateway submission into dedicated helpers.
+  - `ActivationManager.start` (C / 14) → **A / 5** (#1567) — decomposed startup into `_start_existing_client`, `_start_via_gateway`, `_schedule_polling` and related helpers.
+
+Some C-grade functions remain in other modules, but this document is scoped to the orchestration paths above. Other radon plans (for example `radon_runtime_sdk.md`, `radon_control_plane.md`) track cleanup for the remaining hotspots.
+
+## Common anti-patterns
+
+Before the refactors, orchestration paths often exhibited the following anti-patterns.
+
+- Single methods handled **validation → external calls → retry/backoff → result merging → error handling → metrics/logging**, driving CC to C/D grades.
+- Network/broker/WorldService error handling and downgrade rules were modeled as nested `if`/`try` blocks, making the happy path hard to see and tests coarse-grained.
+- Retry policies, logging formats and error mappings were duplicated across modules, increasing synchronization cost for changes.
+- Success/partial-success/failure was expressed via a mix of booleans, `None` values, exceptions and ad-hoc `dict` error payloads, leading to inconsistent branching at call sites.
+
+## Applied patterns / design direction
+
+To address the anti-patterns above, the following patterns were applied across the scope of #1549.
+
+- **Pipeline / Chain of Responsibility**
+  - Components such as `TradeOrderDispatcher`, `StrategySubmissionHelper` and `StrategyWorker` now follow a step-based pipeline where small step objects/methods (for example `ComputeContextStep`, `DiffQueueMapStep`, `WorldBindingPersistStep`) each own a single concern and the main orchestrator manages sequence only.
+- **Explicit Result types**
+  - Result objects like `GatewayCallResult`, `StrategySubmissionResult`, `DiffOutcome`, `QueueResolution` and `TopicEnsureResult` model success/partial-success/failure and diagnostics explicitly.
+  - Callers can branch on a single `ok` flag or well-defined fields instead of mixing booleans, exceptions and `None` checks.
+- **Shared helpers/decorators**
+  - Kafka topic verification/creation (`TopicVerificationPolicy`, `TopicCreateRetryStrategy`), DAG diff streaming (`DiffStreamClient`), Gateway HTTP calls (`GatewayClient._post`) and WorldService context merging (`ComputeContextService`) were factored into helper layers.
+  - Orchestration methods now primarily compose these helpers rather than implementing low-level control flow.
+- **Explicit downgrade/fallback modeling**
+  - Diff failure → TagQuery fallback, CRC sentinel fallback and WorldService stale/unavailable downgrade flows are represented via Result types and dedicated helper methods so the policies are visible and testable.
+
+## Validation checklist
+
+The following checklist is recommended when modifying workflow orchestration paths in this scope.
+
+- radon complexity / MI
+  - `uv run --with radon -m radon cc -s qmtl/services/dagmanager/diff_service.py qmtl/services/dagmanager/kafka_admin.py`
+  - `uv run --with radon -m radon cc -s qmtl/services/gateway/strategy_submission.py qmtl/services/gateway/dagmanager_client.py qmtl/services/gateway/worker.py`
+  - `uv run --with radon -m radon cc -s qmtl/runtime/sdk/gateway_client.py qmtl/runtime/sdk/tag_manager_service.py qmtl/runtime/sdk/backfill_engine.py qmtl/runtime/sdk/activation_manager.py`
+  - Optionally, full snapshot: `uv run --with radon -m radon cc -s -n C qmtl/services/dagmanager qmtl/services/gateway qmtl/runtime/sdk`
+- Regression tests
+  - `uv run -m pytest -W error -n auto qmtl/services/dagmanager qmtl/services/gateway qmtl/runtime/sdk`
+- Docs build
+  - `uv run mkdocs build`
+
+With this work and the checklist above, the workflow orchestration complexity review in #1549 is considered complete.
+

--- a/docs/ko/architecture/radon_workflow_orchestration.md
+++ b/docs/ko/architecture/radon_workflow_orchestration.md
@@ -1,0 +1,98 @@
+# 워크플로 오케스트레이션 Radon 정비 계획
+
+## 범위
+- 대상 모듈:
+  - `qmtl/services/dagmanager/diff_service.py`, `kafka_admin.py`
+  - `qmtl/services/gateway/strategy_submission.py`, `dagmanager_client.py`, `worker.py`
+  - `qmtl/runtime/sdk/gateway_client.py`, `tag_manager_service.py`, `backfill_engine.py`, `activation_manager.py`
+- 연관 이슈:
+  - #1549 워크플로 오케스트레이션 복잡도 정리 (메타)
+  - #1563 DiffService 큐/센티넬 오케스트레이션 리팩터링
+  - #1564 KafkaAdmin 토픽 검증/생성 오케스트레이션 정리
+  - #1565 Gateway 전략 제출 컨텍스트/큐맵/월드 바인딩 파이프라인 정리
+  - #1566 Gateway DAG diff 워커 및 gRPC 클라이언트 오케스트레이션 정리
+  - #1567 Runtime SDK Gateway/태그/백필/액티베이션 오케스트레이션 정리
+
+이 문서는 위 이슈들을 통해 진행한 워크플로 오케스트레이션 경로의 복잡도 정비 결과를 요약하고, 이후 작업에서 재사용할 설계 패턴을 정리한다.
+
+## 기본 radon 스냅샷 (계획 수립 시점)
+
+다음 함수들은 radon CC 리포트 기준으로 C/D 급 복잡도를 보이면서, DAG Diff·토픽 오케스트레이션·전략 제출·Runtime SDK 오케스트레이션의 핵심 경로를 형성했다.
+
+| 파일 | 함수 | CC 등급 / 점수 | 비고 |
+| --- | --- | --- | --- |
+| `services/dagmanager/server.py` | `_KafkaAdminClient.list_topics` | D / 21 | 토픽 메타데이터 조회 + 검증 + 예외 처리 일체. |
+| `services/dagmanager/diff_service.py` | `DiffService._hash_compare` | C / 20 | 큐 바인딩, cross-context 검증, 센티넬/CRC/메트릭 처리까지 한 함수에 집중. |
+| `services/dagmanager/kafka_admin.py` | `KafkaAdmin._verify_topic` | C / 13 | 토픽 존재/콜리전/파라미터 검증과 예외 흐름이 혼재. |
+| `services/gateway/strategy_submission.py` | `StrategySubmissionHelper._build_queue_outputs` | C / 14 | Diff 호출 + fallback 큐맵 + CRC 센티넬까지 단일 함수에서 오케스트레이션. |
+| `services/gateway/strategy_submission.py` | `StrategySubmissionHelper._persist_world_bindings` | C / 12 | DB/WorldService 양쪽 바인딩/예외 처리가 한 함수에 섞여 있음. |
+| `services/gateway/dagmanager_client.py` | `DagManagerClient.diff` | C / 11 | DiffRequest 생성, gRPC 스트림 수집, CRC 검증, breaker/재시도, namespace 적용까지 모두 포함. |
+| `services/gateway/worker.py` | `StrategyWorker._process` | C / 14 | Redis 상태 로딩, diff 호출, FSM 전이, WS 브로드캐스트, 알림까지 단일 함수. |
+| `runtime/sdk/trade_dispatcher.py` | `TradeOrderDispatcher.dispatch` | C / 20 | 검증·게이팅·중복 제거·HTTP/Kafka 전송까지 단일 메서드에서 처리. |
+| `runtime/sdk/gateway_client.py` | `GatewayClient.post_strategy` | C / 14 | HTTP 요청 구성, breaker, status-code 매핑, pydantic 검증이 한 함수에 집중. |
+| `runtime/sdk/tag_manager_service.py` | `TagManagerService.apply_queue_map` | C / 16 | 큐맵 적용/로그/상태 갱신이 섞여 있어 분기 복잡도가 높음. |
+| `runtime/sdk/backfill_engine.py` | `BackfillEngine._publish_metadata` | C / 17 | 메타데이터 구성·검증·Gateway 호출이 한 메서드에 결합. |
+| `runtime/sdk/activation_manager.py` | `ActivationManager.start` | C / 14 | 활성화 시작, 이벤트 스트림 구독, 상태 초기화 오케스트레이션이 단일 함수에 집중. |
+
+## 결과 요약 (2025-11-16 기준)
+
+서브 이슈 #1563–#1567 을 반영한 이후, 위 경로들의 CC 등급은 다음과 같이 개선되었다.
+
+- DAG Manager
+  - `_KafkaAdminClient.list_topics` (D / 21) → **A / 2** (#1563)
+  - `DiffService._hash_compare` (C / 20) → **A / 1** (#1563) — 토픽 바인딩 계획/실행 분리, Result 타입 도입.
+  - `KafkaAdmin._verify_topic` (C / 13) → **A / 1** (#1564) — `TopicVerificationPolicy` / `TopicEnsureResult` 도입.
+- Gateway
+  - `StrategySubmissionHelper._build_queue_outputs` (C / 14) → **A / 3** (#1565) — `QueueResolution` Result 객체와 `_resolve_queue_map` 스텝으로 분리.
+  - `StrategySubmissionHelper._persist_world_bindings` (C / 12) → **A / 3** (#1565) — 바인딩 대상 계산과 WorldService sync 를 개별 헬퍼로 분리.
+  - `DagManagerClient.diff` (C / 11) → **A / 3** (#1566) — `DiffStreamClient` 헬퍼에 스트림 수집·CRC 검증·namespace 적용 위임.
+  - `StrategyWorker._process` (C / 14) → **A / 4** (#1566) — 락 획득, 컨텍스트 로딩, diff 실행, 브로드캐스트, FSM 전이를 개별 스텝 메서드로 분리.
+- Runtime SDK
+  - `TradeOrderDispatcher.dispatch` (C / 20) → **A / 3** — `DispatchStep` 체인 기반 Pipeline 패턴.
+  - `GatewayClient.post_strategy` (C / 14) → **A / 1** (#1567) — `GatewayCallResult` Result 타입 + `_post` / `_parse_strategy_response` 분리.
+  - `TagManagerService.apply_queue_map` (C / 16) → **A / 3** (#1567) — 매칭 수집/적용/로깅을 `_collect_matches` / `_apply_*_mapping` / `_log_execute_change` 로 분리.
+  - `BackfillEngine._publish_metadata` (C / 17) → **A / 5** (#1567) — 메타데이터 구성과 Gateway 호출을 `_build_metadata_payload` / `_publish_metadata` 로 분리.
+  - `ActivationManager.start` (C / 14) → **A / 5** (#1567) — 시작 시퀀스를 `_start_existing_client` / `_start_via_gateway` / `_schedule_polling` 등으로 분리.
+
+여전히 C 급 복잡도를 갖는 함수가 일부 존재하지만, 이 문서의 범위는 위 오케스트레이션 경로에 한정하며, 다른 모듈에 대한 정비 계획은 별도의 Radon 문서(`radon_runtime_sdk.md`, `radon_control_plane.md` 등)에서 관리한다.
+
+## 공통 불량 패턴 요약
+
+정비 전 오케스트레이션 경로에는 다음과 같은 공통 불량 패턴이 반복되었다.
+
+- 단일 메서드에 \"검증 → 외부 호출 → 재시도/백오프 → 결과 병합 → 예외 처리 → 메트릭/로그 방출\"이 모두 포함되어 radon CC 가 자연스럽게 C/D 로 상승.
+- 네트워크/브로커/WorldService 오류 처리와 다운그레이드 정책이 중첩된 if/try 블록으로만 표현되어, happy-path 를 읽기 어렵고 테스트 단위도 커짐.
+- 재시도 정책, 로깅 포맷, 에러 매핑이 여러 모듈에서 중복 구현되어, 변경 시 동기화 비용이 큼.
+- 성공/부분 성공/실패가 bool 플래그, `None` 반환, 예외, dict 기반 에러 메시지가 혼용된 형태로 표현되어 호출자 계층에서 분기 규칙이 일관되지 않음.
+
+## 적용 패턴 / 설계 방향
+
+위 불량 패턴을 해소하기 위해 다음과 같은 공통 설계 패턴을 적용했다.
+
+- **Pipeline / Chain of Responsibility**
+  - `TradeOrderDispatcher`, `StrategySubmissionHelper`, `StrategyWorker` 등에서 공통적으로, 작은 스텝 객체/메서드(예: `ComputeContextStep`, `DiffQueueMapStep`, `WorldBindingPersistStep`)를 정의하고, 메인 오케스트레이터는 스텝 구성과 실행 순서만 관리하도록 단순화했다.
+- **공통 Result 타입**
+  - `GatewayCallResult`, `StrategySubmissionResult`, `DiffOutcome`, `QueueResolution`, `TopicEnsureResult` 와 같은 Result 객체를 도입해, 성공/부분 성공/실패 상태와 진단 정보를 명시적으로 표현했다.
+  - 호출자는 bool/예외/None 혼용 대신 Result 객체의 `ok` 플래그나 명시적 필드를 기준으로 분기할 수 있다.
+- **공통 헬퍼/데코레이터 추출**
+  - Kafka 토픽 검증/생성(`TopicVerificationPolicy`, `TopicCreateRetryStrategy`), DAG Diff 스트림 수집(`DiffStreamClient`), Gateway HTTP 호출(`GatewayClient._post`), WorldService 컨텍스트 병합(`ComputeContextService`)을 헬퍼·유틸 계층으로 분리했다.
+  - 오케스트레이션 함수는 이 헬퍼들을 조합하는 역할에 집중하도록 하여, 책임과 복잡도를 줄였다.
+- **다운그레이드/폴백 정책의 명시적 모델링**
+  - Diff 실패 시 TagQuery fallback, CRC sentinel fallback, WorldService stale/unavailable 시 compute 컨텍스트 다운그레이드 등은 Result 타입과 전용 메서드로 표현해, 정책이 코드 상에서 명확히 드러나도록 했다.
+
+## 검증 체크리스트
+
+워크플로 오케스트레이션 경로 변경을 검증하기 위한 최소 체크리스트는 다음과 같다.
+
+- radon 복잡도/MI 확인
+  - `uv run --with radon -m radon cc -s qmtl/services/dagmanager/diff_service.py qmtl/services/dagmanager/kafka_admin.py`
+  - `uv run --with radon -m radon cc -s qmtl/services/gateway/strategy_submission.py qmtl/services/gateway/dagmanager_client.py qmtl/services/gateway/worker.py`
+  - `uv run --with radon -m radon cc -s qmtl/runtime/sdk/gateway_client.py qmtl/runtime/sdk/tag_manager_service.py qmtl/runtime/sdk/backfill_engine.py qmtl/runtime/sdk/activation_manager.py`
+  - 필요 시 전체 스냅샷: `uv run --with radon -m radon cc -s -n C qmtl/services/dagmanager qmtl/services/gateway qmtl/runtime/sdk`
+- 회귀 테스트
+  - DiffService, Gateway, Runtime SDK 관련 테스트 모듈: `uv run -m pytest -W error -n auto qmtl/services/dagmanager qmtl/services/gateway qmtl/runtime/sdk`
+- 문서 빌드
+  - `uv run mkdocs build`
+
+이 체크리스트와 위 서브 이슈들을 기준으로, #1549 에서 합의한 워크플로 오케스트레이션 복잡도 정리는 완료된 것으로 간주한다.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Seamless Data Provider Radon Plan: architecture/radon_seamless_data.md
       - History Warmup Radon Plan: architecture/radon_history_warmup.md
       - Runtime SDK Radon Plan: architecture/radon_runtime_sdk.md
+      - Workflow Orchestration Radon Plan: architecture/radon_workflow_orchestration.md
       - Radon Metrics Snapshot (2025-11-14): architecture/metrics/2025-11-14.md
   - Guides:
       - Overview: guides/README.md


### PR DESCRIPTION
Summary:
- Add ko/en architecture docs for workflow orchestration radon plan.
- Capture baseline C/D-grad radon hotspots and the post-refactor outcome for DAG Manager, Gateway and Runtime SDK orchestration paths.
- Document shared patterns (pipeline/result types/helpers) and a validation checklist for future changes.

Details:
- New doc pair: `docs/ko/architecture/radon_workflow_orchestration.md` / `docs/en/architecture/radon_workflow_orchestration.md`.
- Update `mkdocs.yml` navigation under Architecture as "Workflow Orchestration Radon Plan".
- The ko document is the canonical source; the en document is its translation.

Validation:
- `uv run mkdocs build`

Fixes #1549
