### PR TITLE
Connect Runner submissions to WS evaluation runs

### DIFF
--- a/qmtl/interfaces/cli/submit.py
+++ b/qmtl/interfaces/cli/submit.py
@@ -205,6 +205,11 @@ def _print_submission_result_json(result) -> None:
 def _print_ws_section(result) -> None:
     print(_t("\n🌐 WorldService decision (SSOT)"))
     print(f"Status: {result.status}")
+    eval_run_id = getattr(result, "evaluation_run_id", None)
+    if eval_run_id:
+        eval_url = getattr(result, "evaluation_run_url", None)
+        suffix = f" ({eval_url})" if eval_url else ""
+        print(_t("Evaluation run: {}").format(f"{eval_run_id}{suffix}"))
     if result.status == "rejected" and result.rejection_reason:
         print(f"Reason: {result.rejection_reason}")
     if result.threshold_violations:

--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -385,6 +385,18 @@ WORLD_ROUTES: tuple[WorldRoute, ...] = (
         include_payload=True,
     ),
     WorldRoute(
+        "get",
+        "/worlds/{world_id}/strategies/{strategy_id}/runs",
+        "get_evaluation_runs",
+        path_params=("world_id", "strategy_id"),
+    ),
+    WorldRoute(
+        "get",
+        "/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}",
+        "get_evaluation_run",
+        path_params=("world_id", "strategy_id", "run_id"),
+    ),
+    WorldRoute(
         "post",
         "/worlds/{world_id}/apply",
         "post_apply",

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -407,6 +407,31 @@ class WorldServiceClient:
             params=params,
         )
 
+    async def get_evaluation_runs(
+        self,
+        world_id: str,
+        strategy_id: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "GET",
+            f"/worlds/{world_id}/strategies/{strategy_id}/runs",
+            headers=headers,
+        )
+
+    async def get_evaluation_run(
+        self,
+        world_id: str,
+        strategy_id: str,
+        run_id: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "GET",
+            f"/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}",
+            headers=headers,
+        )
+
     async def post_evaluate(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
         return await self._request_json(
             "POST",

--- a/qmtl/services/worldservice/api.py
+++ b/qmtl/services/worldservice/api.py
@@ -18,6 +18,7 @@ from .routers import (
     create_activation_router,
     create_allocations_router,
     create_bindings_router,
+    create_evaluation_runs_router,
     create_policies_router,
     create_rebalancing_router,
     create_validations_router,
@@ -319,6 +320,7 @@ def create_app(
     app.include_router(create_bindings_router(service))
     app.include_router(create_activation_router(service))
     app.include_router(create_allocations_router(service))
+    app.include_router(create_evaluation_runs_router(service))
     app.include_router(
         create_rebalancing_router(
             service,

--- a/qmtl/services/worldservice/decision.py
+++ b/qmtl/services/worldservice/decision.py
@@ -150,7 +150,7 @@ class DecisionEvaluator:
     async def _resolve_policy(
         self, world_id: str, payload: ApplyRequest | EvaluateRequest
     ) -> Policy:
-        policy_payload = payload.policy or await self.store.get_default_policy(world_id)
+        policy_payload = payload.policy if payload.policy is not None else await self.store.get_default_policy(world_id)
         policy = policy_payload
         if isinstance(policy, Policy):
             return policy

--- a/qmtl/services/worldservice/routers/__init__.py
+++ b/qmtl/services/worldservice/routers/__init__.py
@@ -1,6 +1,7 @@
 from .activation import create_activation_router
 from .allocations import create_allocations_router
 from .bindings import create_bindings_router
+from .evaluation_runs import create_evaluation_runs_router
 from .policies import create_policies_router
 from .rebalancing import create_rebalancing_router
 from .validations import create_validations_router
@@ -10,6 +11,7 @@ __all__ = [
     'create_activation_router',
     'create_allocations_router',
     'create_bindings_router',
+    'create_evaluation_runs_router',
     'create_policies_router',
     'create_rebalancing_router',
     'create_validations_router',

--- a/qmtl/services/worldservice/routers/evaluation_runs.py
+++ b/qmtl/services/worldservice/routers/evaluation_runs.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from ..schemas import EvaluationRunModel
+from ..services import WorldService
+
+
+def create_evaluation_runs_router(service: WorldService) -> APIRouter:
+    router = APIRouter()
+
+    @router.get(
+        "/worlds/{world_id}/strategies/{strategy_id}/runs",
+        response_model=list[EvaluationRunModel],
+    )
+    async def list_evaluation_runs(world_id: str, strategy_id: str) -> list[EvaluationRunModel]:
+        runs = await service.store.list_evaluation_runs(world_id=world_id, strategy_id=strategy_id)
+        return [EvaluationRunModel(**run) for run in runs]
+
+    @router.get(
+        "/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}",
+        response_model=EvaluationRunModel,
+    )
+    async def get_evaluation_run(world_id: str, strategy_id: str, run_id: str) -> EvaluationRunModel:
+        record = await service.store.get_evaluation_run(world_id, strategy_id, run_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="evaluation run not found")
+        return EvaluationRunModel(**record)
+
+    return router

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -120,6 +120,8 @@ class ApplyRequest(EvaluateRequest):
 
 class ApplyResponse(BaseModel):
     active: List[str]
+    evaluation_run_id: str | None = None
+    evaluation_run_url: str | None = None
 
 
 class ApplyAck(BaseModel):

--- a/qmtl/services/worldservice/shared_schemas.py
+++ b/qmtl/services/worldservice/shared_schemas.py
@@ -43,6 +43,10 @@ class EvaluateRequest(BaseModel):
     correlations: Dict[tuple[str, str], float] | None = None
     policy: Policy | Dict[str, Any] | None = None
     series: Dict[str, StrategySeries] | None = None
+    run_id: str | None = None
+    stage: str | None = None
+    risk_tier: str | None = None
+    strategy_id: str | None = None
 
 
 class ActivationEnvelope(BaseModel):

--- a/qmtl/services/worldservice/storage/repositories/__init__.py
+++ b/qmtl/services/worldservice/storage/repositories/__init__.py
@@ -16,6 +16,7 @@ from ..worlds import WorldRepository
 
 from .activation_repo import PersistentActivationRepository
 from .binding_repo import PersistentBindingRepository
+from .evaluation_runs import PersistentEvaluationRunRepository
 from .policy_repo import PersistentPolicyRepository
 from .world_repo import PersistentWorldRepository
 
@@ -38,4 +39,5 @@ __all__ = [
     "PersistentPolicyRepository",
     "PersistentBindingRepository",
     "PersistentActivationRepository",
+    "PersistentEvaluationRunRepository",
 ]


### PR DESCRIPTION
## Summary
- attach evaluation_run_id/url through Runner.submit results and CLI
- record evaluation runs in WorldService and expose endpoints via Gateway
- add tests covering SDK metadata and WS run retrieval

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q

Fixes #1865