### PR TITLE
Add validation rule results to policy engine

### DIFF
--- a/qmtl/services/worldservice/__init__.py
+++ b/qmtl/services/worldservice/__init__.py
@@ -4,6 +4,26 @@ Avoid importing the ASGI application at import time to prevent cycles.
 Import ``create_app`` from ``qmtl.services.worldservice.api`` where needed.
 """
 
-from .policy_engine import Policy, evaluate_policy, parse_policy
+from .policy_engine import (
+    Policy,
+    PolicyEvaluationResult,
+    DataCurrencyRule,
+    SampleRule,
+    PerformanceRule,
+    RiskConstraintRule,
+    RuleResult,
+    evaluate_policy,
+    parse_policy,
+)
 
-__all__ = ["Policy", "evaluate_policy", "parse_policy"]
+__all__ = [
+    "Policy",
+    "PolicyEvaluationResult",
+    "DataCurrencyRule",
+    "SampleRule",
+    "PerformanceRule",
+    "RiskConstraintRule",
+    "RuleResult",
+    "evaluate_policy",
+    "parse_policy",
+]

--- a/tests/qmtl/services/worldservice/test_policy_engine.py
+++ b/tests/qmtl/services/worldservice/test_policy_engine.py
@@ -4,6 +4,7 @@ from qmtl.services.worldservice.policy_engine import (
     CorrelationRule,
     HysteresisRule,
     Policy,
+    PolicyEvaluationResult,
     ThresholdRule,
     TopKRule,
     evaluate_policy,
@@ -14,7 +15,11 @@ from qmtl.services.worldservice.policy_engine import (
 def test_threshold_filtering():
     policy = Policy(thresholds={"sharpe": ThresholdRule(metric="sharpe", min=0.5)})
     metrics = {"s1": {"sharpe": 0.6}, "s2": {"sharpe": 0.4}}
-    assert evaluate_policy(metrics, policy) == ["s1"]
+    result = evaluate_policy(metrics, policy)
+    assert result.selected == ["s1"]
+    perf = result.rule_results["s2"]["performance"]
+    assert perf.status == "fail"
+    assert perf.reason_code == "performance_thresholds_failed"
 
 
 def test_topk_selection():
@@ -24,7 +29,9 @@ def test_topk_selection():
         "s2": {"sharpe": 0.8},
         "s3": {"sharpe": 1.5},
     }
-    assert evaluate_policy(metrics, policy) == ["s3", "s1"]
+    result = evaluate_policy(metrics, policy)
+    assert result.selected == ["s3", "s1"]
+    assert result.rule_results["s2"]["performance"].reason_code == "performance_rank_outside_top_k"
 
 
 def test_topk_missing_metrics_sorted_last():
@@ -35,7 +42,9 @@ def test_topk_missing_metrics_sorted_last():
         "s3": {"sharpe": 0.4},
     }
 
-    assert evaluate_policy(metrics, policy) == ["s1", "s3"]
+    result = evaluate_policy(metrics, policy)
+    assert result.selected == ["s1", "s3"]
+    assert result.rule_results["s2"]["data_currency"].reason_code == "metrics_missing"
 
 
 def test_threshold_missing_metric_excludes_strategy():
@@ -50,7 +59,9 @@ def test_threshold_missing_metric_excludes_strategy():
         "s2": {"sharpe": 0.7},
     }
 
-    assert evaluate_policy(metrics, policy) == ["s1"]
+    result = evaluate_policy(metrics, policy)
+    assert result.selected == ["s1"]
+    assert result.rule_results["s2"]["performance"].status == "fail"
 
 
 def test_correlation_rule_filters_highly_correlated_candidates():
@@ -65,7 +76,9 @@ def test_correlation_rule_filters_highly_correlated_candidates():
         ("s2", "s3"): 0.4,
     }
 
-    assert evaluate_policy(metrics, policy, correlations=correlations) == ["s1", "s3"]
+    result = evaluate_policy(metrics, policy, correlations=correlations)
+    assert result.selected == ["s1", "s3"]
+    assert result.rule_results["s2"]["risk_constraint"].reason_code == "correlation_constraint_failed"
 
 
 def test_hysteresis_preserves_active_entries_on_exit_threshold():
@@ -75,7 +88,9 @@ def test_hysteresis_preserves_active_entries_on_exit_threshold():
         "s2": {"score": 0.55},
     }
 
-    assert evaluate_policy(metrics, policy, prev_active=["s1"]) == ["s1"]
+    result = evaluate_policy(metrics, policy, prev_active=["s1"])
+    assert result.selected == ["s1"]
+    assert result.rule_results["s1"]["risk_constraint"].reason_code == "risk_constraints_ok"
 
 
 def test_parse_policy_from_yaml_payload():
@@ -125,5 +140,32 @@ def test_parse_policy_from_bytes_with_combined_rules():
         correlations=correlations,
     )
 
+    assert isinstance(selected, PolicyEvaluationResult)
     assert policy.thresholds["score"].min == 0.3
-    assert set(selected) == {"s1", "s2", "s3"}
+    assert set(selected.selected) == {"s1", "s2", "s3"}
+
+
+def test_rule_results_include_expected_metadata():
+    policy = Policy(
+        thresholds={
+            "sharpe": ThresholdRule(metric="sharpe", min=1.0),
+            "max_drawdown": ThresholdRule(metric="max_drawdown", max=0.2),
+        },
+        correlation=CorrelationRule(max=0.5),
+    )
+    metrics = {
+        "s1": {"sharpe": 1.2, "max_drawdown": 0.1, "num_trades": 25},
+        "s2": {"sharpe": 1.1, "max_drawdown": 0.1},
+    }
+    correlations = {("s1", "s2"): 0.9}
+
+    result = evaluate_policy(metrics, policy, correlations=correlations)
+
+    assert result.rule_results["s1"]["data_currency"].status == "pass"
+    assert result.rule_results["s1"]["sample"].severity == "soft"
+    assert result.rule_results["s1"]["performance"].status == "pass"
+    assert result.rule_results["s2"]["performance"].status == "pass"
+    risk = result.rule_results["s2"]["risk_constraint"]
+    assert risk.status == "fail"
+    assert risk.reason_code == "correlation_constraint_failed"
+    assert set(result.rule_results["s1"].keys()) >= {"data_currency", "sample", "performance", "risk_constraint"}

--- a/tests/qmtl/services/worldservice/test_worldservice_api.py
+++ b/tests/qmtl/services/worldservice/test_worldservice_api.py
@@ -228,6 +228,13 @@ async def test_evaluation_run_creation_and_fetch():
             assert record["stage"] == "backtest"
             assert record["metrics"]["returns"]["sharpe"] == 1.5
             assert record["summary"]["status"] == "pass"
+            assert record["validation"]["results"]
+            assert set(record["validation"]["results"].keys()) >= {
+                "data_currency",
+                "sample",
+                "performance",
+                "risk_constraint",
+            }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary:
- add ValidationRule abstraction with RuleResult metadata and PolicyEvaluationResult
- wrap threshold/top-k/correlation/hysteresis into rules and propagate results into evaluation runs
- extend tests for rule metadata and evaluation run storage

Fixes #1866

Tests:
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow' -n auto
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q -n auto tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q