### PR TITLE
Fix world apply plan file hint

### DIFF
--- a/qmtl/interfaces/cli/submit.py
+++ b/qmtl/interfaces/cli/submit.py
@@ -276,7 +276,7 @@ def _print_allocation_section(allocation, *, world_id: str | None = None, notice
 
 def _print_allocation_guidance(world_id: str) -> None:
     alloc_cmd = f"qmtl world allocations -w {world_id}"
-    apply_cmd = f"qmtl world apply {world_id} --run-id <id> [--plan plan.json]"
+    apply_cmd = f"qmtl world apply {world_id} --run-id <id> [--plan-file plan.json]"
     print(_t("Next steps: {alloc_cmd} to refresh snapshot, {apply_cmd} to request apply/rollback.").format(
         alloc_cmd=alloc_cmd,
         apply_cmd=apply_cmd,

--- a/tests/qmtl/interfaces/cli/test_submit_output.py
+++ b/tests/qmtl/interfaces/cli/test_submit_output.py
@@ -115,3 +115,11 @@ def test_cli_emits_json_with_ws_and_precheck_sections(capsys):
     assert payload["ws"]["activation"]["strategy_id"] == "s-json"
     assert payload["ws"]["threshold_violations"][0]["metric"] == "sharpe"
     assert payload["precheck"]["status"] == "passed"
+
+
+def test_allocation_guidance_uses_plan_file_hint(capsys):
+    cli_submit._print_allocation_guidance("demo-world")
+
+    output = capsys.readouterr().out
+
+    assert "qmtl world apply demo-world --run-id <id> [--plan-file plan.json]" in output


### PR DESCRIPTION
## Summary
- correct the world apply guidance emitted after submissions to reference the --plan-file flag for plan files
- add a regression test covering the plan file guidance output

## Testing
- python -m pytest tests/qmtl/interfaces/cli/test_submit_output.py -k plan_file_hint -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69335681864c8329b290329d2951ebe3)