### PR TITLE
Add PySR HOF strategy helpers and examples

### DIFF
--- a/qmtl/integrations/sr/__init__.py
+++ b/qmtl/integrations/sr/__init__.py
@@ -18,6 +18,7 @@ DAG:
 
 Adapters:
     - load_pysr_hof_as_dags: Load PySR hall_of_fame.csv as DAG specs
+    - load_pysr_hof_as_strategies: Load PySR hall_of_fame.csv as Strategy classes
     - adapters: Subpackage with generic and Operon adapters
 
 Strategy Templates:
@@ -60,7 +61,7 @@ from .dag import (  # noqa: F401
 )
 
 # Adapters
-from .pysr_adapter import load_pysr_hof_as_dags  # noqa: F401
+from .pysr_adapter import load_pysr_hof_as_dags, load_pysr_hof_as_strategies  # noqa: F401
 from . import adapters  # noqa: F401
 
 # Strategy Templates
@@ -92,6 +93,7 @@ __all__ = [
     "ExpressionDagBuilder",
     # Adapters
     "load_pysr_hof_as_dags",
+    "load_pysr_hof_as_strategies",
     "adapters",
     # Strategy Templates
     "build_expression_strategy",

--- a/qmtl/integrations/sr/pysr_adapter.py
+++ b/qmtl/integrations/sr/pysr_adapter.py
@@ -9,6 +9,7 @@ from typing import List
 import sympy as sp
 
 from .dag import ExpressionDagSpec, build_expression_dag
+from .strategy_template import build_strategy_from_dag_spec
 
 REQUIRED_COLS = {"Equation", "Complexity", "Loss"}
 
@@ -79,3 +80,38 @@ def load_pysr_hof_as_dags(
         specs.append(spec)
 
     return specs
+
+
+def load_pysr_hof_as_strategies(
+    *,
+    history_provider: object,
+    hof_path: Path | None = None,
+    outputs_base: Path | None = None,
+    max_nodes: int = 20,
+    data_spec: dict | None = None,
+    spec_version: str = "v1",
+    sr_engine: str | None = "pysr",
+) -> List[type]:
+    """Load PySR HOF as Strategy classes wired with Seamless provider.
+
+    This convenience helper chains ``load_pysr_hof_as_dags`` with
+    ``build_strategy_from_dag_spec`` so the caller can directly submit
+    the resulting strategies to ``Runner.submit``.
+    """
+
+    dag_specs = load_pysr_hof_as_dags(
+        hof_path=hof_path,
+        outputs_base=outputs_base,
+        max_nodes=max_nodes,
+        data_spec=data_spec,
+        spec_version=spec_version,
+    )
+
+    return [
+        build_strategy_from_dag_spec(
+            spec,
+            history_provider=history_provider,
+            sr_engine=sr_engine,
+        )
+        for spec in dag_specs
+    ]

--- a/scripts/pysr_hof_to_dag.py
+++ b/scripts/pysr_hof_to_dag.py
@@ -33,6 +33,18 @@ def main() -> None:
         help="Drop expressions whose DAG node_count exceeds this threshold.",
     )
     parser.add_argument(
+        "--data-spec",
+        type=str,
+        default=None,
+        help="JSON string or file path describing the Seamless data spec to embed.",
+    )
+    parser.add_argument(
+        "--spec-version",
+        type=str,
+        default="v1",
+        help="Expression spec_version used for hashing and compatibility labels.",
+    )
+    parser.add_argument(
         "--out",
         type=Path,
         default=None,
@@ -40,11 +52,21 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    data_spec = None
+    if args.data_spec:
+        candidate_path = Path(args.data_spec)
+        if candidate_path.exists():
+            data_spec = json.loads(candidate_path.read_text())
+        else:
+            data_spec = json.loads(args.data_spec)
+
     hof_path = args.hof
     specs = load_pysr_hof_as_dags(
         hof_path=hof_path,
         outputs_base=Path("outputs"),
         max_nodes=args.max_nodes,
+        data_spec=data_spec,
+        spec_version=args.spec_version,
     )
     out_path = args.out
     if out_path is None:


### PR DESCRIPTION
## Summary
- add a convenience loader to convert PySR hall_of_fame outputs into Strategy classes via build_strategy_from_dag_spec
- allow the PySR HOF CLI to embed data_spec/spec_version metadata and document the end-to-end runner path
- extend SR integration tests to cover data_spec/spec_version metadata and strategy serialization

## Testing
- uv run -m pytest -W error -n auto tests/qmtl/integrations/sr/test_pysr_adapter.py tests/qmtl/integrations/sr/test_strategy_template.py

Fixes #1715

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692952c08770832995126ffd22ce378a)