### PR TITLE
Add EvaluationRun persistence

### DIFF
--- a/qmtl/runtime/sdk/materialize_job.py
+++ b/qmtl/runtime/sdk/materialize_job.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+"""Compute-only materialization/verification jobs built on SeamlessDataProvider."""
+
+from dataclasses import dataclass, replace, asdict
+from typing import Any, Callable, Mapping, MutableMapping
+import time
+import json
+import hashlib
+from pathlib import Path
+import asyncio
+
+import pandas as pd
+
+from qmtl.foundation.config import SeamlessConfig
+from qmtl.runtime.sdk.configuration import get_seamless_config
+from qmtl.runtime.sdk.seamless import SeamlessBuilder, build_assembly, hydrate_builder
+from qmtl.runtime.sdk.seamless_data_provider import (
+    BackfillConfig,
+    SeamlessDataProvider,
+    SeamlessFetchMetadata,
+)
+from qmtl.runtime.sdk.conformance import ConformanceReport
+
+
+@dataclass(slots=True)
+class MaterializeReport:
+    """Summary of a materialization run."""
+
+    dataset_fingerprint: str | None
+    as_of: int | str | None
+    coverage_bounds: tuple[int, int] | None
+    conformance_flags: dict[str, int]
+    conformance_warnings: tuple[str, ...]
+    sla_violation: dict[str, Any] | None
+    retention_class: str
+    retention_ttl_seconds: int | None
+    rows: int
+    requested_range: tuple[int, int]
+    contract_version: str | None
+    priority: str | None
+    checkpoint_key: str
+    resumed: bool
+    attempts: int
+
+
+class MaterializeSeamlessJob:
+    """Compute-only materialization helper that reuses the Seamless backfill path."""
+
+    def __init__(
+        self,
+        *,
+        provider: SeamlessDataProvider | None = None,
+        preset: str | None = None,
+        preset_options: Mapping[str, object] | None = None,
+        builder_config: Mapping[str, object] | None = None,
+        builder: SeamlessBuilder | None = None,
+        start: int | None = None,
+        end: int | None = None,
+        interval: int = 60,
+        node_id: str = "materialize",
+        artifact_dir: str | None = None,
+        retention_class: str = "research-short",
+        retention_ttl_seconds: int | None = None,
+        priority: str | None = None,
+        contract_version: str | None = None,
+        require_live: bool | None = None,
+        backfill_config: BackfillConfig | None = None,
+        seamless_config: SeamlessConfig | None = None,
+        now: Callable[[], float] | None = None,
+        checkpoint_dir: str | Path | None = None,
+        resume: bool = True,
+        max_attempts: int = 1,
+        retry_backoff_seconds: float = 0.5,
+    ) -> None:
+        if provider is None and preset is None and builder_config is None and builder is None:
+            raise ValueError("provider or preset/builder_config is required")
+        if interval <= 0:
+            raise ValueError("interval must be positive")
+        if max_attempts <= 0:
+            raise ValueError("max_attempts must be positive")
+
+        self._provider = provider
+        self._preset = preset
+        self._preset_options: Mapping[str, object] = preset_options or {}
+        self._builder_config: Mapping[str, object] = builder_config or {}
+        self._builder = builder
+        self._start = start
+        self._end = end
+        self._interval = int(interval)
+        self._node_id = node_id
+        self._artifact_dir = artifact_dir
+        self._retention_class = retention_class
+        self._retention_ttl_seconds = retention_ttl_seconds
+        self._priority = priority
+        self._contract_version = contract_version
+        self._require_live = require_live
+        self._backfill_config = backfill_config or BackfillConfig()
+        self._seamless_config = seamless_config
+        self._now = now or time.time
+        self._checkpoint_dir = Path(checkpoint_dir) if checkpoint_dir else None
+        self._resume = resume
+        self._max_attempts = max_attempts
+        self._retry_backoff_seconds = retry_backoff_seconds
+
+    async def run(self) -> MaterializeReport:
+        """Execute materialization and return a summary report."""
+
+        provider = self._provider or self._build_provider()
+        start, end = self._resolve_range(self._start, self._end)
+        checkpoint_key = self._compute_checkpoint_key(start, end)
+
+        if self._resume:
+            cached = self._maybe_load_checkpoint(checkpoint_key)
+            if cached:
+                return cached
+
+        self._enforce_live_requirement(provider)
+        attempts = 0
+        last_exc: Exception | None = None
+        while attempts < self._max_attempts:
+            attempts += 1
+            try:
+                result = await provider.fetch(
+                    start,
+                    end,
+                    node_id=self._node_id,
+                    interval=self._interval,
+                )
+                break
+            except Exception as exc:  # pragma: no cover - defensive loop guard
+                last_exc = exc
+                if attempts >= self._max_attempts:
+                    raise
+                await asyncio.sleep(self._retry_backoff_seconds * attempts)
+        else:  # pragma: no cover - defensive, loop always breaks or raises
+            if last_exc:
+                raise last_exc
+            raise RuntimeError("materialize: exhausted attempts without exception")
+
+        metadata = result.metadata
+        self._validate_contract(metadata)
+        report = provider.last_conformance_report or ConformanceReport()
+        materialize_report = MaterializeReport(
+            dataset_fingerprint=metadata.dataset_fingerprint,
+            as_of=metadata.as_of,
+            coverage_bounds=metadata.coverage_bounds,
+            conformance_flags=metadata.conformance_flags,
+            conformance_warnings=metadata.conformance_warnings,
+            sla_violation=metadata.sla_violation,
+            retention_class=self._retention_class,
+            retention_ttl_seconds=self._retention_ttl_seconds,
+            rows=metadata.rows,
+            requested_range=metadata.requested_range,
+            contract_version=self._contract_version,
+            priority=self._priority,
+            checkpoint_key=checkpoint_key,
+            resumed=False,
+            attempts=attempts,
+        )
+        self._persist_checkpoint(checkpoint_key, materialize_report)
+        return materialize_report
+
+    def _build_provider(self) -> SeamlessDataProvider:
+        """Hydrate a Seamless provider from presets/builder config."""
+
+        config = self._build_seamless_config()
+        assembly = self._build_assembly()
+        provider = SeamlessDataProvider(
+            cache_source=assembly.cache_source,
+            storage_source=assembly.storage_source,
+            backfiller=assembly.backfiller,
+            live_feed=assembly.live_feed,
+            registrar=assembly.registrar,
+            backfill_config=self._backfill_config,
+            seamless_config=config,
+        )
+        return provider
+
+    def _build_seamless_config(self) -> SeamlessConfig:
+        base = self._seamless_config or get_seamless_config()
+        if self._artifact_dir:
+            return replace(base, artifact_dir=self._artifact_dir, artifacts_enabled=True)
+        return base
+
+    def _build_assembly(self):
+        builder = self._builder or SeamlessBuilder()
+        config: MutableMapping[str, object] = {}
+        config.update(self._builder_config)
+        if self._preset:
+            config.setdefault("preset", self._preset)
+            if self._preset_options:
+                config.setdefault("options", self._preset_options)
+        assembly = build_assembly(config, builder=builder)
+        return assembly
+
+    def _enforce_live_requirement(self, provider: SeamlessDataProvider) -> None:
+        requires_live = self._require_live
+        if requires_live is None:
+            requires_live = bool(self._builder_config.get("live") or self._preset_options.get("live"))
+        if requires_live and getattr(provider, "live_feed", None) is None:
+            raise ValueError("live feed is required by preset/config but missing")
+
+    def _validate_contract(self, metadata: SeamlessFetchMetadata) -> None:
+        if not self._contract_version:
+            return
+        fingerprint = metadata.dataset_fingerprint
+        if fingerprint is None:
+            raise ValueError("contract_version provided but dataset_fingerprint is missing")
+        tokens = [token for token in str(fingerprint).split(":") if token]
+        if self._contract_version not in tokens and fingerprint != self._contract_version:
+            raise ValueError(
+                f"contract_version '{self._contract_version}' does not match dataset_fingerprint '{fingerprint}'"
+            )
+
+    def _resolve_range(self, start: int | None, end: int | None) -> tuple[int, int]:
+        resolved_start = int(start if start is not None else self._now())
+        resolved_end = int(end if end is not None else self._now())
+        if resolved_start > resolved_end:
+            raise ValueError("start must be <= end")
+        return resolved_start, resolved_end
+
+    def _compute_checkpoint_key(self, start: int, end: int) -> str:
+        parts = [
+            self._preset or "",
+            str(self._builder_config) if self._builder_config else "",
+            str(start),
+            str(end),
+            str(self._interval),
+            self._contract_version or "",
+            self._retention_class,
+            self._priority or "",
+        ]
+        digest = hashlib.blake2s("|".join(parts).encode("utf-8"), digest_size=12).hexdigest()
+        return f"materialize:{digest}"
+
+    def _checkpoint_path(self, key: str) -> Path | None:
+        if not self._checkpoint_dir and not self._artifact_dir:
+            return None
+        base = Path(self._checkpoint_dir or self._artifact_dir or ".").expanduser()
+        return base / f"{key}.json"
+
+    def _maybe_load_checkpoint(self, key: str) -> MaterializeReport | None:
+        path = self._checkpoint_path(key)
+        if not path or not path.exists():
+            return None
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            raw["checkpoint_key"] = key
+            raw["resumed"] = True
+            return MaterializeReport(**raw)
+        except Exception:
+            return None
+
+    def _persist_checkpoint(self, key: str, report: MaterializeReport) -> None:
+        path = self._checkpoint_path(key)
+        if not path:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            data = asdict(report)
+            data["resumed"] = report.resumed
+            data["checkpoint_key"] = key
+            path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        except Exception:
+            return
+
+
+__all__ = ["MaterializeReport", "MaterializeSeamlessJob"]

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -350,6 +350,91 @@ class AllocationSnapshotResponse(BaseModel):
     allocations: Dict[str, WorldAllocationSnapshot] = Field(default_factory=dict)
 
 
