### PR TITLE
Add coverage for lag monitor thresholds

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,9 +66,9 @@ def _close_event_loop():
     """Ensure the default asyncio loop is closed to avoid ResourceWarning at teardown."""
 
     yield
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
+    policy = asyncio.get_event_loop_policy()
+    loop = getattr(getattr(policy, "_local", None), "_loop", None)
+    if loop is None:
         return
     if loop.is_running():
         loop.call_soon(loop.stop)


### PR DESCRIPTION
## Summary
- add lag monitor tests covering missing lag defaults and metric updates when lag clears
- avoid teardown warnings by skipping event-loop closure when no loop exists

## Testing
- uv run -m pytest -W error tests/qmtl/services/dagmanager/test_lag_monitor.py

Closes #1681

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69233b5f520c8329a675c352f9193eb1)