### PR TITLE
Align SubmitResult/ExecutionDomain and world data presets

### DIFF
--- a/docs/en/architecture/worldservice.md
+++ b/docs/en/architecture/worldservice.md
@@ -50,6 +50,10 @@ Non-goals:
 - To‑Be
   - WS evaluation results (active/weight/contribution/violations) are treated as the **single world-level source of truth**, with SDK/Runner exposing them directly; `ValidationPipeline` becomes a hint/local pre-check only.
   - `DecisionEnvelope`/`ActivationEnvelope` schemas and Runner/CLI `SubmitResult` are aligned so that “submit strategy → inspect world decision” reads as a single flow.
+- Contract (aligned)
+  - `/worlds/{id}/evaluate` produces `DecisionEnvelope`/`ActivationEnvelope` that map directly to `SubmitResult.ws.decision/activation`; CLI `--output json` emits the same WS/Precheck-separated structure.
+  - Local `ValidationPipeline` output lives only in `SubmitResult.precheck`; `status/weight/rank/contribution` SSOT is always WS.
+  - `ActivationEnvelope` (`GET/PUT /worlds/{id}/activation`) shares the same schema as `SubmitResult.ws.activation`, exposing `active/weight/etag/run_id/state_hash`.
 
 #### ExecutionDomain / effective_mode
 

--- a/docs/en/getting-started/quickstart.md
+++ b/docs/en/getting-started/quickstart.md
@@ -78,34 +78,33 @@ python my_strategy.py
 On success, you'll receive results like:
 
 ```python
-SubmitResult(
-    strategy_id="momentum_btc_1m_abc123",
-    status="valid",              # valid | invalid | pending
-    world="quickstart_demo",
-    mode="backtest",
-    downgraded=False,            # True if forced into safe compute-only
-    downgrade_reason=None,       # e.g., "missing_as_of" when backtest inputs are incomplete
-    safe_mode=False,             # True when orders are gated off for safety
-    
-    # Performance metrics
-    metrics={
-        "sharpe": 1.45,
-        "max_drawdown": -0.08,
-        "win_rate": 0.55,
-        "profit_factor": 1.32,
-    },
-    
-    # Position in world (simulation values in backtest)
-    contribution=0.0,            # Not yet activated
-    weight=0.0,
-    rank=None,
-    
-    # Improvement hints
-    improvement_hints=[
-        "Sharpe 1.5 or higher enables paper mode promotion",
-        "Recommend minimum 30-day backtest (current: 7 days)"
-    ]
-)
+{
+  "strategy_id": "momentum_btc_1m_abc123",
+  "status": "valid",              # valid | invalid | pending | rejected
+  "world": "quickstart_demo",
+  "mode": "backtest",
+  "downgraded": false,            # True if forced into safe compute-only
+  "downgrade_reason": null,       # e.g., "missing_as_of" when backtest inputs are incomplete
+  "safe_mode": false,
+  "ws": {                         # WorldService is the SSOT for decisions/activations
+    "decision": { "world_id": "quickstart_demo", "effective_mode": "validate", "etag": "..." },
+    "activation": { "strategy_id": "momentum_btc_1m_abc123", "weight": 0.10, "active": true },
+    "metrics": { "sharpe": 1.45, "max_drawdown": -0.08, "win_rate": 0.55, "profit_factor": 1.32 },
+    "threshold_violations": [],
+    "rejection_reason": null
+  },
+  "precheck": {                   # Local ValidationPipeline reference only
+    "status": "passed",
+    "violations": [],
+    "metrics": { "sharpe": 1.4, "max_drawdown": -0.09 }
+  }
+}
+```
+
+The CLI can emit the same WS/Precheck-separated JSON with:
+
+```bash
+qmtl submit strategies.momentum:MomentumStrategy --world quickstart_demo --mode backtest --output json
 ```
 
 ---

--- a/docs/en/guides/sdk_tutorial.md
+++ b/docs/en/guides/sdk_tutorial.md
@@ -192,6 +192,17 @@ workspace/
   - `🌐 WorldService decision (SSOT)` — includes WS `status/weight/rank/contribution` and WS threshold violations.
   - `🧪 Local pre-check (ValidationPipeline)` — local metrics/violations/hints for reference only (not authoritative).
 - `downgraded/safe_mode/downgrade_reason` remain at the top so you can see default-safe downgrades.
