### PR TITLE
Add cache view helper utilities

### DIFF
--- a/qmtl/runtime/indicators/volatility.py
+++ b/qmtl/runtime/indicators/volatility.py
@@ -16,13 +16,14 @@ def volatility_node(source: Node, window: int, *, name: str | None = None) -> No
     """
 
     def compute(view: CacheView):
-        data = [v for _, v in view[source][source.interval][-(window + 1):]]
-        if len(data) < window + 1:
+        frame = view.as_frame(source, source.interval, window=window + 1)
+        if len(frame.frame) < window + 1:
             return None
-        returns = [(data[i] / data[i - 1]) - 1 for i in range(1, len(data))]
+
+        returns = frame.returns()
         if len(returns) < 2:
             return 0.0
-        return stdev(returns)
+        return stdev(list(returns)[-window:])
 
     return Node(
         input=source,

--- a/qmtl/runtime/sdk/__init__.py
+++ b/qmtl/runtime/sdk/__init__.py
@@ -12,6 +12,7 @@ from .node import (
 from .arrow_cache import NodeCacheArrow
 from .backfill_state import BackfillState
 from .cache_view import CacheView
+from .cache_view_tools import CacheFrame
 from .auto_backfill import (
     AutoBackfillStrategy,
     FetcherBackfillStrategy,
@@ -87,6 +88,7 @@ __all__ = [
     "NodeCacheArrow",
     "BackfillState",
     "CacheView",
+    "CacheFrame",
     "Strategy",
     "buy_signal",
     "Runner",

--- a/qmtl/runtime/sdk/cache_view.py
+++ b/qmtl/runtime/sdk/cache_view.py
@@ -135,3 +135,38 @@ class CacheView:
             start=start,
             end=end,
         )
+
+    # ------------------------------------------------------------------
+    def as_frame(
+        self,
+        node: "Node" | str,
+        interval: int,
+        *,
+        window: int | None = None,
+        columns: Sequence[str] | None = None,
+    ):
+        """Delegate to :func:`cache_view_tools.as_frame`."""
+
+        from .cache_view_tools import as_frame as _as_frame
+
+        return _as_frame(self, node, interval, window=window, columns=columns)
+
+    def window(self, node: "Node" | str, interval: int, length: int):
+        """Delegate to :func:`cache_view_tools.window`."""
+
+        from .cache_view_tools import window as _window
+
+        return _window(self, node, interval, length)
+
+    def align_frames(
+        self,
+        specs: Sequence[tuple["Node" | str, int]],
+        *,
+        window: int | None = None,
+        columns: Mapping["Node" | str, Sequence[str]] | Sequence[str] | None = None,
+    ):
+        """Delegate to :func:`cache_view_tools.align_frames`."""
+
+        from .cache_view_tools import align_frames as _align_frames
+
+        return _align_frames(self, specs, window=window, columns=columns)

--- a/qmtl/runtime/sdk/cache_view_tools.py
+++ b/qmtl/runtime/sdk/cache_view_tools.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+from .cache_view import CacheView
+from .node import Node
+
+
+@dataclass(frozen=True)
+class CacheFrame:
+    """Pandas-backed view over a cache leaf."""
+
+    frame: pd.DataFrame
+
+    def returns(self, *, window: int = 1, dropna: bool = True):
+        """Percentage change over ``window`` periods."""
+
+        return self.pct_change(window=window, dropna=dropna)
+
+    def pct_change(self, *, window: int = 1, dropna: bool = True):
+        if window < 1:
+            raise ValueError("window must be >= 1")
+
+        target = self.frame if self.frame.shape[1] > 1 else self.frame.iloc[:, 0]
+        changed = target.pct_change(periods=window)
+        return changed.dropna() if dropna else changed
+
+    def validate_columns(self, required: Sequence[str]) -> "CacheFrame":
+        missing = [column for column in required if column not in self.frame.columns]
+        if missing:
+            raise KeyError(f"Missing columns: {', '.join(missing)}")
+        return self
+
+    def align_with(self, *others: "CacheFrame") -> list["CacheFrame"]:
+        frames = [self.frame, *(other.frame for other in others)]
+        if not frames:
+            return []
+
+        common_index = frames[0].index
+        for frame in frames[1:]:
+            common_index = common_index.intersection(frame.index)
+        common_index = common_index.sort_values()
+
+        return [CacheFrame(frame.loc[common_index]) for frame in frames]
+
+
+def window(view: CacheView, node: Node | str, interval: int, length: int) -> list[tuple[Any, Any]]:
+    """Return the trailing ``length`` entries for ``(node, interval)``."""
+
+    if length < 0:
+        raise ValueError("length must be non-negative")
+
+    series_view = view[node][interval]
+    data = _as_sequence(series_view)
+    if length == 0:
+        return []
+    return list(data[-length:])
+
+
+def as_frame(
+    view: CacheView,
+    node: Node | str,
+    interval: int,
+    *,
+    window: int | None = None,
+    columns: Sequence[str] | None = None,
+) -> CacheFrame:
+    """Convert a cache leaf into a :class:`CacheFrame`."""
+
+    series = _slice_series(view, node, interval, window)
+    timestamps: list[int] = []
+    values: list[Any] = []
+    for item in series:
+        if not isinstance(item, Sequence) or isinstance(item, (str, bytes, bytearray)):
+            raise TypeError("cache leaf entries must be (timestamp, value) pairs")
+        if len(item) != 2:
+            raise ValueError("cache leaf entries must unpack into timestamp and value")
+        ts, value = item
+        timestamps.append(int(ts))
+        values.append(value)
+
+    frame = _build_frame(timestamps, values, columns)
+    return CacheFrame(frame)
+
+
+def align_frames(
+    view: CacheView,
+    specs: Sequence[tuple[Node | str, int]],
+    *,
+    window: int | None = None,
+    columns: Mapping[Node | str, Sequence[str]] | Sequence[str] | None = None,
+) -> list[CacheFrame]:
+    """Materialize and align multiple cache leaves on their shared timestamps."""
+
+    frames: list[CacheFrame] = []
+    for node, interval in specs:
+        column_spec: Sequence[str] | None
+        if isinstance(columns, Mapping):
+            column_spec = columns.get(node)
+        else:
+            column_spec = columns
+        frames.append(as_frame(view, node, interval, window=window, columns=column_spec))
+
+    if not frames:
+        return []
+    return frames[0].align_with(*frames[1:])
+
+
+def _slice_series(
+    view: CacheView, node: Node | str, interval: int, window: int | None
+) -> Sequence[Any]:
+    series_view = view[node][interval]
+    data = _as_sequence(series_view)
+    if window is None:
+        return data[:]
+    if window < 0:
+        raise ValueError("window must be non-negative")
+    if window == 0:
+        return []
+    return data[-window:]
+
+
+def _as_sequence(series_view: Any) -> Sequence[Any]:
+    data = series_view
+    if isinstance(series_view, CacheView):
+        data = object.__getattribute__(series_view, "_data")
+    if data is None:
+        return []
+    if not isinstance(data, Sequence) or isinstance(data, (str, bytes, bytearray)):
+        raise TypeError("cache leaf must be a sequence of (timestamp, value) pairs")
+    return data
+
+
+def _build_frame(
+    timestamps: Sequence[int], values: Sequence[Any], columns: Sequence[str] | None
+) -> pd.DataFrame:
+    if not values:
+        if columns is None:
+            return pd.DataFrame(index=pd.Index([], name="t"))
+        return pd.DataFrame(columns=list(columns), index=pd.Index([], name="t"))
+
+    first_value = values[0]
+    if isinstance(first_value, Mapping):
+        inferred_columns = columns or _collect_mapping_columns(values)
+        _validate_mapping_columns(values, inferred_columns)
+        rows = [{column: value.get(column) for column in inferred_columns} for value in values]
+        return pd.DataFrame(rows, index=pd.Index(timestamps, name="t"), columns=list(inferred_columns))
+
+    if isinstance(first_value, Sequence) and not isinstance(first_value, (str, bytes, bytearray)):
+        inferred_columns = columns or [f"value_{i}" for i in range(len(first_value))]
+        if columns is not None and len(first_value) != len(columns):
+            raise ValueError("sequence values must match the number of columns")
+        rows = [list(value) for value in values]
+        return pd.DataFrame(rows, index=pd.Index(timestamps, name="t"), columns=list(inferred_columns))
+
+    inferred_columns = columns or ["value"]
+    if columns is not None and len(inferred_columns) != 1:
+        raise ValueError("scalar values can only map to a single column")
+    return pd.DataFrame(values, index=pd.Index(timestamps, name="t"), columns=list(inferred_columns))
+
+
+def _collect_mapping_columns(values: Sequence[Mapping[str, Any]]) -> list[str]:
+    keys: set[str] = set()
+    for value in values:
+        keys.update(value.keys())
+    return sorted(keys)
+
+
+def _validate_mapping_columns(values: Sequence[Mapping[str, Any]], columns: Sequence[str]) -> None:
+    missing = []
+    for column in columns:
+        if not all(column in value for value in values):
+            missing.append(column)
+    if missing:
+        raise KeyError(f"Missing columns: {', '.join(missing)}")

--- a/tests/qmtl/runtime/sdk/test_cache_view_tools.py
+++ b/tests/qmtl/runtime/sdk/test_cache_view_tools.py
@@ -1,0 +1,57 @@
+import pandas as pd
+import pytest
+
+from qmtl.runtime.sdk.cache_view import CacheView
+
+
+def test_window_and_as_frame_single_node():
+    view = CacheView({"a": {1: [(1, {"price": 1}), (2, {"price": 2}), (3, {"price": 3})]}})
+
+    window = view.window("a", 1, 2)
+    assert window == [(2, {"price": 2}), (3, {"price": 3})]
+
+    frame = view.as_frame("a", 1, window=2, columns=["price"])
+    assert list(frame.frame.index) == [2, 3]
+    assert frame.frame["price"].tolist() == [2, 3]
+    assert pytest.approx(frame.returns().tolist()) == [0.5]
+
+
+def test_align_frames_with_shared_timestamps():
+    view = CacheView(
+        {
+            "a": {1: [(1, 1), (2, 2), (3, 3)]},
+            "b": {1: [(2, 20), (3, 30), (4, 40)]},
+        }
+    )
+
+    aligned = view.align_frames([("a", 1), ("b", 1)])
+    assert len(aligned) == 2
+
+    left, right = aligned
+    assert list(left.frame.index) == [2, 3]
+    assert left.frame["value"].tolist() == [2, 3]
+    assert right.frame["value"].tolist() == [20, 30]
+
+
+def test_missing_columns_raise():
+    view = CacheView({"a": {1: [(1, {"price": 1})]}})
+
+    frame = view.as_frame("a", 1, columns=["price"])
+    frame.validate_columns(["price"])
+
+    with pytest.raises(KeyError):
+        view.as_frame("a", 1, columns=["price", "volume"])
+
+    with pytest.raises(KeyError):
+        frame.validate_columns(["volume"])
+
+
+def test_track_access_and_pct_change():
+    view = CacheView({"a": {1: [(1, 1), (2, 2), (3, 4)]}}, track_access=True)
+
+    frame = view.as_frame("a", 1, window=3)
+    assert view.access_log() == [("a", 1)]
+
+    pct = frame.pct_change(window=2)
+    assert isinstance(pct, pd.Series)
+    assert pct.tolist() == [3.0]


### PR DESCRIPTION
## Summary
- add `cache_view_tools` helpers to turn cache leaves into pandas-backed frames, compute returns, and align windows safely
- expose convenience delegates on `CacheView`, export `CacheFrame`, and update the volatility indicator to use the new helper API
- cover windowing, alignment, column validation, and access tracking with new SDK unit tests

## Testing
- uv run -m pytest -W error -n auto *(fails: existing failures in seamless provider metadata handling, snapshot optional imports, and dagmanager metrics gauges)*
- uv run -m pytest tests/qmtl/runtime/sdk/test_cache_view_tools.py tests/qmtl/runtime/indicators/test_volatility.py -W error


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eb8e215908329aea29b431c1c4ad1)