### PR TITLE
Phase 4 determinism observability and contract coverage

### DIFF
--- a/docs/en/architecture/architecture.md
+++ b/docs/en/architecture/architecture.md
@@ -625,6 +625,10 @@ points-in-time, and provides a durable audit trail.
 
 Meeting all items marks the QMTL v0.9 "Determinism" milestone.
 
+### Observability & runbook
+- Gateway metrics: `nodeid_checksum_mismatch_total{source="dag"}`, `nodeid_missing_fields_total{field,node_type}`, `nodeid_mismatch_total{node_type}`, `tagquery_nodeid_mismatch_total`.
+- Runbook: follow `docs/en/operations/determinism.md` for NodeID CRC/TagQuery mismatches; if the counters rise, regenerate DAG node_ids and re-run the Core Loop contract suite (`tests/e2e/core_loop`).
+
 ---
 
 ## 8. Additional Guidance

--- a/docs/en/design/core_loop_roadmap_tasks.md
+++ b/docs/en/design/core_loop_roadmap_tasks.md
@@ -29,9 +29,9 @@ Representative issue numbers are in parentheses. Phase 2 is the current focus.
 - [x] Add preset-driven examples/guides and wire live examples into CI/contract tests (#1778, #1789) — core-loop demo world carries the standard data preset and the contract test asserts auto-wiring.
 
 ## Phase 4 – NodeID/TagQuery + Determinism wrap-up (T4/T5 P0)
-- Implement/verify NodeID/TagQuery determinism per engine (#1783) → observe/test (#1784).
-- Code the Determinism checklist (#1785) → metrics/dashboards (#1786) → runbook hardening (#1787).
-- Expand Core Loop contract suite with NodeID/TagQuery and Determinism cases (#1789).
+- [x] Implement/verify NodeID/TagQuery determinism per engine (#1783) → observe/test (#1784) — TagQueryNode NodeIDs now hash the canonical query spec (sorted/deduped `query_tags` + `match_mode` + interval) with SDK/Gateway normalization plus queue_map match_mode passthrough and determinism tests.
+- [x] Code the Determinism checklist (#1785) → metrics/dashboards (#1786) → runbook hardening (#1787) — Added NodeID CRC/missing-field/mismatch + TagQuery-specific counters and linked the runbook (`operations/determinism.md`) from architecture for response guidance.
+- [x] Expand Core Loop contract suite with NodeID/TagQuery and Determinism cases (#1789) — Contract test ensures Gateway determinism counters increment on NodeID mismatches.
 
 ## Phase 5 – CI gate landing (T6 P0)
 - Integrate the Core Loop contract suite as a CI merge blocker (#1790).

--- a/docs/en/operations/determinism.md
+++ b/docs/en/operations/determinism.md
@@ -1,0 +1,43 @@
+---
+title: "Determinism Runbook — NodeID/TagQuery mismatch response"
+tags: [operations, determinism, runbook]
+author: "QMTL Team"
+last_modified: 2025-09-01
+---
+
+{{ nav_links() }}
+
+# Determinism Runbook — NodeID/TagQuery mismatch response
+
+## What to watch
+- Gateway metrics:
+  - `nodeid_checksum_mismatch_total{source="dag"}`: submitted `node_ids_crc32` differs from the recomputed value.
+  - `nodeid_missing_fields_total{field,node_type}`: canonical NodeID inputs missing.
+  - `nodeid_mismatch_total{node_type}`: submitted `node_id` differs from `compute_node_id`.
+  - `tagquery_nodeid_mismatch_total`: TagQueryNode-specific mismatch counter.
+- When alerts fire, capture the offending DAG/queue_map so the submission can be replayed locally.
+
+## Immediate actions
+1) **CRC mismatch (`nodeid_checksum_mismatch_total`)**
+   - Decode the DAG JSON and recompute `node_ids_crc32` locally (`qmtl.foundation.common.crc32_of_list`).
+   - Ensure SDK- and Gateway-computed node_ids match, regenerate CRC, and resubmit.
+
+2) **Missing fields (`nodeid_missing_fields_total`)**
+   - Read the missing field labels from metrics/logs and regenerate the DAG with the latest SDK.
+   - Verify `code_hash`, `config_hash`, `schema_hash`, and `schema_compat_id` are present for every node.
+
+3) **NodeID mismatch (`nodeid_mismatch_total`)**
+   - Recompute with `compute_node_id` and compare with the submitted value.
+   - For TagQueryNode, ensure `query_tags` are sorted/deduped and both `match_mode` and `interval` are present before recalculating.
+
+## Recovery checks
+- Resubmit with the fixed DAG and ensure the counters stop increasing.
+- Run the Core Loop contract suite to confirm there are no regressions:
+
+```bash
+CORE_LOOP_STACK_MODE=inproc uv run -m pytest -q tests/e2e/core_loop -q
+```
+
+## References
+- Design baseline: `docs/en/architecture/architecture.md` §7 Determinism & Operational Checklist.
+- World/domain isolation checks: `tests/e2e/test_world_isolation.py`.

--- a/docs/ko/architecture/architecture.md
+++ b/docs/ko/architecture/architecture.md
@@ -745,4 +745,9 @@ QMTL은 **append-only commit log** 설계를 채택하여 모든 상태 변화�
 위 목록이 모두 충족된 시점을 QMTL v0.9 “Determinism” 마일스톤으로 삼는다.
 
 
+### 관측 · 런북 연결
+- Gateway 메트릭: `nodeid_checksum_mismatch_total{source="dag"}`, `nodeid_missing_fields_total{field,node_type}`, `nodeid_mismatch_total{node_type}`, `tagquery_nodeid_mismatch_total`.
+- Runbook: `docs/ko/operations/determinism.md`를 따라 NodeID 재계산/CRC·TagQuery 불일치 시 대응한다. 메트릭이 상승하면 DAG 재생성(해시 재계산) 후 Core Loop 계약 테스트(`tests/e2e/core_loop`)로 복구를 확인한다.
+
+
 {{ nav_links() }}

--- a/docs/ko/design/core_loop_roadmap_tasks.md
+++ b/docs/ko/design/core_loop_roadmap_tasks.md
@@ -29,9 +29,9 @@
 - [x] preset 기반 실행 예제/가이드 작성, CI/계약 테스트에서 실제로 도는 예제 붙이기 (#1778, #1789 연동) — core-loop demo world가 표준 data preset을 포함하고 계약 테스트에서 auto-wiring을 검증.
 
 ## Phase 4 – NodeID/TagQuery + Determinism 마무리 (T4/T5 P0)
-- NodeID/TagQuery 결정성 규칙 구현/검증: 엔진별 적용 (#1783) → 관측/테스트(#1784).
-- Determinism 체크리스트 코드化 (#1785) → 관측 메트릭/대시보드 (#1786) → 런북 보강 (#1787).
-- Core Loop 계약 스위트에 NodeID/TagQuery·Determinism 관련 케이스 확장 (#1789).
+- [x] NodeID/TagQuery 결정성 규칙 구현/검증: 엔진별 적용 (#1783) → 관측/테스트(#1784) — TagQueryNode NodeID가 query spec(정렬·중복 제거된 query_tags + match_mode + interval)에 따라 해시되도록 SDK/Gateway 정규화, queue_map match_mode 전달 및 결정성 테스트 추가.
+- [x] Determinism 체크리스트 코드化 (#1785) → 관측 메트릭/대시보드 (#1786) → 런북 보강 (#1787) — NodeID CRC/필드/불일치·TagQuery 전용 메트릭 추가, `operations/determinism.md` 런북/architecture 링크로 대응 경로 명시.
+- [x] Core Loop 계약 스위트에 NodeID/TagQuery·Determinism 관련 케이스 확장 (#1789) — Gateway determinism 메트릭이 NodeID 불일치 시 증가하는지 검증하는 계약 테스트 추가.
 
 ## Phase 5 – CI 게이트 정착 (T6 P0 마무리)
 - Core Loop 계약 스위트를 CI merge-blocker로 통합 (#1790).

--- a/docs/ko/operations/determinism.md
+++ b/docs/ko/operations/determinism.md
@@ -1,0 +1,43 @@
+---
+title: "Determinism 런북 — NodeID/TagQuery 불일치 대응"
+tags: [operations, determinism, runbook]
+author: "QMTL Team"
+last_modified: 2025-09-01
+---
+
+{{ nav_links() }}
+
+# Determinism 런북 — NodeID/TagQuery 불일치 대응
+
+## 모니터링 포인트
+- Gateway 메트릭
+  - `nodeid_checksum_mismatch_total{source="dag"}`: 제출된 `node_ids_crc32`가 재계산 값과 불일치
+  - `nodeid_missing_fields_total{field,node_type}`: canonical NodeID 입력 필드 누락
+  - `nodeid_mismatch_total{node_type}`: 제출된 `node_id`가 `compute_node_id`와 다름
+  - `tagquery_nodeid_mismatch_total`: TagQueryNode 전용 불일치 카운터
+- 경보 발생 시 직전 제출/큐맵을 덤프해 재현 가능한 DAG 스냅샷을 확보한다.
+
+## 즉시 대응 절차
+1) **CRC 불일치 (`nodeid_checksum_mismatch_total`)**
+   - DAG JSON을 풀어 `node_ids_crc32`를 로컬에서 재계산한다(`qmtl.foundation.common.crc32_of_list`).
+   - SDK가 생성한 node_id와 Gateway 재계산 값이 같은지 확인 후 CRC를 재생성해 제출한다.
+
+2) **필수 필드 누락 (`nodeid_missing_fields_total`)**
+   - 누락된 필드를 로그/메트릭에서 확인 후 SDK를 최신 버전으로 재생성한다.
+   - `code_hash/config_hash/schema_hash/schema_compat_id`가 모두 채워졌는지 검증한다.
+
+3) **NodeID 불일치 (`nodeid_mismatch_total`)**
+   - `compute_node_id`로 재계산해 제출된 값과 비교한다.
+   - TagQueryNode인 경우 `query_tags` 정렬/중복 제거, `match_mode`, `interval`이 모두 params에 포함됐는지 확인하고 재계산한다.
+
+## 복구 검증
+- 수정한 DAG로 재제출 후 메트릭 증가가 멈추는지 확인한다.
+- Core Loop 계약 테스트를 실행해 회귀가 없는지 확인:
+
+```bash
+CORE_LOOP_STACK_MODE=inproc uv run -m pytest -q tests/e2e/core_loop -q
+```
+
+## 참고
+- 설계 근거: `docs/ko/architecture/architecture.md` §6 Deterministic Checklist.
+- 세계/도메인 격리 검증: `tests/e2e/test_world_isolation.py`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Seamless Stack Templates: operations/seamless_stack.md
       - WS Load & Endurance: operations/ws_load_testing.md
       - World Activation Runbook: operations/activation.md
+      - Determinism Runbook: operations/determinism.md
       - Rebalancing Execution: operations/rebalancing_execution.md
       - Rebalancing Schema Coordination: operations/rebalancing_schema_coordination.md
       - Schema Registry Governance: operations/schema_registry_governance.md

--- a/qmtl/foundation/common/tagquery.py
+++ b/qmtl/foundation/common/tagquery.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 """Common helpers for TagQuery normalization shared by SDK and Gateway."""
 
 from enum import Enum
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 __all__ = [
     "MatchMode",
     "split_tags",
     "normalize_match_mode",
     "normalize_queues",
+    "canonical_tag_query_params",
+    "canonical_tag_query_params_from_node",
 ]
 
 
@@ -55,3 +57,81 @@ def normalize_queues(raw: Iterable[Any]) -> list[str]:
             raise ValueError("queue descriptor missing 'queue'")
         queues.append(str(val))
     return queues
+
+
+def canonical_tag_query_params(
+    tags: Iterable[str] | str | None,
+    *,
+    interval: Any,
+    match_mode: MatchMode | str | None,
+    require_tags: bool = False,
+    require_interval: bool = False,
+) -> dict[str, Any]:
+    """Return a canonical TagQuery spec used for deterministic NodeIDs.
+
+    Parameters
+    ----------
+    tags:
+        Raw tag list or comma-separated string.
+    interval:
+        Interval value associated with the query. Coerced to ``int`` when possible.
+    match_mode:
+        Requested match mode; defaults to ``MatchMode.ANY`` when falsy.
+    require_tags:
+        If ``True``, raise ``ValueError`` when no tags remain after normalization.
+    require_interval:
+        If ``True``, raise ``ValueError`` when ``interval`` cannot be coerced.
+    """
+
+    normalized_tags = split_tags(tags)
+    deduped = sorted({tag for tag in normalized_tags})
+    if require_tags and not deduped:
+        raise ValueError("TagQuery requires at least one tag")
+
+    try:
+        interval_val = int(interval) if interval is not None else None
+    except Exception:
+        interval_val = None
+    if require_interval and interval_val is None:
+        raise ValueError("TagQuery interval is required")
+
+    return {
+        "query_tags": deduped,
+        "match_mode": normalize_match_mode(
+            match_mode.value if isinstance(match_mode, MatchMode) else match_mode
+        ).value,
+        "interval": interval_val,
+    }
+
+
+def canonical_tag_query_params_from_node(
+    node: Mapping[str, Any],
+    *,
+    require_tags: bool = False,
+    require_interval: bool = False,
+) -> dict[str, Any]:
+    """Extract and canonicalize TagQuery parameters from a node mapping."""
+
+    params_source = node.get("params")
+    tags: Any = None
+    match_mode: Any = None
+    interval: Any = node.get("interval")
+
+    if isinstance(params_source, Mapping):
+        tags = params_source.get("query_tags") or params_source.get("tags")
+        match_mode = params_source.get("match_mode")
+        if interval is None and "interval" in params_source:
+            interval = params_source.get("interval")
+
+    if tags is None:
+        tags = node.get("tags")
+    if match_mode is None:
+        match_mode = node.get("match_mode")
+
+    return canonical_tag_query_params(
+        tags,
+        interval=interval,
+        match_mode=match_mode,
+        require_tags=require_tags,
+        require_interval=require_interval,
+    )

--- a/qmtl/services/gateway/submission/node_identity.py
+++ b/qmtl/services/gateway/submission/node_identity.py
@@ -9,8 +9,9 @@ from fastapi import HTTPException
 from qmtl.foundation.common import (
     NodeValidationError,
     NodeValidationReport,
-    enforce_node_identity,
+    validate_node_identity,
 )
+from qmtl.services.gateway import metrics as gw_metrics
 
 
 class NodeIdentityValidator:
@@ -19,8 +20,12 @@ class NodeIdentityValidator:
     def validate(
         self, dag: dict[str, Any], node_ids_crc32: int
     ) -> NodeValidationReport:
-        nodes: Iterable[Any] = dag.get("nodes", [])
+        nodes_iter: Iterable[Any] = dag.get("nodes", [])
+        nodes = list(nodes_iter)
+        report = validate_node_identity(nodes, node_ids_crc32)
+        gw_metrics.record_node_identity_report(report, nodes)
         try:
-            return enforce_node_identity(nodes, node_ids_crc32)
+            report.raise_for_issues()
+            return report
         except NodeValidationError as exc:  # pragma: no cover - exercised via tests
             raise HTTPException(status_code=400, detail=exc.detail) from exc

--- a/qmtl/services/gateway/submission/queue_map_resolver.py
+++ b/qmtl/services/gateway/submission/queue_map_resolver.py
@@ -6,6 +6,8 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any, Iterable, Iterator
 
+from qmtl.foundation.common.tagquery import canonical_tag_query_params_from_node
+
 
 @dataclass(frozen=True)
 class _TagQueryNode:
@@ -53,9 +55,15 @@ class QueueMapResolver:
             node_id = node.get("node_id")
             if not isinstance(node_id, str) or not node_id:
                 continue
-            tags = node.get("tags", [])
-            interval = int(node.get("interval", 0))
-            match_mode = node.get("match_mode", "any")
+            try:
+                spec = canonical_tag_query_params_from_node(
+                    node, require_tags=True, require_interval=True
+                )
+            except ValueError:
+                continue
+            tags = spec.get("query_tags", [])
+            interval = int(spec.get("interval") or 0)
+            match_mode = spec.get("match_mode", "any")
             yield _TagQueryNode(
                 node_id=node_id,
                 tags=tags,

--- a/tests/qmtl/runtime/sdk/factories/node.py
+++ b/tests/qmtl/runtime/sdk/factories/node.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Mapping, Sequence
 
 from qmtl.foundation.common import compute_node_id, crc32_of_list
 from qmtl.foundation.common.nodespec import serialize_nodespec
+from qmtl.foundation.common.tagquery import canonical_tag_query_params
 
 
 def _normalize_dependencies(deps: Sequence[Any] | None) -> list[str]:
@@ -126,8 +127,15 @@ def tag_query_node_payload(
     """Build a canonical TagQuery node payload."""
 
     tag_list = list(tags)
-    resolved_params = params if params is not None else {"tags": tag_list, "match_mode": match_mode}
-    extras = {"tags": tag_list}
+    resolved_params = (
+        params
+        if params is not None
+        else canonical_tag_query_params(tag_list, interval=interval, match_mode=match_mode)
+    )
+    extras = {
+        "tags": list(resolved_params.get("query_tags") or tag_list),
+        "match_mode": resolved_params.get("match_mode", match_mode),
+    }
     return canonical_node_payload(
         node_type="TagQueryNode",
         interval=interval,

--- a/tests/qmtl/runtime/sdk/test_tag_query_node.py
+++ b/tests/qmtl/runtime/sdk/test_tag_query_node.py
@@ -53,3 +53,20 @@ def test_tag_query_node_id_whitespace_normalization():
     node_reference = TagQueryNode(["t1", "t2"], interval="60s", period=1)
 
     assert node_from_http.node_id == node_reference.node_id
+
+
+def test_tag_query_node_id_depends_on_match_mode():
+    node_any = TagQueryNode(["t1", "t2"], interval="60s", period=1, match_mode=MatchMode.ANY)
+    node_all = TagQueryNode(["t1", "t2"], interval="60s", period=1, match_mode=MatchMode.ALL)
+
+    assert node_any.node_id != node_all.node_id
+
+
+def test_tag_query_node_serializes_canonical_query_spec():
+    node = TagQueryNode(["b", "a"], interval="60s", period=1, match_mode="all")
+    payload = node.to_dict()
+
+    assert payload["params"]["query_tags"] == ["a", "b"]
+    assert payload["params"]["match_mode"] == "all"
+    assert payload["match_mode"] == "all"
+    assert payload["tags"] == ["a", "b"]


### PR DESCRIPTION
Summary:
- Add NodeID/TagQuery determinism observability metrics and route validation wiring
- Add determinism runbooks and link checklist to operational response
- Extend core loop contract test to assert Gateway metrics on NodeID mismatch

Testing:
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q
- CORE_LOOP_STACK_MODE=inproc uv run -m pytest -q tests/e2e/core_loop -q