+- Use `--output json` to receive WS/Precheck-separated JSON directly from the CLI.
+
+### Execution mode/domain rules (default-safe)
+- Only `backtest | paper | live` are user-facing; legacy execution_domain hints are ignored.
+- WS `effective_mode` takes priority; missing/ambiguous modes are forced to compute-only (backtest).
+- In `backtest/paper`, missing `as_of` or `dataset_fingerprint` triggers safe-mode downgrades (`downgrade_reason=missing_as_of`).
+
+### World-based data preset on-ramp
+- When `world.data.presets[]` is defined, Runner/CLI auto-configures Seamless providers.
+- Pick a world-defined preset with `--data-preset <id>`; if omitted, the first preset is used.
+- You can omit `history_provider` on `StreamInput`; world presets are injected automatically (covered by `tests/e2e/core_loop`).
 
 ## Cache Access
 

--- a/docs/en/guides/strategy_workflow.md
+++ b/docs/en/guides/strategy_workflow.md
@@ -165,12 +165,12 @@ switch to `Runner.submit(strategy_cls, world=...)`. Activation and queue
 updates are delivered via the Gateway's opaque control stream on the `/events/subscribe`
 WebSocket; WS remains the authority for policy and activation.
 
-Execution domains are now surfaced explicitly on envelopes:
+Execution mode/domain rules (WS-first, default-safe):
 
-- WorldService decisions emit `effective_mode` (`validate|compute-only|paper|live`).
-- Gateway/SDKs derive `execution_domain` (`backtest|dryrun|live|shadow`) using the normative mapping `validate → backtest (orders gated OFF)`, `compute-only → backtest`, `paper → dryrun`, `live → live`.
-- Example: [`dryrun_live_switch_strategy.py`]({{ code_url('qmtl/examples/strategies/dryrun_live_switch_strategy.py') }}) toggles between `dryrun` and `live` by reading `connectors.execution_domain`. Legacy `trade_mode=paper` values are coerced to `dryrun` for compatibility.
-- Offline runs mirror the `backtest` domain, so a `validate` decision never publishes orders until promotion completes.
+- Only `mode=backtest|paper|live` are accepted; `execution_domain` hints are ignored.
+- WS `effective_mode` is authoritative; missing/ambiguous modes are forced to compute-only (backtest).
+- In `backtest`/`paper`, missing `as_of` or `dataset_fingerprint` triggers safe-mode downgrades (`downgrade_reason=missing_as_of`, orders gated).
+- `ActivationEnvelope`/`DecisionEnvelope` carry `compute_context` and serialize identically across WS/Runner/CLI; CLI `--output json` shows the same structure.
 
 ```bash
 # start with built-in defaults

--- a/docs/ko/architecture/worldservice.md
+++ b/docs/ko/architecture/worldservice.md
@@ -50,6 +50,10 @@ QMTL 전체의 핵심 가치인 **“전략 로직에만 집중하면 시스템�
 - To‑Be
   - WS 평가 결과(active/weight/contribution/violations)가 **월드 차원의 단일 출처**로 간주되고, SDK/Runner는 이를 그대로 사용자에게 노출하되 `ValidationPipeline`은 힌트·로컬 사전 검사 역할로 한정됩니다.
   - `DecisionEnvelope`/`ActivationEnvelope` 스키마와 Runner/CLI `SubmitResult` 구조가 일치하도록 정리해, “전략 제출 → 월드 평가 결과 확인”이 한눈에 이어지도록 합니다.
+- 계약 (정렬 상태)
+  - `/worlds/{id}/evaluate` → `DecisionEnvelope`/`ActivationEnvelope` 값이 `SubmitResult.ws.decision/activation`에 그대로 매핑됩니다. CLI `--output json`은 WS/Precheck가 분리된 동일 JSON을 출력합니다.
+  - 로컬 `ValidationPipeline` 출력은 `SubmitResult.precheck`에만 담기며, `status/weight/rank/contribution`의 SSOT는 WS입니다.
+  - `ActivationEnvelope`(`GET/PUT /worlds/{id}/activation`) 필드와 `SubmitResult.ws.activation` 필드가 동일 스키마를 사용해 활성/weight/etag/run_id/state_hash를 노출합니다.
 
 #### ExecutionDomain / effective_mode
 

--- a/docs/ko/getting-started/quickstart.md
+++ b/docs/ko/getting-started/quickstart.md
@@ -78,34 +78,33 @@ python my_strategy.py
 성공하면 다음과 같은 결과를 받습니다:
 
 ```python
