### PR TITLE
Expose allocation snapshot in Runner submit output

### DIFF
--- a/docs/en/architecture/architecture.md
+++ b/docs/en/architecture/architecture.md
@@ -145,15 +145,13 @@ From the user’s perspective, QMTL’s **Core Loop** is:
 - As‑Is
   - WorldService can compute world and cross‑world allocation plans through `/allocations`
     and its internal rebalancing engine.
-  - Runner.submit/CLI and the capital allocation path are **loosely coupled**; practical
-    capital movements rely on separate operational/scheduling loops.
+  - Runner.submit/CLI now fetch the latest `/allocations` snapshot for the submitted world to show applied world/strategy shares, but this is informational only; capital movements still rely on separate operational/scheduling loops.
 - To‑Be
   - The strategy submission/evaluation loop and the world allocation loop are described as
     a **two‑step standard flow** across this document, `worldservice.md`, and the world/ops guides:
     1) `Runner.submit(..., world=...)` → WS evaluation/activation, and  
     2) world allocation/rebalancing via `/allocations` and `/rebalancing/*` (exposed through the `qmtl world allocations|rebalance-*` CLI).
-  - WorldService’s world/strategy allocation summaries are surfaced in CLI/docs so that operators can
-    accept/adjust/execute them without reconstructing the flow from multiple documents.
+  - Core Loop surfaces (docs/CLI) link to `/allocations` snapshots so operators can inspect the applied state while keeping proposal vs. applied boundaries explicit; apply/rebalancing remains an auditable operational step.
 
 ### Core Principle: Simplicity > Backward Compatibility
 

--- a/docs/en/design/core_loop_roadmap.md
+++ b/docs/en/design/core_loop_roadmap.md
@@ -104,6 +104,7 @@ Each track is structured as “Direction (Design North Star) → Key Milestones 
   - Ensure apply/rollback/audit timelines are visible in WorldAuditLog and dashboards.
 - **P2‑T2‑M4 — World-level rebalancing / allocation flow**
   - Connect `/allocations` and the rebalancing engine to the Core Loop “deploy/allocate capital” step, with an operational approval/execute/rollback flow.
+  - Surface `/allocations` snapshots (world/strategy totals) from Runner.submit/CLI for the submitted world to make the proposal (evaluation/activation) vs applied (allocation) boundary clear while keeping apply/execute as an auditable ops step (#1817).
 
 ### 4.3 Concrete Work Examples
 
@@ -112,6 +113,8 @@ Each track is structured as “Direction (Design North Star) → Key Milestones 
   - Add unit tests enforcing default-safe ExecutionDomain/effective_mode behaviour.
 - `docs/en/architecture/worldservice.md` / `docs/ko/architecture/worldservice.md`  
   - Keep As‑Is/To‑Be sections synced with the T2 milestones and enrich examples showing how Runner.submit/CLI consume WS results.
+- Core Loop contract tests  
+  - Extend `tests/e2e/core_loop/test_core_loop_stack.py` with a “submit → allocation summary available” path to lock in the `/allocations` snapshot surface (#1817).
 
 ## 5. T3 — Data Plane / Seamless Track
 

--- a/docs/ko/architecture/architecture.md
+++ b/docs/ko/architecture/architecture.md
@@ -127,16 +127,16 @@ QMTL 아키텍처 전반의 **핵심 설계 가치**는 다음 한 문장으로 
 - As‑Is
   - WorldService는 `/allocations`와 내부 rebalancing 엔진으로
     world/world‑간 자본 배분 계획을 계산할 수 있다.
-  - 하지만 Runner.submit/CLI와 자본 배분 경로는 **느슨하게 결합**되어 있어,
-    실제 자본 이동에는 별도의 운영/스케줄링 루프가 필요하다.
+  - Runner.submit/CLI는 제출된 world에 대해 `/allocations` 스냅샷(월드/전략 비중)을 조회해 보여주지만,
+    이는 적용 상태를 드러내는 표면일 뿐이며 실제 자본 이동은 여전히 별도의 운영/스케줄링 루프가 필요하다.
 - To‑Be
   - 전략 제출/평가 루프와 월드 자본 배분 루프를 본 문서, `worldservice.md`,
     world/운영 가이드 전반에서 **표준 두 단계 루프**로 서술한다.
     1) `Runner.submit(..., world=...)` → WS 평가/활성화,  
     2) `/allocations`·`/rebalancing/*` 및 `qmtl world allocations|rebalance-*` CLI를 통한
        월드 자본 배분/리밸런싱 적용 단계로 이어지는 흐름을 고정한다.
