### PR TITLE
Implement Kafka ownership adapter for Gateway

### DIFF
--- a/qmtl/services/gateway/ownership.py
+++ b/qmtl/services/gateway/ownership.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+import importlib
+import importlib.util
 import logging
-from typing import Any, Optional, Protocol, Dict, Set, cast
+from typing import Any, Optional, Protocol, Dict, Set, cast, Iterable, Callable
 
 from .database import PostgresDatabase, pg_try_advisory_lock, pg_advisory_unlock
 from . import metrics as gw_metrics
@@ -15,6 +18,116 @@ class KafkaOwnership(Protocol):
 
     async def release(self, key: int) -> None:
         """Release Kafka-based ownership for ``key``."""
+
+
+class KafkaPartitionOwnership:
+    """Kafka-based ownership using consumer group partition assignments.
+
+    A key maps deterministically to a Kafka partition. Ownership is granted
+    when the local consumer is assigned that partition. Postgres advisory locks
+    remain available to :class:`OwnershipManager` as a fallback.
+    """
+
+    def __init__(
+        self,
+        consumer: Any,
+        topic: str,
+        *,
+        partitioner: Callable[[int, int], int] | None = None,
+        start_timeout: float = 5.0,
+        rebalance_backoff: float = 0.05,
+        rebalance_attempts: int = 3,
+    ) -> None:
+        self._consumer = consumer
+        self._topic = topic
+        self._partitioner = partitioner or (lambda key, count: key % count)
+        self._start_timeout = start_timeout
+        self._rebalance_backoff = rebalance_backoff
+        self._rebalance_attempts = rebalance_attempts
+        self._started = False
+        self._start_lock = asyncio.Lock()
+
+    async def acquire(self, key: int) -> bool:
+        await self._ensure_started()
+        partitions = self._partitions()
+        if not partitions:
+            return False
+
+        target_partition = self._select_partition(key, partitions)
+        assignment = await self._assignment()
+        return (self._topic, target_partition) in assignment
+
+    async def release(self, key: int) -> None:  # pragma: no cover - no-op guard
+        return None
+
+    async def _ensure_started(self) -> None:
+        async with self._start_lock:
+            if self._started:
+                return
+            await asyncio.wait_for(self._consumer.start(), timeout=self._start_timeout)
+            self._started = True
+
+    def _partitions(self) -> list[int]:
+        parts = self._consumer.partitions_for_topic(self._topic) or set()
+        return sorted(parts)
+
+    async def _assignment(self) -> set[tuple[str, int]]:
+        for _ in range(self._rebalance_attempts):
+            assignment = self._normalize_assignment(self._consumer.assignment())
+            if assignment:
+                return assignment
+            await asyncio.sleep(self._rebalance_backoff)
+        return set()
+
+    def _select_partition(self, key: int, partitions: Iterable[int]) -> int:
+        as_list = list(partitions)
+        if not as_list:
+            return 0
+        index = self._partitioner(key, len(as_list)) % len(as_list)
+        return as_list[index]
+
+    def _normalize_assignment(self, assignment: Iterable[Any]) -> set[tuple[str, int]]:
+        normalized: set[tuple[str, int]] = set()
+        for item in assignment:
+            topic = getattr(item, "topic", None)
+            partition = getattr(item, "partition", None)
+            if topic is None or partition is None:
+                try:
+                    topic, partition = item
+                except Exception:
+                    continue
+            normalized.add((str(topic), int(partition)))
+        return normalized
+
+
+def create_kafka_ownership(
+    bootstrap_servers: str,
+    topic: str,
+    group_id: str,
+    *,
+    start_timeout: float = 5.0,
+    rebalance_backoff: float = 0.05,
+    rebalance_attempts: int = 3,
+) -> KafkaOwnership:
+    """Build :class:`KafkaPartitionOwnership` using ``aiokafka`` when available."""
+
+    spec = importlib.util.find_spec("aiokafka")
+    if spec is None:
+        raise RuntimeError("aiokafka is required for Kafka ownership mode")
+    aiokafka = importlib.import_module("aiokafka")
+    consumer = aiokafka.AIOKafkaConsumer(
+        topic,
+        bootstrap_servers=bootstrap_servers,
+        group_id=group_id,
+        enable_auto_commit=False,
+    )
+    return KafkaPartitionOwnership(
+        consumer,
+        topic,
+        start_timeout=start_timeout,
+        rebalance_backoff=rebalance_backoff,
+        rebalance_attempts=rebalance_attempts,
+    )
 
 
 class OwnershipManager:
@@ -101,4 +214,9 @@ class OwnershipManager:
             self._last_owner[key] = owner
 
 
-__all__ = ["OwnershipManager", "KafkaOwnership"]
+__all__ = [
+    "OwnershipManager",
+    "KafkaOwnership",
+    "KafkaPartitionOwnership",
+    "create_kafka_ownership",
+]

--- a/qmtl/services/gateway/worker.py
+++ b/qmtl/services/gateway/worker.py
@@ -14,7 +14,7 @@ from .ws import WebSocketHub
 from .fsm import StrategyFSM
 from .redis_queue import RedisTaskQueue
 from ..dagmanager.alerts import AlertManager
-from .ownership import OwnershipManager
+from .ownership import KafkaOwnership, OwnershipManager
 from ..dagmanager.kafka_admin import partition_key
 
 
@@ -54,6 +54,7 @@ class StrategyWorker:
         alert_manager: Optional[AlertManager] = None,
         grpc_fail_threshold: int = 3,
         manager: Optional[OwnershipManager] = None,
