### PR TITLE
Enforce deployment profiles for prod

### DIFF
--- a/docs/en/architecture/architecture.md
+++ b/docs/en/architecture/architecture.md
@@ -30,6 +30,13 @@ Bootstrap workflows and operational validation steps live in
 
 ---
 
+## Deployment profiles
+
+- **dev**: Default for local development. Missing Redis/Kafka/Neo4j/ControlBus DSNs fall back to in-memory stubs to speed up experiments.
+- **prod**: Requires persistent backends across the stack. Missing `gateway.redis_dsn`, `gateway.database_backend=postgres` + `gateway.database_dsn`, `gateway.controlbus_brokers`/`controlbus_topics`, `gateway.commitlog_bootstrap`/`commitlog_topic`, `dagmanager.neo4j_dsn`, `dagmanager.kafka_dsn`, or `worldservice.server.redis` causes startup to fail.
+
+`qmtl config validate --target all` reports errors (not warnings) when `profile: prod` omits required DSNs, and the Gateway CLI enforces the same rule to prevent mixed modes (partial in-memory fallbacks).
+
 ### Default-Safe Principle
 
 - When configuration is thin or ambiguous, **downgrade to compute-only (backtest)**. Missing `execution_domain`/`as_of` must never yield live/dryrun promotion.

--- a/docs/en/architecture/dag-manager.md
+++ b/docs/en/architecture/dag-manager.md
@@ -22,6 +22,9 @@ Additional references
 - Reference: [Commit-Log Design](../reference/commit_log.md), [TagQuery Specification](../reference/tagquery.md)
 - Operations guides: [Timing Controls](../operations/timing_controls.md)
 
+!!! note "Deployment profile"
+    With `profile: dev`, missing Neo4j/Kafka DSNs fall back to in-memory graph and queue managers. With `profile: prod`, missing `dagmanager.neo4j_dsn` or `dagmanager.kafka_dsn` stops the process before startup.
+
 ---
 
 ## 0. Responsibilities & Design Principles

--- a/docs/en/architecture/gateway.md
+++ b/docs/en/architecture/gateway.md
@@ -30,6 +30,9 @@ Additional references
 - Operations: [Risk Management](../operations/risk_management.md), [Timing Controls](../operations/timing_controls.md)
 - Reference: [Brokerage API](../reference/api/brokerage.md), [Commit-Log Design](../reference/commit_log.md), [World/Activation API](../reference/api_world.md)
 
+!!! note "Deployment profile"
+    With `profile: dev`, missing Redis/ControlBus/Commit-Log settings fall back to in-memory shims. With `profile: prod`, missing `gateway.redis_dsn`, `gateway.database_backend=postgres` + `gateway.database_dsn`, `gateway.controlbus_brokers`/`controlbus_topics`, or `gateway.commitlog_bootstrap`/`commitlog_topic` stops Gateway before it starts.
+
 > This extended edition enlarges the previous document by approx. 75 % and adopts an explicit, graduate-level rigor. All threat models, formal API contracts, latency distributions, and CI/CD semantics are fully enumerated.
 > Legend: **Sx** = Section, **Rx** = Requirement, **Ax** = Assumption.
 

--- a/docs/en/architecture/worldservice.md
+++ b/docs/en/architecture/worldservice.md
@@ -20,6 +20,9 @@ WorldService is the system of record (SSOT) for Worlds. It owns:
 - Audit & RBAC: every policy/update/decision/apply event is logged and authorized
 - Events: emits activation/policy updates to the internal ControlBus
 
+!!! note "Deployment profile"
+    With `profile: dev`, WorldService uses an in-memory activation store when Redis is not configured. With `profile: prod`, missing `worldservice.server.redis` fails fast before startup; in-memory mode is not allowed.
+
 !!! warning "Default-safe"
 - Do not default to live when inputs are missing or ambiguous; downgrade to compute-only (backtest) if `execution_domain` is empty or omitted. WS API calls must not persist live by default.
 - With `allow_live=false` (default), activation/domain switches must not move to live even if operators request it. Only promote when policy validation passes (required signals, hysteresis, dataset_fingerprint anchored).

