### PR TITLE
Phase1: WS-first execution domains and core loop contracts

### DIFF
--- a/.github/issues/README.md
+++ b/.github/issues/README.md
@@ -10,6 +10,7 @@ This directory contains prepared GitHub issue templates for improving QMTL's tes
   - 목적/범위/배제, 단일 출처 스펙 링크(ko/en), 오픈 질문/결정자, 착수·종료 게이트, 마이그레이션/롤백, 후속 작업 체크리스트가 포함됩니다.  
   - 스펙 본문은 반드시 문서(예: `docs/ko/design/core_loop_roadmap.md`)에만 두고, 이슈에는 링크와 상태(`draft — subject to change`)만 적으세요.  
   - 계약 테스트 스켈레톤은 `@pytest.mark.contract + xfail`로 추가 후, 스펙 확정 시 `xfail`을 제거해 강제 실패로 전환합니다.
+  - CI에 Core Loop 계약 스위트(`tests/e2e/core_loop`)가 추가되었습니다. inproc 스택 기준으로 병렬 실행되며, ExecutionDomain default-safe 다운그레이드와 SubmitResult 필드가 커버됩니다.
 
 ### High Priority
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,9 @@ jobs:
           WS_MODE: service
         run: |
           uv run -m pytest -q tests/e2e/world_smoke -q
+
+      - name: Core Loop contract suite
+        env:
+          CORE_LOOP_STACK_MODE: inproc
+        run: |
+          uv run -m pytest -q tests/e2e/core_loop -q

