### PR TITLE
Enable mypy for runtime pipeline and sdk packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,6 @@ module = [
   "qmtl.runtime.indicators.*",
   "qmtl.runtime.io.*",
   "qmtl.runtime.nodesets.*",
-  "qmtl.runtime.pipeline.*",
   "qmtl.runtime.reference_models.*",
   "qmtl.runtime.transforms.*",
   "qmtl.services.*",
@@ -174,6 +173,12 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = [
   "qmtl.runtime.sdk.*",
+]
+ignore_errors = false
+
+[[tool.mypy.overrides]]
+module = [
+  "qmtl.runtime.pipeline.*",
 ]
 ignore_errors = false
 

--- a/qmtl/runtime/pipeline/execution_nodes/_shared.py
+++ b/qmtl/runtime/pipeline/execution_nodes/_shared.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Callable, Mapping, MutableMapping
+from typing import Any, Callable, Mapping, MutableMapping, Sequence, cast
 
 from qmtl.services.dagmanager.kafka_admin import compute_key
 from qmtl.runtime.sdk.node import CacheView, Node, ProcessingNode
@@ -17,9 +17,13 @@ def latest_entry(view: CacheView, node: Node) -> CacheEntry | None:
     """Return the most recent cache entry for ``node`` if available."""
 
     data = view[node][node.interval]
+    if isinstance(data, CacheView):
+        data = object.__getattribute__(data, "_data")
+    if not isinstance(data, Sequence):
+        return None
     if not data:
         return None
-    return data[-1]
+    return cast(CacheEntry, data[-1])
 
 
 def normalise_watermark_gate(

--- a/qmtl/runtime/pipeline/execution_nodes/execution.py
+++ b/qmtl/runtime/pipeline/execution_nodes/execution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from typing import Any, Mapping
 
 from qmtl.runtime.sdk.execution_modeling import (
     ExecutionFill,
@@ -36,13 +37,15 @@ class ExecutionNode(ProcessingNode):
             period=1,
         )
 
-    def _compute(self, view: CacheView) -> dict | None:
+    def _compute(self, view: CacheView) -> dict[str, Any] | None:
         latest = latest_entry(view, self.order)
         if latest is None:
             return None
         ts, order = latest
+        if not isinstance(order, Mapping):
+            return None
         if self.execution_model is None:
-            return order
+            return dict(order)
         price = float(order["price"])
         qty = float(order["quantity"])
         side = OrderSide.BUY if qty >= 0 else OrderSide.SELL
@@ -57,6 +60,4 @@ class ExecutionNode(ProcessingNode):
             market_data=market,
             timestamp=ts,
         )
-        if isinstance(fill, ExecutionFill):
-            return asdict(fill)
-        return fill
+        return asdict(fill)

--- a/qmtl/runtime/pipeline/execution_nodes/sizing.py
+++ b/qmtl/runtime/pipeline/execution_nodes/sizing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable, Mapping
 
 from qmtl.runtime.sdk.node import CacheView, Node, ProcessingNode
 from qmtl.runtime.sdk.portfolio import Portfolio
@@ -21,7 +21,7 @@ class SizingNode(ProcessingNode):
         *,
         portfolio: Portfolio,
         name: str | None = None,
-        weight_fn: Callable[[dict], float] | None = None,
+        weight_fn: Callable[[Mapping[str, Any]], float] | None = None,
     ) -> None:
         self.order = order
         self.portfolio = portfolio
@@ -34,9 +34,11 @@ class SizingNode(ProcessingNode):
             period=1,
         )
 
-    def _compute(self, view: CacheView) -> dict | None:
+    def _compute(self, view: CacheView) -> dict[str, Any] | None:
         latest = latest_entry(view, self.order)
         if latest is None:
             return None
         _, order = latest
+        if not isinstance(order, Mapping):
+            return None
         return apply_sizing(order, self.portfolio, weight_fn=self.weight_fn)

--- a/qmtl/runtime/pipeline/execution_nodes/timing.py
+++ b/qmtl/runtime/pipeline/execution_nodes/timing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any, Mapping
 
 from qmtl.runtime.sdk.node import CacheView, Node, ProcessingNode
 from qmtl.runtime.sdk.timing_controls import TimingController
@@ -26,13 +27,16 @@ class TimingGateNode(ProcessingNode):
             period=1,
         )
 
-    def _compute(self, view: CacheView) -> dict | None:
+    def _compute(self, view: CacheView) -> dict[str, Any] | None:
         latest = latest_entry(view, self.order)
         if latest is None:
             return None
         ts, order = latest
+        if not isinstance(order, Mapping):
+            return None
+        order_payload = dict(order)
         dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
         ok, reason, _ = self.controller.validate_timing(dt)
         if ok:
-            return order
+            return order_payload
         return {"rejected": True, "reason": reason}

--- a/qmtl/runtime/pipeline/micro_batch.py
+++ b/qmtl/runtime/pipeline/micro_batch.py
@@ -32,8 +32,8 @@ class MicroBatchNode(ProcessingNode):
         if not seq:
             return None
         # Identify distinct timestamps (ordered as in seq)
-        timestamps = [ts for ts, _ in seq]
-        distinct = []
+        timestamps: list[int] = [int(ts) for ts, _ in seq]
+        distinct: list[int] = []
         for ts in timestamps:
             if not distinct or distinct[-1] != ts:
                 distinct.append(ts)


### PR DESCRIPTION
## Summary
- remove the blanket mypy ignore for runtime pipeline modules and keep sdk checks enabled
- tighten typing in pipeline execution nodes to validate cache payloads and avoid Any returns
- annotate micro-batching timestamp handling and clean up order publishing interval handling

## Testing
- uv run --with mypy -m mypy

Fixes #1668

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927de6d58588329b68963f043ebef84)