--- a/docs/en/operations/backend_quickstart.md
+++ b/docs/en/operations/backend_quickstart.md
@@ -18,6 +18,9 @@ This quickstart brings up the core QMTL backend services for local development:
 See also: Docker usage and full stack notes in [Docker & Compose](docker.md) and
 end-to-end tests in [E2E Testing](e2e_testing.md).
 
+!!! tip "Check the deployment profile"
+    `profile: dev` (default) allows in-memory fallbacks when Redis/Kafka/Neo4j/commit-log settings are empty. For production, set `profile: prod` and fill `gateway.redis_dsn`, `gateway.database_backend=postgres` + `gateway.database_dsn`, `gateway.controlbus_*`, `gateway.commitlog_*`, `dagmanager.neo4j_dsn`, `dagmanager.kafka_dsn`, and `worldservice.server.redis` so that `qmtl config validate` and service startup succeed.
+
 ## Prerequisites
 
 - Python environment managed by uv: `uv venv && uv pip install -e .[dev]`

--- a/docs/ko/architecture/architecture.md
+++ b/docs/ko/architecture/architecture.md
@@ -30,6 +30,13 @@ last_modified: 2025-12-06
 
 ---
 
+## 배포 프로필
+
+- **dev**: 로컬 개발용 기본값이다. Redis/Kafka/Neo4j/ControlBus가 비어 있으면 인메모리 대체 구현을 사용하며, 빠르게 실험하거나 튜닝할 때 적합하다.
+- **prod**: 모든 컴포넌트가 영속 백엔드를 사용해야 한다. `gateway.redis_dsn`, `gateway.database_backend=postgres` + `gateway.database_dsn`, `gateway.controlbus_brokers`/`controlbus_topics`, `gateway.commitlog_bootstrap`/`commitlog_topic`, `dagmanager.neo4j_dsn`, `dagmanager.kafka_dsn`, `worldservice.server.redis`가 누락되면 부팅 전에 오류를 반환한다.
+
+`qmtl config validate --target all`는 `profile: prod`에서 필수 항목이 빠지면 경고 대신 오류를 보고하며, Gateway CLI 역시 동일한 조건을 강제해 혼합 모드(일부만 인메모리)를 차단한다.
+
 ## 0. 개요: 이론적 동기와 시스템화의 목적
 
 QMTL은 전략 기반 데이터 흐름 처리 시스템으로, 복잡한 계산 DAG(Directed Acyclic Graph)를 효율적으로 실행하고, 반복적 계산을 피하면서 재사용 가능한 컴퓨팅 자원을 최대한 활용하는 것을 주요 목표로 한다. 특히 DAG의 구성요소를 연산 단위로 분해하고 이를 전역적으로 식별·재활용할 수 있도록 함으로써, 유사하거나 동일한 전략 간에 불필요한 계산 자원 낭비를 최소화할 수 있다. 예를 들어 A 전략과 B 전략이 공통적으로 사용하는 가격 신호 처리 노드가 있다면, 해당 노드는 한 번만 실행되고 그 결과는 두 전략에서 모두 참조할 수 있게 된다. 이는 고빈도 실행 환경 또는 다중 전략 포트폴리오 환경에서 시간 복잡도와 메모리 사용량을 획기적으로 줄이는 데 기여한다.

--- a/docs/ko/architecture/dag-manager.md
+++ b/docs/ko/architecture/dag-manager.md
@@ -22,6 +22,9 @@ spec_version: v1.1
 - 레퍼런스: [Commit‑Log 설계](../reference/commit_log.md), [TagQuery 사양](../reference/tagquery.md)
 - 운영 가이드: [타이밍 컨트롤](../operations/timing_controls.md)
 
+!!! note "배포 프로필"
+    `profile: dev`에서는 Neo4j/Kafka 설정이 비어 있으면 인메모리 그래프/큐 매니저를 사용합니다. `profile: prod`에서는 `dagmanager.neo4j_dsn`과 `dagmanager.kafka_dsn`이 비어 있으면 프로세스가 기동 전에 실패합니다.
+
 ---
 
 ## 0. 역할 요약 & 설계 철학

