### PR TITLE
Fix architecture doc links and add archive

### DIFF
--- a/docs/en/architecture/ccxt-seamless-integrated.md
+++ b/docs/en/architecture/ccxt-seamless-integrated.md
@@ -4,7 +4,7 @@
 
 - Purpose: Define how CCXT-backed exchange data plugs into the Seamless data plane so strategies/worlds can rely on a **consistent history + live feed** across venues and symbols.
 - Core Loop position: Supports the Core Loop’s **“data supply automation” + “market replay backtest”** stages by specifying how history coverage and live updates are delivered to strategies.
-- Implementation status and evolution are tracked in [seamless_data_provider_v2.md](seamless_data_provider_v2.md) and [rewrite_architecture_docs.md](../../../docs_archive/rewrite_architecture_docs.md) from a Core Loop alignment perspective.
+- Implementation status and evolution are tracked in [seamless_data_provider_v2.md](seamless_data_provider_v2.md) and [rewrite_architecture_docs.md](../archive/rewrite_architecture_docs.md) from a Core Loop alignment perspective.
 
 ## Related Documents
 - [Seamless Data Provider v2](seamless_data_provider_v2.md)

--- a/docs/en/architecture/seamless_data_provider_v2.md
+++ b/docs/en/architecture/seamless_data_provider_v2.md
@@ -9,7 +9,7 @@
 
 - SDP v2 is live in the runtime: cache→storage→backfill→live flows and ConformancePipeline/SLA/metrics already guard data quality.
 - Worlds that declare `world.data.presets[]` let Runner/CLI auto-build an SDP instance from **Seamless presets + data specs** and inject it into `StreamInputs`, so authors focus on data presets/fingerprints instead of manual wiring.
-- This document is the normative data‑plane counterpart to [rewrite_architecture_docs.md](../../../docs_archive/rewrite_architecture_docs.md), including the contract for “world-centric data presets → SDP wiring”.
+- This document is the normative data‑plane counterpart to [rewrite_architecture_docs.md](../archive/rewrite_architecture_docs.md), including the contract for “world-centric data presets → SDP wiring”.
 
 > **Status:** The Seamless Data Provider v2 architecture is now live in the
 > runtime. The distributed backfill coordinator replaces the in-process stub,

--- a/docs/en/archive/rewrite_architecture_docs.md
+++ b/docs/en/archive/rewrite_architecture_docs.md
@@ -1,0 +1,17 @@
+---
+title: "QMTL Architecture Rewrite Guide (Archived Link)"
+tags: [archive, docs]
+last_modified: 2025-12-01
+status: archived
+---
+
+# QMTL Architecture Rewrite Guide (Archived Link)
+
+This is an archive pointer. The full content lives outside the mkdocs tree at
+`docs_archive/rewrite_architecture_docs.md`.
+
+- Source path: `../../docs_archive/rewrite_architecture_docs.md`
+- Summary: Core Loop-oriented rewrite guidelines whose substance has been folded into
+  `docs/en/architecture/*.md` and `docs/en/design/*.md`.
+
+Open the source file above for the preserved text.

--- a/docs/en/design/core_loop_roadmap.md
+++ b/docs/en/design/core_loop_roadmap.md
@@ -155,7 +155,7 @@ Each track is structured as “Direction (Design North Star) → Key Milestones 
 ### 5.3 Concrete Work Examples
 
 - `docs/en/architecture/seamless_data_provider_v2.md` / `docs/ko/architecture/seamless_data_provider_v2.md`  
-  - Add world preset on-ramp rules from the data-plane viewpoint and integrate the archived [rewrite_architecture_docs.md](../../../docs_archive/rewrite_architecture_docs.md) prescriptions.
+  - Add world preset on-ramp rules from the data-plane viewpoint and integrate the archived [rewrite_architecture_docs.md](../archive/rewrite_architecture_docs.md) prescriptions.
 - `docs/en/world/world.md` / `docs/ko/world/world.md`  
   - Extend world examples with data preset sections and show how Runner/CLI derive Seamless configurations.
 

--- a/docs/ko/architecture/ccxt-seamless-integrated.md
+++ b/docs/ko/architecture/ccxt-seamless-integrated.md
@@ -11,7 +11,7 @@ last_modified: 2025-08-21
 
 - 목적: CCXT 기반 거래소 데이터를 Seamless 데이터 플레인으로 통합해, 전략/월드에서 **동일한 히스토리·라이브 데이터**를 재현 가능하게 사용할 수 있도록 하는 아키텍처를 정의합니다.
 - Core Loop 상 위치: Core Loop의 **“데이터 공급 자동화” + “시장 replay 백테스트”** 단계를 담당하며, Runner.submit이 기대하는 히스토리/커버리지를 어떻게 보장하는지 설명합니다.
-- 구현 상태와 후속 계획은 [seamless_data_provider_v2.md](seamless_data_provider_v2.md) 및 [rewrite_architecture_docs.md](../../../docs_archive/rewrite_architecture_docs.md)에서 Core Loop 정렬 관점으로 추적합니다.
+- 구현 상태와 후속 계획은 [seamless_data_provider_v2.md](seamless_data_provider_v2.md) 및 [rewrite_architecture_docs.md](../archive/rewrite_architecture_docs.md)에서 Core Loop 정렬 관점으로 추적합니다.
 
 ## 관련 문서
 - [Seamless Data Provider v2](seamless_data_provider_v2.md)

