### PR TITLE
Handle control bus readiness probe failures in validation

### DIFF
--- a/qmtl/foundation/config_validation.py
+++ b/qmtl/foundation/config_validation.py
@@ -75,7 +75,12 @@ async def _check_controlbus(
     except ModuleNotFoundError:
         return ValidationIssue("warning", "aiokafka not installed; skipping ControlBus validation")
 
-    ready = await probe.ready()
+    try:
+        ready = await probe.ready()
+    except Exception as exc:
+        return ValidationIssue(
+            "error", f"ControlBus brokers unreachable ({broker_list}): {exc}")
+
     if ready:
         return ValidationIssue("ok", f"ControlBus brokers reachable ({broker_list})")
     return ValidationIssue("error", f"ControlBus brokers unreachable ({broker_list})")


### PR DESCRIPTION
## Summary
- guard ControlBus readiness probe calls so broker connection failures surface as validation errors instead of exceptions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab458177c8329b2907b32a5ae9f96)