### PR TITLE
Refine WorldService config, metrics, and rebalancing validation (Fixes #1595, Refs #1551)

### DIFF
--- a/qmtl/services/worldservice/rebalancing/rule_based.py
+++ b/qmtl/services/worldservice/rebalancing/rule_based.py
@@ -32,56 +32,10 @@ class ProportionalRebalancer(Rebalancer):
     """
 
     def plan(self, ctx: RebalanceContext) -> RebalancePlan:
-        if ctx.world_alloc_before <= 0:
-            # No prior allocation → only strategy deltas matter; treat world scale as 1.0
-            gw = 1.0 if ctx.world_alloc_after > 0 else 0.0
-        else:
-            gw = ctx.world_alloc_after / ctx.world_alloc_before
-
-        # Precompute strategy scaling
-        gs: Dict[str, float] = {}
-        for sid, after in ctx.strategy_alloc_after.items():
-            before = ctx.strategy_alloc_before.get(sid, 0.0)
-            if before <= 0.0:
-                # New strategy allocation; let world scaling drive
-                gs[sid] = gw if ctx.world_alloc_after > 0 else 0.0
-            else:
-                gs[sid] = after / before
-
-        # Aggregate current exposure per (venue, symbol) and per-strategy
-        # and compute per-position target → delta.
-        venue_symbol_delta_notional: Dict[tuple[str | None, str], float] = {}
-
-        for pos in ctx.positions:
-            # Scaling semantics: preserve each strategy sleeve's relative structure
-            # and apply a single scalar to its entire vector. When explicit
-            # strategy totals are provided, use the ratio (after/before).
-            # Otherwise, cascade the world factor.
-            s_factor = gs.get(pos.strategy_id, gw)
-            target_notional = pos.notional * s_factor
-            delta_notional = target_notional - pos.notional
-            key = (pos.venue, pos.symbol)
-            venue_symbol_delta_notional[key] = venue_symbol_delta_notional.get(key, 0.0) + delta_notional
-
-        # Convert notional to quantity deltas with lot rounding and thresholding
-        deltas: List[SymbolDelta] = []
-        for (venue, symbol), d_notional in venue_symbol_delta_notional.items():
-            if abs(d_notional) < ctx.min_trade_notional:
-                continue
-            # We need a representative mark to convert to quantity. Use
-            # the average mark across slices for this (venue, symbol).
-            marks: List[float] = [
-                p.mark for p in ctx.positions if p.symbol == symbol and p.venue == venue and p.mark > 0
-            ]
-            if not marks:
-                # Cannot size without a mark; skip safely
-                continue
-            avg_mark = sum(marks) / len(marks)
-            raw_qty = 0.0 if avg_mark == 0 else d_notional / avg_mark
-            qty = _round_lot(symbol, raw_qty, ctx.lot_size_by_symbol)
-            if qty == 0.0:
-                continue
-            deltas.append(SymbolDelta(symbol=symbol, delta_qty=qty, venue=venue))
+        gw = _compute_world_scale(ctx.world_alloc_before, ctx.world_alloc_after)
+        gs = _compute_strategy_scales(ctx, gw)
+        venue_symbol_delta_notional = _aggregate_position_deltas(ctx, gw, gs)
+        deltas = _materialize_symbol_deltas(ctx, venue_symbol_delta_notional)
 
         return RebalancePlan(
             world_id=ctx.world_id,
@@ -89,3 +43,59 @@ class ProportionalRebalancer(Rebalancer):
             scale_by_strategy=gs,
             deltas=deltas,
         )
+
+
+def _compute_world_scale(before: float, after: float) -> float:
+    if before <= 0:
+        return 1.0 if after > 0 else 0.0
+    return after / before
+
+
+def _compute_strategy_scales(ctx: RebalanceContext, gw: float) -> Dict[str, float]:
+    gs: Dict[str, float] = {}
+    for sid, after in ctx.strategy_alloc_after.items():
+        before = ctx.strategy_alloc_before.get(sid, 0.0)
+        if before <= 0.0:
+            gs[sid] = gw if ctx.world_alloc_after > 0 else 0.0
+        else:
+            gs[sid] = after / before
+    return gs
+
+
+def _aggregate_position_deltas(
+    ctx: RebalanceContext, gw: float, gs: Dict[str, float]
+) -> Dict[tuple[str | None, str], float]:
+    venue_symbol_delta_notional: Dict[tuple[str | None, str], float] = {}
+    for pos in ctx.positions:
+        s_factor = gs.get(pos.strategy_id, gw)
+        target_notional = pos.notional * s_factor
+        delta_notional = target_notional - pos.notional
+        key = (pos.venue, pos.symbol)
+        venue_symbol_delta_notional[key] = (
+            venue_symbol_delta_notional.get(key, 0.0) + delta_notional
+        )
+    return venue_symbol_delta_notional
+
+
+def _materialize_symbol_deltas(
+    ctx: RebalanceContext,
+    venue_symbol_delta_notional: Dict[tuple[str | None, str], float],
+) -> List[SymbolDelta]:
+    deltas: List[SymbolDelta] = []
+    for (venue, symbol), d_notional in venue_symbol_delta_notional.items():
+        if abs(d_notional) < ctx.min_trade_notional:
+            continue
+        marks: List[float] = [
+            p.mark
+            for p in ctx.positions
+            if p.symbol == symbol and p.venue == venue and p.mark > 0
+        ]
+        if not marks:
+            continue
+        avg_mark = sum(marks) / len(marks)
+        raw_qty = 0.0 if avg_mark == 0 else d_notional / avg_mark
+        qty = _round_lot(symbol, raw_qty, ctx.lot_size_by_symbol)
+        if qty == 0.0:
+            continue
+        deltas.append(SymbolDelta(symbol=symbol, delta_qty=qty, venue=venue))
+    return deltas


### PR DESCRIPTION
This PR reduces complexity and clarifies validation logic across several WorldService components, while preserving existing behaviour and contracts.

Summary
- `qmtl/services/worldservice/config.py`: factor `load_worldservice_server_config` into `_parse_bind_config`, `_parse_auth_config`, and `_normalize_auth_tokens`, simplifying the top-level function and keeping error messages and defaults intact.
- `qmtl/services/worldservice/decision.py`: split `augment_metrics_with_linearity` into `_extract_equity_series`, `_materialize_equity_curve`, and `_augment_with_portfolio_metrics` so per-series and portfolio metrics are computed in small, focused helpers.
- `qmtl/services/worldservice/rebalancing/rule_based.py`: refactor `ProportionalRebalancer.plan` into `_compute_world_scale`, `_compute_strategy_scales`, `_aggregate_position_deltas`, and `_materialize_symbol_deltas`, making the rebalancing rules easier to reason about while preserving plan outputs.
- `qmtl/services/worldservice/storage/nodes.py`: introduce `_normalize_legacy_single_bucket` and `_normalize_bucket` so `_ensure_bucket` becomes a thin orchestrator, while keeping audit emissions and domain normalisation behaviour unchanged.
- Confirm radon now reports B or better for the originally flagged functions/methods (config loader, decision metrics, rebalancer plan, and world node bucket handling), and keep the ValidationCacheRepository bucket logic as-is for now due to its tight coupling with legacy payloads.
- Run the WorldService-focused suites (`test_linearity_wiring.py`, `test_rebalancing.py`, `test_worldservice_api.py`, and storage repository tests) to validate behaviour.

Fixes #1595
Refs #1551