### PR TITLE
Enforce gateway commit log for prod profile

### DIFF
--- a/docs/en/reference/commit_log.md
+++ b/docs/en/reference/commit_log.md
@@ -4,6 +4,12 @@ Gateway can optionally publish and consume commit-log records via Kafka. The
 settings below live under the `gateway` section of the YAML configuration
 file.
 
+- When running with ``profile: prod`` the Gateway process **exits during
+  startup** if ``commitlog_bootstrap`` or ``commitlog_topic`` are missing to
+  avoid silent loss of ingestion durability.
+- For local development (``profile: dev``), leaving these fields blank simply
+  disables commit-log publishing and emits an informational log.
+
 ```yaml
 gateway:
   commitlog_bootstrap: "localhost:9092"

--- a/docs/ko/architecture/gateway.md
+++ b/docs/ko/architecture/gateway.md
@@ -32,6 +32,7 @@ spec_version: v1.2
 
 !!! note "배포 프로필"
     `profile: dev`에서는 Redis/ControlBus/Commit‑Log 설정이 비어 있으면 인메모리 대체 구현을 사용합니다. `profile: prod`에서는 `gateway.redis_dsn`, `gateway.database_backend=postgres` + `gateway.database_dsn`, `gateway.controlbus_brokers`/`controlbus_topics`, `gateway.commitlog_bootstrap`/`commitlog_topic`이 모두 채워져 있지 않으면 Gateway가 기동 전에 실패합니다.
+    `profile: dev`에서 커밋 로그 필드를 비우면 게이트웨이는 단순히 커밋 로그 라이터를 비활성화하고 정보 로그를 남깁니다.
 
 > 이 확장판은 기존 문서 대비 약 75% 분량이 늘었으며, 연구 중심의 엄밀한 기술 명세 형식을 채택했습니다. 모든 위협 모델, 공식 API 계약, 지연 분포, CI/CD 의미론을 완전하게 기술합니다.
 > 표기: **Sx** = 섹션, **Rx** = 요구사항, **Ax** = 가정.


### PR DESCRIPTION
## Summary
- enforce commit-log configuration checks during gateway startup when running in the prod profile while keeping the dev-mode opt-out
- add gateway CLI coverage for commit-log disablement, prod failure, and configured success paths
- document the prod requirement and dev-only disablement in the commit-log reference and gateway architecture guide

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q

Fixes #1838

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343049e67083298e97d3c984d3de4b)