### PR TITLE
Add validation sample handshake for SR submissions

### DIFF
--- a/qmtl/integrations/sr/__init__.py
+++ b/qmtl/integrations/sr/__init__.py
@@ -67,6 +67,11 @@ from . import adapters  # noqa: F401
 from .strategy_template import (  # noqa: F401
     build_expression_strategy,
     build_strategy_from_dag_spec,
+    submit_with_validation,
+    validate_strategy_against_sample,
+    ValidationSample,
+    ValidationSampleMismatch,
+    ValidationResult,
 )
 
 # Expression Keys
@@ -91,6 +96,11 @@ __all__ = [
     # Strategy Templates
     "build_expression_strategy",
     "build_strategy_from_dag_spec",
+    "submit_with_validation",
+    "validate_strategy_against_sample",
+    "ValidationSample",
+    "ValidationSampleMismatch",
+    "ValidationResult",
     # Expression Keys
     "compute_expression_key",
     "normalize_ast",


### PR DESCRIPTION
## Summary
- add validation_sample parsing utilities and a submit_with_validation wrapper that rejects mismatches before submission
- expose SR validation helpers via the integrations package and enable DAG strategies to evaluate payloads for sample checks
- add unit coverage for matching, mismatch, and epsilon-tolerant validation scenarios

## Testing
- python -m pytest tests/qmtl/integrations/sr/test_strategy_template.py -q

Fixes #1714

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69293ae182f08329a05ce7818c7121fb)