### PR TITLE
Share WorldService evaluation schemas

### DIFF
--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -6,7 +6,13 @@ from typing import Any, Dict, List, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .policy_engine import Policy
-from .shared_schemas import ActivationEnvelope, DecisionEnvelope, SeamlessArtifactPayload
+from .shared_schemas import (
+    ActivationEnvelope,
+    DecisionEnvelope,
+    EvaluateRequest,
+    SeamlessArtifactPayload,
+    StrategySeries,
+)
 
 
 class ExecutionDomainEnum(StrEnum):
@@ -25,12 +31,6 @@ class WorldNodeStatusEnum(StrEnum):
     PAUSED = "paused"
     STOPPED = "stopped"
     ARCHIVED = "archived"
-
-
-class StrategySeries(BaseModel):
-    equity: List[float] | None = None
-    pnl: List[float] | None = None
-    returns: List[float] | None = None
 
 
 class World(BaseModel):
@@ -99,14 +99,6 @@ class ActivationRequest(BaseModel):
 class ApplyPlan(BaseModel):
     activate: List[str] = Field(default_factory=list)
     deactivate: List[str] = Field(default_factory=list)
-
-
-class EvaluateRequest(BaseModel):
-    metrics: Dict[str, Dict[str, float]] = Field(default_factory=dict)
-    previous: List[str] | None = None
-    correlations: Dict[tuple[str, str], float] | None = None
-    policy: Policy | None = None
-    series: Dict[str, StrategySeries] | None = None
 
 
 class ApplyRequest(EvaluateRequest):

--- a/qmtl/services/worldservice/shared_schemas.py
+++ b/qmtl/services/worldservice/shared_schemas.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from .policy_engine import Policy
+
+
+class StrategySeries(BaseModel):
+    equity: List[float] | None = None
+    pnl: List[float] | None = None
+    returns: List[float] | None = None
 
 
 class SeamlessArtifactPayload(BaseModel):
@@ -29,6 +37,14 @@ class DecisionEnvelope(BaseModel):
     artifact: SeamlessArtifactPayload | None = None
 
 
+class EvaluateRequest(BaseModel):
+    metrics: Dict[str, Dict[str, float]] = Field(default_factory=dict)
+    previous: List[str] | None = None
+    correlations: Dict[tuple[str, str], float] | None = None
+    policy: Policy | Dict[str, Any] | None = None
+    series: Dict[str, StrategySeries] | None = None
+
+
 class ActivationEnvelope(BaseModel):
     world_id: str
     strategy_id: str
@@ -47,5 +63,7 @@ class ActivationEnvelope(BaseModel):
 __all__ = [
     "ActivationEnvelope",
     "DecisionEnvelope",
+    "EvaluateRequest",
     "SeamlessArtifactPayload",
+    "StrategySeries",
 ]

--- a/tests/e2e/world_smoke/servers/worldservice_stub.py
+++ b/tests/e2e/world_smoke/servers/worldservice_stub.py
@@ -19,11 +19,13 @@ import json
 from dataclasses import dataclass
 from typing import Any, Dict
 
+import time
 import uvicorn
-from fastapi import FastAPI, Response, Request, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from pydantic import BaseModel
 import yaml
-import time
+
+from qmtl.services.worldservice.shared_schemas import EvaluateRequest
 
 
 app = FastAPI()
@@ -106,11 +108,6 @@ async def activation(wid: str) -> Response:
 @app.get("/worlds/{wid}/{topic}/state_hash")
 async def state_hash(wid: str, topic: str) -> dict:
     return {"state_hash": f"{topic}-hash"}
-
-
-class EvaluateRequest(BaseModel):
-    as_of: str | None = None
-
 
 @app.post("/worlds/{wid}/evaluate")
 async def evaluate(wid: str, req: EvaluateRequest) -> dict:

--- a/tests/qmtl/services/worldservice/test_shared_schemas.py
+++ b/tests/qmtl/services/worldservice/test_shared_schemas.py
@@ -1,5 +1,4 @@
-from qmtl.services.worldservice import schemas
-from qmtl.services.worldservice import shared_schemas
+from qmtl.services.worldservice import schemas, shared_schemas
 
 
 def test_shared_envelopes_reused():
@@ -12,3 +11,10 @@ def test_activation_envelope_fields_cover_state_hash():
     fields = set(shared_schemas.ActivationEnvelope.model_fields)
     assert "state_hash" in fields
     assert set(schemas.ActivationEnvelope.model_fields) == fields
+
+
+def test_evaluate_request_and_series_shared():
+    assert schemas.EvaluateRequest is shared_schemas.EvaluateRequest
+    assert schemas.StrategySeries is shared_schemas.StrategySeries
+    payload = shared_schemas.EvaluateRequest()
+    assert payload.metrics == {}


### PR DESCRIPTION
## Summary
- move WorldService evaluation request and series schemas into the shared module used by SDK/Runner
- re-export shared evaluation types through WorldService schemas and align the smoke-test stub with the shared request model
- expand schema-sharing tests to cover evaluation and activation payloads

## Testing
- uv run -m pytest tests/qmtl/services/worldservice/test_shared_schemas.py

Fixes #1771

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69315e94a9108329931dff78a9d73cf8)