### PR TITLE
Align WorldService storage with documented world schema

### DIFF
--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -34,9 +34,19 @@ class WorldNodeStatusEnum(StrEnum):
 
 
 class World(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     id: str
     name: str | None = None
+    description: str | None = None
+    owner: str | None = None
+    labels: List[str] = Field(default_factory=list)
+    state: Literal["ACTIVE", "SUSPENDED", "DELETED"] = "ACTIVE"
     allow_live: bool = False
+    circuit_breaker: bool = False
+    default_policy_version: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
 
 
 class PolicyRequest(BaseModel):

--- a/qmtl/services/worldservice/storage/facade.py
+++ b/qmtl/services/worldservice/storage/facade.py
@@ -79,6 +79,7 @@ class Storage:
 
     async def set_default_policy(self, world_id: str, version: int) -> None:
         self._policies.set_default(world_id, version)
+        self._worlds.update(world_id, {"default_policy_version": version})
         await self.invalidate_validation_cache(world_id)
 
     async def get_default_policy(self, world_id: str) -> Optional[Policy]:

--- a/qmtl/services/worldservice/storage/persistent.py
+++ b/qmtl/services/worldservice/storage/persistent.py
@@ -353,6 +353,7 @@ class PersistentStorage:
 
     async def set_default_policy(self, world_id: str, version: int) -> None:
         await self._policy_repo.set_default(world_id, version)
+        await self._world_repo.update(world_id, {"default_policy_version": version})
         await self.invalidate_validation_cache(world_id)
 
     async def get_default_policy(self, world_id: str) -> Optional[Any]:

--- a/tests/qmtl/services/worldservice/storage/test_world_repository.py
+++ b/tests/qmtl/services/worldservice/storage/test_world_repository.py
@@ -1,26 +1,70 @@
 from __future__ import annotations
 
+from itertools import cycle
+
+from qmtl.services.worldservice.storage import models
 from qmtl.services.worldservice.storage.audit import AuditLogRepository
 from qmtl.services.worldservice.storage.worlds import WorldRepository
 
 
-def test_world_repository_persists_records_and_audits() -> None:
+def test_world_repository_persists_records_and_audits(monkeypatch) -> None:
+    timestamps = cycle([
+        "2025-01-01T00:00:00Z",
+        "2025-01-02T00:00:00Z",
+        "2025-01-03T00:00:00Z",
+    ])
+    monkeypatch.setattr(models, "_iso_timestamp", lambda: next(timestamps))
+
     audit = AuditLogRepository()
     repo = WorldRepository(audit)
 
-    record = repo.create({"id": "world-1", "name": "First"})
+    record = repo.create({
+        "id": "world-1",
+        "name": "First",
+        "labels": ["core", "beta"],
+        "contract_id": "cid-1",
+    })
     assert record.id == "world-1"
-    assert repo.get("world-1") == {"id": "world-1", "name": "First"}
+    assert repo.get("world-1") == {
+        "id": "world-1",
+        "name": "First",
+        "description": None,
+        "owner": None,
+        "labels": ["core", "beta"],
+        "state": "ACTIVE",
+        "allow_live": False,
+        "circuit_breaker": False,
+        "default_policy_version": None,
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+        "contract_id": "cid-1",
+    }
 
-    repo.update("world-1", {"description": "primary"})
+    repo.update(
+        "world-1",
+        {
+            "description": "primary",
+            "owner": "alice",
+            "allow_live": True,
+            "labels": ["core", "stable"],
+        },
+    )
     assert repo.get("world-1") == {
         "id": "world-1",
         "name": "First",
         "description": "primary",
+        "owner": "alice",
+        "labels": ["core", "stable"],
+        "state": "ACTIVE",
+        "allow_live": True,
+        "circuit_breaker": False,
+        "default_policy_version": None,
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-02T00:00:00Z",
+        "contract_id": "cid-1",
     }
 
     entries = audit.list_entries("world-1")
-    assert [event["event"] for event in entries] == [
-        "world_created",
-        "world_updated",
-    ]
+    assert [event["event"] for event in entries] == ["world_created", "world_updated"]
+    assert entries[0]["world"]["created_at"] == "2025-01-01T00:00:00Z"
+    assert entries[1]["world"]["updated_at"] == "2025-01-02T00:00:00Z"

--- a/tests/qmtl/services/worldservice/test_worldservice_api.py
+++ b/tests/qmtl/services/worldservice/test_worldservice_api.py
@@ -125,7 +125,14 @@ async def test_world_crud_policy_apply_and_events():
             # Create world
             await client.post("/worlds", json={"id": "w1", "name": "World"})
             r = await client.get("/worlds")
-            assert r.json() == [{"id": "w1", "name": "World", "allow_live": False}]
+            worlds = r.json()
+            assert worlds[0]["id"] == "w1"
+            assert worlds[0]["name"] == "World"
+            assert worlds[0]["allow_live"] is False
+            assert worlds[0]["state"] == "ACTIVE"
+            assert worlds[0]["circuit_breaker"] is False
+            assert "created_at" in worlds[0]
+            assert "updated_at" in worlds[0]
 
             overrides_resp = await client.get("/worlds/w1/edges/overrides")
             assert overrides_resp.status_code == 200


### PR DESCRIPTION
## Summary
- normalize WorldService world records with documented fields (state, allow_live, circuit_breaker, timestamps, labels) and persist default policy version updates in both in-memory and persistent storage
- expand World API schema to accept the documented fields while allowing extra metadata
- update world repository and API tests to assert the enriched world shape and audit timestamps

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q

Fixes #1835

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693430391e9c8329ae81acf62d8274e9)