### PR TITLE
Handle zero-notional positions in fallback allocation

### DIFF
--- a/qmtl/services/worldservice/rebalancing/adapter.py
+++ b/qmtl/services/worldservice/rebalancing/adapter.py
@@ -62,7 +62,8 @@ def allocate_strategy_deltas(
     for d in plan.deltas:
         key = (d.venue, d.symbol)
         strat_notional = bucket.get(key, {})
-        if strat_notional:
+        total_notional = sum(strat_notional.values()) if strat_notional else 0.0
+        if strat_notional and total_notional > 0:
             out.extend(
                 _allocate_existing_delta(world_id, d.symbol, d.delta_qty, d.venue, strat_notional)
             )


### PR DESCRIPTION
## Summary
- route rebalance deltas through fallback weights when existing positions have zero notional
- add regression test covering fallback allocation for zero-notional positions

## Testing
- uv run -m pytest -W error -n auto tests/qmtl/services/worldservice/test_rebalancing.py::test_allocate_strategy_deltas_falls_back_when_notional_zero_with_positions


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dbb5e25608329aaebfcfc560deaa1)