-SubmitResult(
-    strategy_id="momentum_btc_1m_abc123",
-    status="valid",              # valid | invalid | pending
-    world="quickstart_demo",
-    mode="backtest",
-    downgraded=False,            # 안전기본으로 강등되었는지 여부
-    downgrade_reason=None,       # 예: backtest 필수 입력 누락 시 "missing_as_of"
-    safe_mode=False,             # True면 주문 게이트 OFF 상태
-    
-    # 성과 지표
-    metrics={
-        "sharpe": 1.45,
-        "max_drawdown": -0.08,
-        "win_rate": 0.55,
-        "profit_factor": 1.32,
-    },
-    
-    # 월드 내 위치 (backtest에서는 시뮬레이션 값)
-    contribution=0.0,            # 아직 활성화 전
-    weight=0.0,
-    rank=None,
-    
-    # 개선 힌트
-    improvement_hints=[
-        "Sharpe 1.5 이상이면 paper 모드 승격 가능",
-        "최소 30일 백테스트 권장 (현재: 7일)"
-    ]
-)
+{
+  "strategy_id": "momentum_btc_1m_abc123",
+  "status": "valid",              # valid | invalid | pending | rejected
+  "world": "quickstart_demo",
+  "mode": "backtest",
+  "downgraded": false,            # 안전기본 강등 여부 (필요 시 compute-only로 전환)
+  "downgrade_reason": null,       # 예: backtest 필수 입력 누락 시 "missing_as_of"
+  "safe_mode": false,             # True면 주문 게이트 OFF 상태
+  "ws": {                         # WorldService가 SSOT로 제공하는 결정/활성 요약
+    "decision": { "world_id": "quickstart_demo", "effective_mode": "validate", "etag": "..." },
+    "activation": { "strategy_id": "momentum_btc_1m_abc123", "weight": 0.10, "active": true },
+    "metrics": { "sharpe": 1.45, "max_drawdown": -0.08, "win_rate": 0.55, "profit_factor": 1.32 },
+    "threshold_violations": [],
+    "rejection_reason": null
+  },
+  "precheck": {                   # 로컬 ValidationPipeline 참고용 출력
+    "status": "passed",
+    "violations": [],
+    "metrics": { "sharpe": 1.4, "max_drawdown": -0.09 }
+  }
+}
+```
+
+CLI에서도 동일하게 `--output json` 플래그로 WS/Precheck가 분리된 결과를 받을 수 있습니다:
+
+```bash
+qmtl submit strategies.momentum:MomentumStrategy --world quickstart_demo --mode backtest --output json
 ```
 
 ---

--- a/docs/ko/guides/sdk_tutorial.md
+++ b/docs/ko/guides/sdk_tutorial.md
@@ -154,6 +154,17 @@ workspace/
   - `🌐 WorldService decision (SSOT)` — `status/weight/rank/contribution`과 WS 기준 threshold 위반 목록.
   - `🧪 Local pre-check (ValidationPipeline)` — 로컬 지표/위반/힌트(WS와 달라도 SSOT가 아니므로 참고용).
 - `downgraded/safe_mode/downgrade_reason`은 여전히 최상위에 표시되어 default-safe 강등 여부를 확인할 수 있습니다.
+- `--output json` 플래그를 사용하면 WS/Precheck가 분리된 JSON을 그대로 받아볼 수 있습니다.
+
+### 실행 모드·도메인 규칙 (default-safe)
+- 사용자에게 노출되는 모드는 `backtest | paper | live` 뿐이며, 내부 execution_domain 힌트는 무시됩니다.
+- WS 결정(`effective_mode`)이 우선이며, 모호/누락 시 항상 compute-only(backtest)로 강등됩니다.
+- `backtest/paper` 모드에서 `as_of`나 `dataset_fingerprint`가 없으면 안전모드(`safe_mode=True`, `downgrade_reason=missing_as_of`)로 표시됩니다.
+
+### 데이터 preset 자동 연결 (world 기반 온램프)
+- `world.data.presets[]`가 정의된 월드는 Runner/CLI가 자동으로 Seamless provider를 구성합니다.
+- `--data-preset <id>`로 월드에 선언된 preset을 선택할 수 있으며, 생략 시 첫 번째 preset을 사용합니다.
+- StreamInput에 `history_provider`를 직접 설정하지 않아도 world preset이 자동 주입됩니다(계약 테스트 `tests/e2e/core_loop`에서 검증).
 
 ## 캐시 조회
 

--- a/docs/ko/guides/strategy_workflow.md
+++ b/docs/ko/guides/strategy_workflow.md
@@ -154,12 +154,12 @@ Manager 구성이 신호/가격 입력을 바인딩하도록 할 수 있습니�
 `Runner.submit(strategy_cls, world=...)`로 전환합니다(Gateway URL은 `QMTL_GATEWAY_URL`). 활성화와 큐 업데이트는
 Gateway의 `/events/subscribe` WebSocket 제어 스트림으로 전달되며, 정책과 활성화의 권한은 WS에 있습니다.
 
-실행 도메인은 이제 봉투(envelope)에 명시적으로 표기됩니다:
+실행 모드/도메인 규칙(WS 우선·default-safe):
 
-- WorldService 결정은 `effective_mode`(`validate|compute-only|paper|live`)를 방출합니다.
-- Gateway/SDK는 규범 매핑(`validate → backtest(주문 게이트 OFF)`, `compute-only → backtest`, `paper → dryrun`, `live → live`)을 사용해 `execution_domain`(`backtest|dryrun|live|shadow`)을 도출합니다.
-- 예시: [`dryrun_live_switch_strategy.py`]({{ code_url('qmtl/examples/strategies/dryrun_live_switch_strategy.py') }})는 `connectors.execution_domain`을 읽어 `dryrun`과 `live`를 전환합니다. 레거시 `trade_mode=paper` 값은 호환성 유지를 위해 `dryrun`으로 변환됩니다.
-- 오프라인 실행은 `backtest` 도메인을 반영하므로, `validate` 결정은 프로모션 완료 전까지 주문을 발행하지 않습니다.
+- 사용자 입력은 `mode=backtest|paper|live`만 인정하며, `execution_domain` 힌트는 무시됩니다.
+- WS `effective_mode`만이 권한을 가지며, 모호/누락 시 compute-only(backtest)로 강등됩니다.
+- `backtest`/`paper`에서 `as_of`나 `dataset_fingerprint`가 없으면 안전모드(`downgrade_reason=missing_as_of`, 주문 게이트 OFF)로 표시됩니다.
+- `ActivationEnvelope`/`DecisionEnvelope`에 담긴 `compute_context`는 WS/Runner/CLI에서 동일 스키마로 직렬화되며, CLI `--output json`으로 그대로 확인할 수 있습니다.
 
 ```bash
 # start with built-in defaults

