### PR TITLE
Add typing protocols for runner dependencies

### DIFF
--- a/qmtl/runtime/sdk/metrics.py
+++ b/qmtl/runtime/sdk/metrics.py
@@ -27,6 +27,7 @@ from qmtl.foundation.common.metrics_shared import (
     clear_cross_context_cache_hits as _clear_cross_context_cache_hits,
     clear_nodecache_resident_bytes as _clear_nodecache_resident_bytes,
 )
+from .protocols import MetricWithValueProtocol
 
 _WORLD_ID = "default"
 _REGISTERED_METRICS: set[str] = set()
@@ -411,7 +412,7 @@ orders_rejected_total = _counter(
 # ---------------------------------------------------------------------------
 # Alpha performance metrics
 # ---------------------------------------------------------------------------
-alpha_sharpe = _gauge(
+alpha_sharpe: MetricWithValueProtocol = _gauge(
     "alpha_sharpe",
     "Alpha strategy Sharpe ratio",
     reset=lambda g: g.set(0.0),
@@ -419,7 +420,7 @@ alpha_sharpe = _gauge(
     test_value_factory=lambda: 0.0,
 )
 
-alpha_max_drawdown = _gauge(
+alpha_max_drawdown: MetricWithValueProtocol = _gauge(
     "alpha_max_drawdown",
     "Alpha strategy maximum drawdown",
     reset=lambda g: g.set(0.0),

--- a/qmtl/runtime/sdk/protocols.py
+++ b/qmtl/runtime/sdk/protocols.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Protocols for SDK runtime dependencies used by the runner."""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class HistoryProviderProtocol(Protocol):
+    """Minimal interface for history providers consumed by :mod:`runner`."""
+
+    def bind_stream(self, node: object) -> None: ...
+
+
+class HistoryProviderNodeProtocol(Protocol):
+    """Nodes that can coerce history providers provided by the runner."""
+
+    def _coerce_history_provider(
+        self, provider: HistoryProviderProtocol | object | None
+    ) -> HistoryProviderProtocol | object | None: ...
+
+
+@runtime_checkable
+class TagQueryManagerProtocol(Protocol):
+    """Subset of :class:`TagQueryManager` used by the runner."""
+
+    async def resolve_tags(self, *, offline: bool = False) -> None: ...
+
+    async def stop(self) -> None: ...
+
+
+class StrategyWithTagManagerProtocol(Protocol):
+    """Strategies annotated with an optional tag query manager."""
+
+    tag_query_manager: TagQueryManagerProtocol | None
+
+
+class MetricWithValueProtocol(Protocol):
+    """Metrics that expose both ``set`` and a cached ``_val`` attribute."""
+
+    _val: float
+
+    def set(self, value: float) -> None: ...


### PR DESCRIPTION
## Summary
- introduce protocols that describe history providers, tag query managers, and metrics used by the SDK runner
- apply the protocols to history provider wiring and alpha metrics so attr-defined suppressions are no longer needed
- refactor alpha performance handling into typed helper routines for clearer mypy inference

## Testing
- uv run --with mypy -m mypy qmtl/runtime/sdk/runner.py *(fails: existing mypy errors across qmtl/runtime/sdk unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234c0949a883299378815d8447003d)