--- a/docs/en/getting-started/quickstart.md
+++ b/docs/en/getting-started/quickstart.md
@@ -83,6 +83,9 @@ SubmitResult(
     status="valid",              # valid | invalid | pending
     world="quickstart_demo",
     mode="backtest",
+    downgraded=False,            # True if forced into safe compute-only
+    downgrade_reason=None,       # e.g., "missing_as_of" when backtest inputs are incomplete
+    safe_mode=False,             # True when orders are gated off for safety
     
     # Performance metrics
     metrics={

--- a/docs/ko/getting-started/quickstart.md
+++ b/docs/ko/getting-started/quickstart.md
@@ -83,6 +83,9 @@ SubmitResult(
     status="valid",              # valid | invalid | pending
     world="quickstart_demo",
     mode="backtest",
+    downgraded=False,            # 안전기본으로 강등되었는지 여부
+    downgrade_reason=None,       # 예: backtest 필수 입력 누락 시 "missing_as_of"
+    safe_mode=False,             # True면 주문 게이트 OFF 상태
     
     # 성과 지표
     metrics={

--- a/qmtl/interfaces/cli/submit.py
+++ b/qmtl/interfaces/cli/submit.py
@@ -134,6 +134,10 @@ def _submit_and_print_result(strategy_cls, args: argparse.Namespace, overrides: 
         print(_t("Error: {}").format(str(e)), file=sys.stderr)
         return 1
 
+    if getattr(result, "downgraded", False) or getattr(result, "safe_mode", False):
+        reason = getattr(result, "downgrade_reason", None) or "unspecified"
+        print(_t("⚠️  Safe mode: execution was downgraded ({})").format(reason), file=sys.stderr)
+
     _print_submission_result(result)
     return 0 if result.status != "rejected" else 1
 
@@ -145,6 +149,9 @@ def _print_submission_result(result) -> None:
     print(f"Status:      {result.status}")
     print(f"World:       {result.world}")
     print(f"Mode:        {result.mode.value}")
+    if getattr(result, "downgraded", False) or getattr(result, "safe_mode", False):
+        reason = getattr(result, "downgrade_reason", None) or "unspecified"
+        print(f"Safe mode:   downgraded ({reason})")
 
     if result.status == "active":
         _print_active_result(result)

--- a/qmtl/runtime/sdk/metrics.py
+++ b/qmtl/runtime/sdk/metrics.py
@@ -116,6 +116,17 @@ seamless_cache_miss_total = _counter(
     test_value_factory=dict,
 )
 
+# ---------------------------------------------------------------------------
+# Execution context safety
+# ---------------------------------------------------------------------------
+execution_domain_downgrade_total = _counter(
+    "execution_domain_downgrade_total",
+    "Total number of SDK execution context downgrades to compute-only safe mode",
+    ["reason"],
+    test_value_attr="_vals",
+    test_value_factory=dict,
+)
+
 seamless_cache_resident_bytes = _gauge(
     "seamless_cache_resident_bytes",
     "Resident bytes held by Seamless in-memory cache",

--- a/qmtl/runtime/sdk/runner.py
+++ b/qmtl/runtime/sdk/runner.py
@@ -230,6 +230,20 @@ class Runner:
                 "Missing dataset metadata for %s run; forcing compute-only mode",
                 resolution.context.get("execution_mode"),
             )
+        if resolution.downgraded or resolution.safe_mode:
+            reason = resolution.downgrade_reason or "unknown"
+            logger.warning(
+                "Execution context downgraded to safe compute-only path",
+                extra={
+                    "reason": reason,
+                    "execution_mode": resolution.context.get("execution_mode"),
+                    "execution_domain": resolution.context.get("execution_domain"),
+                },
+            )
+            try:
+                sdk_metrics.execution_domain_downgrade_total.labels(reason=reason).inc()
+            except Exception:  # pragma: no cover - metrics best-effort
+                logger.debug("Failed to record downgrade metric", exc_info=True)
         return resolution.context, resolution.force_offline
 
     # ------------------------------------------------------------------

--- a/qmtl/runtime/sdk/strategy_bootstrapper.py
+++ b/qmtl/runtime/sdk/strategy_bootstrapper.py
@@ -155,9 +155,12 @@ class StrategyBootstrapper:
         execution_domain_override: str | None = None
         raw_domain = meta_payload.get("execution_domain")
         if isinstance(raw_domain, str) and raw_domain.strip():
-            canonical = resolve_execution_domain(raw_domain)
-            execution_domain_override = canonical or raw_domain.strip().lower()
-            meta_payload["execution_domain"] = execution_domain_override
+            logger.warning(
+                "runner.execution_domain_hint_ignored",
+                extra={"execution_domain": raw_domain},
+            )
+            meta_payload.pop("execution_domain", None)
+            execution_domain_override = None
         raw_fp = meta_payload.get("dataset_fingerprint") or meta_payload.get(
             "datasetFingerprint"
         )
@@ -190,9 +193,6 @@ class StrategyBootstrapper:
                 "world": world_id,
                 "domain": effective_domain,
             }
-            if meta_payload is None:
-                meta_payload = {}
-            meta_payload.setdefault("execution_domain", effective_domain)
         return dag_meta, meta_payload
 
     async def _maybe_submit_strategy(

--- a/qmtl/services/worldservice/storage/normalization.py
+++ b/qmtl/services/worldservice/storage/normalization.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from qmtl.foundation.common.compute_context import resolve_execution_domain
+
 from .constants import (
     DEFAULT_EXECUTION_DOMAIN,
     DEFAULT_WORLD_NODE_STATUS,
@@ -11,16 +13,37 @@ from .constants import (
 
 
 def _normalize_execution_domain(execution_domain: str | None) -> str:
-    """Normalise *execution_domain* to a canonical, validated value."""
+    """Normalise *execution_domain* to a canonical, validated value.
+
+    - Missing/empty/default values are downgraded to the default compute-only domain.
+    - Common aliases (compute-only/compute_only, paper/sim, prod/live) are mapped
+      via ``resolve_execution_domain``.
+    - Unknown tokens surface a clear error so callers can fix inputs instead of
+      silently running in an unintended domain.
+    """
 
     if execution_domain is None:
         return DEFAULT_EXECUTION_DOMAIN
-    candidate = str(execution_domain).strip().lower()
-    if not candidate:
+
+    raw = str(execution_domain).strip()
+    if not raw:
         return DEFAULT_EXECUTION_DOMAIN
-    if candidate not in EXECUTION_DOMAINS:
-        raise ValueError(f"unknown execution_domain: {execution_domain}")
-    return candidate
+
+    resolved = resolve_execution_domain(raw)
+    if resolved is None or resolved.strip().lower() in {"", "default"}:
+        return DEFAULT_EXECUTION_DOMAIN
+
+    candidate = resolved.strip().lower()
+    if candidate == DEFAULT_EXECUTION_DOMAIN:
+        return DEFAULT_EXECUTION_DOMAIN
+    if candidate in EXECUTION_DOMAINS:
+        return candidate
+
+    allowed = ", ".join(sorted(EXECUTION_DOMAINS))
+    raise ValueError(
+        f"unknown execution_domain '{execution_domain}'; expected one of {allowed} "
+        "(aliases like 'compute-only' -> backtest, 'paper/sim' -> dryrun)"
+    )
 
 
 def _normalize_world_node_status(status: str | None) -> str:

--- a/tests/e2e/core_loop/README.md
+++ b/tests/e2e/core_loop/README.md
@@ -22,4 +22,9 @@ Configuration knobs:
 - `CORE_LOOP_WORLD_ID` / `CORE_LOOP_WORLD_IDS`: optional world ids when using an external service.
 - `CORE_LOOP_ARTIFACT_DIR`: override the artifacts directory (`.artifacts/core_loop` by default).
 
+Contract tests:
+- Marked with `@pytest.mark.contract` and currently `xfail` while the spec is in draft.
+- Include ExecutionDomain default-safe downgrade expectations: running the demo strategy without
+  `as_of` in backtest mode should yield a safe-mode warning and `SubmitResult.downgrade_reason`.
+
 References: docs/ko/design/core_loop_roadmap.md, docs/en/design/core_loop_roadmap_issue_drafts.md.

--- a/tests/e2e/core_loop/conftest.py
+++ b/tests/e2e/core_loop/conftest.py
@@ -10,6 +10,10 @@ import yaml
 from .stack import CoreLoopStackHandle, bootstrap_core_loop_stack
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "contract: Core Loop contract test")
+
+
 @pytest.fixture(scope="session")
 def core_loop_artifact_dir():
     path = Path(os.environ.get("CORE_LOOP_ARTIFACT_DIR", ".artifacts/core_loop"))

--- a/tests/e2e/core_loop/worlds/core-loop-demo.yml
+++ b/tests/e2e/core_loop/worlds/core-loop-demo.yml
@@ -13,6 +13,23 @@ world:
     topk:
       total: 1
 
+  data:
+    presets:
+      - id: "ohlcv-demo"
+        preset: "ohlcv.binance.spot.1m"
+        universe:
+          symbols: ["BTCUSDT"]
+          asset_class: "crypto"
+          venue: "binance"
+        window:
+          warmup_bars: 60
+          min_history: "7d"
+        seamless:
+          sla_preset: "baseline"
+          conformance_preset: "strict-blocking"
+        live:
+          max_lag: "45s"
+
   execution:
     mode_default: "backtest"
     position_exit_on_deactivate: "market"

--- a/tests/e2e/core_loop/worlds/core_loop_demo_strategy.py
+++ b/tests/e2e/core_loop/worlds/core_loop_demo_strategy.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from qmtl.runtime.sdk import Mode, Runner, Strategy, StreamInput
+
+
+class CoreLoopDemoStrategy(Strategy):
+    def setup(self) -> None:
+        price = StreamInput(tags=["core-loop-demo"], interval="60s", period=1)
+        self.add_nodes([price])
+
+
+if __name__ == "__main__":
+    Runner.submit(CoreLoopDemoStrategy, world="core-loop-demo", mode=Mode.BACKTEST)

--- a/tests/qmtl/runtime/sdk/test_submit.py
+++ b/tests/qmtl/runtime/sdk/test_submit.py
@@ -70,6 +70,9 @@ class TestSubmitResult:
         assert result.contribution is None
         assert result.weight is None
         assert result.rank is None
+        assert result.downgraded is False
+        assert result.downgrade_reason is None
+        assert result.safe_mode is False
 
     def test_full_result(self):
         result = SubmitResult(
@@ -100,6 +103,8 @@ class TestSubmitResult:
         assert result.status == "rejected"
         assert result.rejection_reason == "Policy threshold not met"
         assert len(result.improvement_hints) == 1
+        assert result.downgraded is False
+        assert result.safe_mode is False
 
     def test_submit_result_embeds_envelopes(self):
         decision = DecisionEnvelope(
@@ -132,6 +137,22 @@ class TestSubmitResult:
         assert result.world == decision.world_id == activation.world_id
         assert result.strategy_id == activation.strategy_id
         assert result.weight == activation.weight
+        assert result.downgraded is False
+
+    def test_submit_result_downgrade_flags(self):
+        result = SubmitResult(
+            strategy_id="s2",
+            status="pending",
+            world="w",
+            mode=Mode.BACKTEST,
+            downgraded=True,
+            downgrade_reason="missing_as_of",
+            safe_mode=True,
+        )
+
+        assert result.downgraded is True
+        assert result.downgrade_reason == "missing_as_of"
+        assert result.safe_mode is True
 
 
 class TestSubmitFunction:

--- a/tests/qmtl/services/gateway/test_compute_context_service.py
+++ b/tests/qmtl/services/gateway/test_compute_context_service.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from qmtl.foundation.common.compute_context import DowngradeReason
+from qmtl.services.gateway.submission.context_service import ComputeContextService
+
+
+class DummyWorldClient:
+    def __init__(self, payload, stale: bool = False):
+        self.payload = payload
+        self.stale = stale
+        self.calls: list[str] = []
+
+    async def get_decide(self, world_id: str):
+        self.calls.append(world_id)
+        return self.payload, self.stale
+
+
+@pytest.mark.asyncio
+async def test_world_decision_overrides_submission_hints() -> None:
+    decision = {
+        "world_id": "world-1",
+        "policy_version": 1,
+        "effective_mode": "live",
+        "reason": "policy_evaluated",
+        "as_of": "2025-01-01T00:00:00Z",
+        "ttl": "300s",
+        "etag": "etag-1",
+    }
+    client = DummyWorldClient(decision)
+    payload = types.SimpleNamespace(meta={"execution_domain": "shadow"}, world_ids=["world-1"])
+
+    ctx = await ComputeContextService(world_client=client).build(payload)
+
+    assert ctx.execution_domain == "live"  # WS decision wins
+    assert ctx.downgraded is False
+    assert client.calls == ["world-1"]
+
+
+@pytest.mark.asyncio
+async def test_missing_world_decision_downgrades_to_safe_mode() -> None:
+    client = DummyWorldClient(payload=None, stale=False)
+    payload = types.SimpleNamespace(meta=None, world_ids=["world-missing"])
+
+    ctx = await ComputeContextService(world_client=client).build(payload)
+
+    assert ctx.execution_domain == "backtest"
+    assert ctx.safe_mode is True
+    assert ctx.downgraded is True
+    assert ctx.downgrade_reason == DowngradeReason.DECISION_UNAVAILABLE

--- a/tests/qmtl/services/worldservice/storage/test_normalization.py
+++ b/tests/qmtl/services/worldservice/storage/test_normalization.py
@@ -16,6 +16,11 @@ from qmtl.services.worldservice.storage.normalization import (
         (None, DEFAULT_EXECUTION_DOMAIN),
         ("", DEFAULT_EXECUTION_DOMAIN),
         ("   ", DEFAULT_EXECUTION_DOMAIN),
+        ("default", DEFAULT_EXECUTION_DOMAIN),
+        ("compute-only", "backtest"),
+        ("compute_only", "backtest"),
+        ("paper", "dryrun"),
+        ("sim", "dryrun"),
         ("  LIVE  ", "live"),
         ("DryRun", "dryrun"),
         (" shadow ", "shadow"),
@@ -25,7 +30,7 @@ def test_normalize_execution_domain_defaults_and_lowercases(raw: object, expecte
     assert _normalize_execution_domain(raw) == expected
 
 
-@pytest.mark.parametrize("raw", ["paper", 123])
+@pytest.mark.parametrize("raw", ["weird", 123])
 def test_normalize_execution_domain_rejects_unknown_values(raw: object) -> None:
     with pytest.raises(ValueError, match="unknown execution_domain"):
         _normalize_execution_domain(raw)  # type: ignore[arg-type]


### PR DESCRIPTION
Summary:
- Enforce WS-first execution-domain resolution end-to-end (runner/CLI/WS), propagate safe-mode/downgrade reason in execution context + SubmitResult, and emit minimal metrics/logs.
- Normalize compute_context/default-safe handling in gateway/worldservice and SDK; align validation cache responses and domain aliases.
- Activate core loop contract suite with default-safe downgrade cases, demo preset/strategy, and docs/README notes.

Testing:
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k "not slow"
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/core_loop -q

Closes #1773
Closes #1767
Closes #1768
Closes #1774
Closes #1779
Closes #1780
Closes #1775
Closes #1789