### PR TITLE
Add tests for DAGManager config and repository state

### DIFF
--- a/tests/qmtl/services/dagmanager/test_completion_monitor.py
+++ b/tests/qmtl/services/dagmanager/test_completion_monitor.py
@@ -82,3 +82,100 @@ async def test_completion_emits_event():
     assert tags == ["t1"]
     assert mode == "any"
     assert version == 1
+
+
+class RecordingBus(ControlBusProducer):
+    def __init__(self) -> None:
+        self.published: list[tuple] = []
+
+    async def publish_queue_update(
+        self, tags, interval, queues, match_mode: str = "any", *, version: int = 1
+    ) -> None:  # type: ignore[override]
+        self.published.append((list(tags), interval, list(queues), match_mode, version))
+
+
+class StaticRepo(NodeRepository):
+    def __init__(self, record: NodeRecord | None) -> None:
+        self.record = record
+
+    def get_nodes(self, node_ids):
+        return {}
+
+    def insert_sentinel(self, sentinel_id, node_ids, version):
+        pass
+
+    def get_queues_by_tag(self, tags, interval, match_mode="any"):
+        return []
+
+    def get_node_by_queue(self, queue):
+        return self.record
+
+
+class FixedAdmin(KafkaAdmin):
+    def __init__(self, sizes):
+        super().__init__(client=None)  # type: ignore[arg-type]
+        self._sizes = sizes
+        self._calls = 0
+
+    def get_topic_sizes(self):  # type: ignore[override]
+        size = self._sizes[self._calls] if self._calls < len(self._sizes) else {}
+        self._calls += 1
+        return size
+
+
+@pytest.mark.asyncio
+async def test_completion_resets_stall_counter_on_growth():
+    repo = DummyRepo()
+    bus = RecordingBus()
+    admin = FixedAdmin([{"q1": 1}, {"q1": 2}, {"q1": 2}])
+    monitor = QueueCompletionMonitor(repo, admin, bus=bus, threshold=1)
+
+    await monitor.check_once()  # baseline
+    await monitor.check_once()  # growth resets stall counter
+    await monitor.check_once()  # now stalled for one interval
+
+    assert bus.published, "Completion event should fire after growth then stall"
+    assert bus.published[0][1] == "60s"
+
+
+@pytest.mark.asyncio
+async def test_completion_emits_only_once_per_topic():
+    repo = DummyRepo()
+    bus = RecordingBus()
+    admin = FixedAdmin([{"q1": 5}, {"q1": 5}, {"q1": 5}])
+    monitor = QueueCompletionMonitor(repo, admin, bus=bus, threshold=1)
+
+    await monitor.check_once()
+    await monitor.check_once()
+    await monitor.check_once()
+
+    assert len(bus.published) == 1
+    assert monitor._completed == {"q1"}
+
+
+@pytest.mark.asyncio
+async def test_completion_requires_metadata():
+    record = NodeRecord(
+        node_id="n2",
+        node_type="N",
+        code_hash="c",
+        schema_hash="s",
+        schema_id="id1",
+        interval=None,
+        period=None,
+        tags=[],
+        bucket=None,
+        is_global=False,
+        topic="q2",
+    )
+    repo = StaticRepo(record)
+    bus = RecordingBus()
+    admin = FixedAdmin([{"q2": 1}, {"q2": 1}, {"q2": 1}])
+    monitor = QueueCompletionMonitor(repo, admin, bus=bus, threshold=2)
+
+    await monitor.check_once()
+    await monitor.check_once()
+    await monitor.check_once()
+
+    assert bus.published == []
+    assert monitor._completed == set()

