### PR TITLE
Refine Neo4j reconnect abstractions

### DIFF
--- a/qmtl/foundation/common/__init__.py
+++ b/qmtl/foundation/common/__init__.py
@@ -1,5 +1,11 @@
 from .crc import crc32_of_list
-from .reconnect import ReconnectingRedis, ReconnectingNeo4j
+from .reconnect import (
+    Neo4jDriverLike,
+    Neo4jSessionLike,
+    ReconnectingRedis,
+    ReconnectingNeo4j,
+    create_neo4j_driver,
+)
 from .circuit_breaker import AsyncCircuitBreaker
 from .four_dim_cache import FourDimCache
 from .hashutils import hash_bytes
@@ -21,8 +27,11 @@ from .health import CheckResult, Code, classify_result, probe_http, probe_http_a
 
 __all__ = [
     "crc32_of_list",
+    "Neo4jDriverLike",
+    "Neo4jSessionLike",
     "ReconnectingRedis",
     "ReconnectingNeo4j",
+    "create_neo4j_driver",
     "AsyncCircuitBreaker",
     "FourDimCache",
     "hash_bytes",

--- a/qmtl/foundation/common/reconnect.py
+++ b/qmtl/foundation/common/reconnect.py
@@ -2,12 +2,44 @@ from __future__ import annotations
 
 """Connection wrappers with automatic reconnection."""
 
-from typing import Any, Callable
+from typing import Any, Callable, Protocol, runtime_checkable
 
 from .circuit_breaker import AsyncCircuitBreaker
 import asyncio
 
 import redis.asyncio as redis
+
+
+@runtime_checkable
+class Neo4jSessionLike(Protocol):
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+    def close(self) -> None:
+        ...
+
+    def __enter__(self) -> "Neo4jSessionLike":
+        ...
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        ...
+
+
+@runtime_checkable
+class Neo4jDriverLike(Protocol):
+    def session(self, *args: Any, **kwargs: Any) -> Neo4jSessionLike:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+def create_neo4j_driver(uri: str, auth: tuple[str, str]) -> Neo4jDriverLike:
+    """Factory that creates a Neo4j driver instance."""
+
+    from neo4j import GraphDatabase
+
+    return GraphDatabase.driver(uri, auth=auth)
 
 
 class ReconnectingRedis:
@@ -39,38 +71,46 @@ class ReconnectingRedis:
 class _ReconnectingSession:
     def __init__(
         self,
-        factory: Callable[[], Any],
+        session_factory: Callable[[], Neo4jSessionLike],
         reconnect: Callable[[], None],
+        *,
+        attempts: int = 2,
         breaker: AsyncCircuitBreaker | None = None,
     ) -> None:
-        self._factory = factory
+        self._session_factory = session_factory
         self._reconnect = reconnect
-        self._session = self._factory()
+        self._attempts = attempts
+        self._session: Neo4jSessionLike = self._session_factory()
         self._breaker: AsyncCircuitBreaker | None = breaker
 
+    def _refresh_session(self) -> None:
+        self._session.close()
+        self._reconnect()
+        self._session = self._session_factory()
+
+    def _run_with_breaker(self, *args: Any, **kwargs: Any) -> Any:
+        breaker = self._breaker
+        assert breaker is not None
+
+        async def _call() -> Any:
+            return await asyncio.to_thread(self._session.run, *args, **kwargs)
+
+        async def _execute() -> Any:
+            breaker_call = breaker(_call)
+            return await breaker_call()
+
+        return asyncio.run(_execute())
+
     def run(self, *args: Any, **kwargs: Any) -> Any:
-        for attempt in range(2):
+        for attempt in range(self._attempts):
             try:
                 if self._breaker is None:
                     return self._session.run(*args, **kwargs)
-                else:
-                    breaker = self._breaker
-                    assert breaker is not None
-
-                    async def _call() -> Any:
-                        return await asyncio.to_thread(self._session.run, *args, **kwargs)
-
-                    async def _run_with_breaker() -> Any:
-                        breaker_call = breaker(_call)
-                        return await breaker_call()
-
-                    return asyncio.run(_run_with_breaker())
+                return self._run_with_breaker(*args, **kwargs)
             except Exception:
-                if attempt == 1:
+                if attempt >= self._attempts - 1:
                     raise
-                self._session.close()
-                self._reconnect()
-                self._session = self._factory()
+                self._refresh_session()
         raise RuntimeError("unreachable")
 
     def close(self) -> None:
@@ -86,18 +126,24 @@ class _ReconnectingSession:
 class ReconnectingNeo4j:
     """Neo4j driver wrapper with reconnection logic."""
 
-    def __init__(self, uri: str, user: str, password: str, *, attempts: int = 2) -> None:
-        from neo4j import GraphDatabase  # type: ignore[import-not-found]
-
+    def __init__(
+        self,
+        uri: str,
+        user: str,
+        password: str,
+        *,
+        attempts: int = 2,
+        driver_factory: Callable[[str, tuple[str, str]], Neo4jDriverLike] | None = None,
+    ) -> None:
         self._uri = uri
         self._auth = (user, password)
         self._attempts = attempts
-        self._GraphDatabase = GraphDatabase
-        self._driver = GraphDatabase.driver(self._uri, auth=self._auth)
+        self._driver_factory = driver_factory or create_neo4j_driver
+        self._driver: Neo4jDriverLike = self._driver_factory(self._uri, self._auth)
 
     def _reconnect(self) -> None:
         self._driver.close()
-        self._driver = self._GraphDatabase.driver(self._uri, auth=self._auth)
+        self._driver = self._driver_factory(self._uri, self._auth)
 
     def session(
         self,
@@ -105,13 +151,24 @@ class ReconnectingNeo4j:
         breaker: AsyncCircuitBreaker | None = None,
         **kwargs: Any,
     ) -> _ReconnectingSession:
-        def factory():
+        def factory() -> Neo4jSessionLike:
             return self._driver.session(*args, **kwargs)
 
-        return _ReconnectingSession(factory, self._reconnect, breaker)
+        return _ReconnectingSession(
+            factory,
+            self._reconnect,
+            attempts=self._attempts,
+            breaker=breaker,
+        )
 
     def close(self) -> None:
         self._driver.close()
 
 
-__all__ = ["ReconnectingRedis", "ReconnectingNeo4j"]
+__all__ = [
+    "Neo4jDriverLike",
+    "Neo4jSessionLike",
+    "create_neo4j_driver",
+    "ReconnectingRedis",
+    "ReconnectingNeo4j",
+]


### PR DESCRIPTION
## Summary
- add Neo4j driver and session protocols plus a factory to decouple from direct GraphDatabase imports
- refactor reconnecting Neo4j session logic to use the protocols with configurable retry attempts
- export the new abstractions alongside existing reconnect utilities

## Testing
- python -m pytest tests/qmtl/foundation/common/reliability/test_reconnect.py::test_reconnecting_neo4j tests/qmtl/services/dagmanager/test_circuit_breaker_neo4j.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab213908483299705e0156ecc815f)