### PR TITLE
Add tests for allocation snapshot messaging

### DIFF
--- a/tests/qmtl/interfaces/cli/test_world_cli.py
+++ b/tests/qmtl/interfaces/cli/test_world_cli.py
@@ -203,6 +203,20 @@ def test_allocations_warns_on_stale_snapshot(monkeypatch, capsys):
     assert "stale" in out.lower()
 
 
+def test_allocations_hint_when_snapshot_missing(monkeypatch, capsys):
+    def fake_get(path, params=None):
+        return 200, {"allocations": {}}
+
+    monkeypatch.setattr(world, "http_get", fake_get)
+
+    exit_code = world.cmd_world(["allocations", "--world-id", "w1"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "No allocation records found" in out
+    assert "qmtl world apply w1" in out
+
+
 def test_world_apply_posts_payload(monkeypatch, capsys):
     posts: list[tuple[str, dict]] = []
 

--- a/tests/qmtl/services/worldservice/test_worldservice_api.py
+++ b/tests/qmtl/services/worldservice/test_worldservice_api.py
@@ -208,6 +208,19 @@ async def test_world_crud_policy_apply_and_events():
 
 
 @pytest.mark.asyncio
+async def test_allocations_missing_snapshot_returns_empty_payload():
+    bus = DummyBus()
+    app = create_app(bus=bus, storage=Storage())
+
+    async with httpx.ASGITransport(app=app) as asgi:
+        async with httpx.AsyncClient(transport=asgi, base_url="http://test") as client:
+            response = await client.get("/allocations", params={"world_id": "absent"})
+
+    assert response.status_code == 200
+    assert response.json() == {"allocations": {}}
+
+
+@pytest.mark.asyncio
 async def test_apply_rejects_invalid_gating_policy():
     bus = DummyBus()
     app = create_app(bus=bus, storage=Storage())


### PR DESCRIPTION
## Summary
- add CLI coverage to assert allocation hints are shown when snapshots are missing
- add worldservice API contract test for missing allocation snapshots

Fixes #1825

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933565d94c08329b2dee0a107e0994d)