--- a/docs/ko/architecture/gateway.md
+++ b/docs/ko/architecture/gateway.md
@@ -28,7 +28,10 @@ spec_version: v1.2
 
 추가 참고
 - 운영 가이드: [리스크 관리](../operations/risk_management.md), [타이밍 컨트롤](../operations/timing_controls.md)
-- 레퍼런스: [Brokerage API](../reference/api/brokerage.md), [Commit‑Log 설계](../reference/commit_log.md), [World/Activation API](../reference/api_world.md)
+ - 레퍼런스: [Brokerage API](../reference/api/brokerage.md), [Commit‑Log 설계](../reference/commit_log.md), [World/Activation API](../reference/api_world.md)
+
+!!! note "배포 프로필"
+    `profile: dev`에서는 Redis/ControlBus/Commit‑Log 설정이 비어 있으면 인메모리 대체 구현을 사용합니다. `profile: prod`에서는 `gateway.redis_dsn`, `gateway.database_backend=postgres` + `gateway.database_dsn`, `gateway.controlbus_brokers`/`controlbus_topics`, `gateway.commitlog_bootstrap`/`commitlog_topic`이 모두 채워져 있지 않으면 Gateway가 기동 전에 실패합니다.
 
 > 이 확장판은 기존 문서 대비 약 75% 분량이 늘었으며, 연구 중심의 엄밀한 기술 명세 형식을 채택했습니다. 모든 위협 모델, 공식 API 계약, 지연 분포, CI/CD 의미론을 완전하게 기술합니다.
 > 표기: **Sx** = 섹션, **Rx** = 요구사항, **Ax** = 가정.

--- a/docs/ko/architecture/worldservice.md
+++ b/docs/ko/architecture/worldservice.md
@@ -20,6 +20,9 @@ WorldService는 월드의 단일 진실 소스(SSOT)입니다. 다음을 소유�
 - 감사 및 RBAC: 각 정책/업데이트/결정/적용 이벤트를 로깅하고 권한을 검사
 - 이벤트: 내부 ControlBus로 활성화/정책 업데이트 발행
 
+!!! note "배포 프로필"
+    `profile: dev`에서는 활성화 캐시 Redis가 비어 있으면 인메모리 저장소를 사용합니다. `profile: prod`에서는 `worldservice.server.redis`가 비어 있으면 프로세스가 기동 전에 실패하며, 인메모리 모드는 지원하지 않습니다.
+
 !!! warning "안전 기본값"
 - 입력이 모호하거나 부족하면 live로 기본 설정하지 않고 compute-only(backtest)로 강등해야 합니다. `execution_domain`을 비우거나 생략한 WS API 호출이 live로 저장되면 안 됩니다.
 - `allow_live=false`(기본)일 때는 운영자가 요청하더라도 활성/도메인이 live로 전환되지 않습니다. 정책 검증(필수 지표, 히스테리시스, dataset_fingerprint 고정)이 통과될 때에만 승격을 허용하세요.

--- a/docs/ko/operations/backend_quickstart.md
+++ b/docs/ko/operations/backend_quickstart.md
@@ -17,6 +17,9 @@ last_modified: 2025-09-23
 
 추가로 [Docker & Compose](docker.md) 의 전체 스택 설명과 [E2E 테스트](e2e_testing.md) 문서를 참고하세요.
 
+!!! tip "배포 프로필 체크"
+    `profile: dev`(기본)에서는 redis/kafka/neo4j/commit-log가 비어 있어도 인메모리 대체 구현으로 기동됩니다. 운영 배포에서는 `profile: prod`를 지정하고, `gateway.redis_dsn`, `gateway.database_backend=postgres` + `gateway.database_dsn`, `gateway.controlbus_*`, `gateway.commitlog_*`, `dagmanager.neo4j_dsn`, `dagmanager.kafka_dsn`, `worldservice.server.redis`를 모두 채워야 `qmtl config validate`와 서비스 부팅이 성공합니다.
+
 ## 사전 준비
 
 - uv로 관리하는 Python 환경: `uv venv && uv pip install -e .[dev]`

--- a/qmtl/examples/templates/config/qmtl.maximal.yml
+++ b/qmtl/examples/templates/config/qmtl.maximal.yml
@@ -1,6 +1,8 @@
 # Example configuration for production-style deployments.
 # Replace placeholder endpoints and credentials with your infrastructure values.
 
