### PR TITLE
Speed up demo warmup and tighten submit pipeline

### DIFF
--- a/qmtl/interfaces/cli/v2.py
+++ b/qmtl/interfaces/cli/v2.py
@@ -169,8 +169,16 @@ COMMANDS: dict[str, CommandHandler] = {
     "init": cmd_init,
     "version": cmd_version,
 }
+LEGACY_COMMANDS = {
+    **LEGACY_COMMANDS,
+    "config": "Use 'qmtl config validate|generate' for configuration utilities",
+}
 _ADMIN_COMMANDS_FULL, _ = _command_tables(admin=True)
-ADMIN_COMMANDS = {k: v for k, v in _ADMIN_COMMANDS_FULL.items() if k not in COMMANDS}
+ADMIN_COMMANDS = {
+    k: v
+    for k, v in _ADMIN_COMMANDS_FULL.items()
+    if k not in COMMANDS and k != "config"
+}
 
 
 def _extract_lang(argv: List[str]) -> tuple[List[str], str | None]:

--- a/qmtl/runtime/sdk/world_data.py
+++ b/qmtl/runtime/sdk/world_data.py
@@ -408,12 +408,14 @@ def _generate_demo_ohlcv_frame(
     symbols: Sequence[Any] | None,
 ) -> pd.DataFrame:
     rng = np.random.default_rng(seed)
-    start_ts = int(time.time()) - bars * max(1, int(interval_ms / 1000))
+    interval_sec = max(1, int(interval_ms / 1000))
+    now_bucket = int(time.time()) // interval_sec * interval_sec
+    start_ts = now_bucket - (max(bars, 1) - 1) * interval_sec
     rows = []
     price = 100.0
     symbol = str(symbols[0]) if symbols else "demo"
     for i in range(max(bars, 1)):
-        ts = start_ts + i * max(1, int(interval_ms / 1000))
+        ts = start_ts + i * interval_sec
         drift = rng.normal(loc=0.0, scale=0.002)
         open_px = price
         close_px = max(0.1, price * (1 + drift))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,14 @@ from qmtl.runtime.sdk import runtime
 from qmtl.runtime.sdk.arrow_cache import reload_arrow_cache
 
 
+@pytest.fixture(autouse=True)
+def _reset_event_loop_policy():
+    """Ensure a fresh default event loop policy each test to avoid stale state."""
+
+    asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
+    yield
+
+
 def _close_loops(loops: List[asyncio.AbstractEventLoop]) -> None:
     for loop in loops:
         if loop.is_closed():


### PR DESCRIPTION
## Summary
- align demo Seamless preset seeding with the current bucket to satisfy warmup coverage quickly and register conformance schemas with the registry
- adjust Runner.submit gateway probing/allocation fetch to behave in tests and service mode while keeping offline paths working
- tidy CLI v2 admin/legacy command sets and add asyncio loop policy reset fixture for tests

## Testing
- uv run --with mypy -m mypy
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'