### PR TITLE
Add smoke tests for SDK shims and transform aliases

### DIFF
--- a/tests/qmtl/conftest.py
+++ b/tests/qmtl/conftest.py
@@ -1,0 +1,14 @@
+"""Shared fixtures for qmtl namespace tests."""
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _provide_event_loop() -> None:
+    """Ensure a default event loop exists to satisfy global teardown hooks."""
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield

--- a/tests/qmtl/sdk/test_shim_imports.py
+++ b/tests/qmtl/sdk/test_shim_imports.py
@@ -1,0 +1,26 @@
+"""Smoke tests for public SDK shim modules."""
+
+import importlib
+
+
+def test_sdk_package_reexports_core_symbols():
+    import qmtl.sdk as sdk
+    import qmtl.runtime.sdk as runtime_sdk
+
+    assert sdk.Node is runtime_sdk.Node
+    assert sdk.CacheView is runtime_sdk.CacheView
+    assert sdk.Runner is runtime_sdk.Runner
+
+
+def test_sdk_submodules_passthrough_runtime_symbols():
+    cases = [
+        ("node", "Node"),
+        ("cache_view", "CacheView"),
+        ("runner", "Runner"),
+    ]
+
+    for module_name, symbol in cases:
+        module = importlib.import_module(f"qmtl.sdk.{module_name}")
+        runtime_module = importlib.import_module(f"qmtl.runtime.sdk.{module_name}")
+
+        assert getattr(module, symbol) is getattr(runtime_module, symbol)

--- a/tests/qmtl/transforms/test_placeholder_transforms.py
+++ b/tests/qmtl/transforms/test_placeholder_transforms.py
@@ -1,0 +1,133 @@
+"""Smoke coverage for thin transform shims and placeholders."""
+
+import importlib
+import math
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    (
+        "module_name",
+        "runtime_module",
+        "symbol",
+        "args",
+        "expected",
+    ),
+    [
+        (
+            "acceptable_price_band",
+            "acceptable_price_band",
+            "overshoot",
+            (0.2, 1.0, 1.5),
+            0.0,
+        ),
+        (
+            "execution_diffusion_contraction",
+            "execution_diffusion_contraction",
+            "hazard_probability",
+            ([0.0, 0.5], [0.0, 1.0, 1.0]),
+            1.0 / (1.0 + math.exp(-0.5)),
+        ),
+        (
+            "gap_amplification",
+            "gap_amplification",
+            "cancel_limit_ratio",
+            (2.0, 4.0),
+            0.5,
+        ),
+        (
+            "hazard_utils",
+            "hazard_utils",
+            "execution_cost",
+            (0.1, 0.02, 0.03),
+            0.1,
+        ),
+        (
+            "impact",
+            "impact",
+            "impact",
+            (100.0, 200.0, 10.0, 0.5),
+            math.sqrt(0.5) / (10.0**0.5),
+        ),
+        (
+            "order_book_clustering_collapse",
+            "order_book_clustering_collapse",
+            "hazard_probability",
+            (
+                {
+                    "C": 0.0,
+                    "Cliff": 0.0,
+                    "Gap": 0.0,
+                    "CH": 0.0,
+                    "RL": 0.0,
+                    "Shield": 0.0,
+                    "QDT_inv": 0.0,
+                    "Pers": 0.0,
+                },
+                (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            ),
+            0.5,
+        ),
+        (
+            "publisher",
+            "publisher",
+            "publisher_node",
+            ("payload",),
+            "payload",
+        ),
+        (
+            "quantum_liquidity_echo",
+            "quantum_liquidity_echo",
+            "accumulate_echo",
+            ([1.0, 0.5], 1.0, 2.0),
+            sum(
+                alpha * math.exp(-k * 1.0 / 2.0)
+                for k, alpha in enumerate([1.0, 0.5], start=1)
+            ),
+        ),
+        (
+            "rate_of_change",
+            "rate_of_change",
+            "rate_of_change_series",
+            ([1.0, 2.0],),
+            1.0,
+        ),
+        (
+            "resiliency",
+            "resiliency",
+            "impact",
+            (50.0, 100.0, 10.0, 0.5),
+            math.sqrt(0.5) / (10.0**0.5),
+        ),
+        (
+            "tactical_liquidity_bifurcation",
+            "tactical_liquidity_bifurcation",
+            "tlbh_alpha",
+            (0.6, 0.5, 1.2, 0.1, 1.0, 0.0, 0.0),
+            0.6 * 0.5 * 1.2,
+        ),
+    ],
+)
+def test_transform_shims_passthrough_and_execute(
+    module_name: str, runtime_module: str, symbol: str, args: tuple, expected: float | str
+) -> None:
+    module = importlib.import_module(f"qmtl.transforms.{module_name}")
+    runtime = importlib.import_module(f"qmtl.runtime.transforms.{runtime_module}")
+
+    exported = getattr(module, symbol)
+    runtime_attr = getattr(runtime, symbol)
+
+    assert exported is runtime_attr
+
+    result = exported(*args)
+    if isinstance(expected, float):
+        assert result == pytest.approx(expected)
+    else:
+        assert result == expected
+
+
+def test_credit_liquidity_amplification_placeholder_returns_zero() -> None:
+    from qmtl.transforms.credit_liquidity_amplification import credit_liquidity_amplification
+
+    assert credit_liquidity_amplification(0, 0, 0, 0, 0, 0, 0, 0, 0) == 0.0


### PR DESCRIPTION
## Summary
- add smoke tests to ensure qmtl.sdk shim modules expose runtime SDK symbols
- cover transform shim modules and the credit liquidity placeholder with lightweight execution checks
- provide a session-scoped event loop fixture for qmtl tests to satisfy teardown hooks

## Testing
- uv run -m pytest -W error -n auto tests/qmtl/sdk tests/qmtl/transforms/test_placeholder_transforms.py

Fixes #1675

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923379519bc8329a279e73e8fc79290)