### PR TITLE
Fix mypy errors in gateway services

### DIFF
--- a/qmtl/services/gateway/ws/duplicate.py
+++ b/qmtl/services/gateway/ws/duplicate.py
@@ -10,8 +10,8 @@ class DuplicateTracker:
     def __init__(self, window: int = 10000) -> None:
         if window <= 0:
             raise ValueError("window must be positive")
-        self._ids = deque(maxlen=window)
-        self._seen = set()
+        self._ids: deque[str] = deque(maxlen=window)
+        self._seen: set[str] = set()
 
     def seen(self, event: Mapping[str, Any] | None) -> bool:
         """Return ``True`` if the CloudEvent has been observed recently."""

--- a/tests/qmtl/services/gateway/test_submission_dag_loader.py
+++ b/tests/qmtl/services/gateway/test_submission_dag_loader.py
@@ -10,7 +10,7 @@ from qmtl.services.gateway.submission.dag_loader import DagLoader
 
 
 def test_decode_accepts_base64_payload() -> None:
-    dag = {"nodes": [], "meta": {}}
+    dag: dict[str, object] = {"nodes": [], "meta": {}}
     encoded = base64.b64encode(json.dumps(dag).encode()).decode()
 
     loader = DagLoader()
@@ -20,7 +20,7 @@ def test_decode_accepts_base64_payload() -> None:
 
 
 def test_load_validates_schema(monkeypatch) -> None:
-    dag = {"nodes": [], "meta": {}}
+    dag: dict[str, object] = {"nodes": [], "meta": {}}
     loader = DagLoader()
 
     calls: list[dict] = []
@@ -54,4 +54,6 @@ def test_load_raises_on_invalid_schema(monkeypatch) -> None:
         loader.load("{}")
 
     assert exc.value.status_code == 400
-    assert exc.value.detail["code"] == "E_SCHEMA_INVALID"
+    detail = exc.value.detail
+    assert isinstance(detail, dict)
+    assert detail["code"] == "E_SCHEMA_INVALID"


### PR DESCRIPTION
## Summary
- ensure shared account policy margin checks use typed totals and safe casts
- annotate websocket duplicate tracker buffers for clearer typing
- type dag loader gateway tests to validate detail payload access

## Testing
- uv run --with mypy -m mypy qmtl/services/gateway/shared_account_policy.py qmtl/services/gateway/ws/duplicate.py tests/qmtl/services/gateway/test_submission_dag_loader.py --follow-imports=skip --ignore-missing-imports
- uv run -m pytest -W error -n auto tests/qmtl/services/gateway/test_submission_dag_loader.py

Fixes #1621

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a9b98fb8883298bb5a0103cd388aa)