### PR TITLE
Update mypy overrides for runtime sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,13 +151,29 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-  "qmtl.runtime.*",
+  "qmtl.runtime.alpha_metrics",
+  "qmtl.runtime.plugin_loader",
+  "qmtl.runtime.brokerage.*",
+  "qmtl.runtime.generators.*",
+  "qmtl.runtime.helpers.*",
+  "qmtl.runtime.indicators.*",
+  "qmtl.runtime.io.*",
+  "qmtl.runtime.nodesets.*",
+  "qmtl.runtime.pipeline.*",
+  "qmtl.runtime.reference_models.*",
+  "qmtl.runtime.transforms.*",
   "qmtl.services.*",
   "qmtl.foundation.*",
   "qmtl.examples.*",
   "tests.*",
 ]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = [
+  "qmtl.runtime.sdk.*",
+]
+ignore_errors = false
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
## Summary
- narrow the runtime mypy override to explicitly cover non-SDK runtime modules
- add a dedicated override for `qmtl.runtime.sdk.*` with errors enabled to baseline SDK typing issues

## Testing
- `uv run --with mypy -m mypy qmtl/runtime/sdk` *(fails due to existing type errors being baselined)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923494868e88329a345e419d9739eaf)