+profile: dev
+
 worldservice:
   url: https://worldservice.example.com
   timeout: 1.5

--- a/qmtl/examples/templates/config/qmtl.minimal.yml
+++ b/qmtl/examples/templates/config/qmtl.minimal.yml
@@ -1,6 +1,8 @@
 # Example unified configuration for local development.
 # Adjust endpoints and credentials to match your deployment.
 
+profile: dev
+
 worldservice:
   url: http://localhost:8080
   timeout: 0.3

--- a/qmtl/interfaces/cli/config.py
+++ b/qmtl/interfaces/cli/config.py
@@ -15,6 +15,7 @@ from qmtl.foundation.config_validation import (
     validate_config_structure,
     validate_dagmanager_config,
     validate_gateway_config,
+    validate_worldservice_config,
 )
 from qmtl.interfaces.config_templates import (
     available_profiles,
@@ -58,7 +59,7 @@ def _build_validate_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--target",
-        choices=["schema", "gateway", "dagmanager", "all"],
+        choices=["schema", "gateway", "dagmanager", "worldservice", "all"],
         default="all",
         help=_("Limit validation to a specific service"),
     )
@@ -164,6 +165,8 @@ def _resolve_targets(target: str) -> List[str]:
         targets.append("gateway")
     if target in {"dagmanager", "all"}:
         targets.append("dagmanager")
+    if target in {"worldservice", "all"}:
+        targets.append("worldservice")
     return targets
 
 
@@ -185,9 +188,17 @@ async def _validate_targets(unified, targets: List[str], offline: bool) -> Dict[
     results: Dict[str, Dict[str, ValidationIssue]] = {}
     results["schema"] = validate_config_structure(unified)
     if "gateway" in targets:
-        results["gateway"] = await validate_gateway_config(unified.gateway, offline=offline)
+        results["gateway"] = await validate_gateway_config(
+            unified.gateway, offline=offline, profile=unified.profile
+        )
     if "dagmanager" in targets:
-        results["dagmanager"] = await validate_dagmanager_config(unified.dagmanager, offline=offline)
+        results["dagmanager"] = await validate_dagmanager_config(
+            unified.dagmanager, offline=offline, profile=unified.profile
+        )
+    if "worldservice" in targets:
+        results["worldservice"] = validate_worldservice_config(
+            unified.worldservice.server, profile=unified.profile
+        )
     return results
 
 

--- a/tests/qmtl/foundation/config/test_unified_config.py
+++ b/tests/qmtl/foundation/config/test_unified_config.py
@@ -75,9 +75,28 @@ def test_load_unified_config_defaults(tmp_path: Path) -> None:
     config_file.write_text("{}")
     config = load_config(str(config_file))
     assert isinstance(config, UnifiedConfig)
+    assert config.profile.value == "dev"
     assert config.gateway.redis_dsn is None
     assert config.dagmanager.grpc_port == 50051
     assert config.present_sections == frozenset()
+
+
+def test_load_unified_config_profile(tmp_path: Path) -> None:
+    config_file = tmp_path / "profile.yml"
+    config_file.write_text(yaml.safe_dump({"profile": "prod", "gateway": {}}))
+
+    config = load_config(str(config_file))
+
+    assert config.profile is not None
+    assert config.profile.value == "prod"
+
+
+def test_load_unified_config_rejects_unknown_profile(tmp_path: Path) -> None:
+    config_file = tmp_path / "profile.yml"
+    config_file.write_text(yaml.safe_dump({"profile": "qa"}))
+
+    with pytest.raises(ValueError, match="profile must be one of: dev, prod"):
+        load_config(str(config_file))
 
 
 def test_load_unified_config_worldservice_server(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a unified DeploymentProfile flag and enforce persistent backends for prod in gateway/dagmanager/worldservice validation and gateway startup
- expand config CLI/tests/templates to cover prod-only requirements and worldservice validation
- document the supported dev/prod profiles across architecture and backend quickstart guides

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q

Fixes #1834

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69342b93be4c83298de467fc531cdd84)