--- a/qmtl/runtime/helpers/runtime.py
+++ b/qmtl/runtime/helpers/runtime.py
@@ -139,20 +139,14 @@ def determine_execution_mode(
     offline_requested: bool,
     gateway_url: str | None,
 ) -> str:
-    """Determine the execution mode from user inputs and existing context."""
+    """Determine the execution mode from user inputs and existing context.
+
+    execution_domain hints are intentionally ignored; callers must pass
+    explicit_mode (or set execution_mode in context) to steer behaviour.
+    """
 
     if explicit_mode is not None:
         return _normalize_mode(explicit_mode)
-
-    derived = _mode_from_domain(execution_domain)
-    if derived is not None:
-        return derived
-
-    domain_hint = merged_context.get("execution_domain")
-    if domain_hint:
-        derived = _mode_from_domain(domain_hint)
-        if derived is not None:
-            return derived
 
     existing = merged_context.get("execution_mode")
     if existing:

--- a/qmtl/runtime/sdk/execution_context.py
+++ b/qmtl/runtime/sdk/execution_context.py
@@ -82,9 +82,12 @@ def resolve_execution_context(
 
     merge_context(merged, context)
 
+    # Legacy execution_domain hints are ignored to enforce WS-first rules.
+    merged.pop("execution_domain", None)
+
     mode = determine_execution_mode(
         explicit_mode=execution_mode,
-        execution_domain=execution_domain,
+        execution_domain=None,
         merged_context=merged,
         trade_mode=trade_mode,
         offline_requested=offline_requested,

--- a/qmtl/services/gateway/world_payloads.py
+++ b/qmtl/services/gateway/world_payloads.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from qmtl.foundation.common.compute_context import (
-    ComputeContext,
-    build_worldservice_compute_context,
-)
+from qmtl.foundation.common.compute_context import ComputeContext, build_worldservice_compute_context
 
 from .compute_context import resolve_execution_domain
 
@@ -38,16 +35,21 @@ def augment_decision_payload(world_id: str, payload: Any) -> Any:
 
 
 def augment_activation_payload(payload: Any) -> Any:
-    """Attach derived execution-domain metadata to activation envelopes."""
+    """Attach derived compute-context metadata to activation envelopes."""
 
     if not isinstance(payload, dict):
         return payload
+    world_id = payload.get("world_id")
+    effective_mode = payload.get("effective_mode")
+    derived_domain = resolve_execution_domain(effective_mode)
+    if derived_domain is not None:
+        payload["execution_domain"] = derived_domain
 
-    domain = resolve_execution_domain(payload.get("effective_mode"))
-    if domain is not None:
-        payload["execution_domain"] = domain
-    else:
-        payload.pop("execution_domain", None)
+    if world_id and effective_mode is not None:
+        context = assemble_compute_context(str(world_id), payload)
+        payload["compute_context"] = context.to_dict(include_flags=True)
+        if context.execution_domain:
+            payload["execution_domain"] = context.execution_domain
     return payload
 
 

--- a/tests/qmtl/interfaces/cli/test_submit_output.py
+++ b/tests/qmtl/interfaces/cli/test_submit_output.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
+
 from qmtl.interfaces.cli import submit as cli_submit
 from qmtl.runtime.sdk import Mode
 from qmtl.runtime.sdk.submit import PrecheckResult, StrategyMetrics, SubmitResult
+from qmtl.services.worldservice.shared_schemas import ActivationEnvelope, DecisionEnvelope
 
 
 def test_cli_prints_ws_and_precheck_sections(capsys):
@@ -63,3 +66,52 @@ def test_cli_prints_ws_rejection_and_precheck(capsys):
     assert "Threshold violations (WS)" in output
     assert "Local pre-check (ValidationPipeline)" in output
     assert "Threshold violations (pre-check)" in output
+
+
+def test_cli_emits_json_with_ws_and_precheck_sections(capsys):
+    decision = DecisionEnvelope(
+        world_id="w-json",
+        policy_version=1,
+        effective_mode="validate",
+        reason="stub",
+        as_of="2025-01-01T00:00:00Z",
+        ttl="60s",
+        etag="etag-1",
+    )
+    activation = ActivationEnvelope(
+        world_id="w-json",
+        strategy_id="s-json",
+        side="long",
+        active=True,
+        weight=0.25,
+        etag="etag-2",
+        run_id="run-1",
+        ts="2025-01-01T00:00:01Z",
+    )
+    result = SubmitResult(
+        strategy_id="s-json",
+        status="active",
+        world="w-json",
+        mode=Mode.BACKTEST,
+        contribution=0.05,
+        weight=0.25,
+        rank=1,
+        metrics=StrategyMetrics(sharpe=2.0, max_drawdown=0.05),
+        decision=decision,
+        activation=activation,
+        threshold_violations=[{"metric": "sharpe", "threshold_type": "min", "threshold_value": 1.0}],
+        precheck=PrecheckResult(
+            status="passed",
+            metrics=StrategyMetrics(sharpe=1.5, max_drawdown=0.1),
+            violations=[],
+        ),
+    )
+
+    cli_submit._emit_submission_result(result, output_format="json")
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+
+    assert payload["ws"]["decision"]["world_id"] == "w-json"
+    assert payload["ws"]["activation"]["strategy_id"] == "s-json"
+    assert payload["ws"]["threshold_violations"][0]["metric"] == "sharpe"
+    assert payload["precheck"]["status"] == "passed"

--- a/tests/qmtl/interfaces/cli/test_v2.py
+++ b/tests/qmtl/interfaces/cli/test_v2.py
@@ -191,6 +191,12 @@ class TestCLIInit:
 class TestSubmitStrategyRoot:
     """Strategy resolution driven by qmtl.yml project section."""
 
+    def test_submit_requires_world(self, capsys):
+        result = cmd_submit(["strategies.demo:DemoStrategy", "--world", "   "])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "world must be provided" in captured.err
+
     def test_submit_uses_project_strategy_root_and_default_world(
         self, tmp_path, monkeypatch
     ):

--- a/tests/qmtl/runtime/helpers/test_runtime_helpers.py
+++ b/tests/qmtl/runtime/helpers/test_runtime_helpers.py
@@ -42,7 +42,8 @@ def test_determine_execution_mode_derived_from_context() -> None:
         gateway_url=None,
     )
 
-    assert mode == "dryrun"
+    # execution_domain hints are ignored; fallback to default-safe backtest
+    assert mode == "backtest"
 
 
 def test_determine_execution_mode_accepts_paper_alias() -> None:
@@ -73,7 +74,7 @@ def test_determine_execution_mode_defaults_to_live_when_gateway() -> None:
     assert mode == "live"
 
 
-def test_determine_execution_mode_retains_shadow_domain() -> None:
+def test_determine_execution_mode_ignores_execution_domain_hint() -> None:
     mode = determine_execution_mode(
         explicit_mode=None,
         execution_domain="shadow",
@@ -83,7 +84,8 @@ def test_determine_execution_mode_retains_shadow_domain() -> None:
         gateway_url=None,
     )
 
-    assert mode == "shadow"
+    # legacy hints no longer steer execution mode
+    assert mode == "backtest"
 
 
 def test_resolve_execution_context_downgrades_missing_as_of() -> None:
@@ -137,20 +139,6 @@ def test_determine_execution_mode_rejects_deprecated_or_unknown_modes(bad_mode: 
         determine_execution_mode(
             explicit_mode=bad_mode,
             execution_domain=None,
-            merged_context=merged,
-            trade_mode="backtest",
-            offline_requested=False,
-            gateway_url=None,
-        )
-
-
-def test_determine_execution_mode_rejects_invalid_domain_hint() -> None:
-    merged: dict[str, str] = {}
-
-    with pytest.raises(ValueError):
-        determine_execution_mode(
-            explicit_mode=None,
-            execution_domain="papertrade",
             merged_context=merged,
             trade_mode="backtest",
             offline_requested=False,

--- a/tests/qmtl/runtime/sdk/test_world_data.py
+++ b/tests/qmtl/runtime/sdk/test_world_data.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from qmtl.foundation.config import SeamlessConfig
+from qmtl.runtime.sdk.world_data import resolve_world_data_selection
+
+
+def _write_presets(tmp_path) -> str:
+    yaml_text = textwrap.dedent(
+        """
+        data_presets:
+          demo.ohlcv:
+            interval_ms: 60000
+            stabilization_bars: 10
+            provider:
+              preset: demo.inmemory.ohlcv
+              options:
+                bars: 5
+          alt.ohlcv:
+            provider:
+              preset: demo.inmemory.ohlcv
+        """
+    )
+    path = tmp_path / "presets.yml"
+    path.write_text(yaml_text)
+    return str(path)
+
+
+def _world_payload() -> dict:
+    return {
+        "world": {
+            "id": "core",
+            "data": {
+                "presets": [
+                    {"id": "default", "preset": "demo.ohlcv", "universe": {"symbols": ["BTC"]}},
+                    {"id": "alt", "preset": "alt.ohlcv"},
+                ]
+            },
+        }
+    }
+
+
+def test_resolve_world_data_selection_prefers_first_when_no_override(tmp_path) -> None:
+    presets_path = _write_presets(tmp_path)
+    config = SeamlessConfig(presets_file=presets_path)
+
+    selection = resolve_world_data_selection(
+        world_description=_world_payload(),
+        world_id="core",
+        data_preset_id=None,
+        seamless_config=config,
+    )
+
+    assert selection is not None
+    assert selection.world_preset_id == "default"
+    assert selection.data_preset_key == "demo.ohlcv"
+    assert selection.spec.provider_name == "demo.inmemory.ohlcv"
+    assert selection.spec.interval_ms == 60000
+
+
+def test_resolve_world_data_selection_uses_override_id(tmp_path) -> None:
+    presets_path = _write_presets(tmp_path)
+    config = SeamlessConfig(presets_file=presets_path)
+
+    selection = resolve_world_data_selection(
+        world_description=_world_payload(),
+        world_id="core",
+        data_preset_id="alt",
+        seamless_config=config,
+    )
+
+    assert selection.world_preset_id == "alt"
+    assert selection.data_preset_key == "alt.ohlcv"
+
+
+def test_resolve_world_data_selection_raises_when_missing_preset(tmp_path) -> None:
+    presets_path = _write_presets(tmp_path)
+    config = SeamlessConfig(presets_file=presets_path)
+    bad_world = {"world": {"id": "core"}, "data": {"presets": []}}
+
+    with pytest.raises(ValueError, match="does not define data.presets"):
+        resolve_world_data_selection(
+            world_description=bad_world,
+            world_id="core",
+            data_preset_id=None,
+            seamless_config=config,
+        )
+
+
+def test_resolve_world_data_selection_raises_when_override_missing(tmp_path) -> None:
+    presets_path = _write_presets(tmp_path)
+    config = SeamlessConfig(presets_file=presets_path)
+
+    with pytest.raises(ValueError, match="has no data preset with id 'missing'"):
+        resolve_world_data_selection(
+            world_description=_world_payload(),
+            world_id="core",
+            data_preset_id="missing",
+            seamless_config=config,
+        )

--- a/tests/qmtl/services/gateway/test_world_proxy_activation.py
+++ b/tests/qmtl/services/gateway/test_world_proxy_activation.py
@@ -93,7 +93,7 @@ async def test_activation_backend_error_no_cache(
     [
         ("validate", "backtest"),
         ("compute-only", "backtest"),
-        ("paper", "dryrun"),
+        ("paper", "backtest"),
         ("live", "live"),
         ("shadow", "shadow"),
     ],

--- a/tests/qmtl/services/worldservice/storage/test_normalization.py
+++ b/tests/qmtl/services/worldservice/storage/test_normalization.py
@@ -24,13 +24,15 @@ from qmtl.services.worldservice.storage.normalization import (
         ("  LIVE  ", "live"),
         ("DryRun", "dryrun"),
         (" shadow ", "shadow"),
+        ("backtest", "backtest"),
+        ("  BACKTEST  ", "backtest"),
     ],
 )
 def test_normalize_execution_domain_defaults_and_lowercases(raw: object, expected: str) -> None:
     assert _normalize_execution_domain(raw) == expected
 
 
-@pytest.mark.parametrize("raw", ["weird", 123])
+@pytest.mark.parametrize("raw", ["unknown", "legacy", "weird", 123])
 def test_normalize_execution_domain_rejects_unknown_values(raw: object) -> None:
     with pytest.raises(ValueError, match="unknown execution_domain"):
         _normalize_execution_domain(raw)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- WS-first SubmitResult/CLI JSON alignment with decision/activation and default-safe rules in docs (ko/en)
- Harden execution-domain normalization across Runner/CLI/WS/Gateway; require non-empty world inputs
- Validate world data preset on-ramp paths and add gateway activation compute_context enrichment

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- uv run -m pytest -W error -n auto
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q
- CORE_LOOP_STACK_MODE=inproc uv run -m pytest -q tests/e2e/core_loop -q

Fixes #1755
Fixes #1756
Fixes #1758
Fixes #1759
Fixes #1760
Fixes #1767
Docs: updates toward #1769