### PR TITLE
Add tests for WorldService normalization and policy engine

### DIFF
--- a/tests/qmtl/services/worldservice/storage/test_normalization.py
+++ b/tests/qmtl/services/worldservice/storage/test_normalization.py
@@ -1,0 +1,51 @@
+import pytest
+
+from qmtl.services.worldservice.storage.constants import (
+    DEFAULT_EXECUTION_DOMAIN,
+    DEFAULT_WORLD_NODE_STATUS,
+)
+from qmtl.services.worldservice.storage.normalization import (
+    _normalize_execution_domain,
+    _normalize_world_node_status,
+)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, DEFAULT_EXECUTION_DOMAIN),
+        ("", DEFAULT_EXECUTION_DOMAIN),
+        ("   ", DEFAULT_EXECUTION_DOMAIN),
+        ("  LIVE  ", "live"),
+        ("DryRun", "dryrun"),
+        (" shadow ", "shadow"),
+    ],
+)
+def test_normalize_execution_domain_defaults_and_lowercases(raw: object, expected: str) -> None:
+    assert _normalize_execution_domain(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["paper", 123])
+def test_normalize_execution_domain_rejects_unknown_values(raw: object) -> None:
+    with pytest.raises(ValueError, match="unknown execution_domain"):
+        _normalize_execution_domain(raw)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, DEFAULT_WORLD_NODE_STATUS),
+        ("", DEFAULT_WORLD_NODE_STATUS),
+        ("   ", DEFAULT_WORLD_NODE_STATUS),
+        (" RUNNING ", "running"),
+        ("Paused", "paused"),
+    ],
+)
+def test_normalize_world_node_status_defaults_and_lowercases(raw: object, expected: str) -> None:
+    assert _normalize_world_node_status(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["ready", object()])
+def test_normalize_world_node_status_rejects_unknown_values(raw: object) -> None:
+    with pytest.raises(ValueError, match="unknown world node status"):
+        _normalize_world_node_status(raw)  # type: ignore[arg-type]

--- a/tests/qmtl/services/worldservice/test_policy_engine.py
+++ b/tests/qmtl/services/worldservice/test_policy_engine.py
@@ -1,8 +1,11 @@
 from qmtl.services.worldservice.policy_engine import (
+    CorrelationRule,
+    HysteresisRule,
     Policy,
     ThresholdRule,
     TopKRule,
     evaluate_policy,
+    parse_policy,
 )
 
 
@@ -20,3 +23,76 @@ def test_topk_selection():
         "s3": {"sharpe": 1.5},
     }
     assert evaluate_policy(metrics, policy) == ["s3", "s1"]
+
+
+def test_topk_missing_metrics_sorted_last():
+    policy = Policy(top_k=TopKRule(metric="sharpe", k=2))
+    metrics = {
+        "s1": {"sharpe": 1.0},
+        "s2": {},
+        "s3": {"sharpe": 0.4},
+    }
+
+    assert evaluate_policy(metrics, policy) == ["s1", "s3"]
+
+
+def test_threshold_missing_metric_excludes_strategy():
+    policy = Policy(
+        thresholds={
+            "sharpe": ThresholdRule(metric="sharpe", min=0.5),
+            "drawdown": ThresholdRule(metric="drawdown", max=0.1),
+        }
+    )
+    metrics = {
+        "s1": {"sharpe": 0.6, "drawdown": 0.05},
+        "s2": {"sharpe": 0.7},
+    }
+
+    assert evaluate_policy(metrics, policy) == ["s1"]
+
+
+def test_correlation_rule_filters_highly_correlated_candidates():
+    policy = Policy(correlation=CorrelationRule(max=0.5))
+    metrics = {
+        "s1": {"alpha": 0.1},
+        "s2": {"alpha": 0.2},
+        "s3": {"alpha": 0.3},
+    }
+    correlations = {
+        ("s1", "s2"): 0.8,
+        ("s2", "s3"): 0.4,
+    }
+
+    assert evaluate_policy(metrics, policy, correlations=correlations) == ["s1", "s3"]
+
+
+def test_hysteresis_preserves_active_entries_on_exit_threshold():
+    policy = Policy(hysteresis=HysteresisRule(metric="score", enter=0.6, exit=0.4))
+    metrics = {
+        "s1": {"score": 0.45},
+        "s2": {"score": 0.55},
+    }
+
+    assert evaluate_policy(metrics, policy, prev_active=["s1"]) == ["s1"]
+
+
+def test_parse_policy_from_yaml_payload():
+    raw = """
+    thresholds:
+      sharpe:
+        metric: sharpe
+        min: 0.7
+    top_k:
+      metric: sharpe
+      k: 2
+    hysteresis:
+      metric: sharpe
+      enter: 1.0
+      exit: 0.8
+    """
+
+    parsed = parse_policy(raw)
+
+    assert parsed.thresholds["sharpe"].min == 0.7
+    assert parsed.top_k == TopKRule(metric="sharpe", k=2)
+    assert parsed.hysteresis == HysteresisRule(metric="sharpe", enter=1.0, exit=0.8)


### PR DESCRIPTION
## Summary
- add normalization tests covering execution domain and node status defaults and invalid inputs
- expand policy engine tests for threshold gaps, top-k ordering, correlation filtering, hysteresis, and YAML parsing

## Testing
- uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 tests/qmtl/services/worldservice/storage/test_normalization.py tests/qmtl/services/worldservice/test_policy_engine.py

Fixes #1677

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69233b42e8a08329865eee47f3e09c22)