### PR TITLE
services/worldservice: augment_metrics_with_linearity 전략 패턴 도입

### DIFF
--- a/qmtl/services/worldservice/decision.py
+++ b/qmtl/services/worldservice/decision.py
@@ -25,51 +25,8 @@ def augment_metrics_with_linearity(
     metrics: Dict[str, Dict[str, float]],
     series: Dict[str, StrategySeries] | None,
 ) -> Dict[str, Dict[str, float]]:
-    if not series:
-        return metrics
-
-    out: Dict[str, Dict[str, float]] = {k: dict(v) for k, v in (metrics or {}).items()}
-
-    equities = _extract_equity_series(series, out)
-    _augment_with_portfolio_metrics(equities, out)
-
-    return out
-
-
-def _extract_equity_series(
-    series: Dict[str, StrategySeries],
-    out: Dict[str, Dict[str, float]],
-) -> Dict[str, List[float]]:
-    equities: Dict[str, List[float]] = {}
-    for sid, s in series.items():
-        eq = _materialize_equity_curve(s)
-        if not eq or len(eq) < 2:
-            continue
-        equities[sid] = eq
-        m1 = equity_linearity_metrics(eq)
-        m2 = equity_linearity_metrics_v2(eq)
-        slot = out.setdefault(sid, {})
-        slot.update(
-            {
-                "el_v1_score": m1["score"],
-                "el_v1_r2_up": m1["r2_up"],
-                "el_v1_straightness": m1["straightness_ratio"],
-                "el_v1_monotonicity": m1["monotonicity"],
-                "el_v1_new_high_frac": m1["new_high_frac"],
-                "el_v1_net_gain": m1["net_gain"],
-                "el_v2_score": m2["score"],
-                "el_v2_tvr": m2["tvr"],
-                "el_v2_tuw": m2["tuw"],
-                "el_v2_r2_up": m2["r2_up"],
-                "el_v2_spearman_rho": m2["spearman_rho"],
-                "el_v2_t_slope": m2["t_slope"],
-                "el_v2_t_slope_sig": m2["t_slope_sig"],
-                "el_v2_mdd_norm": m2["mdd_norm"],
-                "el_v2_net_gain": m2["net_gain"],
-            }
-        )
-        slot.update(alpha_performance_metrics_from_series(s))
-    return equities
+    augmentor = _LinearityMetricsAugmentor()
+    return augmentor.augment(metrics, series)
 
 
 def _materialize_equity_curve(series: StrategySeries) -> List[float] | None:
@@ -87,31 +44,84 @@ def _materialize_equity_curve(series: StrategySeries) -> List[float] | None:
     return None
 
 
