### PR TITLE
Add validation profile DSL v1

### DIFF
--- a/docs/en/world/policy_engine.md
+++ b/docs/en/world/policy_engine.md
@@ -4,25 +4,47 @@ This guide describes how to define and apply world policies.
 
 ## Sample Policy
 
-A sample policy is provided in [`sample_policy.yml`](./sample_policy.yml):
+A sample policy using validation profiles is provided in [`sample_policy.yml`](./sample_policy.yml):
 
 ```yaml
-thresholds:
-  sharpe:
+validation_profiles:
+  backtest:
+    sample:
+      min_effective_years: 2.0
+      min_trades_total: 50
+    performance:
+      sharpe_min: 0.5
+      max_dd_max: 0.25
+      gain_to_pain_min: 1.0
+    robustness:
+      dsr_min: 0.15
+    risk:
+      adv_utilization_p95_max: 0.5
+      participation_rate_p95_max: 0.4
+  paper:
+    sample:
+      min_effective_years: 3.0
+    performance:
+      sharpe_min: 0.8
+      max_dd_max: 0.2
+      gain_to_pain_min: 1.2
+    robustness:
+      dsr_min: 0.25
+
+default_profile_by_stage:
+  backtest_only: backtest
+  paper_only: paper
+
+selection:
+  top_k:
     metric: sharpe
-    min: 0.5
-  drawdown:
-    metric: drawdown
-    max: 0.2
-top_k:
-  metric: sharpe
-  k: 3
-correlation:
-  max: 0.8
-hysteresis:
-  metric: sharpe
-  enter: 0.6
-  exit: 0.4
+    k: 3
+  correlation:
+    max: 0.8
+  hysteresis:
+    metric: sharpe
+    enter: 0.6
+    exit: 0.4
 ```
 
 ## Applying a Policy

--- a/docs/en/world/sample_policy.yml
+++ b/docs/en/world/sample_policy.yml
@@ -1,16 +1,38 @@
-thresholds:
-  sharpe:
+validation_profiles:
+  backtest:
+    sample:
+      min_effective_years: 2.0
+      min_trades_total: 50
+    performance:
+      sharpe_min: 0.5
+      max_dd_max: 0.25
+      gain_to_pain_min: 1.0
+    robustness:
+      dsr_min: 0.15
+    risk:
+      adv_utilization_p95_max: 0.5
+      participation_rate_p95_max: 0.4
+  paper:
+    sample:
+      min_effective_years: 3.0
+    performance:
+      sharpe_min: 0.8
+      max_dd_max: 0.2
+      gain_to_pain_min: 1.2
+    robustness:
+      dsr_min: 0.25
+
+default_profile_by_stage:
+  backtest_only: backtest
+  paper_only: paper
+
+selection:
+  top_k:
     metric: sharpe
-    min: 0.5
-  drawdown:
-    metric: drawdown
-    max: 0.2
-top_k:
-  metric: sharpe
-  k: 3
-correlation:
-  max: 0.8
-hysteresis:
-  metric: sharpe
-  enter: 0.6
-  exit: 0.4
+    k: 3
+  correlation:
+    max: 0.8
+  hysteresis:
+    metric: sharpe
+    enter: 0.6
+    exit: 0.4

--- a/docs/ko/world/policy_engine.md
+++ b/docs/ko/world/policy_engine.md
@@ -14,22 +14,44 @@ last_modified: 2025-08-21
 샘플 정책은 [`sample_policy.yml`](./sample_policy.yml)에 포함되어 있습니다:
 
 ```yaml
-thresholds:
-  sharpe:
+validation_profiles:
+  backtest:
+    sample:
+      min_effective_years: 2.0
+      min_trades_total: 50
+    performance:
+      sharpe_min: 0.5
+      max_dd_max: 0.25
+      gain_to_pain_min: 1.0
+    robustness:
+      dsr_min: 0.15
+    risk:
+      adv_utilization_p95_max: 0.5
+      participation_rate_p95_max: 0.4
+  paper:
+    sample:
+      min_effective_years: 3.0
+    performance:
+      sharpe_min: 0.8
+      max_dd_max: 0.2
+      gain_to_pain_min: 1.2
+    robustness:
+      dsr_min: 0.25
+
+default_profile_by_stage:
+  backtest_only: backtest
+  paper_only: paper
+
+selection:
+  top_k:
     metric: sharpe
-    min: 0.5
-  drawdown:
-    metric: drawdown
-    max: 0.2
-top_k:
-  metric: sharpe
-  k: 3
-correlation:
-  max: 0.8
-hysteresis:
-  metric: sharpe
-  enter: 0.6
-  exit: 0.4
+    k: 3
+  correlation:
+    max: 0.8
+  hysteresis:
+    metric: sharpe
+    enter: 0.6
+    exit: 0.4
 ```
 
 ## 정책 적용

