### PR TITLE
Enable mypy for examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ module = [
   "qmtl.runtime.reference_models.*",
   "qmtl.services.*",
   "qmtl.foundation.*",
-  "qmtl.examples.*",
   "tests.*",
 ]
 ignore_errors = true

--- a/qmtl/examples/brokerage_demo/ccxt_binance_futures_nodeset_demo.py
+++ b/qmtl/examples/brokerage_demo/ccxt_binance_futures_nodeset_demo.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from qmtl.runtime.sdk import Node, StreamInput  # type: ignore[import-untyped]
+from qmtl.runtime.sdk import Node, StreamInput
 from qmtl.runtime.nodesets.recipes import make_ccxt_futures_nodeset
 from qmtl.runtime.sdk.util import parse_interval
 

--- a/qmtl/examples/metrics/metrics_recorder_example.py
+++ b/qmtl/examples/metrics/metrics_recorder_example.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput

--- a/qmtl/examples/parallel/parallel_strategies_example.py
+++ b/qmtl/examples/parallel/parallel_strategies_example.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput

--- a/qmtl/examples/parallel/questdb_parallel_example.py
+++ b/qmtl/examples/parallel/questdb_parallel_example.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
-from qmtl.runtime.io import QuestDBRecorder  # type: ignore[import-untyped]
+from qmtl.runtime.io import QuestDBRecorder
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput
 from qmtl.runtime.sdk.event_service import EventRecorderService

--- a/qmtl/examples/scripts/worldservice_apply_demo.py
+++ b/qmtl/examples/scripts/worldservice_apply_demo.py
@@ -14,7 +14,7 @@ import json
 import sys
 import uuid
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 import httpx
 
