### PR TITLE
Add compute_fn helper guide and update examples

### DIFF
--- a/docs/en/guides/ergonomic_compute_fn_patterns.md
+++ b/docs/en/guides/ergonomic_compute_fn_patterns.md
@@ -1,0 +1,72 @@
+# Ergonomic compute_fn patterns with helpers
+
+`CacheView` already contains every input a node needs, but hand-writing window slicing, column validation, and multi-input alignment quickly becomes verbose. This guide shows how to express `compute_fn` steps declaratively with the helper APIs.
+
+## What the helper layer provides
+
+- **Windowed reads:** `view.window(node, interval, length)` slices to the desired length. Use `view.as_frame(..., window=...)` when you need a DataFrame.
+- **Column validation:** `CacheFrame.validate_columns([...])` fails fast when required columns are missing.
+- **Multi-input alignment:** `view.align_frames([(node, interval), ...], window=...)` aligns data frames on their shared timestamps.
+
+## 1) Windowed reads and frame conversion
+
+```python
+from qmtl.runtime.sdk import StreamInput
+from qmtl.runtime.sdk.cache_view import CacheView
+
+price = StreamInput(interval="1m", period=30)
+view: CacheView = ...
+
+# Fetch the latest 10 entries
+latest_price = view.window(price, 60, 10)
+
+# Convert to a DataFrame with the same window
+price_frame = view.as_frame(price, 60, window=10, columns=["close"]).validate_columns(["close"])
+```
+
+## 2) Column validation and derived calculations
+
+After validating the required columns on a `CacheFrame`, reuse helpers such as `returns`/`pct_change` directly.
+
+```python
+momentum = price_frame.returns(window=1, dropna=False)
+signal = (momentum > 0).astype(int)
+```
+
+## 3) Aligning multiple inputs
+
+When combining multiple upstreams, `align_frames` preserves the intersection of timestamps across inputs.
+
+```python
+aligned = view.align_frames([(price_node, 60), (signal_node, 60)], window=20)
+price_frame, signal_frame = aligned
+
+close = price_frame.validate_columns(["close"]).frame["close"]
+flag = signal_frame.validate_columns(["flag"]).frame["flag"]
+merged = close.to_frame("close").assign(flag=flag.values)
+```
+
+## 4) End-to-end compute_fn example
+
+The pattern below wires **window → column validation → multi-input alignment** purely through helpers.
+
+```python
+from qmtl.runtime.sdk import Node
+
+price_node = Node(...)
+signal_node = Node(...)
+
+
+def compute(view):
+    price_frame, signal_frame = view.align_frames(
+        [(price_node, 60), (signal_node, 60)],
+        window=12,
+    )
+
+    returns = price_frame.validate_columns(["close"]).returns(window=1, dropna=False)
+    flags = signal_frame.validate_columns(["flag"]).frame["flag"]
+
+    return returns.to_frame("close_return").assign(flag=flags.values)
+```
+
+Using the helper layer keeps `compute_fn` focused on merging and alignment logic, and tests can exercise the same helpers for concise, end-to-end coverage.

