### PR TITLE
Enforce prod backend requirements and remove drift docs

### DIFF
--- a/qmtl/services/dagmanager/server.py
+++ b/qmtl/services/dagmanager/server.py
@@ -184,6 +184,34 @@ class TopicConfigLoader:
         return config
 
 
+def _enforce_persistent_backends(
+    cfg: DagManagerConfig, *, profile: DeploymentProfile
+) -> None:
+    if profile is not DeploymentProfile.PROD:
+        return
+
+    if not cfg.neo4j_dsn:
+        message = _(
+            "Prod profile requires dagmanager.neo4j_dsn; in-memory repository is disabled"
+        )
+        logging.error(message)
+        raise SystemExit(message)
+
+    if not cfg.kafka_dsn:
+        message = _(
+            "Prod profile requires dagmanager.kafka_dsn; in-memory queue manager is disabled"
+        )
+        logging.error(message)
+        raise SystemExit(message)
+
+    if not cfg.controlbus_dsn or not cfg.controlbus_queue_topic:
+        message = _(
+            "Prod profile requires ControlBus broker/topic for DAG Manager"
+        )
+        logging.error(message)
+        raise SystemExit(message)
+
+
 @dataclass
 class _KafkaAdminClient:
     """Thin wrapper around :mod:`confluent_kafka` for metadata access."""
@@ -327,6 +355,7 @@ async def _run(
     profile: DeploymentProfile = DeploymentProfile.DEV,
 ) -> None:
     set_topic_namespace_enabled(cfg.enable_topic_namespace)
+    _enforce_persistent_backends(cfg, profile=profile)
     driver = None
     repo = None
     admin_client = None

--- a/qmtl/services/gateway/tests/test_cli_profile_guards.py
+++ b/qmtl/services/gateway/tests/test_cli_profile_guards.py
@@ -42,3 +42,24 @@ def test_enforce_database_profile_requires_dsn(caplog: pytest.LogCaptureFixture)
 
     assert "gateway.database_dsn" in caplog.text
 
+
+def test_controlbus_required_in_prod(caplog: pytest.LogCaptureFixture) -> None:
+    config = GatewayConfig()
+
+    with pytest.raises(SystemExit):
+        cli._build_controlbus_consumer(config, profile=DeploymentProfile.PROD)
+
+    assert "controlbus_brokers/controlbus_topics" in caplog.text
+
+
+def test_controlbus_optional_in_dev(caplog: pytest.LogCaptureFixture) -> None:
+    config = GatewayConfig()
+
+    with caplog.at_level("INFO"):
+        consumer = cli._build_controlbus_consumer(
+            config, profile=DeploymentProfile.DEV
+        )
+
+    assert consumer is None
+    assert any("ControlBus consumer disabled" in msg for msg in caplog.messages)
+


### PR DESCRIPTION
## Summary
- enforce production-only backend requirements for Gateway, WorldService, and DAG Manager to prevent in-memory fallbacks
- add prod-mode guard rails and tests for ControlBus and storage selection while cleaning up stale inconsistency docs
- remove obsolete backend inconsistency audit pages from the documentation navigation

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693487c5a1948329954ceb87b2ca403e)