-  - WorldService가 제안하는 world/strategy allocations 요약이 CLI/문서에서도 자연스럽게 노출되어,
-    운영자가 별도 문서 병합 없이 수용·조정·실행 플로우를 따라갈 수 있도록 한다.
+  - Core Loop 표면(문서/CLI)이 `/allocations` 스냅샷과 연결되어 평가/활성(제안)과 배분(적용) 단계를 명확히 구분한 채 탐색할 수 있게 하되,
+    적용/실행은 감사 가능한 운영 단계로 남긴다.
 
 ### 기본 원칙: 단순성 > 하위 호환성
 

--- a/docs/ko/design/core_loop_roadmap.md
+++ b/docs/ko/design/core_loop_roadmap.md
@@ -147,6 +147,7 @@ P‑A/B/C/P‑0 중 어느 것에도 매핑되지 않는 변경은 “합리적�
   - Apply 실행/롤백/감사 로그를 WorldAuditLog와 운영 대시보드에서 확인할 수 있도록 한다.
 - **P2‑T2‑M4 — 월드 단위 리밸런싱/자본 배분 플로우 완성**
   - `/allocations` API와 Rebalancing 엔진을 Core Loop의 “배포/자본 배분” 단계와 연결하고, 운영 플로우(승인/실행/롤백)를 문서화한다.