-def _augment_with_portfolio_metrics(
-    equities: Dict[str, List[float]],
-    out: Dict[str, Dict[str, float]],
-) -> None:
-    if not equities:
-        return
-    minlen = min(len(v) for v in equities.values())
-    if minlen < 2:
-        return
-    portfolio = [sum(v[i] for v in equities.values()) for i in range(minlen)]
-    p1 = equity_linearity_metrics(portfolio)
-    p2 = equity_linearity_metrics_v2(portfolio)
-    portfolio_returns = equity_curve_to_returns(portfolio)
-    for sid in equities.keys():
-        slot = out.setdefault(sid, {})
-        slot.update(
-            {
-                "portfolio_el_v1_score": p1["score"],
-                "portfolio_el_v2_score": p2["score"],
-                "portfolio_el_v2_tvr": p2["tvr"],
-                "portfolio_el_v2_tuw": p2["tuw"],
-                "portfolio_el_v2_mdd_norm": p2["mdd_norm"],
-            }
-        )
-        slot.update(alpha_performance_metrics_from_returns(portfolio_returns))
+class _LinearityMetricsAugmentor:
+    """Strategy-style helper to augment metrics with linearity signals."""
+
+    def augment(
+        self,
+        metrics: Dict[str, Dict[str, float]],
+        series: Dict[str, StrategySeries] | None,
+    ) -> Dict[str, Dict[str, float]]:
+        if not series:
+            return metrics
+
+        out: Dict[str, Dict[str, float]] = {k: dict(v) for k, v in (metrics or {}).items()}
+        equities = self._extract_equity_series(series, out)
+        self._augment_with_portfolio_metrics(equities, out)
+        return out
+
+    def _extract_equity_series(
+        self,
+        series: Dict[str, StrategySeries],
+        out: Dict[str, Dict[str, float]],
+    ) -> Dict[str, List[float]]:
+        equities: Dict[str, List[float]] = {}
+        for sid, s in series.items():
+            eq = _materialize_equity_curve(s)
+            if not eq or len(eq) < 2:
+                continue
+            equities[sid] = eq
+            m1 = equity_linearity_metrics(eq)
+            m2 = equity_linearity_metrics_v2(eq)
+            slot = out.setdefault(sid, {})
+            slot.update(
+                {
+                    "el_v1_score": m1["score"],
+                    "el_v1_r2_up": m1["r2_up"],
+                    "el_v1_straightness": m1["straightness_ratio"],
+                    "el_v1_monotonicity": m1["monotonicity"],
+                    "el_v1_new_high_frac": m1["new_high_frac"],
+                    "el_v1_net_gain": m1["net_gain"],
+                    "el_v2_score": m2["score"],
+                    "el_v2_tvr": m2["tvr"],
+                    "el_v2_tuw": m2["tuw"],
+                    "el_v2_r2_up": m2["r2_up"],
+                    "el_v2_spearman_rho": m2["spearman_rho"],
+                    "el_v2_t_slope": m2["t_slope"],
+                    "el_v2_t_slope_sig": m2["t_slope_sig"],
+                    "el_v2_mdd_norm": m2["mdd_norm"],
+                    "el_v2_net_gain": m2["net_gain"],
+                }
+            )
+            slot.update(alpha_performance_metrics_from_series(s))
+        return equities
+
+    def _augment_with_portfolio_metrics(
+        self,
+        equities: Dict[str, List[float]],
+        out: Dict[str, Dict[str, float]],
+    ) -> None:
+        if not equities:
+            return
+        minlen = min(len(v) for v in equities.values())
+        if minlen < 2:
+            return
+        portfolio = [sum(v[i] for v in equities.values()) for i in range(minlen)]
+        p1 = equity_linearity_metrics(portfolio)
+        p2 = equity_linearity_metrics_v2(portfolio)
+        portfolio_returns = equity_curve_to_returns(portfolio)
+        for sid in equities.keys():
+            slot = out.setdefault(sid, {})
+            slot.update(
+                {
+                    "portfolio_el_v1_score": p1["score"],
+                    "portfolio_el_v2_score": p2["score"],
+                    "portfolio_el_v2_tvr": p2["tvr"],
+                    "portfolio_el_v2_tuw": p2["tuw"],
+                    "portfolio_el_v2_mdd_norm": p2["mdd_norm"],
+                }
+            )
+            slot.update(alpha_performance_metrics_from_returns(portfolio_returns))
 
 
 class DecisionEvaluator:


### PR DESCRIPTION
Summary\n-------\nWorldService에서 선형성·알파 메트릭 확장 로직을 `_LinearityMetricsAugmentor` 전략형 보조 객체로 분리해, 서비스 함수의 책임을 정리했습니다.\n\nChanges\n-------\n- `qmtl/services/worldservice/decision.py`\n  - `_LinearityMetricsAugmentor` 클래스 도입 (augment, _extract_equity_series, _augment_with_portfolio_metrics).\n  - `augment_metrics_with_linearity`는 보조 객체를 호출하는 얇은 래퍼로 단순화.\n  - `_materialize_equity_curve`는 재사용 가능한 헬퍼로 유지.\n\nRadon\n-----\n- `augment_metrics_with_linearity`: A 래퍼로 단순화, 실제 복잡도는 `_LinearityMetricsAugmentor` 내부로 이동 (B/A 수준).\n\nTesting\n-------\n- `uv run -m pytest tests/qmtl/services/worldservice/test_linearity_wiring.py -q`\n\nFixes #1579\nRefs #1552