### PR TITLE
Add Kafka producer protocol and refactor control bus producers

### DIFF
--- a/qmtl/services/kafka.py
+++ b/qmtl/services/kafka.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Iterable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class KafkaProducerLike(Protocol):
+    async def start(self) -> None:  # pragma: no cover - interface
+        ...
+
+    async def stop(self) -> None:  # pragma: no cover - interface
+        ...
+
+    async def send_and_wait(self, topic: str, value: bytes, *, key: bytes | None = None) -> object:  # pragma: no cover - interface
+        ...
+
+
+def create_kafka_producer(brokers: Iterable[str]) -> KafkaProducerLike | None:
+    """Create an ``AIOKafkaProducer`` when available.
+
+    Returns ``None`` if the optional ``aiokafka`` dependency is not installed or
+    fails to import.
+    """
+
+    try:  # pragma: no cover - optional dependency
+        from aiokafka import AIOKafkaProducer
+    except Exception:
+        return None
+    return AIOKafkaProducer(bootstrap_servers=list(brokers))
+
+
+__all__ = ["KafkaProducerLike", "create_kafka_producer"]

--- a/tests/qmtl/services/dagmanager/test_grpc_server.py
+++ b/tests/qmtl/services/dagmanager/test_grpc_server.py
@@ -535,6 +535,12 @@ class DummyProducer:
     def __init__(self) -> None:
         self.sent: list[tuple[str, bytes, bytes | None]] = []
 
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
     async def send_and_wait(self, topic, data, key=None):
         self.sent.append((topic, data, key))
 

--- a/tests/qmtl/services/worldservice/test_controlbus_producer.py
+++ b/tests/qmtl/services/worldservice/test_controlbus_producer.py
@@ -8,6 +8,12 @@ class DummyProducer:
     def __init__(self) -> None:
         self.sent: list[tuple[str, bytes, bytes | None]] = []
 
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
     async def send_and_wait(self, topic: str, data: bytes, key: bytes | None = None) -> None:
         self.sent.append((topic, data, key))
 


### PR DESCRIPTION
## Summary
- add a KafkaProducerLike protocol and factory to encapsulate optional aiokafka imports
- update control bus producers to depend on the protocol and remove untyped producer fields
- align tests with the protocol-compliant producer interface

## Testing
- uv run -m pytest tests/qmtl/services/worldservice/test_controlbus_producer.py tests/qmtl/services/dagmanager/test_grpc_server.py -k "controlbus or DummyProducer"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab465b4888329950f492c935e1a34)