+        kafka_owner: Optional[KafkaOwnership] = None,
     ) -> None:
         self.redis = redis_client
         self.database = database
@@ -66,7 +67,7 @@ class StrategyWorker:
         self.alerts = alert_manager
         self._grpc_fail_thresh = grpc_fail_threshold
         self._grpc_fail_count = 0
-        self.manager = manager or OwnershipManager(database)
+        self.manager = manager or OwnershipManager(database, kafka_owner)
 
     async def healthy(self) -> bool:
         """Return ``True`` if all critical dependencies are reachable."""

--- a/tests/qmtl/foundation/config/test_gateway_config.py
+++ b/tests/qmtl/foundation/config/test_gateway_config.py
@@ -83,6 +83,9 @@ def test_gateway_config_defaults() -> None:
     assert cfg.rebalance_schema_version == 1
     assert cfg.alpha_metrics_capable is False
     assert cfg.compute_context_contract is None
+    assert cfg.ownership.mode == "postgres"
+    assert cfg.ownership.topic == "gateway.ownership"
+    assert cfg.ownership.group_id == "gateway-ownership"
     caps = cfg.build_health_capabilities()
     assert caps.rebalance_schema_version == 1
     assert caps.alpha_metrics_capable is False
@@ -99,3 +102,23 @@ def test_gateway_config_builds_capabilities_from_values() -> None:
     assert caps.rebalance_schema_version == 2
     assert caps.alpha_metrics_capable is True
     assert caps.compute_context_contract == "compute:v2"
+
+
+def test_gateway_config_parses_ownership_block(tmp_path: Path) -> None:
+    ownership = {
+        "mode": "kafka",
+        "bootstrap": "kafka:9092",
+        "topic": "gateway.ownership",
+        "group_id": "locks",
+        "start_timeout": 1.5,
+    }
+    config_file = tmp_path / "ownership.yml"
+    config_file.write_text(yaml.safe_dump({"gateway": {"ownership": ownership}}))
+
+    config = load_config(str(config_file))
+
+    assert config.gateway.ownership.mode == "kafka"
+    assert config.gateway.ownership.bootstrap == "kafka:9092"
+    assert config.gateway.ownership.topic == "gateway.ownership"
+    assert config.gateway.ownership.group_id == "locks"
+    assert config.gateway.ownership.start_timeout == 1.5

--- a/tests/qmtl/services/gateway/test_kafka_partition_ownership.py
+++ b/tests/qmtl/services/gateway/test_kafka_partition_ownership.py
@@ -1,0 +1,92 @@
+from collections import deque
+
+import pytest
+
+from qmtl.services.gateway.ownership import KafkaPartitionOwnership
+
+
+class _StubPartition:
+    def __init__(self, topic: str, partition: int) -> None:
+        self.topic = topic
+        self.partition = partition
+
+
+class _StubConsumer:
+    def __init__(
+        self,
+        topic: str,
+        partitions: set[int],
+        assignments: list[set[int]],
+    ) -> None:
+        self._topic = topic
+        self._partitions = partitions
+        self._assignments = deque(assignments)
+        self.start_calls = 0
+
+    async def start(self) -> None:
+        self.start_calls += 1
+
+    def partitions_for_topic(self, topic: str):
+        assert topic == self._topic
+        return self._partitions
+
+    def assignment(self):
+        current = self._assignments[0] if self._assignments else set()
+        if len(self._assignments) > 1:
+            current = self._assignments.popleft()
+        return {_StubPartition(self._topic, partition) for partition in current}
+
+
+@pytest.mark.asyncio
+async def test_acquire_succeeds_when_assigned_partition() -> None:
+    consumer = _StubConsumer(
+        topic="gateway.ownership",
+        partitions={0, 1},
+        assignments=[{1}],
+    )
+    owner = KafkaPartitionOwnership(
+        consumer,
+        "gateway.ownership",
+        rebalance_attempts=1,
+        rebalance_backoff=0,
+    )
+
+    assert await owner.acquire(5)
+    assert consumer.start_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_acquire_waits_for_assignment_before_checking() -> None:
+    consumer = _StubConsumer(
+        topic="gateway.ownership",
+        partitions={0, 1},
+        assignments=[set(), {1}],
+    )
+    owner = KafkaPartitionOwnership(
+        consumer,
+        "gateway.ownership",
+        rebalance_attempts=2,
+        rebalance_backoff=0,
+    )
+
+    assert await owner.acquire(3)
+    assert consumer.start_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_acquire_returns_false_when_partition_unassigned() -> None:
+    consumer = _StubConsumer(
+        topic="gateway.ownership",
+        partitions={0, 1},
+        assignments=[{0}],
+    )
+    owner = KafkaPartitionOwnership(
+        consumer,
+        "gateway.ownership",
+        rebalance_attempts=1,
+        rebalance_backoff=0,
+    )
+
+    assert await owner.acquire(3) is False
+    assert consumer.start_calls == 1
+


### PR DESCRIPTION
## Summary
- add a KafkaPartitionOwnership adapter and factory, wiring StrategyWorker to accept Kafka-based ownership alongside Postgres fallback
- extend gateway ownership configuration and validation (including aiokafka probing) plus matching unit coverage
- document the Kafka ownership path in the gateway architecture pages and add targeted Kafka ownership tests

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q

Fixes #1839

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934304fa95083298fe5e018c2ab1f9b)