### PR TITLE
Fix mypy issues for Enhance SR expression DAG builder

### DIFF
--- a/qmtl/integrations/sr/adapters/operon.py
+++ b/qmtl/integrations/sr/adapters/operon.py
@@ -18,7 +18,7 @@ from ..types import BaseSRCandidate
 # Type checking imports (won't fail if pyoperon not installed)
 if TYPE_CHECKING:
     try:
-        import pyoperon  # type: ignore
+        import pyoperon
     except ImportError:
         pass
 
@@ -53,11 +53,11 @@ class OperonCandidate(BaseSRCandidate):
 # Check if pyoperon is available
 _PYOPERON_AVAILABLE = False
 try:
-    import pyoperon  # type: ignore
+    import pyoperon
 
     _PYOPERON_AVAILABLE = True
 except ImportError:
-    pyoperon = None  # type: ignore
+    pyoperon = None
 
 
 def is_pyoperon_available() -> bool:

--- a/qmtl/integrations/sr/dag.py
+++ b/qmtl/integrations/sr/dag.py
@@ -87,7 +87,7 @@ _INDICATOR_NODE_MAP: dict[str, NodeMapping] = {
 
 def _sort_key(expr: sp.Expr) -> str:
     try:
-        return sp.srepr(expr)
+        return str(sp.srepr(expr))
     except Exception:  # pragma: no cover - defensive fallback
         return str(expr)
 

--- a/qmtl/integrations/sr/strategy_template.py
+++ b/qmtl/integrations/sr/strategy_template.py
@@ -6,57 +6,63 @@ Seamless Data Provider와 동일 데이터를 사용하도록 Strategy를 생성
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence, TYPE_CHECKING, cast
 
 from .expression_key import compute_expression_key
 
 try:
-    from dataclasses import asdict
+    from dataclasses import asdict as _dataclass_asdict
 except Exception:  # pragma: no cover - fallback
-    asdict = None  # type: ignore
+    dataclass_asdict: Callable[[Any], dict[str, Any]] | None = None
+else:
+    dataclass_asdict = cast(Callable[[Any], dict[str, Any]], _dataclass_asdict)
 
 _RUNTIME_AVAILABLE = False
-try:  # pragma: no cover - optional at runtime
-    from qmtl.runtime.sdk import Strategy  # type: ignore
-    from qmtl.runtime.sdk.node import StreamInput, ProcessingNode  # type: ignore
+if TYPE_CHECKING:
+    from qmtl.runtime.sdk import Strategy
+    from qmtl.runtime.sdk.node import ProcessingNode, StreamInput
+else:
+    try:  # pragma: no cover - optional at runtime
+        from qmtl.runtime.sdk import Strategy
+        from qmtl.runtime.sdk.node import StreamInput, ProcessingNode
 
-    _RUNTIME_AVAILABLE = True
-except Exception:  # pragma: no cover - fallback for tests/docs
-    class Strategy:  # type: ignore
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            self.nodes: list[Any] = []
+        _RUNTIME_AVAILABLE = True
+    except Exception:  # pragma: no cover - fallback for tests/docs
+        class Strategy:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                self.nodes: list[Any] = []
 
-        def add_nodes(self, nodes: Any) -> None:
-            if not isinstance(nodes, Sequence):
-                nodes = [nodes]
-            self.nodes.extend(list(nodes))
+            def add_nodes(self, nodes: Any) -> None:
+                if not isinstance(nodes, Sequence):
+                    nodes = [nodes]
+                self.nodes.extend(list(nodes))
 
-        def serialize(self) -> dict[str, Any]:
-            return {"schema_version": "v1", "nodes": [], "meta": {}}
+            def serialize(self) -> dict[str, Any]:
+                return {"schema_version": "v1", "nodes": [], "meta": {}}
 
-        def on_start(self) -> None: ...
+            def on_start(self) -> None: ...
 
-        def on_finish(self) -> None: ...
+            def on_finish(self) -> None: ...
 
-        def setup(self) -> None: ...
+            def setup(self) -> None: ...
 
-    class StreamInput:  # type: ignore
-        def __init__(self, *, interval: Any = None, period: Any = None, history_provider: Any = None) -> None:
-            self.interval = interval
-            self.period = period
-            self.history_provider = history_provider
-            self.node_id = "stream_input"
-            self.dataset_fingerprint = None
+        class StreamInput:
+            def __init__(self, *, interval: Any = None, period: Any = None, history_provider: Any = None) -> None:
+                self.interval = interval
+                self.period = period
+                self.history_provider = history_provider
+                self.node_id = "stream_input"
+                self.dataset_fingerprint = None
 
-    class ProcessingNode:  # type: ignore
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            self.input = args[0] if args else None
-            self.compute_fn = kwargs.get("compute_fn")
-            self.interval = kwargs.get("interval")
-            self.period = kwargs.get("period")
-            self.tags = kwargs.get("tags", [])
-            self.node_id = "processing_node"
-            self.dataset_fingerprint = None
+        class ProcessingNode:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                self.input = args[0] if args else None
+                self.compute_fn = kwargs.get("compute_fn")
+                self.interval = kwargs.get("interval")
+                self.period = kwargs.get("period")
+                self.tags = kwargs.get("tags", [])
+                self.node_id = "processing_node"
+                self.dataset_fingerprint = None
 
 
 def _compile_expression(expression: str, modules: str | tuple[str, ...] = "numpy"):
@@ -111,7 +117,7 @@ def build_expression_strategy(
         interval = data_spec.get("interval") or data_spec.get("timeframe")
         period = data_spec.get("period") or data_spec.get("min_history")
 
-    class ExpressionStrategy(Strategy):  # type: ignore[misc]
+    class ExpressionStrategy(Strategy):
         _expression = expression
         _data_spec = dict(data_spec) if isinstance(data_spec, Mapping) else None
         _sr_engine = sr_engine
@@ -205,7 +211,7 @@ def build_expression_strategy(
             return self._evaluate_payload(payload)
 
         def serialize(self) -> dict[str, Any]:
-            dag = super().serialize()
+            dag = cast(dict[str, Any], super().serialize())
             meta = dag.setdefault("meta", {})
             sr_meta = meta.setdefault("sr", {})
             sr_meta.update(
@@ -238,10 +244,10 @@ def build_strategy_from_dag_spec(
     data_spec = getattr(dag_spec, "data_spec", None)
     expression_key = getattr(dag_spec, "expression_key", None)
 
-    dag_dict = None
-    if asdict and hasattr(dag_spec, "__dataclass_fields__"):
+    dag_dict: dict[str, Any] | None = None
+    if dataclass_asdict is not None and hasattr(dag_spec, "__dataclass_fields__"):
         try:  # pragma: no cover - defensive
-            dag_dict = asdict(dag_spec)  # type: ignore[arg-type]
+            dag_dict = dataclass_asdict(dag_spec)
         except Exception:
             dag_dict = None
 


### PR DESCRIPTION
## Summary
- normalize Sympy expressions to generate spec-versioned `expression_key` values
- map arithmetic, logical, and indicator nodes onto runtime-friendly DAG payloads
- expand SR DAG tests to cover normalization, mapping, and runtime graph generation
- resolve mypy findings in SR DAG construction, strategy templates, and the Operon adapter

## Testing
- uv run --with mypy -m mypy


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928abcea5f883298725ae64b3ab76d5)