--- a/docs/ko/world/sample_policy.yml
+++ b/docs/ko/world/sample_policy.yml
@@ -1,16 +1,38 @@
-thresholds:
-  sharpe:
+validation_profiles:
+  backtest:
+    sample:
+      min_effective_years: 2.0
+      min_trades_total: 50
+    performance:
+      sharpe_min: 0.5
+      max_dd_max: 0.25
+      gain_to_pain_min: 1.0
+    robustness:
+      dsr_min: 0.15
+    risk:
+      adv_utilization_p95_max: 0.5
+      participation_rate_p95_max: 0.4
+  paper:
+    sample:
+      min_effective_years: 3.0
+    performance:
+      sharpe_min: 0.8
+      max_dd_max: 0.2
+      gain_to_pain_min: 1.2
+    robustness:
+      dsr_min: 0.25
+
+default_profile_by_stage:
+  backtest_only: backtest
+  paper_only: paper
+
+selection:
+  top_k:
     metric: sharpe
-    min: 0.5
-  drawdown:
-    metric: drawdown
-    max: 0.2
-top_k:
-  metric: sharpe
-  k: 3
-correlation:
-  max: 0.8
-hysteresis:
-  metric: sharpe
-  enter: 0.6
-  exit: 0.4
+    k: 3
+  correlation:
+    max: 0.8
+  hysteresis:
+    metric: sharpe
+    enter: 0.6
+    exit: 0.4

--- a/qmtl/runtime/sdk/validation_pipeline.py
+++ b/qmtl/runtime/sdk/validation_pipeline.py
@@ -719,7 +719,7 @@ class ValidationPipeline:
         policy: Policy,
     ) -> bool:
         metrics_dict = {strategy_id: metrics.to_policy_metrics()}
-        active = evaluate_policy(metrics_dict, policy)
+        active = evaluate_policy(metrics_dict, policy, stage="backtest")
         return strategy_id in active
 
     def _build_failure_result(

--- a/qmtl/services/worldservice/__init__.py
+++ b/qmtl/services/worldservice/__init__.py
@@ -7,6 +7,8 @@ Import ``create_app`` from ``qmtl.services.worldservice.api`` where needed.
 from .policy_engine import (
     Policy,
     PolicyEvaluationResult,
+    SelectionConfig,
+    ValidationProfile,
     DataCurrencyRule,
     SampleRule,
     PerformanceRule,
@@ -19,6 +21,8 @@ from .policy_engine import (
 __all__ = [
     "Policy",
     "PolicyEvaluationResult",
+    "SelectionConfig",
+    "ValidationProfile",
     "DataCurrencyRule",
     "SampleRule",
     "PerformanceRule",

--- a/qmtl/services/worldservice/decision.py
+++ b/qmtl/services/worldservice/decision.py
@@ -139,7 +139,13 @@ class DecisionEvaluator:
         policy = await self._resolve_policy(world_id, payload)
         prev = await self._resolve_previous(world_id, payload)
         metrics = self._augment_metrics(payload)
-        return evaluate_policy(metrics, policy, prev, payload.correlations)
+        return evaluate_policy(
+            metrics,
+            policy,
+            prev,
+            payload.correlations,
+            stage=getattr(payload, "stage", None),
+        )
 
     async def _apply_plan(self, world_id: str, payload: ApplyRequest) -> PolicyEvaluationResult:
         prev = payload.previous or await self.store.get_decisions(world_id)

--- a/qmtl/services/worldservice/services.py
+++ b/qmtl/services/worldservice/services.py
@@ -346,6 +346,9 @@ class WorldService:
             validation_payload["results"] = {
                 name: result.model_dump() for name, result in rule_results.items()
             }
+        if evaluation and evaluation.profile:
+            validation_payload = validation_payload or {}
+            validation_payload.setdefault("profile", evaluation.profile)
         active_flag = strategy_id in (evaluation.selected if evaluation else [])
         summary = {
             "status": "pass" if active_flag else "fail",

--- a/tests/qmtl/services/worldservice/test_policies.py
+++ b/tests/qmtl/services/worldservice/test_policies.py
@@ -18,13 +18,14 @@ async def test_get_policy_and_missing_version():
 
             r = await client.get("/worlds/w1/policies/1")
             assert r.status_code == 200
-            assert r.json() == {
-                "thresholds": {},
-                "top_k": {"metric": "m", "k": 1},
-                "correlation": None,
-                "hysteresis": None,
-            }
+            payload = r.json()
+            assert payload["thresholds"] == {}
+            assert payload["top_k"] == {"metric": "m", "k": 1}
+            assert payload.get("correlation") is None
+            assert payload.get("hysteresis") is None
+            assert payload.get("validation_profiles", {}) == {}
+            assert payload.get("default_profile_by_stage", {}) == {}
+            assert payload.get("selection", {}).get("top_k") == {"metric": "m", "k": 1}
 
             r = await client.get("/worlds/w1/policies/2")
             assert r.status_code == 404
-


### PR DESCRIPTION
## Summary
- add validation_profiles DSL with stage/profile selection and legacy selection.thresholds alias
- emit applied profile metadata in evaluation results/evaluation runs
- refresh docs/sample policy and add coverage tests

Fixes #1867

## Testing
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k "not slow"
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q
- uv run -m pytest -W error -n auto