### PR TITLE
WS-first SubmitResult output and CLI split

### DIFF
--- a/docs/en/design/core_loop_roadmap_tasks.md
+++ b/docs/en/design/core_loop_roadmap_tasks.md
@@ -1,0 +1,42 @@
+# Core Loop Roadmap Tasks
+
+Representative issue numbers are in parentheses. Phase 2 is the current focus.
+
+## Phase 0 – Foundations (spec/skeleton)
+- Create the Core Loop contract test skeleton first: tests/e2e/core_loop scaffold (#1788).
+- Tackle spec work up front:
+  - Set direction for SubmitResult/WS schema alignment (#1764, #1771).
+  - Define world data preset spec (#1776).
+  - Document NodeID/TagQuery determinism rules (#1782).
+  - Gather Determinism checklist items/scope (#1785).
+
+## Phase 1 – ExecutionDomain/default-safe vertical slice (drive one mode/domain rule end-to-end)
+- Lock WS boundary: WS ExecutionDomain validation/downgrade (#1773).
+- Strengthen Runner/CLI input validation (#1767) → implement SDK/CLI default-safe downgrade (#1768).
+- Remove Runner submission hints (WS effective_mode first) (#1774).
+- Align ComputeContext: apply compute_context rules (#1779) → enforce WS-first rule (#1780).
+- Add ExecutionDomain default-safe contract/E2E tests (#1775) + fold into Core Loop contract suite (#1789).
+- Current status: Phase 1 is complete.
+
+## Phase 2 – SubmitResult/WS SSOT tidy-up (T1/T2 P0)
+- [x] Align SubmitResult ↔ WS envelopes and publish a shared module (#1764, #1771) — CLOSED; lock shared WS/SDK schema location/naming to avoid downstream flips.
+- [x] Expose WS results as the SSOT in Runner/CLI/API (#1770) — SubmitResult merges WS first with `precheck` separated; CLI prints WS vs pre-check sections.
+- [x] Clean up SDK/CLI SubmitResult output (#1765) — downgrade/default-safe signals exposed; WS vs precheck split with tests (ties into #1789).
+- [x] Refresh SDK/strategy guides and ops/dev guides to state “WS is the final truth” (#1766, #1772) — ko/en guidance updated with WS SSOT vs pre-check separation and runbook note.
+
+## Phase 3 – World-based data preset on-ramp (T3 P0)
+- Implement Runner/CLI seamless auto-configuration based on the preset spec (#1777).
+- Add preset-driven examples/guides and wire live examples into CI/contract tests (#1778, #1789).
+
+## Phase 4 – NodeID/TagQuery + Determinism wrap-up (T4/T5 P0)
+- Implement/verify NodeID/TagQuery determinism per engine (#1783) → observe/test (#1784).
+- Code the Determinism checklist (#1785) → metrics/dashboards (#1786) → runbook hardening (#1787).
+- Expand Core Loop contract suite with NodeID/TagQuery and Determinism cases (#1789).
+
+## Phase 5 – CI gate landing (T6 P0)
+- Integrate the Core Loop contract suite as a CI merge blocker (#1790).
+- Document how breaking each test maps back to roadmap/architecture intent.
+
+### Parallelization notes
+- Phase 1 (ExecutionDomain line) and Phase 2 (SubmitResult/WS SSOT) can proceed partly in parallel,
+- Phase 3 (data preset) and Phase 4 (NodeID/Determinism) should wait until Phase 1/2 rules are settled.

--- a/docs/en/guides/sdk_tutorial.md
+++ b/docs/en/guides/sdk_tutorial.md
@@ -186,6 +186,13 @@ workspace/
 
 `qmtl submit` prefers `qmtl.yml` for strategy resolution and the default world. Even if `QMTL_STRATEGY_ROOT` or an existing `PYTHONPATH` is present, `project.strategy_root` is applied first to keep behaviour consistent across POSIX and Windows.
 
+### Reading submission results (WS SSOT + pre-check)
+- `SubmitResult` exposes **WorldService output as the single source of truth** for `status/weight/rank/contribution`; local `ValidationPipeline` output is separated into `precheck`.
+- The CLI prints two sections:
+  - `🌐 WorldService decision (SSOT)` — includes WS `status/weight/rank/contribution` and WS threshold violations.
+  - `🧪 Local pre-check (ValidationPipeline)` — local metrics/violations/hints for reference only (not authoritative).
+- `downgraded/safe_mode/downgrade_reason` remain at the top so you can see default-safe downgrades.
+
 ## Cache Access
 
 `compute_fn` receives the read-only `CacheView` returned by `NodeCache.view()`.

--- a/docs/en/operations/activation.md
+++ b/docs/en/operations/activation.md
@@ -18,6 +18,11 @@ last_modified: 2025-08-29
 - Confirm NTP health on WorldService and Gateway nodes
 - Identify `world_id` and current `resource_version`/`etag`
 
+## WS SSOT & client surfaces
+- WorldService activation/evaluation is the single source of truth (SSOT) for `status/weight/contribution`. CLI/SDK submit surfaces WS output directly.
+- Local ValidationPipeline output is shown separately as “pre-check” (non-authoritative) for debugging; investigate WS metrics/logs first when there is a mismatch.
+- Downgrade signals (`downgraded/safe_mode/downgrade_reason`) remain at the top-level to expose default-safe paths from CLI/SDK.
+
 ## Procedures
 
 1) Freeze/Drain
@@ -42,4 +47,3 @@ last_modified: 2025-08-29
 - Use world-scoped metrics such as `pretrade_attempts_total{world_id="demo"}` to verify activation state per world.
 
 {{ nav_links() }}
-

--- a/docs/ko/design/core_loop_roadmap_tasks.md
+++ b/docs/ko/design/core_loop_roadmap_tasks.md
@@ -1,0 +1,42 @@
+# Core Loop 로드맵 태스크
+
+괄호 안은 대표 이슈 번호입니다. Phase 2부터 착수합니다.
+
+## Phase 0 – 기반 깔기 (spec/스켈레톤)
+- Core Loop 계약 테스트 스켈레톤 먼저 생성: tests/e2e/core_loop 골격 (#1788).
+- spec 성 이슈들부터 처리:
+  - SubmitResult/WS 스키마 정렬 방향 잡기 (#1764, #1771).
+  - world data preset 스펙 정의 (#1776).
+  - NodeID/TagQuery 결정성 규칙 문서화 (#1782).
+  - Determinism 체크리스트 항목 목록/범위 정리 (#1785).
+
+## Phase 1 – ExecutionDomain/default-safe 수직 슬라이스(“모드/도메인 규약” 하나를 끝까지 밀기)
+- WS 경계부터 고정: WS ExecutionDomain 검증/강등 (#1773).
+- Runner/CLI 입력 검증 강화 (#1767) → SDK/CLI default-safe 강등 구현 (#1768).
+- Runner 제출 힌트 제거 (WS effective_mode 우선) (#1774).
+- ComputeContext 쪽 정렬: compute_context 규칙 적용 (#1779) → WS 우선 규약 강제 (#1780).
+- ExecutionDomain default-safe 계약/E2E 테스트 추가 (#1775) + Core Loop 계약 스위트에 핵심 케이스로 편입 (#1789).
+- 현재 상태: Phase 1까지 완료.
+
+## Phase 2 – SubmitResult/WS SSOT 정리 (T1/T2 P0)
+- [x] SubmitResult ↔ WS Envelopes 스키마 정렬/공용 모듈 (#1764, #1771) — CLOSED; shared WS/SDK 스키마 위치/명명 확정 후 downstream 뒤집힘 방지.
+- [x] Runner/CLI/API가 WS 결과를 SSOT로 노출하도록 경로 정리 (#1770) — SubmitResult WS 우선 병합 + `precheck` 분리, CLI 출력 섹션 분리 완료.
+- [x] SDK/CLI SubmitResult 출력 정리 (#1765) — downgrade/default-safe 신호 노출 + WS/Precheck 분리, 테스트 추가(#1789 연계).
+- [x] SDK/전략 가이드 업데이트 (#1766) + ops/dev 가이드에서 “WS가 최종 진실”을 명시 (#1772) — ko/en 가이드에 WS SSOT vs pre-check 구분 및 런북 반영.
+
+## Phase 3 – world 기반 데이터 preset 온램프 (T3 P0)
+- 이미 정의한 preset 스펙(#1776)을 기준으로 Runner/CLI Seamless 오토 구성 구현 (#1777).
+- preset 기반 실행 예제/가이드 작성, CI/계약 테스트에서 실제로 도는 예제 붙이기 (#1778, #1789 연동).
+
+## Phase 4 – NodeID/TagQuery + Determinism 마무리 (T4/T5 P0)
+- NodeID/TagQuery 결정성 규칙 구현/검증: 엔진별 적용 (#1783) → 관측/테스트(#1784).
+- Determinism 체크리스트 코드化 (#1785) → 관측 메트릭/대시보드 (#1786) → 런북 보강 (#1787).
+- Core Loop 계약 스위트에 NodeID/TagQuery·Determinism 관련 케이스 확장 (#1789).
+
+## Phase 5 – CI 게이트 정착 (T6 P0 마무리)
+- Core Loop 계약 스위트를 CI merge-blocker로 통합 (#1790).
+- 로드맵/아키텍처 문서와 “이 테스트가 깨지면 어떤 방향성이 깨진 것인지”를 연결해서 문서화.
+
+### 병렬성 관점
+- Phase 1(ExecutionDomain 라인)과 Phase 2(SubmitResult/WS SSOT)는 부분적으로 병렬 가능하지만,
+- Phase 3(데이터 preset)·Phase 4(NodeID/Determinism)는 Phase 1/2에서 기본 규약이 잡힌 이후로 미는 쪽이 안전합니다.

--- a/docs/ko/guides/sdk_tutorial.md
+++ b/docs/ko/guides/sdk_tutorial.md
@@ -148,6 +148,13 @@ workspace/
 
 `qmtl submit`은 `qmtl.yml`을 우선 사용해 전략 경로와 기본 월드를 해석합니다. `QMTL_STRATEGY_ROOT`(선택)나 기존 `PYTHONPATH`가 있더라도 `project.strategy_root`가 최우선으로 적용되어 POSIX/Windows 모두에서 동일하게 동작합니다.
 
+### 제출 결과 해석 (WS SSOT + pre-check)
+- CLI/SDK가 반환하는 `SubmitResult`는 **WorldService 결과를 단일 진실(SSOT)**로 노출하고, 로컬 `ValidationPipeline` 출력은 `precheck` 필드로 분리됩니다.
+- CLI는 두 섹션으로 나뉩니다:
+  - `🌐 WorldService decision (SSOT)` — `status/weight/rank/contribution`과 WS 기준 threshold 위반 목록.
+  - `🧪 Local pre-check (ValidationPipeline)` — 로컬 지표/위반/힌트(WS와 달라도 SSOT가 아니므로 참고용).
+- `downgraded/safe_mode/downgrade_reason`은 여전히 최상위에 표시되어 default-safe 강등 여부를 확인할 수 있습니다.
+
 ## 캐시 조회
 
 `compute_fn`에는 `NodeCache.view()`가 반환하는 **읽기 전용 CacheView** 객체가

--- a/docs/ko/operations/activation.md
+++ b/docs/ko/operations/activation.md
@@ -18,6 +18,11 @@ last_modified: 2025-08-29
 - WorldService와 Gateway 노드의 NTP 상태 확인
 - `world_id`, 현재 `resource_version`/`etag` 파악
 
+## WS SSOT & 클라이언트 노출
+- WorldService 평가/활성 결과가 `status/weight/contribution`의 단일 진실(SSOT)입니다. CLI/SDK `submit`은 WS 출력 그대로를 노출합니다.
+- 로컬 ValidationPipeline 결과는 “pre-check”(비권위) 섹션으로 분리됩니다. 불일치 시 WS 메트릭/로그를 우선 확인하고 pre-check는 참고용으로 사용합니다.
+- `downgraded/safe_mode/downgrade_reason`은 기본 안전 강등 여부를 표시하기 위해 최상단에 유지됩니다.
+
 ## 절차
 
 1) Freeze/Drain

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
       - Core Loop Roadmap: design/core_loop_roadmap.md
       - Core Loop P0 Issue Drafts: design/core_loop_roadmap_issue_drafts.md
       - Core Loop P0 Issue Breakdown: design/core_loop_roadmap_issue_breakdown.md
+      - Core Loop Roadmap Tasks: design/core_loop_roadmap_tasks.md
   - Getting Started:
       - Overview: getting-started/index.md
       - Core Concepts: getting-started/concepts.md
@@ -158,6 +159,7 @@ plugins:
             Core Loop Roadmap: Core Loop 로드맵
             Core Loop P0 Issue Drafts: Core Loop P0 이슈 초안
             Core Loop P0 Issue Breakdown: Core Loop P0 이슈 분할안
+            Core Loop Roadmap Tasks: Core Loop 로드맵 태스크
             Guides: 가이드
             Docs Internationalization: 문서 국제화
             "Layered Template System": "레이어드 템플릿 시스템"

--- a/tests/qmtl/interfaces/cli/test_submit_output.py
+++ b/tests/qmtl/interfaces/cli/test_submit_output.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from qmtl.interfaces.cli import submit as cli_submit
+from qmtl.runtime.sdk import Mode
+from qmtl.runtime.sdk.submit import PrecheckResult, StrategyMetrics, SubmitResult
+
+
+def test_cli_prints_ws_and_precheck_sections(capsys):
+    result = SubmitResult(
+        strategy_id="s-1",
+        status="active",
+        world="w-1",
+        mode=Mode.PAPER,
+        contribution=0.08,
+        weight=0.12,
+        rank=3,
+        threshold_violations=[{"metric": "sharpe", "threshold_type": "min", "threshold_value": 1.0}],
+        metrics=StrategyMetrics(sharpe=1.8, max_drawdown=0.12, correlation_avg=0.4),
+        precheck=PrecheckResult(
+            status="passed",
+            weight=0.05,
+            rank=9,
+            contribution=0.01,
+            metrics=StrategyMetrics(sharpe=1.2, max_drawdown=0.2, correlation_avg=0.1),
+            violations=[{"metric": "sharpe", "threshold_type": "min", "threshold_value": 1.0, "message": "ok"}],
+            improvement_hints=["raise sharpe"],
+            correlation_avg=0.1,
+        ),
+    )
+
+    cli_submit._print_submission_result(result)
+    output = capsys.readouterr().out
+
+    assert "WorldService decision (SSOT)" in output
+    assert "✅ Strategy activated successfully" in output
+    assert "Local pre-check (ValidationPipeline)" in output
+    assert "Threshold violations (WS)" in output
+    assert "Threshold violations (pre-check)" in output
+
+
+def test_cli_prints_ws_rejection_and_precheck(capsys):
+    result = SubmitResult(
+        strategy_id="s-2",
+        status="rejected",
+        world="w-2",
+        mode=Mode.BACKTEST,
+        rejection_reason="WorldService evaluation rejected strategy",
+        threshold_violations=[{"metric": "corr", "threshold_type": "max", "threshold_value": 0.8, "value": 0.9}],
+        improvement_hints=["ws hint"],
+        precheck=PrecheckResult(
+            status="failed",
+            metrics=StrategyMetrics(sharpe=0.5, max_drawdown=0.3),
+            violations=[{"metric": "sharpe", "threshold_type": "min", "threshold_value": 1.0, "value": 0.5}],
+            improvement_hints=["local hint"],
+        ),
+    )
+
+    cli_submit._print_submission_result(result)
+    output = capsys.readouterr().out
+
+    assert "WorldService decision (SSOT)" in output
+    assert "Strategy rejected" in output
+    assert "Threshold violations (WS)" in output
+    assert "Local pre-check (ValidationPipeline)" in output
+    assert "Threshold violations (pre-check)" in output


### PR DESCRIPTION
## Summary
- surface WorldService output as SSOT in SubmitResult, serialize with `to_dict()`, and keep ValidationPipeline in a nested precheck
- split CLI submit output into WS decision vs pre-check sections and add regression tests
- update guides/runbook and roadmap tasks to document WS SSOT vs pre-check and mark Phase 2 complete

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke
- uv run python -m py_compile qmtl/runtime/sdk/submit.py qmtl/interfaces/cli/submit.py

Closes #1770
Closes #1765
Closes #1766
Closes #1772
