### PR TITLE
Fix HistoryFetchResult alias and optional dependency guard

### DIFF
--- a/qmtl/runtime/sdk/arrow_cache/dependencies.py
+++ b/qmtl/runtime/sdk/arrow_cache/dependencies.py
@@ -12,7 +12,10 @@ def _load_optional_module(name: str) -> Any | None:
     spec = importlib.util.find_spec(name)
     if spec is None:
         return None
-    return importlib.import_module(name)
+    try:
+        return importlib.import_module(name)
+    except Exception:  # pragma: no cover - guard optional deps
+        return None
 
 
 pa: Any | None = _load_optional_module("pyarrow")

--- a/qmtl/runtime/sdk/data_io.py
+++ b/qmtl/runtime/sdk/data_io.py
@@ -6,18 +6,20 @@ This module defines the abstract I/O interfaces used by the SDK.
 Concrete implementations live under ``qmtl.runtime.io``.
 """
 
-from typing import Any, Protocol, TYPE_CHECKING, TypeAlias, runtime_checkable
+from typing import Any, Protocol, TypeAlias, runtime_checkable
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import pandas as pd
 
 from .protocols import StreamLike
 
-if TYPE_CHECKING:
-    from .seamless_data_provider import SeamlessFetchResult
+
+class SeamlessFetchResult(Protocol):
+    frame: pd.DataFrame
+    metadata: Any
 
 
-HistoryFetchResult: TypeAlias = pd.DataFrame | "SeamlessFetchResult"
+HistoryFetchResult: TypeAlias = pd.DataFrame | SeamlessFetchResult
 
 
 class DataFetcher(Protocol):


### PR DESCRIPTION
## Summary
- replace the HistoryFetchResult forward reference with a protocol to avoid runtime evaluation errors and the new import cycle
- restore exception handling around optional Arrow/Ray imports so missing or broken dependencies stay optional

## Testing
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b3f164048329bf09f8d77b3ee8ed)