### PR TITLE
Increase gateway control plane coverage

### DIFF
--- a/qmtl/services/gateway/tests/test_api_background.py
+++ b/qmtl/services/gateway/tests/test_api_background.py
@@ -1,0 +1,140 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from qmtl.services.gateway import api
+
+
+class _DummyComponent:
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+        self.ws_hub = None
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _DummyCommitConsumer(_DummyComponent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.consume_calls: list[tuple[Any, int]] = []
+
+    async def start(self) -> None:  # type: ignore[override]
+        await super().start()
+
+    async def consume(self, handler, timeout_ms: int) -> None:  # pragma: no cover - exercised via task
+        self.consume_calls.append((handler, timeout_ms))
+        await asyncio.sleep(0.01)
+
+
+class _DummyHub(_DummyComponent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = False
+        self.stopped = False
+
+
+class _DummyCloseable:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _DummyRedis:
+    def __init__(self) -> None:
+        self.closed = False
+        self.pool_closed = False
+        self.connection_pool = self
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+    async def disconnect(self) -> None:
+        self.pool_closed = True
+
+
+class _DummyWorldClient:
+    def __init__(self) -> None:
+        self.closed = False
+        self._client = self
+
+    async def aclose(self) -> None:  # pragma: no cover - exercised via wrapper
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_background_lifecycle() -> None:
+    ws_hub = _DummyHub()
+    controlbus = _DummyComponent()
+    commit_consumer = _DummyCommitConsumer()
+
+    commit_task = await api._start_background(
+        enable_background=True,
+        controlbus_consumer=controlbus,
+        commit_log_consumer=commit_consumer,
+        commit_log_handler=None,
+        ws_hub=ws_hub,
+    )
+
+    assert controlbus.started is True
+    assert controlbus.ws_hub is ws_hub
+    assert commit_consumer.started is True
+    assert ws_hub.started is True
+    assert commit_task is not None
+
+    await asyncio.sleep(0.02)
+
+    dagmanager = _DummyCloseable()
+    database = _DummyCloseable()
+    redis_conn = _DummyRedis()
+    world_client = _DummyWorldClient()
+
+    await api._stop_background(
+        commit_task=commit_task,
+        ws_hub=ws_hub,
+        controlbus_consumer=controlbus,
+        commit_log_consumer=commit_consumer,
+        commit_log_writer=None,
+        dagmanager=dagmanager,
+        database_obj=database,
+        redis_conn=redis_conn,
+        world_client=world_client,
+    )
+
+    assert controlbus.stopped is True
+    assert commit_consumer.stopped is True
+    assert commit_consumer.consume_calls
+    assert commit_task.cancelled()
+    assert ws_hub.stopped is True
+    assert dagmanager.closed is True
+    assert database.closed is True
+    assert redis_conn.closed is True
+    assert redis_conn.pool_closed is True
+    assert world_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_background_disabled_skips_start() -> None:
+    ws_hub = _DummyHub()
+    controlbus = _DummyComponent()
+    commit_consumer = _DummyCommitConsumer()
+
+    commit_task = await api._start_background(
+        enable_background=False,
+        controlbus_consumer=controlbus,
+        commit_log_consumer=commit_consumer,
+        commit_log_handler=None,
+        ws_hub=ws_hub,
+    )
+
+    assert commit_task is None
+    assert controlbus.started is False
+    assert commit_consumer.started is False
+    assert ws_hub.started is False

--- a/qmtl/services/gateway/tests/test_controlbus_consumer.py
+++ b/qmtl/services/gateway/tests/test_controlbus_consumer.py
@@ -1,0 +1,168 @@
+from typing import Any
+
+import pytest
+
+from qmtl.foundation.common.tagquery import MatchMode
+from qmtl.services.gateway import metrics as gw_metrics
+from qmtl.services.gateway.controlbus_consumer import ControlBusConsumer, ControlBusMessage
+
+
+class _FakeHub:
+    def __init__(self) -> None:
+        self.activations: list[dict[str, Any]] = []
+        self.policies: list[dict[str, Any]] = []
+        self.queue_updates: list[tuple[Any, ...]] = []
+        self.tag_upserts: list[tuple[list[str], int, list[Any]]] = []
+
+    async def send_activation_updated(self, data: dict[str, Any]) -> None:
+        self.activations.append(data)
+
+    async def send_policy_updated(self, data: dict[str, Any]) -> None:
+        self.policies.append(data)
+
+    async def send_queue_update(
+        self,
+        tags: list[str],
+        interval: int,
+        queues: list[Any],
+        mode: MatchMode,
+        *,
+        world_id: str | None = None,
+        execution_domain: str | None = None,
+        etag: str | None = None,
+        ts: str | None = None,
+    ) -> None:
+        self.queue_updates.append(
+            (
+                tags,
+                interval,
+                queues,
+                mode,
+                world_id,
+                execution_domain,
+                etag,
+                ts,
+            )
+        )
+
+    async def send_tagquery_upsert(
+        self, tags: list[str], interval: int, queues: list[Any]
+    ) -> None:
+        self.tag_upserts.append((tags, interval, queues))
+
+
+@pytest.mark.asyncio
+async def test_process_generic_message_routes_and_deduplicates(monkeypatch: pytest.MonkeyPatch) -> None:
+    hub = _FakeHub()
+    consumer = ControlBusConsumer([], ["activation"], "group-a", ws_hub=hub)
+
+    recorded: dict[str, list[Any]] = {"control": [], "dropped": []}
+
+    monkeypatch.setattr(
+        gw_metrics,
+        "record_controlbus_message",
+        lambda topic, ts: recorded["control"].append((topic, ts)),
+    )
+    monkeypatch.setattr(
+        gw_metrics, "record_event_dropped", lambda topic: recorded["dropped"].append(topic)
+    )
+
+    msg = ControlBusMessage(
+        topic="activation",
+        key="k1",
+        etag="e1",
+        run_id="r1",
+        data={"version": 1, "etag": "e1", "run_id": "r1"},
+    )
+
+    await consumer._process_generic_message(msg)
+
+    assert hub.activations == [msg.data]
+    assert recorded["control"] == [("activation", None)]
+
+    await consumer._process_generic_message(msg)
+
+    assert recorded["dropped"] == ["activation"]
+    assert hub.activations == [msg.data]
+
+
+@pytest.mark.asyncio
+async def test_queue_update_emits_tagquery_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    hub = _FakeHub()
+    consumer = ControlBusConsumer([], ["queue"], "group-a", ws_hub=hub)
+
+    control_calls: list[tuple[str, Any]] = []
+    monkeypatch.setattr(
+        gw_metrics,
+        "record_controlbus_message",
+        lambda topic, ts: control_calls.append((topic, ts)),
+    )
+
+    msg = ControlBusMessage(
+        topic="queue",
+        key="k1",
+        etag="etag-1",
+        run_id="run-1",
+        data={
+            "version": 1,
+            "tags": ["t1"],
+            "interval": 15,
+            "queues": [{"queue": "alpha", "global": True}],
+            "match_mode": "any",
+            "etag": "etag-1",
+            "ts": "1",
+            "world_id": "w1",
+            "execution_domain": "exe",
+        },
+    )
+
+    await consumer._process_generic_message(msg)
+
+    assert len(hub.queue_updates) == 1
+    update = hub.queue_updates[0]
+    assert update[0] == ["t1"]
+    assert update[1] == 15
+    assert update[3] == MatchMode.ANY
+    assert hub.tag_upserts == [(["t1"], 15, [{"queue": "alpha", "global": True}])]
+
+    msg2 = ControlBusMessage(
+        topic="queue",
+        key="k1",
+        etag="etag-2",
+        run_id="run-2",
+        data={
+            "version": 1,
+            "tags": ["t1"],
+            "interval": 15,
+            "queues": [{"queue": "alpha", "global": True}],
+            "match_mode": "any",
+            "etag": "etag-2",
+            "ts": "2",
+            "world_id": "w1",
+            "execution_domain": "exe",
+        },
+    )
+
+    await consumer._process_generic_message(msg2)
+
+    assert len(hub.queue_updates) == 2
+    assert hub.tag_upserts == [(["t1"], 15, [{"queue": "alpha", "global": True}])]
+    assert control_calls == [("queue", None), ("queue", None)]
+
+
+@pytest.mark.asyncio
+async def test_rebalancing_validation_error_logged(caplog: pytest.LogCaptureFixture) -> None:
+    consumer = ControlBusConsumer([], ["rebalancing_planned"], "group-a", ws_hub=None)
+    caplog.set_level("WARNING")
+
+    msg = ControlBusMessage(
+        topic="rebalancing_planned",
+        key="k1",
+        etag="e1",
+        run_id="r1",
+        data={"bad": "payload"},
+    )
+
+    await consumer._process_rebalancing_planned(msg)
+
+    assert any("invalid rebalancing_planned payload" in rec.message for rec in caplog.records)

--- a/qmtl/services/gateway/tests/test_ws_server.py
+++ b/qmtl/services/gateway/tests/test_ws_server.py
@@ -1,0 +1,102 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from qmtl.services.gateway.ws.connections import ConnectionRegistry
+from qmtl.services.gateway.ws.server import ServerManager
+
+
+class _FakeSocket:
+    def __init__(self, port: int) -> None:
+        self._port = port
+
+    def getsockname(self):
+        return ("127.0.0.1", self._port)
+
+
+class _FakeServer:
+    def __init__(self, port: int) -> None:
+        self.sockets = [_FakeSocket(port)]
+        self.closed = False
+        self.waited = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.waited = True
+
+
+@pytest.mark.asyncio
+async def test_server_manager_starts_and_tracks_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = ConnectionRegistry()
+    joins: list[object] = []
+    leaves: list[object] = []
+    captured: dict[str, object] = {}
+
+    async def on_join(sock: object) -> None:
+        joins.append(sock)
+
+    async def on_leave(sock: object) -> None:
+        leaves.append(sock)
+
+    async def fake_serve(handler, host, port):
+        captured["acceptor"] = handler
+        return _FakeServer(8765)
+
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(serve=fake_serve))
+
+    manager = ServerManager(registry, on_client_join=on_join, on_client_leave=on_leave)
+
+    port = await manager.ensure_running(start_server=True)
+    assert port == 8765
+
+    acceptor = captured["acceptor"]
+
+    class _Client:
+        def __init__(self) -> None:
+            self.recv_calls = 0
+
+        async def recv(self) -> None:
+            self.recv_calls += 1
+            raise RuntimeError("disconnect")
+
+    client = _Client()
+    await acceptor(client)  # type: ignore[arg-type]
+
+    assert joins == [client]
+    assert leaves == [client]
+    assert await registry.all_clients() == []
+
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_server_manager_respects_start_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = ConnectionRegistry()
+    starts: list[tuple[str, int]] = []
+
+    async def fake_serve(handler, host, port):
+        starts.append((host, port))
+        return _FakeServer(0)
+
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(serve=fake_serve))
+
+    manager = ServerManager(registry)
+
+    port = await manager.ensure_running(start_server=False)
+    assert port == 0
+    assert starts == []
+
+    monkeypatch.setenv("QMTL_WS_ENABLE_SERVER", "1")
+    port = await manager.ensure_running(start_server=False)
+    assert port == 0
+    assert starts == [("127.0.0.1", 0)]
+
+    port_again = await manager.ensure_running(start_server=False)
+    assert port_again == 0
+    assert starts == [("127.0.0.1", 0)]
+
+    monkeypatch.delenv("QMTL_WS_ENABLE_SERVER", raising=False)
+    await manager.stop()


### PR DESCRIPTION
## Summary
- add WebSocket server lifecycle tests covering start flags and client join/leave handling
- exercise ControlBus consumer routing, deduplication, and validation branches with lightweight stubs
- cover API background lifecycle helpers to verify background workers and resource cleanup

## Testing
- uv run -m pytest -W error -n auto qmtl/services/gateway/tests/test_controlbus_consumer.py qmtl/services/gateway/tests/test_ws_server.py qmtl/services/gateway/tests/test_api_background.py

Closes #1673

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692342fa35108329955f3040a287aaa1)