### PR TITLE
Strengthen Core Loop contract coverage

### DIFF
--- a/tests/e2e/core_loop/README.md
+++ b/tests/e2e/core_loop/README.md
@@ -23,8 +23,8 @@ Configuration knobs:
 - `CORE_LOOP_ARTIFACT_DIR`: override the artifacts directory (`.artifacts/core_loop` by default).
 
 Contract tests:
-- Marked with `@pytest.mark.contract` and currently `xfail` while the spec is in draft.
-- Include ExecutionDomain default-safe downgrade expectations: running the demo strategy without
-  `as_of` in backtest mode should yield a safe-mode warning and `SubmitResult.downgrade_reason`.
+- Marked with `@pytest.mark.contract`; CI runs them via `CORE_LOOP_STACK_MODE=inproc uv run -m pytest -q tests/e2e/core_loop -q`.
+- Cover ExecutionDomain default-safe downgrade expectations (missing `as_of` downgrades to compute-only)
+  and ComputeContext precedence/downgrade when WorldService decisions are unavailable.
 
 References: docs/ko/design/core_loop_roadmap.md, docs/en/design/core_loop_roadmap_issue_drafts.md.

--- a/tests/e2e/core_loop/test_compute_context_contract.py
+++ b/tests/e2e/core_loop/test_compute_context_contract.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.foundation.common.compute_context import DowngradeReason
+from qmtl.services.gateway.submission.context_service import ComputeContextService
+from qmtl.services.gateway.world_client import Budget, WorldServiceClient
+from tests.qmtl.services.gateway.helpers import build_strategy_payload
+
+pytestmark = pytest.mark.contract
+
+
+@pytest.mark.asyncio
+async def test_compute_context_prefers_worldservice_decision(core_loop_stack, core_loop_world_id: str):
+    client = WorldServiceClient(
+        core_loop_stack.worlds_url,
+        budget=Budget(timeout=1.0, retries=0),
+    )
+    service = ComputeContextService(world_client=client)
+    bundle = build_strategy_payload(execution_domain="live", include_as_of=False)
+    payload = bundle.payload
+    payload.world_ids = [core_loop_world_id]
+
+    try:
+        ctx = await service.build(payload)
+    finally:
+        await client._client.aclose()
+
+    assert ctx.worlds == (core_loop_world_id,)
+    assert ctx.execution_domain == "backtest"  # derived from WS decision
+    assert ctx.downgraded is False
+    assert ctx.safe_mode is False
+    assert ctx.as_of
+
+
+@pytest.mark.asyncio
+async def test_compute_context_downgrades_when_world_missing(core_loop_stack):
+    client = WorldServiceClient(
+        "http://127.0.0.1:1",
+        budget=Budget(timeout=0.1, retries=0),
+    )
+    service = ComputeContextService(world_client=client)
+    bundle = build_strategy_payload(execution_domain="live", include_as_of=False)
+    payload = bundle.payload
+    payload.world_ids = ["missing-world"]
+
+    try:
+        ctx = await service.build(payload)
+    finally:
+        await client._client.aclose()
+
+    assert ctx.worlds == ("missing-world",)
+    assert ctx.execution_domain == "backtest"
+    assert ctx.safe_mode is True
+    assert ctx.downgraded is True
+    assert ctx.downgrade_reason == DowngradeReason.DECISION_UNAVAILABLE

--- a/tests/e2e/core_loop/test_core_loop_stack.py
+++ b/tests/e2e/core_loop/test_core_loop_stack.py
@@ -14,6 +14,8 @@ import pytest
 from qmtl.foundation.common import crc32_of_list
 from .stack import CoreLoopStackHandle
 
+pytestmark = pytest.mark.contract
+
 
 def _http_json(url: str, *, method: str = "GET", data: dict | None = None, timeout: float = 5.0):
     body = None
@@ -42,7 +44,7 @@ def _http_json(url: str, *, method: str = "GET", data: dict | None = None, timeo
             js = {"status": exc.code, "error": raw or str(exc)}
         raise AssertionError({"status": exc.code, "body": js}) from exc
     except Exception as exc:  # noqa: PERF203
-        pytest.skip(f"core loop stack not reachable: {exc}")
+        raise AssertionError(f"core loop stack not reachable: {exc}") from exc
 
 
 def _world_id_candidates(world_id: str) -> set[str]:


### PR DESCRIPTION
Summary:\n- add ComputeContext contract tests for WS decision precedence and missing-world downgrade paths in the core loop suite\n- mark contract suite explicitly and fail fast when the stack is unreachable\n- refresh core loop README to reflect CI gate and coverage\n\nTesting:\n- uv run --with mypy -m mypy\n- uv run mkdocs build --strict\n- uv run python scripts/check_design_drift.py\n- uv run python scripts/lint_dsn_keys.py\n- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json\n- uv run --with grimp python scripts/check_sdk_layers.py\n- uv run python scripts/check_docs_links.py\n- uv run -m pytest --collect-only -q\n- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'\n- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests\n- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q\n- CORE_LOOP_STACK_MODE=inproc uv run -m pytest -q tests/e2e/core_loop -q\n\nFixes #1788\nFixes #1781\nFixes #1763