### PR TITLE
Docs: Linearity & Alpha Metrics Complexity Plan

### DIFF
--- a/docs/en/architecture/metrics/linearity_and_alpha_metrics_complexity.md
+++ b/docs/en/architecture/metrics/linearity_and_alpha_metrics_complexity.md
@@ -1,0 +1,150 @@
+# Linearity & Alpha Metrics Complexity Plan
+
+## Background and Goals
+
+- This document summarizes the design work for improving the complexity of metric/statistical routines as proposed in issue `#1552`.
+- The goal is to refactor representative functions that had radon CC grade C by splitting the common computation flow (data prep → computation → aggregation) into template/strategy components to improve readability, testability, and reuse.
+- Main targets:
+  - `qmtl/runtime/transforms/linearity_metrics.py: equity_linearity_metrics_v2`
+  - `qmtl/runtime/helpers/runtime.py: compute_alpha_performance_summary`
+  - `qmtl/services/worldservice/decision.py: augment_metrics_with_linearity`
+
+## Shared Design Principles
+
+- **Template Method pattern**
+  - Break complex metric calculations into:
+    - Input normalization/data preparation
+    - Core statistics (slope, R², drawdown, etc.)
+    - Result aggregation/scoring
+  - The top-level function fixes the flow and delegates details to helpers/strategies.
+
+- **Strategy pattern**
+  - Separate per-metric/per-scenario logic into strategy objects.
+  - The service layer focuses on selecting and composing strategies instead of directly depending on low-level statistical implementations.
+
+- **Reusable statistical helpers**
+  - Extract OLS, t-statistics, volatility/drawdown, and summary statistics into small helper functions that can be reused across modules.
+  - Keep helpers as close to pure functions as possible to simplify unit testing and future refactors.
+
+## Refactoring equity_linearity_metrics_v2
+
+### Original issues
+
+- A single function interleaved:
+  - Orientation handling (up/down) and optional log transform
+  - OLS regression and t-statistic computation
+  - TVR, persistence based on time/new highs, and normalized drawdown
+  - Final score aggregation from all components
+- As a result, CC climbed to C(19).
+
+### Improved structure
+
+- Input normalization
+  - `_prepare_oriented_series`  
+    - Normalizes the `pnl` series based on `orientation` (up/down) and `use_log`.
+    - Falls back to the original space when log-transform is not applicable (non-positive values).
+
+- Statistical components
+  - `_trend_components`  
+    - Uses `_ols_slope_r2_t` to get `(slope, r2, t_stat)` and accepts only positive slopes as `r2_up`.
+    - Computes rank correlation via `_spearman_rho` and exposes `t_slope_sig` as a separate component.
+  - `_tvr_multi_scale`  
+    - Downsamples the series at multiple scales (`scales=(1, 5, 20)` etc.) via `_coarse` and applies `_variation_ratio`.
+    - Combines TVR values via geometric mean.
+  - `_persistence_components`  
+    - Uses `_time_under_water` to obtain `tuw` and derives `nh_frac(=1 - tuw)`.
+  - `_normalized_drawdown`  
+    - Normalizes drawdown (`mdd_norm`) using `_max_drawdown` and `net_gain`.
+
+- Score aggregation strategy
+  - `_LinearityComponents` dataclass  
+    - Groups `r2_up`, `spearman_rho`, `tvr`, `tuw`, `nh_frac`, `mdd_norm`, `net_gain`, etc.
+  - `_HarmonicMeanLinearityStrategy`  
+    - First checks directional consistency (whether raw `raw_gain` is aligned with `orientation`).
+    - Aggregates four components—trend (√(r2_up × ρ⁺)), smooth (TVR), persistence (nh_frac), and DD penalty (1/(1 + mdd_norm))—into a harmonic mean after clamping into `(0, 1]`.
+  - `equity_linearity_metrics_v2`  
+    - Becomes a thin orchestrator that wires together the template and strategy, improving CC to grade A.
+
+## Refactoring compute_alpha_performance_summary
+
+### Original issues
+
+- A single function was responsible for:
+  - NaN filtering
+  - Branching between realistic costs vs fixed `transaction_cost`
+  - Excess return, Sharpe, drawdown, and ratio calculations
+  - Adding the alpha_performance prefix and merging execution_* metrics
+- This made the function hard to read, test, and reuse, with CC at C(13).
+
+### Improved structure
+
+- Input cleanup and cost handling
+  - `_clean_returns`  
+    - Filters out NaNs and casts values to `float`.
+  - `_net_returns_and_execution_metrics`  
+    - Applies either:
+      - Realistic costs: `adjust_returns_for_costs` + `calculate_execution_metrics`
+      - Simple costs: deducts `transaction_cost` per period
+    - Returns both `net_returns` and `execution_metrics` in one place.
+
+- Core alpha metrics
+  - `_excess_returns` / `_sharpe_ratio`
+  - `_alpha_core_metrics`  
+    - Computes `sharpe`, `max_drawdown`, `win_ratio`, `profit_factor`, `car_mdd`, `rar_mdd`.
+
+- Top-level template
+  - `compute_alpha_performance_summary` now focuses on:
+    - Cleaning inputs → applying costs → computing core metrics → adding prefixes/merging execution metrics
+  - The resulting schema (`alpha_performance.<metric>`, `execution_<metric>`) remains unchanged, while CC improves to grade A.
+
+## WorldService: Refactoring augment_metrics_with_linearity
+
+### Original issues
+
+- The service-level function `augment_metrics_with_linearity` handled:
+  - Materializing per-strategy equity series
+  - Computing and injecting v1/v2 linearity metrics
+  - Computing and injecting per-strategy alpha metrics
+  - Building a portfolio equity and injecting portfolio-level linearity/alpha metrics
+- The mixed responsibilities made it hard to extend with new linearity/alpha variants.
+
+### Improved structure
+
+- Strategy-style helper
+  - `_LinearityMetricsAugmentor` class
+    - `augment(metrics, series)`  
+      - Acts as the template for what used to be `augment_metrics_with_linearity`.
+      - Copies the input metric map and then injects per-strategy and portfolio metrics in sequence.
+    - `_extract_equity_series`  
+      - Uses `_materialize_equity_curve` to materialize per-strategy equity, then injects v1/v2 linearity and alpha metrics into the slots.
+    - `_augment_with_portfolio_metrics`  
+      - Builds a portfolio equity and injects linearity/alpha metrics into per-strategy slots.
+  - The global function `augment_metrics_with_linearity` is now a thin wrapper around `_LinearityMetricsAugmentor().augment(...)`, preserving the existing service API contract.
+
+## Radon and Verification Strategy
+
+- radon CC goals
+  - `equity_linearity_metrics_v2`: C → A
+  - `compute_alpha_performance_summary`: C → A
+  - `augment_metrics_with_linearity`: keep grade A but move the heavy lifting into `_LinearityMetricsAugmentor` to make future extensions easier.
+- Testing
+  - Linearity metrics:
+    - `tests/qmtl/runtime/transforms/test_equity_linearity.py`
+    - `tests/qmtl/runtime/transforms/test_equity_linearity_v2.py`
+  - Alpha metrics:
+    - `tests/qmtl/runtime/test_alpha_metrics.py`
+  - WorldService wiring:
+    - `tests/qmtl/services/worldservice/test_linearity_wiring.py`
+- Performance and numerical correctness
+  - Reuse the existing test suite to perform numerical regression checks.
+  - Since we refactored existing OLS/statistics into helpers/templates, algorithmic complexity remains the same while readability and reuse improve.
+
+## Future Extensions
+
+- When adding new linearity/alpha metrics:
+  - Extend helpers/strategies in the transforms/helpers layers.
+  - Adjust `_LinearityMetricsAugmentor` or similar strategy-style helpers in the WorldService layer while keeping the external service contract stable.
+- From a radon perspective:
+  - Reuse the template/strategy structure for new metrics to prevent a new wave of CC grade C functions.
+  - Tie back into periodic radon snapshots (for example, the 2025-11-14 snapshot) to catch complexity regressions early.
+