--- a/tests/qmtl/services/dagmanager/test_config_load.py
+++ b/tests/qmtl/services/dagmanager/test_config_load.py
@@ -1,0 +1,55 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from qmtl.services.dagmanager.config import DagManagerConfig, load_dagmanager_config
+
+
+def test_load_config_maps_aliases(tmp_path: Path):
+    config_path = tmp_path / "dag.yml"
+    config_path.write_text(
+        """
+neo4j_url: bolt://neo4j.local
+kafka_uri: kafka://broker.local
+controlbus_url: kafka://controlbus.local
+memory_repo_path: repo.gpickle
+grpc_port: 1234
+""".strip()
+    )
+
+    cfg = load_dagmanager_config(str(config_path))
+
+    assert cfg == DagManagerConfig(
+        neo4j_dsn="bolt://neo4j.local",
+        kafka_dsn="kafka://broker.local",
+        controlbus_dsn="kafka://controlbus.local",
+        memory_repo_path="repo.gpickle",
+        grpc_port=1234,
+    )
+
+
+def test_load_config_raises_on_invalid_yaml(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    config_path = tmp_path / "invalid.yml"
+    config_path.write_text("grpc_port: [oops\n")
+
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(ValueError):
+        load_dagmanager_config(str(config_path))
+
+    assert any("Failed to parse configuration file" in rec.message for rec in caplog.records)
+
+
+def test_load_config_validates_mapping(tmp_path: Path):
+    config_path = tmp_path / "invalid_type.yml"
+    config_path.write_text("- not_a_mapping")
+
+    with pytest.raises(TypeError):
+        load_dagmanager_config(str(config_path))
+
+
+def test_load_config_propagates_missing_file(tmp_path: Path):
+    missing_path = tmp_path / "missing.yml"
+
+    with pytest.raises(FileNotFoundError):
+        load_dagmanager_config(str(missing_path))

--- a/tests/qmtl/services/dagmanager/test_node_repository.py
+++ b/tests/qmtl/services/dagmanager/test_node_repository.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import asyncio
+import networkx as nx
+import pytest
+
+from qmtl.services.dagmanager import node_repository
+from qmtl.services.dagmanager.models import NodeRecord
+
+
+@pytest.fixture(autouse=True)
+def reset_repo_module():
+    importlib.reload(node_repository)
+    yield
+    importlib.reload(node_repository)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def ensure_event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        yield
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+def test_load_graph_falls_back_to_json(tmp_path: Path):
+    graph = nx.DiGraph()
+    graph.add_node(
+        "n1",
+        type="compute",
+        node_type="N",
+        code_hash="c1",
+        schema_hash="s1",
+        schema_id="id1",
+        interval=60,
+        period=None,
+        tags=["t1"],
+        bucket=None,
+        topic="q1",
+        **{"global": False},
+    )
+    data = nx.node_link_data(graph, edges="edges")
+    graph_path = tmp_path / "graph.gpickle"
+    graph_path.write_text(json.dumps(data))
+
+    repo = node_repository.MemoryNodeRepository(str(graph_path))
+
+    nodes = repo.get_nodes(["n1"])
+    assert nodes["n1"].topic == "q1"
+    assert nodes["n1"].node_type == "N"
+
+
+def test_save_graph_falls_back_to_node_link(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    graph_path = tmp_path / "graph.gpickle"
+    repo = node_repository.MemoryNodeRepository(str(graph_path))
+    repo.add_node(
+        NodeRecord(
+            node_id="n1",
+            node_type="N",
+            code_hash="c1",
+            schema_hash="s1",
+            schema_id="id1",
+            interval=60,
+            period=None,
+            tags=["t1"],
+            bucket=None,
+            is_global=False,
+            topic="q1",
+        )
+    )
+
+    def boom(*_args, **_kwargs):
+        raise IOError("boom")
+
+    monkeypatch.setattr(nx, "write_gpickle", boom, raising=False)
+
+    node_repository._save_graph()
+
+    persisted = json.loads(graph_path.read_text())
+    assert persisted["nodes"][0]["id"] == "n1"
+    assert persisted["nodes"][0]["topic"] == "q1"
+
+
+def test_buffering_state_transitions(tmp_path: Path):
+    repo = node_repository.MemoryNodeRepository(str(tmp_path / "graph.gpickle"))
+    repo.add_node(
+        NodeRecord(
+            node_id="n1",
+            node_type="N",
+            code_hash="c1",
+            schema_hash="s1",
+            schema_id="id1",
+            interval=60,
+            period=None,
+            tags=["t1"],
+            bucket=None,
+            is_global=False,
+            topic="q1",
+        )
+    )
+
+    repo.mark_buffering("n1", compute_key="k1", timestamp_ms=20)
+
+    assert repo.get_buffering_nodes(older_than_ms=15) == []
+    assert repo.get_buffering_nodes(older_than_ms=25, compute_key="k1") == ["n1"]
+
+    repo.clear_buffering("n1", compute_key="k1")
+    assert repo.get_buffering_nodes(older_than_ms=25, compute_key="k1") == []
+
+    repo.mark_buffering("n1", timestamp_ms=10)
+    repo.mark_buffering("n1", compute_key="k1", timestamp_ms=20)
+    repo.clear_buffering("n1")
+    assert repo.get_buffering_nodes(older_than_ms=15) == []


### PR DESCRIPTION
## Summary
- add load_dagmanager_config coverage for alias handling and error cases
- ensure MemoryNodeRepository persistence fallback and buffering transitions are exercised
- expand QueueCompletionMonitor tests for stall reset behavior and metadata gating

## Testing
- uv run -m pytest -W error -n auto tests/qmtl/services/dagmanager/test_config_load.py tests/qmtl/services/dagmanager/test_node_repository.py tests/qmtl/services/dagmanager/test_completion_monitor.py

Fixes #1680

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923377f5e2c8329a585c89c4018769f)