+class ReturnsMetrics(BaseModel):
+    sharpe: float | None = None
+    max_drawdown: float | None = None
+    gain_to_pain_ratio: float | None = None
+    time_under_water_ratio: float | None = None
+
+
+class SampleMetrics(BaseModel):
+    effective_history_years: float | None = None
+    n_trades_total: int | None = None
+    n_trades_per_year: float | None = None
+
+
+class RiskMetrics(BaseModel):
+    adv_utilization_p95: float | None = None
+    participation_rate_p95: float | None = None
+
+
+class RobustnessMetrics(BaseModel):
+    deflated_sharpe_ratio: float | None = None
+    sharpe_first_half: float | None = None
+    sharpe_second_half: float | None = None
+
+
+class ValidationHealth(BaseModel):
+    metric_coverage_ratio: float | None = None
+    rules_executed_ratio: float | None = None
+
+
+class DiagnosticsMetrics(BaseModel):
+    strategy_complexity: float | None = None
+    search_intensity: int | None = None
+    returns_source: str | None = None
+    validation_health: ValidationHealth | None = None
+
+
+class EvaluationMetrics(BaseModel):
+    returns: ReturnsMetrics | None = None
+    sample: SampleMetrics | None = None
+    risk: RiskMetrics | None = None
+    robustness: RobustnessMetrics | None = None
+    diagnostics: DiagnosticsMetrics | None = None
+
+
+class RuleResultModel(BaseModel):
+    status: Literal["pass", "fail", "warn"]
+    severity: Literal["blocking", "soft", "info"] | None = None
+    owner: Literal["quant", "risk", "ops"] | None = None
+    reason_code: str | None = None
+    reason: str | None = None
+    tags: List[str] | None = None
+    details: Dict[str, Any] | None = None
+
+
+class EvaluationValidation(BaseModel):
+    policy_version: str | None = None
+    ruleset_hash: str | None = None
+    profile: str | None = None
+    results: Dict[str, RuleResultModel] | None = None
+
+
+class EvaluationSummary(BaseModel):
+    status: Literal["pass", "warn", "fail"] | None = None
+    recommended_stage: Literal[
+        "backtest_only", "paper_only", "paper_ok_live_candidate"
+    ] | None = None
+    override_status: Literal["none", "approved", "rejected"] | None = None
+    override_reason: str | None = None
+    override_actor: str | None = None
+    override_timestamp: str | None = None
+
+
+class EvaluationRunModel(BaseModel):
+    world_id: str
+    strategy_id: str
+    run_id: str
+    stage: Literal["backtest", "paper", "live"] | str
+    risk_tier: Literal["high", "medium", "low"] | str
+    metrics: EvaluationMetrics | None = None
+    validation: EvaluationValidation | None = None
+    summary: EvaluationSummary | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
 __all__ = [
     'AlphaMetricsEnvelope',
     'ActivationEnvelope',
@@ -387,4 +472,15 @@ __all__ = [
     'SymbolDeltaModel',
     'WorldAllocationSnapshot',
     'AllocationSnapshotResponse',
+    'ReturnsMetrics',
+    'SampleMetrics',
+    'RiskMetrics',
+    'RobustnessMetrics',
+    'DiagnosticsMetrics',
+    'ValidationHealth',
+    'EvaluationMetrics',
+    'RuleResultModel',
+    'EvaluationValidation',
+    'EvaluationSummary',
+    'EvaluationRunModel',
 ]

--- a/qmtl/services/worldservice/storage/__init__.py
+++ b/qmtl/services/worldservice/storage/__init__.py
@@ -11,7 +11,13 @@ from .constants import (
 )
 from .facade import Storage
 from .persistent import PersistentStorage
-from .models import ValidationCacheEntry, WorldActivation, WorldAuditLog, WorldPolicies
+from .models import (
+    EvaluationRunRecord,
+    ValidationCacheEntry,
+    WorldActivation,
+    WorldAuditLog,
+    WorldPolicies,
+)
 
 __all__ = [
     "DEFAULT_EDGE_OVERRIDES",
@@ -21,6 +27,7 @@ __all__ = [
     "WORLD_NODE_STATUSES",
     "Storage",
     "PersistentStorage",
+    "EvaluationRunRecord",
     "ValidationCacheEntry",
     "WorldActivation",
     "WorldAuditLog",

--- a/qmtl/services/worldservice/storage/models.py
+++ b/qmtl/services/worldservice/storage/models.py
@@ -374,6 +374,61 @@ class AllocationRun:
 
 
 @dataclass
+class EvaluationRunRecord:
+    """Evaluation run metadata with metrics/validation snapshots."""
+
+    run_id: str
+    world_id: str
+    strategy_id: str
+    stage: str
+    risk_tier: str
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    validation: Dict[str, Any] = field(default_factory=dict)
+    summary: Dict[str, Any] = field(default_factory=dict)
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "run_id": self.run_id,
+            "world_id": self.world_id,
+            "strategy_id": self.strategy_id,
+            "stage": self.stage,
+            "risk_tier": self.risk_tier,
+            "metrics": deepcopy(self.metrics),
+            "validation": deepcopy(self.validation),
+            "summary": deepcopy(self.summary),
+        }
+        if self.created_at is not None:
+            payload["created_at"] = self.created_at
+        if self.updated_at is not None:
+            payload["updated_at"] = self.updated_at
+        return payload
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "EvaluationRunRecord":
+        metrics = payload.get("metrics")
+        metrics_dict = dict(metrics) if isinstance(metrics, Mapping) else {}
+        validation = payload.get("validation")
+        validation_dict = dict(validation) if isinstance(validation, Mapping) else {}
+        summary = payload.get("summary")
+        summary_dict = dict(summary) if isinstance(summary, Mapping) else {}
+
+        return cls(
+            run_id=str(payload["run_id"]),
+            world_id=str(payload["world_id"]),
+            strategy_id=str(payload["strategy_id"]),
+            stage=str(payload.get("stage", "")),
+            risk_tier=str(payload.get("risk_tier", "")),
+            metrics=metrics_dict,
+            validation=validation_dict,
+            summary=summary_dict,
+            created_at=payload.get("created_at"),
+            updated_at=payload.get("updated_at"),
+        )
+
+
+@dataclass
 class ValidationCacheEntry:
     """Cached validation result scoped by ExecutionDomain."""
 
@@ -464,6 +519,7 @@ __all__ = [
     "ActivationEntry",
     "ActivationState",
     "EdgeOverrideRecord",
+    "EvaluationRunRecord",
     "PolicyVersion",
     "ValidationCacheEntry",
     "WorldActivation",

--- a/qmtl/services/worldservice/storage/repositories/evaluation_runs.py
+++ b/qmtl/services/worldservice/storage/repositories/evaluation_runs.py
@@ -1,0 +1,93 @@
+"""Persistent repository for evaluation runs."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from ..models import EvaluationRunRecord
+from .base import AuditLogger, DatabaseDriver
+
+
+class PersistentEvaluationRunRepository:
+    """SQL-backed store for evaluation runs."""
+
+    def __init__(self, driver: DatabaseDriver, audit: AuditLogger) -> None:
+        self._driver = driver
+        self._audit = audit
+
+    async def upsert(self, record: EvaluationRunRecord) -> None:
+        payload = record.to_dict()
+        await self._driver.execute(
+            """
+            INSERT INTO evaluation_runs(
+                world_id,
+                strategy_id,
+                run_id,
+                stage,
+                risk_tier,
+                payload,
+                created_at,
+                updated_at
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(world_id, strategy_id, run_id) DO UPDATE SET
+                stage=excluded.stage,
+                risk_tier=excluded.risk_tier,
+                payload=excluded.payload,
+                updated_at=excluded.updated_at
+            """,
+            record.world_id,
+            record.strategy_id,
+            record.run_id,
+            record.stage,
+            record.risk_tier,
+            json.dumps(payload),
+            record.created_at,
+            record.updated_at,
+        )
+        await self._audit(
+            record.world_id,
+            {
+                "event": "evaluation_run_recorded",
+                "strategy_id": record.strategy_id,
+                "run_id": record.run_id,
+                "stage": record.stage,
+                "risk_tier": record.risk_tier,
+            },
+        )
+
+    async def get(
+        self, world_id: str, strategy_id: str, run_id: str
+    ) -> Optional[EvaluationRunRecord]:
+        row = await self._driver.fetchone(
+            "SELECT payload FROM evaluation_runs WHERE world_id = ? AND strategy_id = ? AND run_id = ?",
+            world_id,
+            strategy_id,
+            run_id,
+        )
+        if not row:
+            return None
+        payload = json.loads(row[0])
+        return EvaluationRunRecord.from_payload(payload)
+
+    async def list(
+        self, *, world_id: str | None = None, strategy_id: str | None = None
+    ) -> List[EvaluationRunRecord]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if world_id is not None:
+            clauses.append("world_id = ?")
+            params.append(world_id)
+        if strategy_id is not None:
+            clauses.append("strategy_id = ?")
+            params.append(strategy_id)
+        where_clause = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = await self._driver.fetchall(
+            f"SELECT payload FROM evaluation_runs {where_clause} ORDER BY created_at",
+            *params,
+        )
+        return [
+            EvaluationRunRecord.from_payload(json.loads(row[0]))
+            for row in rows
+        ]


### PR DESCRIPTION
## Summary
- add EvaluationRun/EvaluationMetrics schema models plus a persistent repository/table to record evaluation runs per world/strategy
- update the in-memory facade/persistent storage implementation and tests so evaluation run data can be recorded and listed by `(world_id, strategy_id, run_id)`
- record a regression test that writes a core v1 metrics/validation snapshot and remove the stale type-ignore in `MaterializeJob` so static checks pass

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q

Fixes #1864
