### PR TITLE
Guard alpha performance metrics against non-string keys

### DIFF
--- a/qmtl/runtime/alpha_metrics.py
+++ b/qmtl/runtime/alpha_metrics.py
@@ -41,6 +41,8 @@ def sanitize_alpha_performance_metrics(raw: Mapping[str, Any]) -> dict[str, floa
 
     sanitized = default_alpha_performance_metrics()
     for key, value in raw.items():
+        if not isinstance(key, str):
+            continue
         alpha_key = _is_alpha_performance_key(key)
         if alpha_key is None:
             continue


### PR DESCRIPTION
## Summary
- skip non-string metric keys when sanitizing alpha performance metrics to avoid AttributeError

## Testing
- uv run -m pytest -W error -n auto tests/qmtl/runtime/test_alpha_metrics.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab8d5ef6483298c22f86bfe9ade5d)