+  - Runner.submit/CLI에서 제출된 world의 `/allocations` 스냅샷(월드/전략 비중)을 노출해 평가/활성(제안)과 배분(적용) 경계를 명확히 하고, apply/execute는 감사 가능한 운영 단계로 남긴다 (#1817).
 
 ### 4.3 구체적인 작업 예시
 
@@ -155,6 +156,8 @@ P‑A/B/C/P‑0 중 어느 것에도 매핑되지 않는 변경은 “합리적�
   - ExecutionDomain/effective_mode 파이프라인에서 default‑safe 규약을 강제하는 유닛 테스트를 추가한다.
 - `docs/ko/architecture/worldservice.md`  
   - As‑Is/To‑Be 섹션에 각 P0 마일스톤의 상태/진행도를 업데이트하고, Runner.submit/CLI와의 연결 예시를 구체화한다.
+- Core Loop 계약 테스트  
+  - `tests/e2e/core_loop/test_core_loop_stack.py`에 “submit → allocation summary 노출” 경로를 추가해 `/allocations` 스냅샷 노출 계약을 고정한다 (#1817).
 - `docs/ko/operations/activation.md`, `docs/ko/operations/rebalancing_execution.md`  
   - 2‑Phase Apply, 활성 TTL/etag, 리밸런싱 승인 플로우를 Core Loop 기준으로 재정리한다.
 

--- a/qmtl/interfaces/cli/submit.py
+++ b/qmtl/interfaces/cli/submit.py
@@ -181,6 +181,7 @@ def _print_submission_result(result) -> None:
         print(f"Safe mode:   downgraded ({reason})")
 
     _print_ws_section(result)
+    _print_allocation_section(getattr(result, "allocation", None))
     if getattr(result, "precheck", None):
         _print_precheck_section(result.precheck)
 
@@ -227,6 +228,33 @@ def _print_rejected_result(result) -> None:
             print(f"  - {hint}")
     if result.threshold_violations:
         _print_thresholds(result.threshold_violations, label=_t("Threshold violations (WS)"))
+
+
+def _print_allocation_section(allocation) -> None:
+    print(_t("\n🏦 World allocation snapshot (applied)"))
+    if not allocation:
+        print(_t("No allocation snapshot found. After rebalancing, use `qmtl world allocations -w <id>` to inspect."))
+        return
+    print(f"World:       {getattr(allocation, 'world_id', 'n/a')}")
+    alloc_value = getattr(allocation, "allocation", None)
+    if alloc_value is not None:
+        print(f"Allocation:  {float(alloc_value):.4f} (total equity share)")
+    run_id = getattr(allocation, "run_id", None)
+    if run_id:
+        etag = getattr(allocation, "etag", None) or "n/a"
+        print(f"Run:         {run_id} (etag={etag})")
+    updated = getattr(allocation, "updated_at", None)
+    if updated:
+        print(f"Updated at:  {updated}")
+    strategies = getattr(allocation, "strategy_alloc_total", None)
+    if strategies:
+        print(_t("Strategy allocations (total equity):"))
+        for sid, ratio in sorted(strategies.items()):
+            try:
+                ratio_val = float(ratio)
+            except (TypeError, ValueError):
+                continue
+            print(f"  - {sid}: {ratio_val:.4f}")
 
 
 def _print_precheck_section(precheck) -> None:

--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -268,6 +268,12 @@ def _register_world_route(
 
 WORLD_ROUTES: tuple[WorldRoute, ...] = (
     WorldRoute("post", "/rebalancing/plan", "post_rebalance_plan", include_payload=True),
+    WorldRoute(
+        "get",
+        "/allocations",
+        "get_allocations",
+        query_params=("world_id",),
+    ),
     WorldRoute("post", "/worlds", "create_world", include_payload=True),
     WorldRoute("get", "/worlds", "list_worlds"),
     WorldRoute(

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -394,6 +394,19 @@ class WorldServiceClient:
             headers=headers,
         )
 
+    async def get_allocations(
+        self,
+        world_id: str | None = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        params = {"world_id": world_id} if world_id else None
+        return await self._request_json(
+            "GET",
+            "/allocations",
+            headers=headers,
+            params=params,
+        )
+
     async def post_evaluate(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
         return await self._request_json(
             "POST",

--- a/tests/e2e/core_loop/stack.py
+++ b/tests/e2e/core_loop/stack.py
@@ -102,8 +102,18 @@ class InProcessCoreLoopStack:
         ws_server.start()
         _wait_http(f"http://127.0.0.1:{ws_port}/health", timeout=15)
 
+        redis_client = None
+        try:
+            import fakeredis.aioredis as fakeredis  # type: ignore
+
+            redis_client = fakeredis.FakeRedis(decode_responses=True)
+        except Exception:
+            # Fall back to real Redis when fakeredis is unavailable
+            redis_client = None
+
         gw_app = create_app(
             ws_hub=WebSocketHub(),
+            redis_client=redis_client,
             worldservice_url=f"http://127.0.0.1:{ws_port}",
             enable_worldservice_proxy=True,
             enable_background=False,

--- a/tests/e2e/core_loop/test_core_loop_stack.py
+++ b/tests/e2e/core_loop/test_core_loop_stack.py
@@ -148,6 +148,26 @@ def test_submit_json_includes_ws_envelope(core_loop_world_id: str, monkeypatch: 
     assert result["code"] in (0, 1)
 
 
+def test_submit_json_includes_allocation(core_loop_world_id: str, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("QMTL_DEFAULT_WORLD", core_loop_world_id)
+    payload, result = _submit_json(
+        "core_loop_demo_strategy:CoreLoopDemoStrategy",
+        world=core_loop_world_id,
+        mode="backtest",
+    )
+
+    allocation = payload.get("allocation")
+    ws_allocation = payload.get("ws", {}).get("allocation")
+    assert allocation == ws_allocation
+    assert allocation is not None, f"payload={payload}"
+    assert allocation.get("world_id") in _world_id_candidates(core_loop_world_id)
+    assert "allocation" in allocation
+    strategies = allocation.get("strategy_alloc_total")
+    if strategies:
+        assert isinstance(strategies, dict)
+    assert result["code"] in (0, 1)
+
+
 def test_core_loop_world_endpoints_available(core_loop_stack: CoreLoopStackHandle, core_loop_world_id: str):
     base = core_loop_stack.worlds_url.rstrip("/")
     wid = urllib.parse.quote(core_loop_world_id)


### PR DESCRIPTION
Expose allocation snapshots after Runner.submit and surface them in CLI output.\n\nFixes #1817