### PR TITLE
Fix gateway health DagManagerClient import initialization

### DIFF
--- a/qmtl/services/gateway/gateway_health.py
+++ b/qmtl/services/gateway/gateway_health.py
@@ -9,9 +9,9 @@ from dataclasses import dataclass
 import redis.asyncio as redis
 
 if TYPE_CHECKING:  # pragma: no cover - optional import for typing
+    from .dagmanager_client import DagManagerClient
     from .database import Database
     from .world_client import WorldServiceClient
-from .dagmanager_client import DagManagerClient
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary
- defer DagManagerClient import in gateway_health to type-checking time to avoid circular initialization failures

## Testing
- uv run -m pytest -W error -n auto qmtl/services/gateway/tests/test_gateway_health.py

Fixes #1658

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69233bb9f1a8832984b03e4e512d2d48)