--- a/docs/ko/architecture/metrics/linearity_and_alpha_metrics_complexity.md
+++ b/docs/ko/architecture/metrics/linearity_and_alpha_metrics_complexity.md
@@ -1,0 +1,149 @@
+# 선형성·알파 메트릭 복잡도 개선 계획
+
+## 배경 및 목표
+
+- 이 문서는 이슈 `#1552`에서 제안된 메트릭·통계 계산 루틴 복잡도 개선 작업의 설계 요약을 다룹니다.
+- radon 기준 C급 복잡도였던 대표 함수들을 대상으로 공통 계산 플로우(데이터 준비 → 계산 → 집계)를 템플릿/전략으로 분리해 이해·테스트·재사용성을 높이는 것을 목표로 합니다.
+- 주요 대상:
+  - `qmtl/runtime/transforms/linearity_metrics.py: equity_linearity_metrics_v2`
+  - `qmtl/runtime/helpers/runtime.py: compute_alpha_performance_summary`
+  - `qmtl/services/worldservice/decision.py: augment_metrics_with_linearity`
+
+## 공통 설계 원칙
+
+- **Template Method 패턴**
+  - 복잡한 메트릭 계산을 다음 단계로 나눕니다.
+    - 입력 정규화/데이터 준비
+    - 핵심 통계량 계산(기울기, R², 드로다운 등)
+    - 결과 집계/스코어링
+  - 상위 함수는 흐름만 고정하고, 세부 계산은 헬퍼/전략에 위임합니다.
+
+- **Strategy 패턴**
+  - 메트릭/시나리오별 계산 방식을 전략 객체로 분리합니다.
+  - 서비스 계층에서는 전략을 선택·조합하는 역할만 담당하고, 개별 수식/통계 구현에 직접 의존하지 않도록 합니다.
+
+- **통계 헬퍼 모듈 재사용**
+  - OLS, t-통계, 변동성/드로다운, 요약 통계 등을 작은 헬퍼 함수로 분리해 여러 모듈에서 재사용합니다.
+  - 각 헬퍼는 순수 함수(pure function)에 가깝게 유지해 단위 테스트와 리팩터링을 용이하게 합니다.
+
+## equity_linearity_metrics_v2 리팩터링
+
+### 기존 문제
+
+- 단일 함수 안에서 다음 요소가 섞여 있어 CC가 C(19)까지 상승했습니다.
+  - 방향 처리(상승/하락)와 로그 변환 적용 여부
+  - OLS 회귀와 t-통계 계산
+  - TVR, 시간·신고점 기반 persistence, 드로다운 정규화
+  - 위 요소를 조합한 최종 score 산출
+
+### 개선된 구조
+
+- 입력 정규화
+  - `_prepare_oriented_series`  
+    - `orientation`(up/down)과 `use_log` 옵션에 따라 `pnl` 시계열을 정규화합니다.
+    - 로그 변환이 불가능한 경우(음수/0 포함)에는 원본 스페이스를 유지합니다.
+
+- 통계 컴포넌트
+  - `_trend_components`  
+    - `_ols_slope_r2_t`를 통해 `(slope, r2, t_stat)`을 구하고, 양의 기울기만 `r2_up`으로 인정합니다.
+    - `_spearman_rho`로 순위 상관을 측정하고, `t_slope_sig`를 별도 컴포넌트로 제공합니다.
+  - `_tvr_multi_scale`  
+    - `_coarse`로 여러 스케일(`scales=(1, 5, 20)` 등)에서 시계열을 다운샘플링하고 `_variation_ratio`를 적용합니다.
+    - 스케일별 TVR을 기하평균으로 합성해 `tvr`를 계산합니다.
+  - `_persistence_components`  
+    - `_time_under_water`로 `tuw`를 구하고, 이를 기반으로 `nh_frac(=1 - tuw)`를 계산합니다.
+  - `_normalized_drawdown`  
+    - `_max_drawdown`과 `net_gain`을 이용해 드로다운을 정규화(`mdd_norm`)합니다.
+
+- 스코어 집계 전략
+  - `_LinearityComponents` dataclass  
+    - `r2_up`, `spearman_rho`, `tvr`, `tuw`, `nh_frac`, `mdd_norm`, `net_gain` 등을 한 구조체로 모읍니다.
+  - `_HarmonicMeanLinearityStrategy`  
+    - 방향 일관성(원시 `raw_gain`이 `orientation`과 부합하는지)을 먼저 검사합니다.
+    - trend(√(r2_up × ρ⁺)), smooth(TVR), persistence(nh_frac), DD penalty(1/(1 + mdd_norm)) 네 컴포넌트를 모두 `(0, 1]`로 클램프한 뒤 조화평균으로 합성합니다.
+  - `equity_linearity_metrics_v2`  
+    - 위 템플릿과 전략을 조합하는 얇은 함수로 단순화되어, CC가 A 등급으로 개선되었습니다.
+
+## compute_alpha_performance_summary 리팩터링
+
+### 기존 문제
+
+- 하나의 함수 안에서:
+  - NaN 필터링
+  - 현실적 비용/고정 transaction_cost 분기
+  - 초과수익 계산과 샤프/드로다운/비율 계산
+  - alpha_performance prefix 부여 및 execution_* 메트릭 머지가 모두 수행되었습니다.
+- 로직 이해와 테스트, 재사용이 어려운 구조로 CC가 C(13)이었습니다.
+
+### 개선된 구조
+
+- 입력 정제/비용 반영
+  - `_clean_returns`  
+    - NaN을 제거하고 `float`로 캐스팅된 수익률 시퀀스를 반환합니다.
+  - `_net_returns_and_execution_metrics`  
+    - `use_realistic_costs`와 `execution_fills` 유무에 따라:
+      - 현실적 비용 모드: `adjust_returns_for_costs` + `calculate_execution_metrics`
+      - 단순 비용 모드: `transaction_cost`를 매 기간 차감
+    - 순수익률(`net_returns`)과 실행 메트릭(`execution_metrics`)을 한 번에 결정합니다.
+
+- 핵심 알파 메트릭 계산
+  - `_excess_returns` / `_sharpe_ratio`
+  - `_alpha_core_metrics`  
+    - `sharpe`, `max_drawdown`, `win_ratio`, `profit_factor`, `car_mdd`, `rar_mdd`를 계산합니다.
+
+- 상위 템플릿 함수
+  - `compute_alpha_performance_summary`는 이제 다음 역할에 집중합니다.
+    - 입력 클린업 → 비용 반영 → 핵심 메트릭 계산 → prefix/실행 메트릭 merge
+  - 결과는 기존과 동일한 스키마(`alpha_performance.<metric>`, `execution_<metric>`)를 유지하며, CC는 A 등급으로 개선되었습니다.
+
+## WorldService: augment_metrics_with_linearity 리팩터링
+
+### 기존 문제
+
+- 서비스 계층 함수 `augment_metrics_with_linearity`가 다음을 모두 수행하고 있었습니다.
+  - per-strategy equity 시계열 materialize
+  - v1/v2 선형성 메트릭 계산 및 주입
+  - per-strategy alpha 메트릭 계산 및 주입
+  - 포트폴리오 equity 구성 및 선형성/알파 메트릭 주입
+- 로직이 길어지고 역할이 섞여 있어, 다른 선형성/알파 변형을 추가하기 어려운 구조였습니다.
+
+### 개선된 구조
+
+- 전략형 보조 객체 도입
+  - `_LinearityMetricsAugmentor` 클래스
+    - `augment(metrics, series)`  
+      - 기존 `augment_metrics_with_linearity`의 템플릿 역할 담당.
+      - 입력 메트릭 맵을 복사하고, per-strategy 및 포트폴리오 메트릭을 순서대로 추가합니다.
+    - `_extract_equity_series`  
+      - `_materialize_equity_curve`를 사용해 strategy별 equity를 만들고, v1/v2 선형성 + alpha 메트릭을 슬롯에 주입합니다.
+    - `_augment_with_portfolio_metrics`  
+      - 공통 포트폴리오 equity를 생성하고, 선형성/알파 메트릭을 per-strategy 슬롯에 주입합니다.
+  - 전역 함수 `augment_metrics_with_linearity`는 `_LinearityMetricsAugmentor().augment(...)`를 호출하는 얇은 래퍼로 축소되어, 서비스 API 계약은 그대로 유지됩니다.
+
+## radon 및 검증 전략
+
+- radon CC 목표
+  - `equity_linearity_metrics_v2`: C → A
+  - `compute_alpha_performance_summary`: C → A
+  - `augment_metrics_with_linearity`: A를 유지하되, 관련 로직을 `_LinearityMetricsAugmentor`로 분리해 향후 확장을 용이하게 함.
+- 테스트 전략
+  - 선형성 메트릭:
+    - `tests/qmtl/runtime/transforms/test_equity_linearity.py`
+    - `tests/qmtl/runtime/transforms/test_equity_linearity_v2.py`
+  - 알파 메트릭:
+    - `tests/qmtl/runtime/test_alpha_metrics.py`
+  - WorldService wiring:
+    - `tests/qmtl/services/worldservice/test_linearity_wiring.py`
+- 성능/숫자 정확도
+  - 기존 테스트 스위트를 재사용해 숫자적 동작을 회귀 검증합니다.
+  - OLS/통계 계산은 기존 구현을 헬퍼/템플릿으로 분리한 형태이기 때문에, 알고리즘 복잡도는 유지되면서 가독성과 재사용성이 향상됩니다.
+
+## 향후 확장 포인트
+
+- 새로운 선형성/알파 지표 추가 시:
+  - transforms/helpers 계층에서는 헬퍼/전략 객체를 확장합니다.
+  - WorldService 계층에서는 `_LinearityMetricsAugmentor` 또는 유사한 전략형 보조 객체만 수정해 서비스 계약을 유지합니다.
+- radon 관점에서:
+  - 새 메트릭 도입 시에도 템플릿/전략 구조를 재사용해 C급 함수가 다시 늘어나지 않도록 합니다.
+  - 정기적인 radon 스냅샷 문서(예: 2025-11-14 스냅샷)와 연동해, 복잡도가 상승하는 지점을 조기에 탐지합니다.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Runtime SDK Radon Plan: architecture/radon_runtime_sdk.md
       - Workflow Orchestration Radon Plan: architecture/radon_workflow_orchestration.md
       - Radon Metrics Snapshot (2025-11-14): architecture/metrics/2025-11-14.md