--- a/docs/ko/guides/ergonomic_compute_fn_patterns.md
+++ b/docs/ko/guides/ergonomic_compute_fn_patterns.md
@@ -1,0 +1,72 @@
+# compute_fn 헬퍼 활용 가이드 (Ergonomic compute_fn patterns)
+
+`CacheView`는 계산 함수가 필요로 하는 모든 입력을 포함하지만, 윈도우 슬라이싱·컬럼 검증·다중 업스트림 정렬을 매번 수동으로 처리하면 코드가 금방 장황해집니다. 본 가이드는 SDK에 추가된 헬퍼 API를 이용해 `compute_fn`을 선언적으로 작성하는 방법을 정리합니다.
+
+## 헬퍼 계층이 제공하는 것
+
+- **윈도우 단위 조회**: `view.window(node, interval, length)`는 원하는 길이만큼 바로 잘라 줍니다. DataFrame이 필요하면 `view.as_frame(..., window=...)`을 사용하세요.
+- **컬럼 존재성 검증**: `CacheFrame.validate_columns([...])`는 필수 컬럼 누락 시 즉시 예외를 던져 조기 실패를 보장합니다.
+- **다중 업스트림 정렬**: `view.align_frames([(node, interval), ...], window=...)`는 공통 타임스탬프에 맞춰 데이터프레임을 교집합으로 정렬합니다.
+
+## 1) 윈도우 조회와 프레임 변환
+
+```python
+from qmtl.runtime.sdk import StreamInput
+from qmtl.runtime.sdk.cache_view import CacheView
+
+price = StreamInput(interval="1m", period=30)
+view: CacheView = ...
+
+# 마지막 10개만 가져오기
+latest_price = view.window(price, 60, 10)
+
+# DataFrame으로 바로 변환 + 윈도우 적용
+price_frame = view.as_frame(price, 60, window=10, columns=["close"]).validate_columns(["close"])
+```
+
+## 2) 컬럼 검증과 파생 계산
+
+`CacheFrame`에서 필요한 컬럼을 검증한 뒤, `returns`/`pct_change` 등 헬퍼를 그대로 활용할 수 있습니다.
+
+```python
+momentum = price_frame.returns(window=1, dropna=False)
+signal = (momentum > 0).astype(int)
+```
+
+## 3) 다중 입력 노드 정렬
+
+여러 업스트림을 한 번에 묶어야 할 때는 `align_frames`가 교집합 인덱스를 유지해 줍니다.
+
+```python
+aligned = view.align_frames([(price_node, 60), (signal_node, 60)], window=20)
+price_frame, signal_frame = aligned
+
+close = price_frame.validate_columns(["close"]).frame["close"]
+flag = signal_frame.validate_columns(["flag"]).frame["flag"]
+merged = close.to_frame("close").assign(flag=flag.values)
+```
+
+## 4) compute_fn 전체 예시
+
+아래 예시는 **윈도우 → 컬럼 검증 → 다중 입력 정렬** 순서를 모두 헬퍼로 처리하는 최소 패턴입니다.
+
+```python
+from qmtl.runtime.sdk import Node
+
+price_node = Node(...)
+signal_node = Node(...)
+
+
+def compute(view):
+    price_frame, signal_frame = view.align_frames(
+        [(price_node, 60), (signal_node, 60)],
+        window=12,
+    )
+
+    returns = price_frame.validate_columns(["close"]).returns(window=1, dropna=False)
+    flags = signal_frame.validate_columns(["flag"]).frame["flag"]
+
+    return returns.to_frame("close_return").assign(flag=flags.values)
+```
+
+헬퍼 계층을 사용하면 `compute_fn`이 값 병합과 정렬에 집중할 수 있으며, 테스트 또한 동일한 헬퍼를 호출하는 방식으로 간결하게 작성할 수 있습니다.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - SDK Tutorial & World ID: guides/sdk_tutorial.md
       - History Data Quickstart: guides/history_data_quickstart.md
       - Strategy Workflow: guides/strategy_workflow.md
+      - Ergonomic compute_fn patterns: guides/ergonomic_compute_fn_patterns.md
       - Microstructure Signals: guides/microstructure_signals.md
       - Short-Term Microstructure Filters: guides/short_term_microstructure.md
       - Docs Internationalization: guides/docs_internationalization.md

--- a/qmtl/examples/strategies/general_strategy.py
+++ b/qmtl/examples/strategies/general_strategy.py
@@ -20,8 +20,10 @@ class GeneralStrategy(Strategy):
         )
 
         def generate_signal(view):
-            price = pd.DataFrame([v for _, v in view[price_stream][60]])
-            momentum = price["close"].pct_change().rolling(5).mean()
+            price_frame = view.as_frame(price_stream, 60, columns=["close"]).validate_columns(
+                ["close"]
+            )
+            momentum = price_frame.frame["close"].pct_change().rolling(5).mean()
             signal = (momentum > 0).astype(int)
             return pd.DataFrame({"signal": signal})
 

--- a/qmtl/examples/strategies/tag_query_aggregation.py
+++ b/qmtl/examples/strategies/tag_query_aggregation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd  # type: ignore[import-untyped]
 
-from qmtl.runtime.sdk import Strategy, Node, TagQueryNode, Runner, EventRecorderService, MatchMode
+from qmtl.runtime.sdk import EventRecorderService, MatchMode, Node, Runner, Strategy, TagQueryNode
 from qmtl.runtime.io import QuestDBRecorder
 
 
@@ -19,7 +19,8 @@ class TagQueryAggregationStrategy(Strategy):
         # Runner takes care of queue resolution and subscriptions via TagQueryManager
 
         def calc_corr(view) -> pd.DataFrame:
-            frames = [pd.DataFrame([v for _, v in view[u][3600]]) for u in view]
+            aligned = view.align_frames([(node_id, 3600) for node_id in view], window=24)
+            frames = [frame.frame for frame in aligned if not frame.frame.empty]
             if not frames:
                 return pd.DataFrame()
             df = pd.concat(frames, axis=1)


### PR DESCRIPTION
## Summary
- add a new ko/en "Ergonomic compute_fn patterns" guide and expose it in navigation
- refresh architecture docs and strategy examples to use the cache view helper API for windows, validation, and alignment
- expand cache_view_tools tests with an end-to-end helper-based compute_fn example

## Testing
- uv run -m pytest tests/qmtl/runtime/sdk/test_cache_view_tools.py -W error -n auto
- uv run mkdocs build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec42d19d483298b95db0f1482c355)