### PR TITLE
Harden TagQuery determinism and metrics

### DIFF
--- a/docs/en/guides/strategy_workflow.md
+++ b/docs/en/guides/strategy_workflow.md
@@ -167,7 +167,9 @@ WebSocket; WS remains the authority for policy and activation.
 
 Execution mode/domain rules (WS-first, default-safe):
 
-- Only `mode=backtest|paper|live` are accepted; `execution_domain` hints are ignored.
+- Prefer `mode=backtest|paper|live`; when missing, a provided `execution_domain` hint
+  is mapped to the canonical mode, and otherwise we downgrade to compute-only
+  (`backtest`) instead of opting into live implicitly.
 - WS `effective_mode` is authoritative; missing/ambiguous modes are forced to compute-only (backtest).
 - In `backtest`/`paper`, missing `as_of` or `dataset_fingerprint` triggers safe-mode downgrades (`downgrade_reason=missing_as_of`, orders gated).
 - `ActivationEnvelope`/`DecisionEnvelope` carry `compute_context` and serialize identically across WS/Runner/CLI; CLI `--output json` shows the same structure.

--- a/docs/en/operations/determinism.md
+++ b/docs/en/operations/determinism.md
@@ -15,6 +15,8 @@ last_modified: 2025-09-01
   - `nodeid_missing_fields_total{field,node_type}`: canonical NodeID inputs missing.
   - `nodeid_mismatch_total{node_type}`: submitted `node_id` differs from `compute_node_id`.
   - `tagquery_nodeid_mismatch_total`: TagQueryNode-specific mismatch counter.
+- SDK metrics:
+  - `tagquery_update_total{outcome,reason}`: TagQuery queue update events classified as `applied`, `deduped`, `unmatched` (no registered node), or `dropped` (`missing_interval|missing_tags|invalid_spec`).
 - When alerts fire, capture the offending DAG/queue_map so the submission can be replayed locally.
 
 ## Immediate actions
@@ -24,11 +26,15 @@ last_modified: 2025-09-01
 
 2) **Missing fields (`nodeid_missing_fields_total`)**
    - Read the missing field labels from metrics/logs and regenerate the DAG with the latest SDK.
-   - Verify `code_hash`, `config_hash`, `schema_hash`, and `schema_compat_id` are present for every node.
+   - Verify `code_hash`, `config_hash`, `schema_hash`, and `schema_compat_id` are present for every node. For TagQueryNode, `interval` and at least one `tag` are now required to pass determinism checks.
 
 3) **NodeID mismatch (`nodeid_mismatch_total`)**
    - Recompute with `compute_node_id` and compare with the submitted value.
    - For TagQueryNode, ensure `query_tags` are sorted/deduped and both `match_mode` and `interval` are present before recalculating.
+
+4) **TagQuery update drops (`tagquery_update_total{outcome="dropped"|"unmatched"}`)**
+   - `missing_interval|missing_tags`: regenerate the DAG/WS TagQuery payloads with canonical tags and interval; queue updates are being rejected before reaching nodes.
+   - `no_registered_node`: check for NodeID drift or TagQuery spec mismatch between the DAG and SDK registration; reconcile and resubmit.
 
 ## Recovery checks
 - Resubmit with the fixed DAG and ensure the counters stop increasing.
@@ -41,3 +47,4 @@ CORE_LOOP_STACK_MODE=inproc uv run -m pytest -q tests/e2e/core_loop -q
 ## References
 - Design baseline: `docs/en/architecture/architecture.md` §7 Determinism & Operational Checklist.
 - World/domain isolation checks: `tests/e2e/test_world_isolation.py`.
+- Dashboards: plot `nodeid_checksum_mismatch_total`, `nodeid_missing_fields_total`, `nodeid_mismatch_total`, `tagquery_nodeid_mismatch_total`, and `tagquery_update_total` to surface drift and queue-update drop rates.

--- a/docs/ko/guides/strategy_workflow.md
+++ b/docs/ko/guides/strategy_workflow.md
@@ -156,7 +156,9 @@ Gateway의 `/events/subscribe` WebSocket 제어 스트림으로 전달되며, �
 
 실행 모드/도메인 규칙(WS 우선·default-safe):
 
-- 사용자 입력은 `mode=backtest|paper|live`만 인정하며, `execution_domain` 힌트는 무시됩니다.
+- 사용자 입력은 `mode=backtest|paper|live`를 우선으로 받습니다. `mode`가 없으면 전달된
+  `execution_domain` 힌트를 표준 모드로 매핑하고, 둘 다 없으면 게이트웨이 여부와 관계없이
+  라이브로 올라가지 않도록 compute-only(`backtest`)로 강등합니다.
 - WS `effective_mode`만이 권한을 가지며, 모호/누락 시 compute-only(backtest)로 강등됩니다.
 - `backtest`/`paper`에서 `as_of`나 `dataset_fingerprint`가 없으면 안전모드(`downgrade_reason=missing_as_of`, 주문 게이트 OFF)로 표시됩니다.
 - `ActivationEnvelope`/`DecisionEnvelope`에 담긴 `compute_context`는 WS/Runner/CLI에서 동일 스키마로 직렬화되며, CLI `--output json`으로 그대로 확인할 수 있습니다.

