### PR TITLE
Preserve cancellation propagation in execute_rpc

### DIFF
--- a/qmtl/foundation/common/rpc.py
+++ b/qmtl/foundation/common/rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from asyncio import CancelledError
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Generic, Protocol, TypeVar
 
@@ -63,6 +64,8 @@ async def execute_rpc(
     try:
         response = await command.execute()
         return RpcOutcome(result=parser.parse(response))
+    except CancelledError:
+        raise
     except Exception as exc:  # pragma: no cover - specifics validated by callers
         if on_error is not None:
             error = on_error(exc)


### PR DESCRIPTION
## Summary
- propagate asyncio cancellations by re-raising CancelledError before general exception handling in execute_rpc
- retain existing RpcOutcome error mapping for other exceptions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a4f855408329a06e979cd8ff527a)