### PR TITLE
Refine backtest and history timing validation (Fixes #1593, Refs #1551)

### DIFF
--- a/qmtl/runtime/sdk/history_coverage.py
+++ b/qmtl/runtime/sdk/history_coverage.py
@@ -39,23 +39,7 @@ def compute_missing_ranges(
     if window.start is None or window.end is None:
         return []
     merged = merge_coverage(coverage or [], window.interval)
-    gaps: list[CoverageRange] = []
-    cursor = window.start
-    for rng in merged:
-        if rng.end < window.start:
-            continue
-        if rng.start > window.end:
-            break
-        if rng.start > cursor:
-            gaps.append(
-                CoverageRange(cursor, min(rng.start - window.interval, window.end))
-            )
-        cursor = max(cursor, rng.end + window.interval)
-        if cursor > window.end:
-            break
-    if cursor <= window.end:
-        gaps.append(CoverageRange(cursor, window.end))
-    return [gap for gap in gaps if gap.start <= gap.end]
+    return _compute_missing_ranges_within_window(merged, window)
 
 
 def coverage_bounds(coverage: Iterable[tuple[int, int]] | None) -> CoverageRange | None:
@@ -77,45 +61,132 @@ def ensure_strict_history(
     required_points: int | None,
     coverage: Iterable[tuple[int, int]] | None,
 ) -> None:
-    required = (required_points or 1) if required_points is not None else 1
+    required = _compute_required_points(required_points)
     total_points = len(timestamps)
 
+    normalized_coverage, bounds, coverage_summary = _normalize_coverage_info(coverage)
+
+    _ensure_history_present(timestamps, required, interval, coverage_summary)
+
+    _apply_coverage_rules(
+        timestamps, normalized_coverage, bounds, interval, total_points=total_points
+    )
+
+    _ensure_minimum_points(
+        total_points, required, interval, coverage_summary=coverage_summary
+    )
+
+
+def _compute_missing_ranges_within_window(
+    merged: list[CoverageRange], window: WarmupWindow
+) -> list[CoverageRange]:
+    gaps: list[CoverageRange] = []
+    cursor = window.start
+    for rng in merged:
+        if rng.end < window.start:
+            continue
+        if rng.start > window.end:
+            break
+        if rng.start > cursor:
+            gaps.append(
+                CoverageRange(cursor, min(rng.start - window.interval, window.end))
+            )
+        cursor = max(cursor, rng.end + window.interval)
+        if cursor > window.end:
+            break
+    if cursor <= window.end:
+        gaps.append(CoverageRange(cursor, window.end))
+    return [gap for gap in gaps if gap.start <= gap.end]
+
+
+def _compute_required_points(required_points: int | None) -> int:
+    if required_points is None:
+        return 1
+    return required_points or 1
+
+
+def _normalize_coverage_info(
+    coverage: Iterable[tuple[int, int]] | None,
+) -> tuple[tuple[tuple[int, int], ...], CoverageRange | None, str]:
     normalized_coverage: tuple[tuple[int, int], ...] = (
         tuple((int(s), int(e)) for s, e in coverage) if coverage else tuple()
     )
     bounds = coverage_bounds(normalized_coverage) if normalized_coverage else None
     coverage_summary = _format_coverage_bounds(bounds)
+    return normalized_coverage, bounds, coverage_summary
 
-    if not timestamps:
-        raise RuntimeError(
-            "history missing in strict mode: no timestamps received "
-            f"(required>={required}, interval={interval}, coverage={coverage_summary})"
+
+def _apply_coverage_rules(
+    timestamps: Sequence[int],
+    normalized_coverage: tuple[tuple[int, int], ...],
+    bounds: CoverageRange | None,
+    interval: int | None,
+    *,
+    total_points: int,
+) -> None:
+    if normalized_coverage and bounds and interval:
+        _ensure_coverage_consistent(
+            timestamps, bounds, interval, total_points=total_points
         )
+    elif not normalized_coverage and interval:
+        _ensure_gapless_sequence(timestamps, interval)
 
-    if normalized_coverage:
-        if bounds and interval:
-            expected = int((bounds.end - bounds.start) // interval) + 1
-            actual = sum(1 for ts in timestamps if bounds.start <= ts <= bounds.end)
-            if actual < expected:
-                raise RuntimeError(
-                    "history gap detected in strict mode: "
-                    f"expected {expected} points in [{bounds.start}, {bounds.end}] at "
-                    f"interval {interval} but received {actual} (total={total_points})"
-                )
-    elif interval:
-        for a, b in zip(timestamps, timestamps[1:]):
-            if (b - a) != interval:
-                raise RuntimeError(
-                    "history gap detected in strict mode: "
-                    f"expected step of {interval} between timestamps but saw {a}->{b}"
-                )
 
-    if total_points < required:
-        raise RuntimeError(
-            "history missing in strict mode: expected at least "
-            f"{required} point(s) but received {total_points} (interval={interval}, "
-            f"coverage={coverage_summary})"
-        )
+def _ensure_history_present(
+    timestamps: Sequence[int],
+    required: int,
+    interval: int | None,
+    coverage_summary: str,
+) -> None:
+    if timestamps:
+        return
+    raise RuntimeError(
+        "history missing in strict mode: no timestamps received "
+        f"(required>={required}, interval={interval}, coverage={coverage_summary})"
+    )
+
+
+def _ensure_coverage_consistent(
+    timestamps: Sequence[int],
+    bounds: CoverageRange,
+    interval: int,
+    *,
+    total_points: int,
+) -> None:
+    expected = int((bounds.end - bounds.start) // interval) + 1
+    actual = sum(1 for ts in timestamps if bounds.start <= ts <= bounds.end)
+    if actual >= expected:
+        return
+    raise RuntimeError(
+        "history gap detected in strict mode: "
+        f"expected {expected} points in [{bounds.start}, {bounds.end}] at "
+        f"interval {interval} but received {actual} (total={total_points})"
+    )
+
+
+def _ensure_gapless_sequence(timestamps: Sequence[int], interval: int) -> None:
+    for a, b in zip(timestamps, timestamps[1:]):
+        if (b - a) != interval:
+            raise RuntimeError(
+                "history gap detected in strict mode: "
+                f"expected step of {interval} between timestamps but saw {a}->{b}"
+            )
+
+
+def _ensure_minimum_points(
+    total_points: int,
+    required: int,
+    interval: int | None,
+    *,
+    coverage_summary: str,
+) -> None:
+    if total_points >= required:
+        return
+    raise RuntimeError(
+        "history missing in strict mode: expected at least "
+        f"{required} point(s) but received {total_points} (interval={interval}, "
+        f"coverage={coverage_summary})"
+    )
 
 
 __all__ = [


### PR DESCRIPTION
This PR reduces complexity in the runtime SDK's backtest and history timing validation paths while preserving existing behaviour.

Summary
- Extract helpers in `qmtl/runtime/sdk/timing_controls.py` so `validate_backtest_timing` delegates per-node work to `_collect_node_timing_issues` and `_iter_interval_samples`, lowering its CC from C to B while keeping the public API and error messages unchanged.
- Refactor `validate_backtest_data` in `qmtl/runtime/sdk/backtest_validation.py` to use a small `_collect_stream_node_data` helper and a clear orchestration loop, improving readability and reducing cyclomatic complexity to B.
- Restructure `qmtl/runtime/sdk/history_coverage.py::ensure_strict_history` and `compute_missing_ranges` into focused helpers (`_compute_missing_ranges_within_window`, `_compute_required_points`, `_normalize_coverage_info`, `_apply_coverage_rules`, etc.), bringing all touched functions to A/B grades while keeping existing RuntimeError messages and semantics intact.
- Verify behaviour with existing suites: `test_timing_controls.py`, `test_backtest_validation.py`, `test_history_coverage_property.py`, `test_history_components.py` and confirm `radon cc -s` shows B or better for the originally flagged functions.

Fixes #1593
Refs #1551