### PR TITLE
Clarify real-time subscription docs

### DIFF
--- a/docs/en/architecture/gateway.md
+++ b/docs/en/architecture/gateway.md
@@ -342,6 +342,9 @@ POST /events/subscribe
 
 - Gateway subscribes to internal ControlBus and relays events to SDK over the descriptor URL.
 - Ordering is guaranteed per key (world_id or tags+interval). Consumers deduplicate via ``etag``/``run_id``. First message per topic SHOULD be a full snapshot or carry a `state_hash`.
+- **Public availability:** The descriptor currently serves SDK internals (ActivationManager, TagQueryManager). There is no
+  general-purpose CLI/SDK helper for user-facing subscriptions yet; external observers should poll Gateway/WorldService
+  endpoints (e.g., `qmtl status`, `GET /worlds/{id}`) until a stable surface is released.
 
 Token (JWT) claims (delegated WS or future use):
 - `aud`: `controlbus`

--- a/docs/en/getting-started/quickstart.md
+++ b/docs/en/getting-started/quickstart.md
@@ -204,6 +204,11 @@ result = Runner.submit(
     # Subscribe to real-time stream in Python
     Runner.subscribe(world="quickstart_demo", on_update=print)
     ```
+
+    _Status:_ The ControlBus stream exists for internal SDK components, but a
+    stable CLI/SDK helper for user-facing subscriptions is not yet shipped.
+    Poll `qmtl status`/`qmtl world info` or REST endpoints for live monitoring
+    until the subscription surface is published.
     
     - Check real-time performance/rank/contribution in dashboard UI
     - Auto-receive promotion/demotion notifications

--- a/docs/en/getting-started/workflow.md
+++ b/docs/en/getting-started/workflow.md
@@ -321,9 +321,11 @@ Automated:
     ```
     
     **Current State:**
-    
+
     - Query via CLI `qmtl status` or `qmtl world info`
-    - Real-time stream subscription not implemented
+    - ControlBus streams exist for internal SDK services (activation/TagQuery),
+      but there is no stable public subscribe helper yet. For now, poll via CLI
+      or REST for world/strategy status.
 
 ---
 

--- a/docs/ko/architecture/gateway.md
+++ b/docs/ko/architecture/gateway.md
@@ -335,6 +335,9 @@ POST /events/subscribe
 
 - Gateway는 내부 ControlBus를 구독하고 디스크립터 URL을 통해 SDK로 이벤트를 중계합니다.
 - 순서는 키(월드 또는 태그+인터벌) 단위로 보장됩니다. 컨슈머는 ``etag``/``run_id``로 중복 제거합니다. 각 토픽의 첫 메시지는 전체 스냅샷이거나 `state_hash`를 포함하는 것이 바람직합니다.
+- **공개 범위:** 이 디스크립터는 현재 ActivationManager, TagQueryManager 등 SDK 내부용입니다. 사용자 대상의 범용
+  CLI/SDK 구독 헬퍼는 아직 없으므로, 안정화된 표면이 제공될 때까지 `qmtl status`, `GET /worlds/{id}` 같은
+  Gateway/WorldService 엔드포인트를 폴링하세요.
 
 토큰(JWT) 클레임(위임 WS 또는 향후 용도):
 - `aud`: `controlbus`

--- a/docs/ko/getting-started/quickstart.md
+++ b/docs/ko/getting-started/quickstart.md
@@ -204,6 +204,11 @@ result = Runner.submit(
     # Python에서 실시간 스트림 구독
     Runner.subscribe(world="quickstart_demo", on_update=print)
     ```
+
+    _현재 상태:_ ControlBus 스트림은 SDK 내부 구성요소용으로 존재하지만,
+    사용자용 안정화된 CLI/SDK 헬퍼는 아직 제공되지 않습니다. 구독 인터페이스가
+    공개될 때까지 `qmtl status`/`qmtl world info` 또는 REST 엔드포인트를
+    주기적으로 조회하세요.
     
     - 대시보드 UI에서 실시간 성과/순위/기여도 확인
     - 승격/강등 알림 자동 수신

--- a/docs/ko/getting-started/workflow.md
+++ b/docs/ko/getting-started/workflow.md
@@ -321,9 +321,11 @@ print(result.metrics.get("correlation_with_portfolio"))
     ```
     
     **현재 상태:**
-    
+
     - CLI `qmtl status` 또는 `qmtl world info`로 조회
-    - 실시간 스트림 구독 미구현
+    - ControlBus 스트림은 활성/TagQuery 등의 SDK 내부 서비스용이며, 아직
+      안정화된 공개 구독 헬퍼는 없습니다. 현재는 CLI나 REST로 월드/전략
+      상태를 폴링하는 방식을 사용하세요.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify in quickstart/workflow docs (ko/en) that user-facing real-time subscription helpers are not yet shipped and recommend polling for now
- document in gateway architecture pages that the event stream descriptor is currently internal-only until a stable surface is released

## Testing
- Not run (doc-only change)

Fixes #1808

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69322a45fcdc8329934d87c4d222aa3c)