--- a/docs/ko/operations/determinism.md
+++ b/docs/ko/operations/determinism.md
@@ -15,6 +15,8 @@ last_modified: 2025-09-01
   - `nodeid_missing_fields_total{field,node_type}`: canonical NodeID 입력 필드 누락
   - `nodeid_mismatch_total{node_type}`: 제출된 `node_id`가 `compute_node_id`와 다름
   - `tagquery_nodeid_mismatch_total`: TagQueryNode 전용 불일치 카운터
+- SDK 메트릭
+  - `tagquery_update_total{outcome,reason}`: TagQuery 큐 업데이트 이벤트의 처리 결과(`applied`/`deduped`/`unmatched`/`dropped` = `missing_interval|missing_tags|invalid_spec`) 분포
 - 경보 발생 시 직전 제출/큐맵을 덤프해 재현 가능한 DAG 스냅샷을 확보한다.
 
 ## 즉시 대응 절차
@@ -24,11 +26,15 @@ last_modified: 2025-09-01
 
 2) **필수 필드 누락 (`nodeid_missing_fields_total`)**
    - 누락된 필드를 로그/메트릭에서 확인 후 SDK를 최신 버전으로 재생성한다.
-   - `code_hash/config_hash/schema_hash/schema_compat_id`가 모두 채워졌는지 검증한다.
+   - `code_hash/config_hash/schema_hash/schema_compat_id`가 모두 채워졌는지 검증한다. TagQueryNode는 `interval`과 최소 한 개의 `tag`가 없으면 결정성 검증을 통과하지 않는다.
 
 3) **NodeID 불일치 (`nodeid_mismatch_total`)**
    - `compute_node_id`로 재계산해 제출된 값과 비교한다.
    - TagQueryNode인 경우 `query_tags` 정렬/중복 제거, `match_mode`, `interval`이 모두 params에 포함됐는지 확인하고 재계산한다.
+
+4) **TagQuery 업데이트 드롭 (`tagquery_update_total{outcome=\"dropped\"|\"unmatched\"}`)**
+   - `missing_interval|missing_tags`: WS/DAG가 내보내는 TagQuery payload에 정규화된 tag와 interval이 포함되도록 재생성한다.
+   - `no_registered_node`: DAG와 SDK 등록된 TagQueryNode 사양이 어긋난 상태이므로 NodeID 정규화 혹은 match_mode/interval 불일치를 점검한다.
 
 ## 복구 검증
 - 수정한 DAG로 재제출 후 메트릭 증가가 멈추는지 확인한다.
@@ -41,3 +47,4 @@ CORE_LOOP_STACK_MODE=inproc uv run -m pytest -q tests/e2e/core_loop -q
 ## 참고
 - 설계 근거: `docs/ko/architecture/architecture.md` §6 Deterministic Checklist.
 - 세계/도메인 격리 검증: `tests/e2e/test_world_isolation.py`.
+- 대시보드: `nodeid_checksum_mismatch_total`, `nodeid_missing_fields_total`, `nodeid_mismatch_total`, `tagquery_nodeid_mismatch_total`, `tagquery_update_total` 지표를 함께 시각화해 결정성 드리프트와 큐 업데이트 드롭률을 감시한다.

--- a/qmtl/runtime/sdk/execution_context.py
+++ b/qmtl/runtime/sdk/execution_context.py
@@ -82,12 +82,14 @@ def resolve_execution_context(
 
     merge_context(merged, context)
 
-    # Legacy execution_domain hints are ignored to enforce WS-first rules.
+    # Legacy execution_domain hints embedded in context mappings are ignored to
+    # enforce WS-first rules; explicit execution_domain parameters are handled
+    # separately when determining execution_mode.
     merged.pop("execution_domain", None)
 
     mode = determine_execution_mode(
         explicit_mode=execution_mode,
-        execution_domain=None,
+        execution_domain=execution_domain,
         merged_context=merged,
         trade_mode=trade_mode,
         offline_requested=offline_requested,

--- a/qmtl/runtime/sdk/metrics.py
+++ b/qmtl/runtime/sdk/metrics.py
@@ -127,6 +127,15 @@ execution_domain_downgrade_total = _counter(
     test_value_factory=dict,
 )
 
+# TagQuery determinism
+tagquery_update_total = _counter(
+    "tagquery_update_total",
+    "Total TagQuery queue update messages processed by TagQueryManager",
+    ["outcome", "reason"],
+    test_value_attr="_vals",
+    test_value_factory=dict,
+)
+
 seamless_cache_resident_bytes = _gauge(
     "seamless_cache_resident_bytes",
     "Resident bytes held by Seamless in-memory cache",


### PR DESCRIPTION
## Summary
- enforce TagQuery-required tags/interval in node validation and sdk manager
- add TagQuery queue-update observability metric and canonical normalization
- update determinism runbooks for new signals and default-safe mapping

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke

Fixes #1761
Fixes #1783
Fixes #1784
Fixes #1785
Fixes #1786
Fixes #1787