@@ -54,7 +54,7 @@ def _post_apply(url: str, world_id: str, payload: Mapping[str, Any]) -> Mapping[
     with httpx.Client(timeout=2.0) as client:
         response = client.post(endpoint, json=payload)
         response.raise_for_status()
-        return response.json()
+        return cast(Mapping[str, Any], response.json())
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/qmtl/examples/strategies/correlation_strategy.py
+++ b/qmtl/examples/strategies/correlation_strategy.py
@@ -1,6 +1,6 @@
 """Correlation strategy example - QMTL v2.0."""
 
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, TagQueryNode, MatchMode
 

--- a/qmtl/examples/strategies/cross_market_lag_strategy.py
+++ b/qmtl/examples/strategies/cross_market_lag_strategy.py
@@ -4,7 +4,7 @@ from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput
 from qmtl.runtime.sdk.event_service import EventRecorderService
 from qmtl.runtime.io import QuestDBHistoryProvider, QuestDBRecorder
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 class CrossMarketLagStrategy(Strategy):
     def setup(self):

--- a/qmtl/examples/strategies/dryrun_live_switch_strategy.py
+++ b/qmtl/examples/strategies/dryrun_live_switch_strategy.py
@@ -59,7 +59,8 @@ class SwitchableStrategy(Strategy):
             data = view[price][price.interval]
             if len(data) < 2:
                 return 0.0
-            prev, last = data[-2][1]["close"], data[-1][1]["close"]
+            prev = float(data[-2][1]["close"])
+            last = float(data[-1][1]["close"])
             return (last - prev) / prev
 
         alpha = Node(input=price, compute_fn=compute_alpha, name="alpha")

--- a/qmtl/examples/strategies/general_strategy.py
+++ b/qmtl/examples/strategies/general_strategy.py
@@ -4,7 +4,7 @@ Demonstrates the simplified Runner.submit() API for strategy submission.
 """
 
 import argparse
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 from qmtl.runtime.io import QuestDBHistoryProvider, QuestDBRecorder
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput

--- a/qmtl/examples/strategies/multi_asset_lag_strategy.py
+++ b/qmtl/examples/strategies/multi_asset_lag_strategy.py
@@ -4,7 +4,7 @@ from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput
 from qmtl.runtime.sdk.event_service import EventRecorderService
 from qmtl.runtime.io import QuestDBHistoryProvider, QuestDBRecorder
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 class MultiAssetLagStrategy(Strategy):
     def setup(self):

--- a/qmtl/examples/strategies/recorder_strategy.py
+++ b/qmtl/examples/strategies/recorder_strategy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput

--- a/qmtl/examples/strategies/tag_query_aggregation.py
+++ b/qmtl/examples/strategies/tag_query_aggregation.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-import pandas as pd  # type: ignore[import-untyped]
+from typing import cast
 
-from qmtl.runtime.sdk import Runner, Strategy, Mode
-from qmtl.runtime.sdk.node import Node, TagQueryNode, MatchMode
-from qmtl.runtime.sdk.event_service import EventRecorderService
+import pandas as pd
+
 from qmtl.runtime.io import QuestDBRecorder
+from qmtl.runtime.sdk import Mode, Runner, Strategy
+from qmtl.runtime.sdk.event_service import EventRecorderService
+from qmtl.runtime.sdk.node import MatchMode, Node, TagQueryNode
 
 
 class TagQueryAggregationStrategy(Strategy):
@@ -24,7 +26,9 @@ class TagQueryAggregationStrategy(Strategy):
 
         def calc_corr(view) -> pd.DataFrame:
             aligned = view.align_frames([(node_id, 3600) for node_id in view], window=24)
-            frames = [frame.frame for frame in aligned if not frame.frame.empty]
+            frames = [
+                cast(pd.DataFrame, frame.frame) for frame in aligned if not frame.frame.empty
+            ]
             if not frames:
                 return pd.DataFrame()
             df = pd.concat(frames, axis=1)

--- a/qmtl/examples/strategies/tag_query_strategy.py
+++ b/qmtl/examples/strategies/tag_query_strategy.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-import pandas as pd  # type: ignore[import-untyped]
-from qmtl.runtime.sdk import Runner, Strategy, Mode
-from qmtl.runtime.sdk.node import Node, TagQueryNode, MatchMode
+from typing import cast
+
+import pandas as pd
+from qmtl.runtime.sdk import Mode, Runner, Strategy
+from qmtl.runtime.sdk.node import MatchMode, Node, TagQueryNode
 
 
 class TagQueryStrategy(Strategy):
@@ -22,7 +24,9 @@ class TagQueryStrategy(Strategy):
 
         def calc_corr(view) -> pd.DataFrame:
             aligned = view.align_frames([(node_id, 3600) for node_id in view], window=24)
-            frames = [frame.frame for frame in aligned if not frame.frame.empty]
+            frames = [
+                cast(pd.DataFrame, frame.frame) for frame in aligned if not frame.frame.empty
+            ]
             if not frames:
                 return pd.DataFrame()
             df = pd.concat(frames, axis=1)
@@ -35,7 +39,8 @@ class TagQueryStrategy(Strategy):
             if not latest:
                 return pd.DataFrame()
             _, corr_df = latest[-1]
-            return pd.DataFrame({"avg_corr": [corr_df.mean().mean()]})
+            corr_frame = cast(pd.DataFrame, corr_df)
+            return pd.DataFrame({"avg_corr": [corr_frame.mean().mean()]})
 
         avg_node = Node(input=corr_node, compute_fn=avg_corr, name="avg_corr")
 

--- a/qmtl/examples/templates/branching.py
+++ b/qmtl/examples/templates/branching.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import argparse
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 
 class BranchingStrategy(Strategy):

--- a/qmtl/examples/templates/layers/brokerage/ccxt_binance.py
+++ b/qmtl/examples/templates/layers/brokerage/ccxt_binance.py
@@ -5,10 +5,16 @@ This module provides Binance brokerage integration.
 
 from __future__ import annotations
 
+from types import ModuleType
+from typing import Any, cast
+
+_ccxt: ModuleType | None
 try:
-    import ccxt
+    import ccxt as _ccxt
 except ImportError:
-    ccxt = None
+    _ccxt = None
+
+ccxt: ModuleType | None = _ccxt
 
 
 class BinanceBroker:
@@ -25,7 +31,8 @@ class BinanceBroker:
         if ccxt is None:
             raise ImportError("CCXT is required for Binance integration. Install with: pip install ccxt")
         
-        self.exchange = ccxt.binance({
+        exchange_factory = cast(Any, ccxt).binance
+        self.exchange: Any = exchange_factory({
             'apiKey': api_key,
             'secret': api_secret,
             'options': {'defaultType': 'future' if testnet else 'spot'},

--- a/qmtl/examples/templates/state_machine.py
+++ b/qmtl/examples/templates/state_machine.py
@@ -9,7 +9,7 @@ ASCII DAG::
 """
 
 import argparse
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput
 

--- a/qmtl/examples/tests/test_brokerage_e2e.py
+++ b/qmtl/examples/tests/test_brokerage_e2e.py
@@ -1,15 +1,23 @@
 from datetime import datetime, timedelta, timezone
+from typing import cast
 
 import pytest
 
-from qmtl.runtime.brokerage import Account, Order, OrderType, TimeInForce
 from qmtl.examples.brokerage_demo.advanced_demo import build_model
+from qmtl.runtime.brokerage import (
+    Account,
+    ExchangeHoursProvider,
+    Order,
+    OrderType,
+    TimeInForce,
+)
 
 
 def test_brokerage_e2e_scenarios():
     model, settlement = build_model()
     acct = Account(cash=100_000.0)
-    hours = model.hours  # type: ignore[attr-defined]
+    hours = cast(ExchangeHoursProvider | None, getattr(model, "hours", None))
+    assert hours is not None
 
     day = datetime(2024, 1, 2, tzinfo=timezone.utc)
     open_ts = datetime.combine(day.date(), hours.market_hours.regular_start, tzinfo=timezone.utc)

--- a/qmtl/examples/utils/backfill_history_example.py
+++ b/qmtl/examples/utils/backfill_history_example.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput

--- a/qmtl/examples/utils/mode_switch_example.py
+++ b/qmtl/examples/utils/mode_switch_example.py
@@ -6,7 +6,7 @@ Demonstrates how to run the same strategy across different modes.
 from __future__ import annotations
 
 import argparse
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 from qmtl.runtime.sdk import Runner, Strategy, Mode
 from qmtl.runtime.sdk.node import Node, StreamInput


### PR DESCRIPTION
## Summary
- remove the mypy ignore for the examples package and address surfaced type issues
- add lightweight typing and casts across example strategies, scripts, and helpers
- tighten brokerage demos and protocols so mypy can validate without broad ignores

## Testing
- uv run --with mypy -m mypy qmtl/examples

Fixes #1671

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692952b880b883298d3311e48aaef721)