### PR TITLE
Simplify downgrade resolution and range subtraction

### DIFF
--- a/tests/qmtl/runtime/sdk/test_history_coverage_property.py
+++ b/tests/qmtl/runtime/sdk/test_history_coverage_property.py
@@ -24,7 +24,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from qmtl.runtime.sdk.history_coverage import WarmupWindow, compute_missing_ranges, merge_coverage
-from qmtl.runtime.sdk.seamless_data_provider import SeamlessDataProvider
+from qmtl.runtime.sdk.seamless_data_provider import SeamlessDataProvider, _RangeOperations
 
 
 def _range_strategy() -> st.SearchStrategy[List[Tuple[int, int]]]:
@@ -149,3 +149,15 @@ def test_find_missing_ranges_matches_history_utilities(
 
     assert dummy_backfiller.calls == expected
     assert result == (len(expected) == 0)
+
+
+def test_subtract_segment_skips_unaligned_ranges() -> None:
+    segments = [(0, 20)]
+    result = _RangeOperations._subtract_segment(segments, sub_start=3, sub_end=10, interval=5)
+    assert result == segments
+
+
+def test_subtract_segment_splits_segment_on_grid() -> None:
+    segments = [(0, 20)]
+    result = _RangeOperations._subtract_segment(segments, sub_start=5, sub_end=10, interval=5)
+    assert result == [(0, 0), (15, 20)]


### PR DESCRIPTION
## Summary
- SLA downgrade 결정을 위반/커버리지/신선도 평가 helper로 분리해  CC를 A로 낮췄습니다.
- 를 겹침/정렬/첫·마지막 제거 구간 helper로 나눠 분기 수를 줄이고 격자 정렬 요구사항을 명확히 했습니다.
- 히스토리 커버리지 프로퍼티 테스트에 세그먼트 감산 유닛 테스트를 추가해 정렬/비정렬 경로를 검증했습니다.

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 tests/qmtl/runtime/sdk/test_seamless_provider.py tests/qmtl/runtime/sdk/test_history_coverage_property.py
- uv run -m pytest -W error -n auto

Closes #1591