### PR TITLE
Enforce SR expression key metadata and validation

### DIFF
--- a/docs/ko/design/sr_integration_proposal.md
+++ b/docs/ko/design/sr_integration_proposal.md
@@ -58,6 +58,33 @@ status: plan-revised
 - WorldPolicy에 `expression_key` 기반 dedup 옵션(replace/reject)을 배선.
 - 정합성 핸드셰이크: 제출 시 샘플 비교 후 불일치면 reject.
 
+!!! note "제출 메타 포맷 (필수)"
+    - `meta.sr`에 포함되는 공통 필드
+        - `expression`, `expression_key`, `spec_version`, `data_spec`, `sr_engine`
+        - `expression_key_meta.value/spec_version`: 해시 버전 구분용
+        - `dedup_policy.expression_key.on_duplicate`: `replace`(기본) 또는 `reject`
+    - 예시(JSON):
+        ```json
+        {
+          "meta": {
+            "sr": {
+              "expression": "x + y",
+              "expression_key": "...",
+              "spec_version": "v1",
+              "data_spec": {"dataset_id": "ohlcv", "snapshot_version": "2025-01-01"},
+              "dedup_policy": {
+                "expression_key": {
+                  "value": "...",
+                  "spec_version": "v1",
+                  "on_duplicate": "replace"
+                }
+              }
+            }
+          }
+        }
+        ```
+    - `expression_key`가 없거나 계산에 실패하면 제출 단계에서 명확한 오류를 반환하고 중복 제어를 건너뛰지 않는다.
+
 ### Phase 2 (선택)
 - Gateway 배치 제출 API, 검증/정합성의 배치 최적화.
 - DAG Manager 직접 병합/캐싱/서브그래프 재사용 스위치 온.

--- a/tests/qmtl/integrations/sr/test_expression_key.py
+++ b/tests/qmtl/integrations/sr/test_expression_key.py
@@ -1,5 +1,7 @@
 """Tests for qmtl.integrations.sr.expression_key module."""
 
+import pytest
+
 from qmtl.integrations.sr.expression_key import (
     compute_expression_key,
     normalize_ast,
@@ -143,18 +145,21 @@ class TestNormalizeAst:
 class TestExpressionKeyEdgeCases:
     """Edge case tests for expression key generation."""
 
-    def test_empty_string_returns_key(self):
-        """Test with empty string - falls back to raw string."""
-        # Empty string falls back to empty string, which gets hashed
-        key = compute_expression_key("")
-        assert isinstance(key, str)
-        assert len(key) == 64
+    def test_empty_string_rejected(self):
+        """Missing expressions should fail fast."""
+        with pytest.raises(ValueError):
+            compute_expression_key("")
 
-    def test_whitespace_only_returns_key(self):
-        """Test with whitespace only - falls back to stripped string."""
-        key = compute_expression_key("   ")
-        assert isinstance(key, str)
-        assert len(key) == 64
+    def test_whitespace_only_rejected(self):
+        """Whitespace-only expressions should fail fast."""
+        with pytest.raises(ValueError):
+            compute_expression_key("   ")
+
+    def test_spec_version_changes_key(self):
+        """Spec version should be part of the hash payload."""
+        key_v1 = compute_expression_key("x + y", spec_version="v1")
+        key_v2 = compute_expression_key("x + y", spec_version="v2")
+        assert key_v1 != key_v2
 
     def test_numeric_constants(self):
         """Test expressions with numeric constants."""


### PR DESCRIPTION
## Summary
- enforce spec_version-aware expression_key computation and fail fast when expressions are missing or cannot be normalized
- centralize SR submission metadata (expression_key_meta, dedup_policy.on_duplicate) for expression and DAG strategies
- document the required SR submission meta payload for World/Gateway expression_key deduplication

## Testing
- python -m pytest tests/qmtl/integrations/sr/test_expression_key.py tests/qmtl/integrations/sr/test_strategy_template.py

Fixes #1716

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929558beb7883299d2fda003f082cd4)