### PR TITLE
Introduce shared validation core and apply to node/tag manager (Refs #1592, Refs #1551)

### DIFF
--- a/docs/en/reference/enhanced_validation.md
+++ b/docs/en/reference/enhanced_validation.md
@@ -59,6 +59,27 @@ QMTLValidationError (base, inherits from ValueError)
 - Must be dictionaries if provided
 - Applied to `config` and `schema` parameters
 
+## Rule / Result pattern overview
+
+As validation rules grow, large if/elif chains inside a single function become
+hard to maintain. To keep complexity under control, QMTL introduces a shared
+`Rule` / `ValidationResult` pattern.
+
+- `qmtl.foundation.validation_core.ValidationMessage`  
+  A structured record with `code`, human‑readable `message`, `severity` and
+  optional `hint`.
+- `qmtl.foundation.validation_core.ValidationResult`  
+  Aggregates multiple `ValidationMessage` instances and exposes an `ok` flag
+  and helpers to inspect errors and warnings.
+- `qmtl.foundation.validation_core.Rule` / `RuleSet`  
+  Rule objects that accept a context object (for example, node parameters or
+  backtest timing) and return a `ValidationResult`, plus a collection type that
+  runs several rules in sequence.
+
+Runtime SDK, WorldService and schema validation logic use this Rule‑based
+design so that adding new checks does not linearly increase each function's
+cyclomatic complexity.
+
 ### Feed Method Validation
 
 The `feed()` method now validates all parameters:

--- a/docs/ko/reference/enhanced_validation.md
+++ b/docs/ko/reference/enhanced_validation.md
@@ -59,6 +59,22 @@ QMTLValidationError (base, inherits from ValueError)
 - 제공된 경우 딕셔너리여야 함
 - `config`, `schema` 파라미터에 적용
 
+## Rule / Result 패턴 개요
+
+검증 규칙이 늘어나면서 개별 함수 안에 if/elif 체인이 쌓이는 문제를 줄이기 위해,
+공통 `Rule` / `ValidationResult` 패턴을 도입했습니다.
+
+- `qmtl.foundation.validation_core.ValidationMessage`  
+  코드(`code`), 사용자 메시지(`message`), 심각도(`severity`), 수정 힌트(`hint`)를 담는 구조체입니다.
+- `qmtl.foundation.validation_core.ValidationResult`  
+  여러 `ValidationMessage`를 모아 `ok` 여부와 오류/경고 목록을 제공합니다.
+- `qmtl.foundation.validation_core.Rule` / `RuleSet`  
+  컨텍스트(예: 노드 파라미터, 백테스트 타이밍)를 입력으로 받아 `ValidationResult`를 반환하는 규칙 객체와,
+  여러 규칙을 순차적으로 실행하는 컬렉션입니다.
+
+런타임 SDK, WorldService, 스키마 검증 로직은 이 Rule 기반 설계를 사용해
+새 규칙 추가 시 기존 함수의 Cyclomatic Complexity가 선형적으로 증가하지 않도록 정리하고 있습니다.
+
 ### feed() 메서드 검증
 
 `feed()` 메서드는 모든 파라미터를 검증합니다:

--- a/qmtl/foundation/__init__.py
+++ b/qmtl/foundation/__init__.py
@@ -1,5 +1,15 @@
 """Foundation layer for shared infrastructure modules."""
 
 from . import common, kafka, proto, schema
+from .validation_core import Rule, RuleSet, ValidationMessage, ValidationResult
 
-__all__ = ["common", "kafka", "proto", "schema"]
+__all__ = [
+    "common",
+    "kafka",
+    "proto",
+    "schema",
+    "Rule",
+    "RuleSet",
+    "ValidationMessage",
+    "ValidationResult",
+]

--- a/qmtl/foundation/validation_core.py
+++ b/qmtl/foundation/validation_core.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Generic, Iterable, Protocol, Sequence, Tuple, TypeVar
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationMessage:
+    """Structured description of a single validation outcome."""
+
+    code: str
+    message: str
+    severity: str = "error"
+    hint: str | None = None
+    field: str | None = None
+    payload: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+            "severity": self.severity,
+        }
+        if self.hint is not None:
+            data["hint"] = self.hint
+        if self.field is not None:
+            data["field"] = self.field
+        if self.payload is not None:
+            data["payload"] = self.payload
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationResult:
+    """Aggregate result produced by one or more validation rules."""
+
+    messages: Tuple[ValidationMessage, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return not any(message.severity == "error" for message in self.messages)
+
+    @classmethod
+    def success(cls) -> "ValidationResult":
+        return cls(messages=())
+
+    @classmethod
+    def from_messages(
+        cls, messages: Sequence[ValidationMessage] | ValidationMessage
+    ) -> "ValidationResult":
+        if isinstance(messages, ValidationMessage):
+            return cls(messages=(messages,))
+        return cls(messages=tuple(messages))
+
+    def with_message(self, message: ValidationMessage) -> "ValidationResult":
+        return ValidationResult(messages=self.messages + (message,))
+
+    def merge(self, *others: "ValidationResult") -> "ValidationResult":
+        merged: list[ValidationMessage] = list(self.messages)
+        for other in others:
+            merged.extend(other.messages)
+        return ValidationResult(messages=tuple(merged))
+
+    def iter_errors(self) -> Iterable[ValidationMessage]:
+        return (message for message in self.messages if message.severity == "error")
+
+    def iter_warnings(self) -> Iterable[ValidationMessage]:
+        return (
+            message for message in self.messages if message.severity == "warning"
+        )
+
+
+ContextT = TypeVar("ContextT")
+
+
+class Rule(Protocol, Generic[ContextT]):
+    """Protocol for validation rules used across QMTL."""
+
+    code: str
+    description: str
+
+    def validate(self, context: ContextT) -> ValidationResult:  # pragma: no cover - interface
+        ...
+
+
+@dataclass(slots=True)
+class RuleSet(Generic[ContextT]):
+    """Collection of rules executed against a single context."""
+
+    rules: Tuple[Rule[ContextT], ...]
+
+    def validate(self, context: ContextT) -> ValidationResult:
+        result = ValidationResult.success()
+        for rule in self.rules:
+            rule_result = rule.validate(context)
+            result = result.merge(rule_result)
+        return result
+
+
+__all__ = ["ValidationMessage", "ValidationResult", "Rule", "RuleSet"]
+

--- a/tests/qmtl/foundation/test_validation_core.py
+++ b/tests/qmtl/foundation/test_validation_core.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from qmtl.foundation.validation_core import (
+    Rule,
+    RuleSet,
+    ValidationMessage,
+    ValidationResult,
+)
+
+
+class _AlwaysOkRule:
+    code = "OK_RULE"
+    description = "Always passes without errors."
+
+    def validate(self, context: object) -> ValidationResult:
+        return ValidationResult.success()
+
+
+class _FailingRule:
+    code = "FAIL_RULE"
+    description = "Always emits a single error."
+
+    def validate(self, context: object) -> ValidationResult:
+        message = ValidationMessage(
+            code=self.code,
+            message=f"invalid context: {context!r}",
+            severity="error",
+            field="value",
+        )
+        return ValidationResult.from_messages(message)
+
+
+def test_validation_message_to_dict() -> None:
+    message = ValidationMessage(
+        code="E_TEST",
+        message="failed",
+        severity="warning",
+        hint="fix it",
+        field="field_name",
+        payload={"extra": "data"},
+    )
+
+    as_dict = message.as_dict()
+    assert as_dict["code"] == "E_TEST"
+    assert as_dict["message"] == "failed"
+    assert as_dict["severity"] == "warning"
+    assert as_dict["hint"] == "fix it"
+    assert as_dict["field"] == "field_name"
+    assert as_dict["payload"] == {"extra": "data"}
+
+
+def test_validation_result_success_and_merge() -> None:
+    ok = ValidationResult.success()
+    assert ok.ok
+    assert tuple(ok.iter_errors()) == ()
+
+    message = ValidationMessage(code="E", message="err")
+    failing = ValidationResult.from_messages(message)
+    merged = ok.merge(failing)
+
+    assert not merged.ok
+    errors = list(merged.iter_errors())
+    assert len(errors) == 1
+    assert errors[0].code == "E"
+
+
+def test_rule_set_combines_results() -> None:
+    rules: tuple[Rule[object], ...] = (_AlwaysOkRule(), _FailingRule())
+    rule_set = RuleSet(rules=rules)
+
+    result = rule_set.validate(context={"value": 1})
+
+    assert not result.ok
+    errors = list(result.iter_errors())
+    assert len(errors) == 1
+    assert errors[0].code == "FAIL_RULE"
+


### PR DESCRIPTION
This PR introduces a shared validation core and applies it to the runtime SDK's node and tag manager paths.

Summary
- Add qmtl.foundation.validation_core with reusable ValidationMessage/ValidationResult primitives and a simple Rule/RuleSet abstraction.
- Export the new primitives from qmtl.foundation so other layers can depend on them.
- Refactor qmtl/runtime/sdk/node_validation.py::validate_node_params to use a small set of Rules operating on a NodeParams context while preserving existing Invalid*Error contracts and messages.
- Refactor TagManagerService.apply_queue_map to delegate per-node mapping to a Rule, keeping orchestration simple and ready for future rule-based extensions.
- Add focused unit tests for the validation core and run existing enhanced validation + tag manager tests to ensure behavior is preserved.

Notes
- This is the first step toward the broader Rule/Result-based validation refactor tracked in #1551.
- Follow-up PRs for #1592/#1593/#1594/#1595 can reuse the same ValidationResult/Rule abstractions.

Refs #1592
Refs #1551