### PR TITLE
Fix Kafka ownership wiring and prod templates

### DIFF
--- a/qmtl/examples/templates/backend_stack.example.yml
+++ b/qmtl/examples/templates/backend_stack.example.yml
@@ -12,6 +12,8 @@ metadata:
     Template for running the core QMTL backend services with durable storage,
     messaging, and observability backends.
 
+profile: prod
+
 backends:
   redis:
     # Dedicated logical databases per service prevent key collisions.
@@ -63,19 +65,6 @@ worldservice:
     tokens: []
   compat_rebalance_v2: false
   alpha_metrics_required: false
-  controlbus:
-    brokers: *kafka_brokers
-    topic: ${backends.kafka.controlbus_topics.policy}
-    consumer_group: worldservice
-  notes:
-    - >-
-      Place this YAML on disk (e.g. /etc/qmtl/backend.yml) and run WorldService
-      from that directory so uvicorn discovers it automatically.
-    - >-
-      Start the service with:
-      uv run uvicorn qmtl.services.worldservice.api:create_app --factory \
-        --host ${worldservice.bind.host} --port ${worldservice.bind.port}
-    - "Ensure aiokafka is installed if ControlBus publishing is required."
 
 # Gateway section matches qmtl.services.gateway.config.GatewayConfig.
 gateway:
@@ -122,11 +111,6 @@ dagmanager:
   controlbus_dsn: redpanda-0:9092
   controlbus_queue_topic: ${backends.kafka.controlbus_topics.queue}
   enable_topic_namespace: true
-  notes:
-    - >-
-      After provisioning Neo4j, initialise schema with:
-      qmtl service dagmanager neo4j-init --uri ${backends.neo4j.dsn} \
-        --user ${backends.neo4j.user} --password <secret>
 
 # Additional operational hints for the full stack.
 notes:

--- a/qmtl/examples/templates/config/qmtl.maximal.yml
+++ b/qmtl/examples/templates/config/qmtl.maximal.yml
@@ -1,7 +1,7 @@
 # Example configuration for production-style deployments.
 # Replace placeholder endpoints and credentials with your infrastructure values.
 
-profile: dev
+profile: prod
 
 worldservice:
   url: https://worldservice.example.com
@@ -20,10 +20,6 @@ worldservice:
     header: Authorization
     tokens:
       - ${WORLDSERVICE_TOKEN}
-  tls:
-    enabled: true
-    certfile: /etc/qmtl/tls/worldservice.crt
-    keyfile: /etc/qmtl/tls/worldservice.key
 
 backends:
   redis:
@@ -36,6 +32,7 @@ backends:
     bootstrap_servers:
       - kafka-1.example.com:9092
       - kafka-2.example.com:9092
+    bootstrap: kafka-1.example.com:9092,kafka-2.example.com:9092
     sasl:
       mechanism: SCRAM-SHA-512
       username: ${KAFKA_USERNAME}
@@ -63,21 +60,13 @@ gateway:
   commitlog_topic: gateway.prod.ingest
   commitlog_group: gateway-prod-commit
   commitlog_transactional_id: gateway-prod-writer
-  commitlog_bootstrap_servers: ${backends.kafka.bootstrap_servers}
+  commitlog_bootstrap: ${backends.kafka.bootstrap}
   events:
     secret: ${secrets.gateway_event_secret}
     ttl: 600
-    jwt_issuer: https://auth.example.com/issuer
-    jwt_audience: qmtl-gateway
   websocket:
     rate_limit_per_sec: 50
-    allowed_origins:
-      - https://app.example.com
-      - https://admin.example.com
   worldservice_url: ${worldservice.url}
-  telemetry:
-    otel_endpoint: https://otel-collector.example.com:4318/v1/traces
-    prometheus_pushgateway: https://prometheus-pushgateway.example.com
 
 dagmanager:
   memory_repo_path: null
@@ -85,11 +74,6 @@ dagmanager:
   neo4j_user: dagmanager
   neo4j_password: ${NEO4J_PASSWORD}
   kafka_dsn: kafka-broker.example.com:9092
-  kafka_security:
-    sasl_mechanism: SCRAM-SHA-512
-    sasl_username: ${KAFKA_USERNAME}
-    sasl_password: ${KAFKA_PASSWORD}
-    security_protocol: SASL_SSL
   grpc_host: 0.0.0.0
   grpc_port: 5443
   http_host: 0.0.0.0
@@ -97,13 +81,6 @@ dagmanager:
   controlbus_dsn: kafka-control.example.com:9093
   controlbus_queue_topic: queue
   enable_topic_namespace: true
-  repositories:
-    neo4j:
-      tls_enabled: true
-      ca_file: /etc/qmtl/tls/neo4j-ca.pem
-  telemetry:
-    otel_endpoint: https://otel-collector.example.com:4318/v1/traces
-    prometheus_pushgateway: https://prometheus-pushgateway.example.com
 
 seamless:
   coordinator_url: https://seamless.example.com/api
