### PR TITLE
Improve mypy coverage for gateway modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,12 +179,6 @@ ignore_errors = false
 
 [[tool.mypy.overrides]]
 module = [
-  "qmtl.services.gateway.tests.*",
-]
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = [
   "qmtl.runtime.sdk.*",
 ]
 ignore_errors = false

--- a/qmtl/services/gateway/tests/test_controlbus_consumer.py
+++ b/qmtl/services/gateway/tests/test_controlbus_consumer.py
@@ -1,10 +1,11 @@
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from qmtl.foundation.common.tagquery import MatchMode
 from qmtl.services.gateway import metrics as gw_metrics
 from qmtl.services.gateway.controlbus_consumer import ControlBusConsumer, ControlBusMessage
+from qmtl.services.gateway.ws.hub import WebSocketHub
 
 
 class _FakeHub:
@@ -54,7 +55,9 @@ class _FakeHub:
 @pytest.mark.asyncio
 async def test_process_generic_message_routes_and_deduplicates(monkeypatch: pytest.MonkeyPatch) -> None:
     hub = _FakeHub()
-    consumer = ControlBusConsumer([], ["activation"], "group-a", ws_hub=hub)
+    consumer = ControlBusConsumer(
+        [], ["activation"], "group-a", ws_hub=cast(WebSocketHub, hub)
+    )
 
     recorded: dict[str, list[Any]] = {"control": [], "dropped": []}
 
@@ -89,7 +92,9 @@ async def test_process_generic_message_routes_and_deduplicates(monkeypatch: pyte
 @pytest.mark.asyncio
 async def test_queue_update_emits_tagquery_once(monkeypatch: pytest.MonkeyPatch) -> None:
     hub = _FakeHub()
-    consumer = ControlBusConsumer([], ["queue"], "group-a", ws_hub=hub)
+    consumer = ControlBusConsumer(
+        [], ["queue"], "group-a", ws_hub=cast(WebSocketHub, hub)
+    )
 
     control_calls: list[tuple[str, Any]] = []
     monkeypatch.setattr(

--- a/qmtl/services/gateway/tests/test_gateway_health.py
+++ b/qmtl/services/gateway/tests/test_gateway_health.py
@@ -4,20 +4,18 @@ import asyncio
 
 import pytest
 
-from qmtl.services.gateway import gateway_health as gh_module
 from qmtl.services.gateway.gateway_health import (
     GatewayHealthCapabilities,
     get_health,
+    reset_status_cache,
 )
 
 
 @pytest.fixture(autouse=True)
 def clear_gateway_health_cache():
-    gh_module._STATUS_CACHE_MAP.clear()  # type: ignore[attr-defined]
-    gh_module._STATUS_CACHE_TS = 0.0  # type: ignore[attr-defined]
+    reset_status_cache()
     yield
-    gh_module._STATUS_CACHE_MAP.clear()  # type: ignore[attr-defined]
-    gh_module._STATUS_CACHE_TS = 0.0  # type: ignore[attr-defined]
+    reset_status_cache()
 
 
 class StubBreaker:

--- a/qmtl/services/gateway/tests/test_nodeid.py
+++ b/qmtl/services/gateway/tests/test_nodeid.py
@@ -22,7 +22,10 @@ class FakeDB(Database):
 
     async def get_status(self, strategy_id: str) -> str | None:  # pragma: no cover - not used
         rec = self.records.get(strategy_id)
-        return rec.get("status") if rec else None
+        if rec is None:
+            return None
+        status = rec.get("status")
+        return status if isinstance(status, str) else None
 
     async def append_event(self, strategy_id: str, event: str) -> None:  # pragma: no cover - not used
         self.events.append((strategy_id, event))

--- a/qmtl/services/gateway/tests/test_strategy_submission_helper.py
+++ b/qmtl/services/gateway/tests/test_strategy_submission_helper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable, cast
 
 import pytest
 from fastapi import HTTPException
@@ -378,7 +378,7 @@ async def test_shared_validation_path(
     with pytest.raises(HTTPException) as exc:
         await helper.process(bundle.payload, config)
 
-    detail = exc.value.detail
+    detail = cast(dict[str, Any], exc.value.detail)
     assert detail["code"] == "E_NODE_ID_MISMATCH"
 
 


### PR DESCRIPTION
## Summary
- enable tighter mypy checking for gateway tests by removing broad ignores
- refine gateway health typing helpers and add a cache reset hook for tests
- align gateway test doubles with expected interfaces to avoid blanket suppressions

## Testing
- uv run --with mypy -m mypy qmtl/services/gateway

Fixes #1670

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69293abd4f608329996bbaff5c469600)