### PR TITLE
Tighten mypy checks for gateway control plane

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,18 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = [
+  "qmtl.services.gateway.*",
+]
+ignore_errors = false
+
+[[tool.mypy.overrides]]
+module = [
+  "qmtl.services.gateway.tests.*",
+]
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = [
   "qmtl.runtime.sdk.*",
 ]
 ignore_errors = false

--- a/qmtl/services/gateway/strategy_manager.py
+++ b/qmtl/services/gateway/strategy_manager.py
@@ -41,7 +41,7 @@ class DecodedDag:
 @dataclass
 class StrategyManager:
     redis: redis.Redis
-    database: PostgresDatabase
+    database: Database
     fsm: StrategyFSM
     degrade: Optional[DegradationManager] = None
     insert_sentinel: bool = True

--- a/qmtl/services/gateway/submission/queue_map_resolver.py
+++ b/qmtl/services/gateway/submission/queue_map_resolver.py
@@ -107,6 +107,8 @@ class QueueMapResolver:
             return
         for item in result:
             queue_name = item.get("queue") if isinstance(item, dict) else str(item)
+            if not isinstance(queue_name, str):
+                continue
             if queue_name not in seen[node_id]:
                 lst.append(item)
                 seen[node_id].add(queue_name)


### PR DESCRIPTION
## Summary
- remove the blanket mypy ignore for gateway modules while keeping gateway tests ignored
- fix gateway control-plane type issues across controlbus handlers, routes, and CLI utilities
- use typed rebalancing plan/delta models and safer resource cleanup to satisfy mypy

## Testing
- uv run --with mypy -m mypy

Fixes #1692

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928a14c76248329a0d36118ef65db90)