### PR TITLE
Refactor schema and nodespec validation helpers (Fixes #1594, Refs #1551)

### DIFF
--- a/qmtl/foundation/schema/validator.py
+++ b/qmtl/foundation/schema/validator.py
@@ -78,14 +78,26 @@ def validate_schema(df: "pd.DataFrame", expected: str | Mapping[str, str]) -> No
 
     spec = _resolve_schema(expected)
 
+    _ensure_required_columns_present(df, spec)
+    _ensure_no_unexpected_columns(df, spec)
+    _ensure_column_types_match(df, spec)
+
+
+def _ensure_required_columns_present(df: "pd.DataFrame", spec: Mapping[str, str]) -> None:
     missing = [col for col in spec if col not in df.columns]
-    if missing:
-        raise InvalidSchemaError(f"missing columns: {', '.join(missing)}")
+    if not missing:
+        return
+    raise InvalidSchemaError(f"missing columns: {', '.join(missing)}")
 
+
+def _ensure_no_unexpected_columns(df: "pd.DataFrame", spec: Mapping[str, str]) -> None:
     unexpected = [col for col in df.columns if col not in spec]
-    if unexpected:
-        raise InvalidSchemaError(f"unexpected columns: {', '.join(unexpected)}")
+    if not unexpected:
+        return
+    raise InvalidSchemaError(f"unexpected columns: {', '.join(unexpected)}")
 
+
+def _ensure_column_types_match(df: "pd.DataFrame", spec: Mapping[str, str]) -> None:
     for col, dtype in spec.items():
         series = df[col]
         if col == "ts":
@@ -98,4 +110,3 @@ def validate_schema(df: "pd.DataFrame", expected: str | Mapping[str, str]) -> No
             raise InvalidSchemaError(
                 f"column '{col}' expected dtype {dtype}, got {series.dtype}"
             )
-


### PR DESCRIPTION
This PR refactors schema and nodespec validation helpers to reduce complexity while preserving existing contracts.

Summary
- In `qmtl/foundation/schema/validator.py`, split `validate_schema` into focused helpers (`_ensure_required_columns_present`, `_ensure_no_unexpected_columns`, `_ensure_column_types_match`) so the top-level function orchestrates validation steps while raising the same `InvalidSchemaError` messages as before.
- In `qmtl/foundation/common/nodespec.py`, factor `_canonicalize_params` into `_canonicalize_mapping`, `_canonicalize_set` and `_is_excluded_param_key`, which keeps the canonicalization behaviour and exclusion rules intact but lowers cyclomatic complexity for the original function.
- Confirm via `radon cc -s` that `validate_schema` and `_canonicalize_params` now score at A/B instead of C, and that all affected tests still pass.
- Run `pytest` for `tests/qmtl/foundation/schema/test_schema_validation.py` and `tests/qmtl/foundation/common/test_nodespec.py` to verify behaviour and existing error messages are unchanged.

Fixes #1594
Refs #1551