+      - Linearity & Alpha Metrics Complexity Plan: architecture/metrics/linearity_and_alpha_metrics_complexity.md
   - Guides:
       - Overview: guides/README.md
       - Layered Templates Quick Start: guides/layered_templates_quickstart.md
@@ -158,6 +159,7 @@ plugins:
             "History Warmup Radon Plan": "History Warmup Radon 계획"
             "Runtime SDK Radon Plan": "런타임 SDK Radon 계획"
             "Radon Metrics Snapshot (2025-11-14)": "라돈 지표 스냅샷 (2025-11-14)"
+            "Linearity & Alpha Metrics Complexity Plan": "선형성·알파 메트릭 복잡도 계획"
             "Layered Templates Quick Start": "레이어 기반 템플릿 퀵스타트"
             "Seamless Data Provider Setup": "심리스 데이터 프로바이더 구성"
             "Testing & Pytest": "테스트 & Pytest"


### PR DESCRIPTION
Summary\n-------\n선형성·알파 메트릭 복잡도 개선 작업(#1552)의 설계와 radon/테스트 전략을 아키텍처 문서로 정리했습니다.\n\nChanges\n-------\n- `docs/ko/architecture/metrics/linearity_and_alpha_metrics_complexity.md`\n  - 이슈 #1552의 목표/범위, 설계 원칙(Template/Strategy), 대상 함수별 리팩터링 구조, radon/테스트/확장 전략 요약.\n- `docs/en/architecture/metrics/linearity_and_alpha_metrics_complexity.md`\n  - 위 한국어 문서의 영어 번역본 (동일한 규범적 내용 유지).\n- `mkdocs.yml`\n  - Architecture 섹션에 새 문서를 `Linearity & Alpha Metrics Complexity Plan`으로 추가.\n  - i18n nav 번역에 "선형성·알파 메트릭 복잡도 계획" 매핑 추가.\n\nValidation\n----------\n- `uv run mkdocs build -q`\n\nCloses #1552\nRefs #1577\nRefs #1578\nRefs #1579