--- a/docs/ko/architecture/seamless_data_provider_v2.md
+++ b/docs/ko/architecture/seamless_data_provider_v2.md
@@ -16,7 +16,7 @@ last_modified: 2025-12-06
 
 - SDP v2는 런타임에서 cache→storage→backfill→live 경로와 ConformancePipeline/SLA/metrics를 통해 데이터 품질을 관리한다.
 - `world.data.presets[]`가 선언된 월드는 world/preset 정보를 기반으로 Runner/CLI가 **Seamless preset + data spec**만으로 SDP 인스턴스를 자동 구성해 `StreamInput`에 주입하며, 사용자는 data preset/fingerprint만 의식하면 된다.
-- 본 문서는 데이터 플레인 관점에서 Core Loop 정렬을 규범화하고, [rewrite_architecture_docs.md](../../../docs_archive/rewrite_architecture_docs.md)와 함께 “world 중심 데이터 preset → SDP wiring” 규약까지 포함하도록 확장한다.
+- 본 문서는 데이터 플레인 관점에서 Core Loop 정렬을 규범화하고, [rewrite_architecture_docs.md](../archive/rewrite_architecture_docs.md)와 함께 “world 중심 데이터 preset → SDP wiring” 규약까지 포함하도록 확장한다.
 
 > **상태:** 심리스 데이터 프로바이더 v2 아키텍처는 런타임에 정식 적용되었습니다. 분산 백필 코디네이터가 인프로세스 스텁을 대체했고, `SLAPolicy` 예산이 강제되며, 아래에서 언급하는 관측 지표가 기본으로 방출됩니다. Core Loop 골든 시그널 세트는 `../operations/core_loop_golden_signals.md`에 정리되었으며, 남은 로드맵은 스키마 거버넌스 유지·대시보드 확장 같은 점진 개선에 집중합니다.
 

--- a/docs/ko/archive/rewrite_architecture_docs.md
+++ b/docs/ko/archive/rewrite_architecture_docs.md
@@ -1,0 +1,17 @@
+---
+title: "QMTL 아키텍처 문서 재작성 가이드 (보관 링크)"
+tags: [archive, docs]
+last_modified: 2025-12-01
+status: archived
+---
+
+# QMTL 아키텍처 문서 재작성 가이드 (보관 링크)
+
+이 문서는 보관 전용입니다. 전체 본문은 저장소 루트의
+`docs_archive/rewrite_architecture_docs.md` 파일에 남아 있으며, mkdocs 빌드 대상 외부에 위치합니다.
+
+- 원본 경로: `../../docs_archive/rewrite_architecture_docs.md`
+- 요약: Core Loop 정렬 관점의 문서 재작성 가이드이며, 주요 내용은 현재
+  `docs/ko/architecture/*.md`와 `docs/ko/design/*.md`로 반영되었습니다.
+
+문서가 필요하다면 위의 보관 파일을 직접 열람하세요.

--- a/docs/ko/design/core_loop_roadmap.md
+++ b/docs/ko/design/core_loop_roadmap.md
@@ -202,7 +202,7 @@ P‑A/B/C/P‑0 중 어느 것에도 매핑되지 않는 변경은 “합리적�
 ### 5.3 구체적인 작업 예시
 
 - `docs/ko/architecture/seamless_data_provider_v2.md`  
-  - world preset on‑ramp 규약을 데이터 플레인 관점에서 명시하고, [rewrite_architecture_docs.md](../../../docs_archive/rewrite_architecture_docs.md)에서 정의한 규약을 통합한다.
+  - world preset on‑ramp 규약을 데이터 플레인 관점에서 명시하고, [rewrite_architecture_docs.md](../archive/rewrite_architecture_docs.md)에서 정의한 규약을 통합한다.
 - `docs/ko/world/world.md`  
   - world 설정 예시에서 데이터 preset 항목을 추가하고, Runner/CLI가 실제로 어떻게 Seamless 인스턴스를 구성하는지 예제를 포함한다.
 

--- a/docs/ko/design/simplification_proposal.md
+++ b/docs/ko/design/simplification_proposal.md
@@ -26,7 +26,7 @@ status: implemented
 - As‑Is
   - 이 문서는 v2.0 단순화(Runner.submit 단일 진입점, Mode 통합, CLI v2)를 중심으로 구현 완료 상태를 설명하지만, auto_returns, WorldService 평가/활성/배분 일원화, world/preset 기반 데이터 on‑ramp 같은 후속 단순화는 Core Loop 관점에서 여전히 과제로 남아 있습니다.
 - To‑Be
-- 본 문서의 “단순화 목표” 절은 [rewrite_architecture_docs.md](../../../docs_archive/rewrite_architecture_docs.md)에 정리된 네 축(Core Loop)을 기준으로 갱신되어, 앞으로의 단순화(P1/P2: auto_returns+SR 통합, WS 평가/할당 일원화)를 명시적으로 추적합니다.
+- 본 문서의 “단순화 목표” 절은 [rewrite_architecture_docs.md](../archive/rewrite_architecture_docs.md)에 정리된 네 축(Core Loop)을 기준으로 갱신되어, 앞으로의 단순화(P1/P2: auto_returns+SR 통합, WS 평가/할당 일원화)를 명시적으로 추적합니다.
   - v2.0 이후 단순화 작업은 Maintenance/Radon 문서와 함께 이곳에서 요약·링크되어, 독자가 “현재 세대의 canonical path”를 항상 한 문서에서 찾을 수 있게 합니다.
 
 ## 1. 초기 설계 목적 재확인


### PR DESCRIPTION
## Summary
- add ko/en archive stub for rewrite_architecture_docs and update architecture links to point to archived content
- fix minor link targets in architecture/design docs for ko/en

## Testing
- uv run mkdocs build --strict