### PR TITLE
Add mypy baseline config and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Install dependencies (dev)
         run: uv pip install -e .[dev]
 
+      - name: Type check (mypy)
+        run: uv run --with mypy -m mypy
+
       - name: Build docs (mkdocs)
         run: uv run mkdocs build --strict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,14 @@ dev = [
     "mkdocs-static-i18n",
     "websocket-client",
     "Babel>=2.13",
+    "mypy",
+    "types-protobuf",
+    "pandas-stubs",
+    "types-grpcio",
+    "types-PyYAML",
+    "types-networkx",
+    "types-psutil",
+    "types-cachetools",
 ]
 
 ray = ["ray"]
@@ -71,8 +79,15 @@ dev = [
     "mkdocs-static-i18n",
     "websocket-client",
     "Babel>=2.13",
+    "mypy",
+    "types-protobuf",
+    "pandas-stubs",
+    "types-grpcio",
+    "types-PyYAML",
+    "types-networkx",
+    "types-psutil",
+    "types-cachetools",
 ]
-
 [project.scripts]
 qmtl = "qmtl.interfaces.cli:main"
 qmtl-commitlog-consumer = "qmtl.services.gateway.commit_log_cli:main"
@@ -109,3 +124,26 @@ include = ["qmtl*"]
   "locale/*/LC_MESSAGES/*.mo",
   "locale/*/LC_MESSAGES/*.po",
 ]
+
+[tool.mypy]
+python_version = "3.11"
+strict = false
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_return_any = true
+warn_unreachable = true
+show_error_codes = true
+pretty = true
+
+files = [
+  "qmtl",
+  "examples",
+]
+
+exclude = [
+  "build",
+  "\\.venv",
+  "\\.venv.*",
+]
+
+ignore_missing_imports = true


### PR DESCRIPTION
Summary:
- Add mypy and third-party type stubs to dev dependencies in pyproject.toml.
- Add a mypy configuration block ([tool.mypy]) covering qmtl/ and examples/ with basic warnings enabled.
- Wire mypy into the CI test job as a dedicated "Type check (mypy)" step.

Notes:
- Current mypy run still reports existing type errors across the codebase; these are intentionally left for follow-up work tracked under the type-safety epic and its sub-issues.

Refs #1620