@@ -115,10 +92,6 @@ seamless:
   early_fingerprint: true
   sla_preset: enterprise
   conformance_preset: strict-blocking
-  auth:
-    client_id: ${SEAMLESS_CLIENT_ID}
-    client_secret: ${SEAMLESS_CLIENT_SECRET}
-    token_url: https://idp.example.com/oauth/token
 
 connectors:
   ccxt_rate_limiter_redis: ${backends.redis.gateway_state}
@@ -131,15 +104,11 @@ connectors:
   trade_max_retries: 10
   trade_backoff: 0.5
   ws_url: wss://gateway.example.com/ws
-  credentials:
-    api_key: ${BROKER_API_KEY}
-    api_secret: ${BROKER_API_SECRET}
 
 telemetry:
   otel_exporter_endpoint: https://otel-collector.example.com:4318/v1/traces
   enable_fastapi_otel: true
   prometheus_url: https://prometheus.example.com
-  grafana_url: https://grafana.example.com
 
 cache:
   arrow_cache_enabled: true
@@ -155,9 +124,6 @@ cache:
   snapshot_url: s3://qmtl-snapshots/prod
   snapshot_strict_runtime: true
   snapshot_format: parquet
-  snapshot_auth:
-    access_key: ${SNAPSHOT_ACCESS_KEY}
-    secret_key: ${SNAPSHOT_SECRET_KEY}
 
 runtime:
   http_timeout_seconds: 5.0
@@ -168,8 +134,6 @@ runtime:
   ws_max_total_time_seconds_test: 30.0
   poll_interval_seconds: 5.0
   poll_interval_seconds_test: 1.0
-  retry_backoff_seconds: 2.0
-  retry_backoff_seconds_test: 0.5
 
 test:
   test_mode: false
@@ -177,6 +141,3 @@ test:
   fixed_now: null
   history_start: 2020-01-01T00:00:00Z
   history_end: null
-  fixtures:
-    orders_path: /etc/qmtl/test/orders.json
-    quotes_path: /etc/qmtl/test/quotes.json

--- a/qmtl/services/gateway/cli.py
+++ b/qmtl/services/gateway/cli.py
@@ -111,6 +111,8 @@ async def _main(argv: list[str] | None = None) -> None:
         enable_otel=telemetry_enabled,
         shared_account_policy_config=config.shared_account_policy,
         health_capabilities=config.build_health_capabilities(),
+        ownership_config=config.ownership,
+        profile=profile,
     )
 
     db = app.state.database

--- a/tests/qmtl/services/gateway/test_ownership_wiring.py
+++ b/tests/qmtl/services/gateway/test_ownership_wiring.py
@@ -1,0 +1,56 @@
+import pytest
+
+from qmtl.foundation.config import DeploymentProfile
+from qmtl.services.gateway.api import create_app
+from qmtl.services.gateway.config import GatewayOwnershipConfig
+from qmtl.services.gateway.database import PostgresDatabase
+from qmtl.services.gateway.ownership import OwnershipManager
+
+
+@pytest.mark.asyncio
+async def test_create_app_wires_kafka_ownership(monkeypatch, fake_redis):
+    ownership_cfg = GatewayOwnershipConfig(
+        mode="kafka",
+        bootstrap="kafka:9092",
+        topic="gateway.ownership",
+        group_id="locks",
+        start_timeout=1.5,
+        rebalance_backoff=0.2,
+        rebalance_attempts=4,
+    )
+    captured: dict[str, object] = {}
+
+    fake_owner = object()
+
+    def fake_create_kafka_ownership(bootstrap_servers, topic, group_id, **kwargs):
+        captured["args"] = (bootstrap_servers, topic, group_id)
+        captured["kwargs"] = kwargs
+        return fake_owner
+
+    from qmtl.services.gateway import ownership as ownership_module
+
+    monkeypatch.setattr(
+        ownership_module, "create_kafka_ownership", fake_create_kafka_ownership
+    )
+
+    db = PostgresDatabase("postgresql://localhost/test")
+
+    app = create_app(
+        redis_client=fake_redis,
+        database=db,
+        ownership_config=ownership_cfg,
+        profile=DeploymentProfile.PROD,
+    )
+
+    assert app.state.kafka_owner is fake_owner
+    assert isinstance(app.state.ownership_manager, OwnershipManager)
+    assert captured["args"] == (
+        "kafka:9092",
+        "gateway.ownership",
+        "locks",
+    )
+    assert captured["kwargs"] == {
+        "start_timeout": 1.5,
+        "rebalance_backoff": 0.2,
+        "rebalance_attempts": 4,
+    }


### PR DESCRIPTION
## Summary
- align the maximal and backend stack templates with the prod config schema and commitlog requirements
- wire Kafka ownership resolution through the gateway app/CLI and ensure DB unlocks when Kafka ownership is absent
- extend config validation and ownership wiring tests to cover prod profiles and Kafka ownership settings

Fixes #1850

## Testing
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934842fb8c083299edeb0cc781cf8c4)