### PR TITLE
Add validation invariant checks

### DIFF
--- a/docs/en/design/worldservice_evaluation_runs_and_metrics_api.md
+++ b/docs/en/design/worldservice_evaluation_runs_and_metrics_api.md
@@ -22,7 +22,7 @@ from the perspective of the Core Loop and the external feedback in [hyophyop/qmt
 Related docs:
 
 - [Architecture](../architecture/architecture.md), [WorldService](../architecture/worldservice.md)
-- [auto_returns unified design (Korean source)](../../ko/design/auto_returns_unified_design.md)
+- [auto_returns unified design (Korean source)](../../ko/archive/auto_returns_unified_design.md)
 - Core Loop decisions: [architecture.md](../architecture/architecture.md#core-loop-summary)
 
 All API shapes and schemas here are **draft-level**. They are meant to drive discussion; any implementation must be reconciled with existing worldservice/gateway/SDK contracts.

--- a/docs/ko/archive/auto_returns_unified_design.md
+++ b/docs/ko/archive/auto_returns_unified_design.md
@@ -1,13 +1,47 @@
 ---
-title: "SDK 자동 returns 파생 통합 설계안"
+title: "SDK 자동 returns 파생 통합 설계안 (Archived)"
 tags: [design, returns, validation, sr, sdk]
 author: "QMTL Team"
-last_modified: 2025-11-30
-status: draft
+last_modified: 2025-12-09
+status: archived
 related_issue: "hyophyop/qmtl#1723"
 ---
 
-# SDK 자동 returns 파생 통합 설계안
+# SDK 자동 returns 파생 통합 설계안 (Archived)
+
+!!! danger "Archived 설계 — World 기반 평가로 대체됨"
+    이 문서는 SDK 레벨에서 price/equity 시계열로부터 returns를 자동 파생(auto_returns)하는 **기존 설계**를 담고 있습니다.  
+    QMTL v2 이후 방향은:
+    
+    - returns/지표/검증은 **항상 World/WorldService 평가 파이프라인**에서 계산하고,
+    - SDK/Runner는 전략 제출 + EvaluationRun/지표 조회만 담당하며,
+    - 로컬 DX는 dev/prod 두 가지 World 스택(dev=로컬, prod=운영)을 통해 **prod와 동일한 플로우를 그대로 dev에서 실행**하는 방식으로 지원합니다.
+    
+    따라서 본 문서의 auto_returns 설계는 **새 구현에서 사용하지 않으며**, 역사적 참고용으로만 유지됩니다.  
+    최신 설계는 다음 문서를 참조하세요:
+    
+    - World 검증 계층 설계: `docs/ko/design/world_validation_architecture.md`
+    - 모델 리스크 관리 프레임워크: `docs/ko/design/model_risk_management_framework.md`
+
+## 0.1 v2 방향 전환: World 기반 평가 & dev/prod 스택
+
+QMTL v2 이후의 returns/지표/검증 플로우는 다음 원칙을 따른다.
+
+- **auto_returns 제거**
+  - SDK/Runner는 price/equity 시계열에서 returns를 자동 파생하지 않는다.
+  - 검증/World 평가에서 사용하는 returns는 전략이 내보낸 equity/pnl/position 시계열과 WorldService 평가 파이프라인에서 파생된 값만 사용한다.
+
+- **World/WS 기반 평가**
+  - `Runner.submit(..., world="...")`는 dev/prod 모두 World/WS 경로를 통해 EvaluationRun과 지표를 생성한다.
+  - SDK는 `SubmitResult`에서 `evaluation_run_id` 또는 WS 링크를 받아,  
+    필요 시 별도 헬퍼(예: `Runner.poll_evaluation(world, run_id, ...)`)로 지표가 준비되었는지 확인하고 EvaluationRun/metrics를 조회한다.
+
+- **dev/prod 두 가지 구성**
+  - dev 스택: 로컬/테스트용 WorldService/Gateway/Seamless 구성 (인메모리 또는 경량 백엔드)로, prod와 동일한 평가/검증 플로우를 사용한다.
+  - prod 스택: 운영용 World/WS 구성을 사용하며, 동일한 Runner/CLI 인터페이스로 연결된다.
+  - 로컬 DX는 “dev World에서 prod와 동일한 제출→EvaluationRun→지표 조회” 플로우를 그대로 실행할 수 있게 하는 방식으로만 지원한다.
+
+이후 섹션들은 SDK auto_returns 설계의 역사적 스냅샷으로 남겨 두며, 새로운 개발에서는 사용하지 않는다.
 
 ## 0. As‑Is / To‑Be 요약
 
@@ -671,4 +705,4 @@ worlds:
 
 - [hyophyop/qmtl#1723](https://github.com/hyophyop/qmtl/issues/1723) — 원본 이슈
 - [hyophyop/hft-factory-strategies#9](https://github.com/hyophyop/hft-factory-strategies/issues/9) — 실제 PnL 검증 에픽
-- [`sr_integration_proposal.md`](./sr_integration_proposal.md) — SR 통합 설계
+- [`sr_integration_proposal.md`](../design/sr_integration_proposal.md) — SR 통합 설계

--- a/docs/ko/design/core_loop_world_roadmap.md
+++ b/docs/ko/design/core_loop_world_roadmap.md
@@ -1,0 +1,289 @@
+---
+title: "Core Loop × WorldService 단계별 고도화 로드맵"
+tags: [design, roadmap, core-loop, worldservice]
+author: "QMTL Team"
+last_modified: 2025-12-08
+status: draft
+---
+
+# Core Loop × WorldService 단계별 고도화 로드맵
+
+이 문서는 Core Loop를 **“전략+월드만 제출하면, 월드가 모드·단계·캠페인을 관리하는 구조”**로 수렴시키기 위한 **실행 로드맵**이다.  
+아키텍처 문서(`architecture/architecture.md`)가 전체 그림을 잡는다면, 이 문서는 **구현 작업자가 “지금 무엇을, 어떤 순서로 바꾸는지”를 잃지 않게 해 주는 북극성 가이드** 역할을 한다.
+
+핵심 목표는 다음 한 줄로 요약된다.
+
+> **사용자는 전략 로직과 월드만 지정하고, “backtest → 검증 → paper → (선택적) live” 단계는 월드 정책과 WorldService가 관리한다.**
+
+여기서 제안하는 단계들은 **강한 순서 제약**이 있다. 가능한 한 아래 순서대로 적용해야 한다.
+
+- Phase 0–1: **계약 정리·WS‑우선 모드 결정** (기존 기능 강화, 행동 변화 최소)
+- Phase 2–3: **Evaluation Run 1급 개념화, world‑first 제출 UX** (API/모델 변화)
+- Phase 4–5: **캠페인 오케스트레이션, 검증 단계 고도화** (전략 생애주기 자동화 수준 확대)
+
+## 0. 사전 합의: 지향점과 비범위
+
+### 0.1 지향점
+
+- 모드는 **사용자가 직접 선택하는 플래그**가 아니라,  
+  **월드 정책과 WorldService가 결정하는 상태**에 가깝게 재정의한다.
+- Core Loop의 표면은 다음 흐름을 기준으로 설계한다.
+
+```text
+전략 작성 → Runner.submit(strategy, world)
+          → (월드 안에서 backtest/검증/승격 후보 선정)
+          → paper/live 후보군 관리
+          → 운영자가 live 적용 여부를 결정
+```
+
+- 소규모 조직에서도 **기술로 리스크를 통제**할 수 있도록,  
+  **월드의 “검증” 단계를 고도화**하고, live 승격은 기본적으로 **명시적인 apply/운영자 승인**을 요구하는 방향을 기본값으로 한다.
+
+### 0.2 비범위
+
+- WorldService 안에 **대규모 백테스트 엔진을 새로 만들지 않는다.**
+  - 히스토리 replay, returns/지표 계산은 기존대로 Runner/SDK/`ValidationPipeline`이 담당한다.
+  - WS는 **이미 계산된 metrics/PnL·지표를 받아 정책을 적용하고, 결과/스냅샷/상태를 관리**하는 역할에 집중한다.
+- Core Loop 변경과 무관한 인프라 리팩터링(브로커 교체, DAG 모델 재설계 등)은 이 로드맵 범위에서 다루지 않는다.
+
+---
+
+## Phase 0 — 목표 형상·계약 정리 (문서 중심)
+
+**목표:** 구현에 앞서 “어디로 가는지”에 대한 서술을 명확히 하고, 기존 문서와 충돌이 없도록 한다.
+
+### 해야 할 일
+
+- `architecture/architecture.md`·`world/world.md`·`design/worldservice_evaluation_runs_and_metrics_api.md`를 기준으로 다음을 문장으로 고정한다.
+  - **WS SSOT 원칙:** 실행 모드/단계의 단일 진실 소스는 항상 WorldService의 `effective_mode`/정책 결과다.
+  - Runner/SDK는 `mode`를 선택하더라도, **WS 결정이 존재하는 한 항상 이를 우선한다.**
+  - “모드는 선택값, WS `effective_mode` + world 정책은 계약”이라는 관점을 문서에서 일관되게 강조한다.
+- World 정책 DSL에서 이미 존재하는 필드들(`data_currency`, `selection.gates`, `hysteresis` 등)을  
+  “Core Loop 단계별 결정에 사용되는 1급 개념”으로 명시한다.
+
+### 산출물
+
+- 업데이트된 설계 문서:
+  - WS SSOT·safe_mode·강등 규칙이 명확히 서술된 `architecture/architecture.md`/`world/world.md`
+  - Evaluation Run 개념이 설명된 `design/worldservice_evaluation_runs_and_metrics_api.md`
+- 이 로드맵 문서(`design/core_loop_world_roadmap.md`)를 **작업자용 참조**로 링크.
+
+---
+
+## Phase 1 — WS‑우선 모드 결정 계약 강화
+
+**목표:** 현재 v2 구현이 이미 가진 “WS 결정 우선, 기본은 compute‑only(backtest)” 행동을 **계약 수준으로 못 박고, 코드·테스트에 반영**한다.
+
+### 해야 할 일
+
+1. **모드 결정 흐름 정리**
+   - `qmtl.runtime.sdk.mode.Mode` / `mode_to_execution_domain` / `execution_domain_to_mode` / `effective_mode_to_mode` 사용처를 점검한다.
+   - `qmtl.runtime.sdk.execution_context.resolve_execution_context`와  
+     `qmtl.runtime.helpers.runtime.determine_execution_mode`가  
+     아래 순서를 따르도록 확인·보완한다.
+     1. explicit `mode` 인자
+     2. 기존 `execution_mode` 컨텍스트
+     3. WS `effective_mode`에서 온 domain 힌트
+     4. 그 외에는 `backtest` (safe default)
+
+2. **WS 결정 우선 적용**
+   - Gateway/SDK가 WS `DecisionEnvelope` / `ActivationEnvelope`를 수신할 때:
+     - `effective_mode`를 로컬 `compute_context` 및 `SubmitResult.ws.*`에 저장한다.
+     - Runner/SDK가 자체적으로 execution_domain을 “승격”하지 않도록 보장한다.
+
+3. **강등(safe_mode)·compute‑only 계약**
+   - WS 결정이 없거나 stale일 때,  
+     또는 `as_of`/`dataset_fingerprint`가 요구 조건을 만족하지 않을 때:
+     - 항상 `execution_domain = backtest`, 주문 게이트 OFF, `safe_mode=True`, `downgraded=True`로 수렴하도록 한다.
+   - 이 동작을 Core Loop 계약 테스트(`tests/e2e/core_loop`)와  
+     별도 유닛 테스트에서 검증한다.
+
+### 산출물
+
+- 코드:
+  - `runtime/sdk/execution_context.py`, `runtime/helpers/runtime.py`, `runtime/sdk/submit.py`의 모드·도메인 결정 경로가 WS‑우선 규칙을 따른다.
+- 테스트:
+  - WS 결정 부재/만료/에러 시 compute‑only로 강등되는 시나리오.
+  - WS `effective_mode=validate/compute-only/paper/live`에 따라 SDK가 도메인을 어떻게 설정하는지 검증.
+
+---
+
+## Phase 2 — Evaluation Run을 1급 개념으로 올리기
+
+**목표:** “이 제출이 지금 월드 내에서 어떤 단계인지”를 월드·WS 관점에서 추적할 수 있도록, Evaluation Run 모델을 실제 도입한다.
+
+### 해야 할 일
+
+1. **모델 정의**
+   - `design/worldservice_evaluation_runs_and_metrics_api.md`의 정의를 기반으로,  
+     WorldService 내부에 다음 스키마를 도입한다.
+     - 키: `(world_id, strategy_id, evaluation_run_id)`
+     - 상태: `submitted / backtest_running / evaluating / evaluated / activated / rejected / expired`
+     - 메타: 생성/갱신 시간, 사용된 데이터 윈도우, 사용된 정책 버전 등.
+
+2. **Runner.submit ↔ Evaluation Run 연동**
+   - Runner.submit 호출 시:
+     - WS/Gateway가 **평가 런을 생성**하거나 이미 존재하는 런을 갱신한다.
+     - `SubmitResult`에 적어도 다음 중 하나를 포함한다.
+       - `evaluation_run_id`
+       - `evaluation_run_url` (상태/메트릭 조회용 링크)
+   - 초기 단계에서는 여전히 “동기 파이프라인”으로 돌아도 괜찮지만,  
+     **결과가 어디에 기록되는지**가 Evaluation Run으로 명확히 남아야 한다.
+
+3. **상태 전이 구현**
+   - Runner/SDK가 backtest/Validation/WS Evaluate를 수행하는 동안:
+     - 적절한 시점에 `backtest_running` / `evaluating` / `evaluated` 등으로 상태를 업데이트한다.
+   - `/worlds/{world}/strategies/{strategy}/runs/{run_id}` 형태의 상태 조회 API를 시범 구현한다.
+
+### 산출물
+
+- WS 코드:
+  - Evaluation Run 저장소/모델 + 상태 전이 로직.
+- API:
+  - 평가 런 상태 조회 endpoint (초기에는 internal/admin 용도여도 괜찮다).
+- Runner/SDK:
+  - `SubmitResult`에 evaluation run 식별자를 포함.
+
+---
+
+## Phase 3 — world‑first 제출 UX & mode 인자 축소
+
+**목표:** 실사용 DX를 “전략 + 월드” 중심으로 재정렬하고, `mode`는 점차 hint/고급 옵션으로 밀어낸다.
+
+### 해야 할 일
+
+1. **API 서피스 정리**
+   - Python:
+     - `Runner.submit(MyStrategy, world="...")`를 문서/예제에서 **기본 추천 경로**로 만든다.
+     - `mode=` 인자는 여전히 허용하되, docstring/가이드에서 “advanced/실험용”으로 명시한다.
+   - CLI:
+     - `qmtl submit strategy.py --world my-world`를 권장 기본 형식으로 문서화한다.
+     - `--mode` 플래그는 고급 옵션 섹션으로 이동한다.
+
+2. **mode=None 코드 경로 지원**
+
+   - 내부적으로 `mode=None`을 허용하고, 이 경우:
+     - 실행 도메인 선택은 **WS `effective_mode` + world/data 정책**에 따라 결정된다.
+     - Runner/SDK는 compute‑only 강등·게이트 설정만 담당한다.
+
+3. **리그레이션 방지**
+
+   - 기존 `mode=Mode.BACKTEST/PAPER/LIVE` 호출은 계속 동작하되,
+     - WS가 붙어 있을 때는 `effective_mode`가 항상 최종 권위가 됨을 테스트로 보장한다.
+
+### 산출물
+
+- 문서:
+  - Getting Started/Guides/Architecture 문서에서 “mode 없는 submit”을 기본 흐름으로 예시.
+- 코드:
+  - `mode=None` 경로 지원 및 테스트.
+
+---
+
+## Phase 4 — backtest/paper/live 캠페인 오케스트레이션
+
+**목표:** World 정책과 Evaluation Run을 이용해 “backtest 캠페인 → paper 캠페인 → (선택적) live 캠페인”을 자동·반복적으로 관리할 수 있는 기반을 만든다.
+
+### 해야 할 일
+
+1. **정책 DSL에 캠페인 윈도우 도입**
+   - `world/world.md`의 정책 예시에 다음과 같은 필드를 추가·정의한다 (이름은 조정 가능).
+     - `campaign.backtest.window`: 최소 backtest 관찰 기간 (예: `180d`)
+     - `campaign.paper.window`: 최소 paper 관찰 기간
+     - `campaign.common.min_trades_per_window`, `min_sample_days` 등
+   - 각 필드는 “해당 단계에서 최소로 관찰되어야 하는 PnL/지표 윈도우”로 설명한다.
+
+2. **캠페인 상태 모델**
+
+   - WorldService에서 Evaluation Run 집계 결과를 기반으로, 월드/전략 조합에 대해 다음과 같은 상태를 유지한다.
+     - `phase: backtest_campaign | paper_campaign | live_campaign`
+     - 각 phase에 대해:
+       - 관찰 시작/종료 시점
+       - 관찰된 sample_days, trades, sharpe, max_dd, drawdown episode 등 핵심 지표
+       - “승격 가능/불가능” 플래그 및 이유
+
+3. **스케줄링 전략**
+
+   - 초기 단계에서는 **외부 스케줄러/워크플로**를 전제로 단순하게 시작한다.
+     - 예: “매일 1회 `/worlds/{id}/evaluate` 호출 → 정책 기반 승격 후보 계산 → `/apply`로 반영 또는 큐에 보관”.
+   - 이후 필요 시 WorldService 내부에 간단한 주기 평가 루프를 추가할 수 있다.
+
+4. **Runner/CLI와의 연결**
+
+   - Runner.submit은 여전히 “단일 호출”이지만,  
+     - `SubmitResult` 또는 별도 CLI 명령어에서 “현재 캠페인 phase/윈도우/승격 조건”을 조회할 수 있게 한다.
+
+### 산출물
+
+- 정책:
+  - 캠페인 윈도우·조건이 들어간 world policy 예제.
+- WS:
+  - 캠페인 상태 집계·조회 API (phase, 진행률, 승격 가능 여부).
+- CLI:
+  - `qmtl world status` 등에서 캠페인 phase와 핵심 지표를 요약해서 보여주는 명령.
+
+---
+
+## Phase 5 — 검증 단계 고도화 & live 승격 거버넌스
+
+**목표:** 소규모 조직에서도 “기술로 리스크를 통제”할 수 있을 만큼 강한 검증 단계를 만들고, live 승격은 기본적으로 운영/거버넌스 단계에 남겨 둔다.
+
+### 해야 할 일
+
+1. **월드 검증 단계 고도화**
+
+   - World 정책 DSL에서 **검증 전용 필드**를 명시적으로 구분한다.
+     - 예: `validation:` 블록 아래에
+       - 데이터 통화성(데이터 랙, missing coverage 비율)
+       - 샘플 충분성(`sample_days`, `trades_60d`, `notional_turnover`)
+       - 리스크 컷(`max_dd_Xd`, `ulcer_index`, tail risk proxy)
+       - 시나리오/스트레스 테스트 결과 플래그
+   - 이 블록은 “**live 후보군에 오르기 위한 최소 조건**”을 정의하는 곳으로 문서화한다.
+
+2. **live 승격 거버넌스 옵션**
+
+   - 정책/월드 설정에 다음과 같은 옵션을 추가한다.
+     - `live_auto_apply: false` (기본값)
+     - `live_requires_manual_approval: true`
+   - 이렇게 하면:
+     - 시스템은 **backtest/paper 캠페인까지 자동으로 후보를 추려 주고**,  
+     - live 전환은 항상 `/apply` 또는 별도 “승인 플로우”를 통해서만 일어난다.
+
+3. **운영자 친화적 리포트**
+
+   - Evaluation Run / 캠페인 상태 / 검증 결과를 바탕으로, 운영자·리스크 담당자가 이해하기 쉬운 리포트를 설계한다.
+     - 예: “최근 180일 Sharpe ≥ 0.8, max_dd ≤ 20%, 거래일 ≥ 60일을 충족하여 live 후보입니다.  
+       다만 상관/섹터 제약 관점에서 A/B 전략과 다소 중복이 있으니 확인이 필요합니다.”
+   - CLI/웹 UI/로그 링크 등 어떤 채널에서 이 정보를 볼지까지 포함해 설계한다.
+
+### 산출물
+
+- 정책:
+  - 검증 단계 고도화가 반영된 world policy 예시 (`validation` 블록, 검증 지표·임계값).
+- WS/도구:
+  - live 승격 후보군 목록, 승격 사유/거부 사유를 요약하는 API/CLI/리포트.
+
+---
+
+## 6. 이 문서를 사용하는 방법 (작업자용 TL;DR)
+
+1. **지금 내가 만지는 코드가 어느 Phase에 속하는지 먼저 정한다.**
+   - 모드 결정/compute‑only 강등 로직을 건드린다면 → Phase 1.
+   - Evaluation Run 모델/WS API를 바꾼다면 → Phase 2.
+   - World 정책 DSL·캠페인 윈도우를 손본다면 → Phase 4–5.
+
+2. **해당 Phase 섹션의 “해야 할 일/산출물” 체크리스트를 그대로 TODO로 사용한다.**
+   - 새 기능을 추가할 때는 “이 로드맵의 어느 단계에 속하는지”를 PR/이슈 설명에 명시한다.
+
+3. **Phase를 건너뛰지 않는다.**
+   - 예를 들어 Evaluation Run을 제대로 도입하지 않은 상태에서 캠페인 오케스트레이션을 구현하면,
+     - 디버깅이 어렵고, WS/Runner 간 책임 경계가 모호해지기 좋다.
+
+4. **live 자동 승격은 항상 마지막에, 그리고 기본은 off.**
+   - 이 문서는 **소규모 조직이 기술로 리스크를 제어할 수 있는 기반**을 제공하려는 것이지,
+     - “사람 손을 완전히 떼는 live 자동화”를 지향하지 않는다.
+   - live 자동 승격이 필요하더라도, 충분한 기간의 검증/캠페인·모니터링이 갖춰진 뒤,  
+     제한된 환경에서만 opt‑in 하도록 계획한다.
+
+이 로드맵 하나만으로도 “Core Loop를 월드 중심으로 고도화한다”는 목적과 방향성을 잃지 않고, 각 단계에서 해야 할 일을 판단할 수 있어야 한다. 세부 API·스키마는 관련 설계 문서(`architecture/*.md`, `world/*.md`, `design/worldservice_evaluation_runs_and_metrics_api.md`)를 함께 참고하되, **“지금 이 변경이 전체 그림에서 어느 Phase인지”**는 항상 이 문서를 기준으로 정한다.
+

--- a/docs/ko/design/model_risk_management_framework.md
+++ b/docs/ko/design/model_risk_management_framework.md
@@ -1,0 +1,241 @@
+---
+title: "QMTL 모델 리스크 관리(MRM) 프레임워크 스케치"
+tags: [design, mrm, governance, validation]
+author: "QMTL Team"
+last_modified: 2025-12-09
+status: draft
+---
+
+# QMTL 모델 리스크 관리(MRM) 프레임워크 스케치
+
+!!! abstract "목표"
+    이 문서는 QMTL에서 사용하는 **전략/월드/검증 시스템 전반에 대한 모델 리스크 관리(Model Risk Management, MRM)** 프레임워크를 개략적으로 정리한다.  
+    `world_validation_architecture.md`가 WorldService 검증 계층의 기술 설계를 다룬다면, 본 문서는 **역할·책임(RACI), 거버넌스, 벤치마크/챌린저, 리포트/아티팩트** 층을 다룬다.
+
+관련 문서:
+
+- World 검증 계층 설계: [world_validation_architecture.md](world_validation_architecture.md)
+- World 사양: [../world/world.md](../world/world.md)
+- 아키텍처 개요: [../architecture/architecture.md](../architecture/architecture.md)
+- WorldService 평가 런 & 메트릭 API: [worldservice_evaluation_runs_and_metrics_api.md](worldservice_evaluation_runs_and_metrics_api.md)
+
+---
+
+## 0. 범위 & 전제
+
+- 범위:
+  - 전략/월드 단위 모델의 **검증·승인·모니터링**에 대한 조직·프로세스 프레임워크
+  - World 검증 계층(Validation Rules/Profiles/EvaluationRun)의 **“사용 규칙”과 책임 분배**
+- 비범위:
+  - 개별 전략 아이디어/팩터의 이론적 타당성 논의
+  - 세부 코드 구현/테스트/배포 파이프라인
+  - 법무·컴플라이언스 정책 자체
+
+전제:
+- 기술 설계는 `world_validation_architecture.md`를 따른다.
+- 본 문서는 **“누가, 언제, 무엇을 승인/리포트/감독하는지”**를 한 페이지에 정리하는 것을 목표로 한다.
+
+---
+
+## 1. 역할 & 책임 (RACI 스케치)
+
+### 1.1 주요 역할 정의
+
+- **Model Owner / PM**
+  - 전략 아이디어, 구현, 성과 책임을 가진 주체
+- **Quant Research**
+  - 전략 연구, 백테스트/실험, 모델링 가정 문서화 담당
+- **Model Validator / Risk**
+  - World 검증 프로파일/룰 설계 및 변경 승인
+  - Validation Report 작성/리뷰
+- **Operations / Trading**
+  - 실행/운영 측면에서 모델 사용 여부·조건 확인
+  - override·비상 중단 등 운영 의사결정 참여
+- **Governance / Committee (선택)**
+  - 고위험 모델/World에 대한 최종 승인/중단 권한
+
+### 1.2 RACI 매트릭스 (개략)
+
+```text
+활동                                 | Owner | Quant | Risk | Ops | Gov
+-------------------------------------+-------+-------+------|-----|----
+전략 아이디어/팩터 설계              |  R    |  A    |  C   |  I  | I
+백테스트/실험 설계                   |  C    |  A    |  C   |  I  | I
+Model Card 작성/업데이트             |  A    |  R    |  C   |  I  | I
+World validation 프로파일 설계/변경  |  C    |  C    |  A/R|  I  | I
+World policy(YAML) 변경 리뷰/승인    |  C    |  C    |  A  |  C  | I
+EvaluationRun/Validation 결과 검토   |  C    |  C    |  A  |  C  | I
+Validation Report 작성/승인          |  I    |  C    |  A/R|  C  | I
+paper 승격 결정                      |  A    |  C    |  C  |  C  | I
+live 승격/중단 결정                  |  C    |  C    |  A  |  A  | R
+override 승인                         |  C    |  C    |  A  |  A  | R
+```
+
+> R: Responsible / A: Accountable / C: Consulted / I: Informed  
+> 실제 조직 구조에 따라 역할은 통합/분리될 수 있으며, 위 표는 최소 프레임워크 스케치다.
+
+---
+
+## 2. 모델 생애주기 & 승인 흐름
+
+### 2.1 단계
+
+1. **개발(Development)**  
+   - 아이디어/팩터 연구, 백테스트, 구현, 코드 리뷰, 기본 품질 검사.
+2. **사전 검증(Pre‑Validation)**  
+   - Model Card 작성, World/validation 프로파일 후보 선택, 로컬 ValidationPipeline 실행.
+3. **정식 검증(Validation)**  
+   - EvaluationRun 생성, validation profiles 적용, Validation Report 초안 작성.
+4. **승인(Approval)**  
+   - paper 승격 승인, live 승격/보류/반려 결정.
+5. **운영/모니터링(Live Monitoring)**  
+   - Live EvaluationRun 정기 생성, 성과 드리프트/리스크 모니터링.
+6. **리뷰/폐기(Review & Decommission)**  
+   - 유효성 상실/전략 종료 시 Validation Report/히스토리 정리, world policy 정리.
+
+### 2.2 World validation과의 연결
+
+- Pre‑Validation/Validation 단계에서:
+  - `world_validation_architecture.md`의 v1 코어 지표/룰을 적용해 go/no‑go 후보군 필터링.
+- Approval 단계에서:
+  - Validation Report + Model Card + risk tier를 근거로 paper/live 승격 여부 결정.
+- Live Monitoring 단계에서:
+  - live vs backtest 성능, validation_health, override 기록을 기반으로 자동/수동 demotion 후보를 관리.
+
+---
+
+## 3. 아티팩트: Model Card, Evaluation Store, Validation Report
+
+### 3.1 Model Card (전략 정의 문서)
+
+각 전략은 최소한 다음 정보를 포함하는 Model Card를 가져야 한다.
+
+- ID/버전: `strategy_id`, `model_card_version`
+- 목적: 타겟 시장/자산군, 투자 가설
+- 데이터: 사용 데이터 소스, 빈도, 전처리, 주요 제한사항
+- 모델 구조: 주요 피처/신호, 규칙/모델 타입(룰 기반, ML 등)
+- 핵심 가정: 트렌드 지속성, 정규성/독립성, 유동성 가정 등
+- 한계/취약성: 데이터 커버리지, 비정상 구간, 구조적 약점
+
+Model Card는 EvaluationRun·Validation Report와 **버전 링크**를 가진다 (`model_card_version`).
+
+### 3.2 Evaluation Store (실험/검증 추적)
+
+`world_validation_architecture.md`에서 제안한 EvaluationRun/EvaluationMetrics/RuleResult 스키마를 기반으로:
+
+- **Evaluation Store**는 각 `(world,strategy,run_id)`에 대한
+  - 메트릭, Rule 결과, policy 버전, override 기록, 코드/데이터 snapshot id를 보관하는 저장소다.
+- 이 Store는:
+  - Validation Report 생성,
+  - 정책 변경 전후 diff 분석,
+  - “나쁜 전략” regression test,
+  - 외부 리스크/감사 대응 시 근거 자료로 사용된다.
+
+### 3.3 Validation Report (사람이 읽는 검증 요약)
+
+Validation Report는 Evaluation Store에 저장된 정보를 사람이 읽기 좋은 형태로 요약한 문서이며, 대략 다음 구조를 갖는다.
+
+- 0. 요약 (Summary)
+- 1. 범위/목적 (Scope & Objective)
+- 2. 모델 설명 (Model Card 요약)
+- 3. 검증 방법 (사용한 프로파일/룰/지표, 벤치마크)
+- 4. 결과 (pass/warn/fail, recommended_stage, 주요 RuleResult)
+- 5. 리스크/한계 (데이터/모델/운영 측 한계)
+- 6. 권고사항 (승격/보류/폐기, 추가 모니터링 조건)
+
+Validation Report는 Risk/Validator가 작성 및 승인하며, live 승격/중단 결정의 주된 근거로 사용된다.
+
+---
+
+## 4. 벤치마크 & 챌린저 모델
+
+### 4.1 벤치마크 유형
+
+가능한 경우 각 전략/World에 대해 다음과 같은 벤치마크를 정의한다.
+
+- 단순 Buy&Hold 또는 cap‑weighted index (동일 universe)
+- naive factor 전략 (단순 모멘텀/밸류/캐리 등)
+- 기존 production 전략 또는 포트폴리오
+
+### 4.2 검증에서의 활용
+
+- CohortRule/PortfolioRule에서:
+  - 후보 전략의 성과/리스크가 벤치마크 대비 의미 있게 개선되었는지(Sharpe uplift, DD/ES 개선 등)를 확인한다.
+- Validation Report에서:
+  - “벤치마크 대비 어느 지점이 개선/악화되었는지”를 명시적으로 기술한다.
+
+벤치마크 자체의 정의/선택은 World/자산군에 따라 달라질 수 있으며, 본 문서는 “벤치마크를 명시적으로 두고 비교한다”는 원칙만을 고정한다.
+
+---
+
+## 5. 모니터링 & 정책 안정성 지표
+
+### 5.1 Live Monitoring 핵심 지표 (개념)
+
+Live Monitoring은 `world_validation_architecture.md`에서 정의한 메트릭을 기반으로, 다음과 같은 지표를 중점적으로 본다.
+
+- 최근 30/60/90일 live Sharpe/MDD/ES vs backtest 기준
+- live_vs_backtest_sharpe_ratio 등 성능 decay 지표
+- override 발생 빈도, 빈도 증가 추세
+
+이 지표는:
+- 자동 demotion 후보 선정,
+- Validation Report 업데이트,
+- World/전략 재검증 우선순위 결정에 사용된다.
+
+### 5.2 Validation Health & Policy Stability
+
+검증 시스템 자체의 건강 상태를 보기 위해 다음과 같은 메타 지표를 추적하는 것을 권장한다.
+
+- validation_health.metric_coverage_ratio
+- validation_health.rules_executed_ratio
+- validation_health.validation_error_count
+- validation_policy_age_days
+- ruleset_change_count_last_90d
+
+이 값들은 World/Stage별로 집계하여:
+- 검증 계층의 미성숙 구간,
+- 과도한 정책 churn,
+- 지속적인 에러/누락 발생 구간을 식별하는 데 사용한다.
+
+---
+
+## 6. 스트리밍 Core Loop와의 정렬
+
+QMTL의 Core Loop는 WorldService/Gateway/SDK가 ControlBus/Commit Log 스트림을 중심으로 동작한다. MRM 프레임워크도 이 스트리밍 특성을 존중해야 한다.
+
+- EvaluationRun/Validation 결과는 **단발성 batch 결과**가 아니라,  
+  “시간에 따라 축적되는 평가/모니터링 이벤트의 스냅샷”으로 취급한다.
+- Runner.submit 경로에서는:
+  - 필수 최소 검증만 동기적으로 수행하고,
+  - 심층 검증/캠페인/Cohort/Portfolio/Stress 룰은 EvaluationRun 이벤트 스트림을 소비하는 별도 파이프라인에서 수행한다.
+- WorldService는 필요 시 `EvaluationRunCreated`/`EvaluationRunUpdated`/`ValidationProfileChanged` 등의 이벤트를 발행하고,  
+  검증/리포트/리스크 모듈은 이를 구독해 비동기적으로 Rule을 실행한다.
+- 리스크 대시보드/검증 UI는 WS DB를 직접 때리기보다는,  
+  스트림에서 만들어진 “상태 뷰”(예: Redis/캐시/머티리얼라이즈드 뷰)를 조회하는 구조를 목표로 한다.
+
+SDK 관점에서는:
+
+- `Runner.submit(..., world="...")` 호출 후,  
+  `SubmitResult`에 포함된 `evaluation_run_id` 또는 월드/Run 링크를 사용해 WS에서 지표가 준비되었는지 조회(poll)하는 패턴을 기본으로 한다.
+- **“지표가 준비되면 호출되는 콜백 헬퍼”** 같은 편의 기능은,
+  - World 검증 계층 설계(`world_validation_architecture.md`)와 SDK 측 EvaluationRun 조회 플로우 설계가 정착된 이후,  
+  - 스트리밍 이벤트(`EvaluationRunUpdated` 등)를 구독하는 형태로 설계·도입 여부를 논의한다.
+
+---
+
+## 7. SR 11‑7 관점에서의 위치
+
+`world_validation_architecture.md` §8에서 기술 설계를 SR 11‑7 관점으로 매핑했다면, 본 문서는 그 위에 **역할/프로세스/리포트 레이어**를 덧붙인다.
+
+- 개념적 건전성:
+  - Model Card, RACI, validation_profiles 설계
+- 결과 분석·벤치마킹:
+  - 벤치마크/챌린저 모델 정의, Validation Report 내 비교 섹션
+- 지속 모니터링:
+  - Live Monitoring, Validation Health/Policy Stability 지표
+- 거버넌스/독립성:
+  - 독립 검증(Repo/권한 분리), override 로깅, 승인 플로우(RACI)
+
+이 문서는 “소규모/중형 조직에서도 현실적으로 운영 가능한 MRM 최소 프레임워크”를 목표로 하며,  
+필요 시 조직 규모·규제 요구에 따라 위원회 구조/리포트 포맷을 세분화해 확장할 수 있다.

--- a/docs/ko/design/world_validation_architecture.md
+++ b/docs/ko/design/world_validation_architecture.md
@@ -1,0 +1,1103 @@
+---
+title: "World 검증 계층 확장 설계 스케치"
+tags: [design, world, validation, core-loop]
+author: "QMTL Team"
+last_modified: 2025-12-08
+status: draft
+---
+
+# World 검증 계층 확장 설계 스케치
+
+!!! abstract "목표"
+    이 문서는 QMTL WorldService의 **검증(Validation) 계층**을 고도화하기 위한 확장 설계 초안이다.  
+    목표는 **소규모 조직도 “기술로 리스크를 제어할 수 있을 만큼 신뢰도 높은 검증 단계를 갖추는 것**이며,  
+    Core Loop × World 로드맵의 Phase 4–5를 뒷받침하는 세부 설계를 제공한다.
+
+관련 문서:
+
+- 아키텍처 개요 및 Core Loop: [architecture/architecture.md](../architecture/architecture.md)
+- World 사양: [world/world.md](../world/world.md)
+- WorldService 평가 런 & 메트릭 API: [design/worldservice_evaluation_runs_and_metrics_api.md](worldservice_evaluation_runs_and_metrics_api.md)
+- Core Loop × World 로드맵: [design/core_loop_world_roadmap.md](core_loop_world_roadmap.md)
+- 모델 리스크 관리 프레임워크: [design/model_risk_management_framework.md](model_risk_management_framework.md)
+- 과거 SDK auto_returns 설계(보관용): [archive/auto_returns_unified_design.md](../archive/auto_returns_unified_design.md)
+
+---
+
+## 0. 배경 & 문제 정의
+
+현재 v2 아키텍처에서 WorldService는 다음 역할을 갖는다.
+
+- 월드 정책(WorldPolicy)에 따라 전략을 평가·선정하고 실행 모드를 관리한다.
+- Evaluation Run 모델을 통해 전략 제출/검증/활성화 단계를 추적한다.
+- `/evaluate`·`/activation`·`/allocations`를 통해 Core Loop 상의 “승격/강등/배분” 결정을 노출한다.
+
+그러나 **검증 단계 자체의 구조와 확장성**은 아직 다음과 같은 과제를 갖는다.
+
+- 검증 규칙(데이터 통화성, 샘플 충분성, 성과/리스크 컷, 과적합/취약성 신호 등)이
+  - 코드에 흩어져 있거나,
+  - DSL 상에서 충분히 구조화되어 있지 않아,
+  - 실제 실패를 관찰한 뒤 검증을 강화하는 루프가 어렵다.
+- Evaluation Run의 메트릭 스키마가 **어떻게 확장될지**(새 지표를 어떻게 추가·소비할지)가 명확하지 않다.
+- 소규모 조직에서 사람이 일일이 검토하기엔
+  - 후보 전략 수가 많고,
+  - 시장/전략 종류가 달라서
+  - “검증을 코드로 강화할 수 있는 여지”가 중요하지만, 이를 전제로 한 설계가 충분히 정리되어 있지 않다.
+
+이 문서는 위 문제를 해결하기 위해,
+
+1. **지표 스키마(Evaluation Metrics)의 확장 가능 구조**,  
+2. **룰 기반 검증 파이프라인(Validation Rules)의 모듈 구조**,  
+3. **World 정책 DSL과의 연결 방식**,  
+4. **실패 → 검증 강화 피드백 루프**
+
+를 하나의 설계로 정리하는 것을 목표로 한다.
+
+### 0.1 범위와 비범위
+
+본 문서는 **WorldService 검증 계층**에 초점을 둔다. 따라서 다음 항목은 의도적으로 스코프 밖에 둔다.
+
+- 전략 아이디어/팩터의 이론적 타당성 검토, 학술적 배경 정리
+- 전략 코드 품질, 유닛/통합 테스트, 배포 파이프라인 설계
+- PM·운용 위원회 의사결정 프로세스, 인센티브/보상 구조
+
+이 영역들은 “모델 개발/사용”과 조직·거버넌스 설계 문서에서 다루며, 본 문서는 **“이미 제출된 전략이 World 안에서 어느 단계까지 올라갈 수 있는지”를 결정하는 검증·모니터링 계층**만을 다룬다.
+
+### 0.2 Runner/SDK/WorldService 역할 (returns/지표)
+
+본 설계는 returns/지표/검증을 **항상 World/WorldService 평가 파이프라인에서 계산**한다는 전제를 둔다.
+
+- SDK/Runner는 전략 제출과 EvaluationRun/지표 조회에만 집중한다.
+  - `Runner.submit(..., world="...")`는 dev/prod 모두 World/WS 경로를 통해 EvaluationRun과 메트릭을 생성한다.
+  - SDK는 `SubmitResult.evaluation_run_id` 또는 WS 링크만 받고,  
+    필요 시 별도 헬퍼(예: `Runner.poll_evaluation(world, run_id, ...)`)로 지표가 준비되었는지 확인한 뒤 EvaluationRun/EvaluationMetrics를 조회한다.
+- returns는 SDK 전처리(auto_returns)에서 파생하지 않는다.
+  - 검증/World 평가에서 사용하는 returns는 전략이 내보낸 equity/pnl/position 시계열과 WorldService 평가 파이프라인에서 파생된 값에 한정한다.
+- dev/prod 두 스택:
+  - dev 스택에서는 로컬/테스트용 WorldService/Gateway/Seamless 구성을 사용하지만,  
+    prod와 동일한 “제출 → EvaluationRun → 지표 조회” 플로우를 그대로 사용한다.
+  - 로컬 DX는 별도 auto_returns 편의 기능이 아니라, dev World에서 prod와 동일한 경로를 실행할 수 있게 하는 방식으로만 지원한다.
+
+과거 SDK auto_returns 설계는 [`archive/auto_returns_unified_design.md`](../archive/auto_returns_unified_design.md)에 아카이브되어 있으며,  
+이 문서는 World/WS 기반 평가 모델을 기준으로 검증 계층을 정의한다.
+
+---
+
+## 1. 설계 원칙
+
+World 검증 계층은 다음 설계 원칙을 따른다.
+
+1. **WS SSOT & 모드 분리**
+   - 실행 모드/단계의 단일 진실 소스는 WorldService `effective_mode`/정책 결과다.
+   - 검증 계층은 “이 전략이 어떤 단계까지 올라갈 수 있는지”를 판정할 뿐,
+     Runner/SDK가 모드를 직접 승격하지 않는다.
+
+2. **레이어드 방어(Defense in Depth)**
+   - 검증은 하나의 거대한 조건문이 아니라, 여러 레이어의 룰로 나뉜다.
+     - 데이터/샘플 레이어
+     - 성과/리스크 컷 레이어
+     - 구조적 제약(상관/익스포저 등) 레이어
+     - 로버스트니스/과적합 신호 레이어
+     - paper/shadow 리허설 레이어
+   - 각 레이어는 독립적으로 pass/fail/warn를 낼 수 있어야 하고,  
+     World 정책은 어떤 레이어 위반으로 후보에서 탈락했는지 표시할 수 있어야 한다.
+
+3. **지표 스키마 확장성**
+   - Evaluation Run 메트릭 스키마는 **“핵심 필드 + 확장 슬롯”** 구조로 설계한다.
+   - 새로운 실패 패턴을 발견했을 때,
+     - Runner/ValidationPipeline에서 새 지표를 계산해 WS로 보내고,
+     - World 정책 DSL에서 이를 곧바로 소비할 수 있어야 한다.
+
+4. **검증 룰의 모듈성**
+   - 검증 로직은 C++식 거대한 if-else가 아니라,
+     - 작은 Rule 객체(또는 함수)들의 집합으로 표현한다.
+   - World 정책 DSL은 “어떤 룰을 어떤 파라미터로 활성화할지”만 선언한다.
+   - 실패가 발견되면 새 Rule을 추가하거나 기존 Rule의 파라미터만 조정해도 대응이 가능해야 한다.
+
+5. **운영자/리스크 관점에서 “이해 가능한 복잡도” 유지**
+   - DSL과 Rule 세트는 “한 페이지 설명”이 가능한 수준을 유지해야 한다.
+   - 검증이 너무 복잡해져서 아무도 무슨 일이 일어나는지 이해하지 못하면,
+     시스템 신뢰도는 오히려 떨어진다.
+
+### 1.1 모델 리스크 관점과 Risk Tiering
+
+전통적인 모델 리스크 관리(MRM, 예: SR 11‑7) 관점에서는 “모델 개발/사용 – 모델 검증 – 거버넌스/통제”의 세 축을 요구한다. World 검증 계층은 이 중 **“검증” 축**을 강화하는 설계이지만, **World/전략별 리스크 티어링**과 **모델 정의/문서화(Model Card)**를 도입하면 전체 Core Loop의 신뢰도를 한 단계 끌어올릴 수 있다.
+
+- `risk_profile` 필드(예시)는 world 또는 WorldPolicy에 추가한다.
+
+  ```yaml
+  risk_profile:
+    tier: high | medium | low          # 자본 영향도/복잡도 기반 티어
+    max_capital_at_risk_pct: 2.0       # 전체 운용 자본 대비 허용 손실 비중
+    client_critical: true | false      # 대외/수탁 자금 포함 여부
+  ```
+
+- Tier에 따라:
+  - 필수 레이어 세트가 달라질 수 있다. 예: `tier=high`는 Data/Sample/Performance/Risk/Robustness/Paper 레이어를 모두 blocking 으로 요구하고, `tier=low`는 일부를 warn 모드로만 운용.
+  - 동일 Rule이라도 티어에 따라 Sharpe/MDD/ES 등 컷을 다르게 가져간다.
+
+또한 각 전략에 대해 간단한 **Model Card**(model/spec 문서)를 정의하고, Evaluation Run에는 `model_card_version`을 연결한다.
+
+- Model Card에는 목적, 사용 데이터/피처, 타임프레임, 핵심 가정, 한계 등을 기록한다.
+- 나중에 문제가 난 전략에 대해 “어떤 가정과 validation 정책 아래 승인되었는지”를 Evaluation Run 수준에서 추적할 수 있다.
+
+---
+
+## 2. Evaluation Run 메트릭 스키마 확장
+
+### 2.1 코어 메트릭 블록 구조
+
+WorldService 평가 런 문서에서 제안한 모델을 확장해, Evaluation Run 메트릭을 다음 블록으로 나눈다.
+
+- `returns`: 순수 전략 수익률 시계열 요약 (샘플 수, 윈도우, Sharpe, MDD, 변동성 등)
+- `pnl`: 계좌/통화 단위 PnL 요약 (총 PnL, PnL max drawdown 등) — 필요 시
+- `sample`: 샘플 충분성과 관련된 지표 (거래일 수, 거래 횟수, notional turnover 등)
+- `risk`: 익스포저, 레버리지, 섹터 concentration 등 구조적 리스크
+- `robustness`: 롤링 Sharpe, 앞/뒤 구간 성과 차이, 파라미터 민감도 프록시 등
+- `diagnostics`: 기타 디버깅용/실험적 지표
+
+스키마 초안(개념적):
+
+```json
+{
+  "world_id": "crypto_mom_1h",
+  "strategy_id": "beta_mkt_simple",
+  "run_id": "2025-12-02T10:00:00Z-uuid",
+  "returns": { "...": "..." },
+  "pnl": { "...": "..." },
+  "sample": { "...": "..." },
+  "risk": { "...": "..." },
+  "robustness": { "...": "..." },
+  "diagnostics": {
+    "extra_metrics": {
+      "my_custom_metric": 0.123,
+      "another_metric": -0.5
+    }
+  }
+}
+```
+
+핵심 아이디어:
+
+- 각 블록은 **내부적으로 Pydantic 모델 또는 유사 구조**로 관리하고,
+- `diagnostics.extra_metrics`는 “실험적 지표/추후 승격 후보”를 넣는 확장 슬롯이다.
+- World 정책 DSL은 코어 블록만을 대상으로 사용해도 되고,
+  필요 시 `diagnostics.extra_metrics["foo"]` 같은 키를 직접 참조하는 규칙도 허용할 수 있다.
+
+### 2.2 지표 추가 플로우
+
+새로운 실패 패턴을 관찰했을 때:
+
+1. Runner/ValidationPipeline에 해당 패턴을 측정하는 지표를 추가한다.
+2. WS Evaluation Run 메트릭 모델에 필드를 추가하거나, `diagnostics.extra_metrics`에 값을 넣는다.
+3. World 정책 DSL에 해당 지표를 사용하는 룰을 추가한다.
+
+이때 기존 정책/코드는 **새 필드를 모르면 무시**하는 방향으로 설계해,  
+점진적인 롤아웃이 가능하도록 한다.
+
+### 2.3 업계 수준 지표 확장 (과적합/다중 테스트 통제)
+
+“소규모 조직에서 쓸 수 있는 검증”을 넘어 **업계에서 통용되는 MRM/과적합 통제 관행**을 반영하려면, 다음 축의 지표를 1급 개념으로 추가하는 것이 유효하다.
+
+- **Sample/Data 축**
+  - `effective_history_years`: 실제 거래일·유효 데이터 기준 연수.
+  - `n_trades_total`, `n_trades_per_year`: 총/연평균 트레이드 수.
+  - `regime_coverage`: 고/중/저 변동성 구간별 거래일/트레이드 비중.
+  - 이 값들을 이용해 “최소 X년 + 최소 Y 트레이드 + 적어도 하락장 레짐 1회 이상 포함” 같은 형태의 SampleRule을 정의할 수 있다.
+
+- **Performance/Risk 축 (Tail/Shape/Path)**
+  - Tail 지표: `var_p01`, `es_p01`(1% VaR/ES), `pnl_tail_index`(파레토 꼬리 지수 프록시 등).
+  - Shape 지표: `skew`, `kurtosis`.
+  - Path 지표: `avg_dd_recovery_time`(평균 DD 회복 기간), `max_consecutive_losses_trades/days`.
+  - PerformanceRule/RiskConstraintRule이 단순 Sharpe/MDD 컷을 넘어 tail/경로 특성을 활용할 수 있다.
+
+- **Robustness 축 (과적합/다중 테스트)**
+  - `probabilistic_sharpe_ratio`(PSR), `deflated_sharpe_ratio`(DSR), `min_track_record_length`.
+  - time‑series cross‑validation 결과:
+    - `cv_folds`(purged & embargoed CV fold 수),
+    - `cv_sharpe_mean`, `cv_sharpe_std`,
+    - `cv_dd_p95`(각 fold DD 95% 분위수) 등.
+  - RobustnessRule은 “out‑of‑sample 일관성”과 “과도하게 좋은 Sharpe의 통계적 신뢰도”를 함께 검증할 수 있다.
+
+- **Diagnostics 축 (복잡도/탐색 강도)**
+  - `strategy_complexity`: 파라미터 수, 코드 cyclomatic complexity, 피처 차원 등으로부터 유도한 복합 지표.
+  - `search_intensity`: 캠페인 내 실험한 변형 개수, 총 백테스트 횟수, 하이퍼파라미터 탐색 예산 등.
+  - 이 값들은 “복잡도·탐색 강도가 높을수록 Sharpe 신뢰도를 더 깎는다”는 형태의 규칙에 활용할 수 있다.
+
+---
+
+## 3. 검증 파이프라인 구조 (Validation Rules)
+
+### 3.1 룰 타입 분류
+
+검증 룰은 크게 다음 카테고리로 나눈다.
+
+1. **DataCurrencyRule**  
+   - 데이터 통화성, 커버리지, missing ratio 등.
+   - 필요 시 입력 데이터 품질(결측/이상치 비율, 베이스라인 벤더/스키마 변경 이벤트) 점검을 포함할 수 있다. 데이터 라인리지·품질 자체의 상세 설계는 별도의 데이터 인프라 문서에서 다루되, DataCurrencyRule은 해당 신호를 소비하는 진입점 역할을 한다.
+2. **SampleRule**  
+   - `sample_days`, `trades_60d`, `notional_turnover` 등 샘플 충분성.
+3. **PerformanceRule**  
+   - Sharpe, MDD, volatility, profit_factor 등 성과/리스크 컷.
+4. **RobustnessRule**  
+   - 롤링 윈도우 성과, 앞/뒤 반기 Sharpe 차이, drawdown episode 분포 등.
+5. **RiskConstraintRule**  
+   - 익스포저/레버리지/섹터 및 상관 제약.
+6. **Paper/ShadowConsistencyRule** (선택)  
+   - paper/shadow 결과가 backtest 특성과 크게 어긋나지 않는지 확인.
+
+각 Rule은 다음 인터페이스를 따른다(의사 코드):
+
+```python
+class ValidationRule(Protocol):
+    name: str
+
+    def evaluate(self, metrics: EvaluationMetrics, context: RuleContext) -> RuleResult:
+        ...
+```
+
+`RuleResult`는 최소한 다음 정보를 포함한다.
+
+- `status`: "pass" | "fail" | "warn"
+- `reason`: string (사람이 읽을 수 있는 사유)
+- `details`: dict (추가 디버깅 정보)
+
+### 3.3 Rule 심각도·소유자 메타데이터
+
+운영/리스크/퀀트 팀 간에 “어떤 룰이 진짜 gate인지”를 명확히 하기 위해, 각 RuleResult에 다음 메타데이터를 추가한다.
+
+- `severity`: `"blocking" | "soft" | "info"`
+  - `blocking`: fail 시 해당 단계 진입 불가.
+  - `soft`: fail 시 가중치/점수에서 페널티만 부여.
+  - `info`: 참고 정보만 제공, 승격/강등에는 직접 사용하지 않음.
+- `owner`: `"quant" | "risk" | "ops"`
+  - 관리 주체(퀀트/리스크/운영)를 명시해 변경 책임을 분리한다.
+
+의사 코드:
+
+```python
+class RuleResult(BaseModel):
+    status: Literal["pass", "fail", "warn"]
+    severity: Literal["blocking", "soft", "info"] = "blocking"
+    owner: Literal["quant", "risk", "ops"] = "quant"
+    reason: str
+    details: dict[str, Any] = {}
+```
+
+World 정책 DSL에서는 다음과 같이 사용한다.
+
+```yaml
+validation:
+  performance:
+    sharpe_mid:
+      min: 0.8
+      severity: blocking
+      owner: risk
+  robustness:
+    dsr_min:
+      min: 0.4
+      severity: soft
+      owner: quant
+```
+
+### 3.4 Cohort/Portfolio/Stress Rule 유형
+
+단일 Evaluation Run(단일 전략)만 보는 Rule 외에, **캠페인/포트폴리오/스트레스 시나리오** 단위의 Rule을 도입하면 업계 수준의 검증에 더 가깝게 다가갈 수 있다.
+
+- **CohortRule (캠페인 단위 룰)**  
+  - 여러 전략 후보를 한 번에 평가해 다중 테스트/랭킹 기반 규칙을 적용한다.
+  - 예: “이번 캠페인에서 DSR 상위 k개만 live 후보로 남기기”, “Sharpe>4 전략이 나오면 캠페인 전체 warn 처리”.
+
+  ```python
+  class CohortRule(Protocol):
+      name: str
+      def evaluate(
+          self,
+          metrics_list: list[EvaluationMetrics],
+          context: RuleContext,
+      ) -> dict[str, RuleResult]:  # run_id -> RuleResult
+          ...
+  ```
+  - 가능하다면 단순 Buy&Hold, cap‑weighted index, naive factor(예: 단순 모멘텀/밸류)와 같은 **벤치마크/챌린저 모델 메트릭**을 함께 받아, 후보 전략의 성과·리스크를 벤치마크 대비 상대적으로 평가하는 확장 포인트를 열어 둔다.
+
+- **PortfolioRule (기존 포트폴리오 대비 인크리멘탈 룰)**  
+  - 새 전략과 기존 live 전략 집합의 조합을 보고 Incremental VaR/ES, 포트폴리오 Sharpe 개선 여부 등을 평가한다.
+  - DSL 예:
+
+    ```yaml
+    validation:
+      portfolio:
+        max_incremental_var_99: 0.5
+        min_portfolio_sharpe_uplift: 0.1
+    ```
+
+- **StressRule (스트레스 시나리오 룰)**  
+  - 미리 정의된 시장 시나리오(“2008 금융위기”, “2020 코로나 쇼크” 등)에 대해
+    재시뮬레이션한 PnL/DD를 입력으로 사용한다.
+  - Evaluation Metrics에 `"stress"` 블록을 두고, 각 시나리오별 DD/ES 컷을 검증한다.
+
+### 3.2 룰 구성 및 실행 전략
+
+- World 정책 DSL은 “활성화할 룰과 파라미터”만 정의한다.
+- WorldService는 DSL을 파싱하여 룰 인스턴스를 구성하고, Evaluation Run 메트릭에 대해 순차/병렬 평가를 수행한다.
+- 룰 실행 결과는 Evaluation Run의 `validation` 섹션에 기록한다.
+
+예시(개념적):
+
+```yaml
+validation:
+  data_currency:
+    max_lag: 5m
+    min_history: 180d
+  sample:
+    min_sample_days: 90
+    min_trades_180d: 60
+  performance:
+    sharpe_mid:
+      min: 0.8
+    max_dd_180d:
+      max: 0.25
+  robustness:
+    rolling_sharpe_min: 0.5
+    max_regime_gap: 0.4
+  risk:
+    exposure:
+      max_leverage: 3.0
+      sector_cap: 0.3
+    tail:
+      p01_daily_return_min: -0.08
+```
+
+이 DSL은 내부적으로 다음 Rule 인스턴스 집합으로 변환된다.
+
+- `DataCurrencyRule(max_lag=5m, min_history=180d)`
+- `SampleRule(min_sample_days=90, min_trades_180d=60)`
+- `PerformanceRule(sharpe_mid_min=0.8, max_dd_180d_max=0.25)`
+- `RobustnessRule(rolling_sharpe_min=0.5, max_regime_gap=0.4)`
+- `RiskConstraintRule(max_leverage=3.0, sector_cap=0.3, p01_min=-0.08)`
+
+---
+
+## 4. World 정책 DSL과의 통합
+
+### 4.1 `validation` 블록 역할 재정의
+
+`world/world.md`의 정책 DSL을 다음과 같이 역할 분리한다.
+
+- `validation:`  
+  - **live/paper 후보군에 오르기 위한 최소 조건**을 정의한다.
+  - validation을 통과하지 못한 전략은 selection/top‑k/hysteresis 단계에 진입하지 못한다.
+- `selection:`  
+  - `gates/score/topk/constraints/hysteresis`는 validation을 통과한 후보들 중에서  
+    “어떤 전략을 어느 비중으로 쓸지”를 결정한다.
+
+이렇게 하면 검증 계층이 **“후보군 필터”** 역할을 맡고,  
+selection 계층은 **“후보군 안에서의 상대적 선택/유지”**를 담당하게 된다.
+
+### 4.2 실행 단계 추천값
+
+검증 결과는 “통과/실패”에 더해 **추천 실행 단계**를 반환할 수 있다.
+
+- `recommended_stage`: `backtest_only | paper_only | paper_ok_live_candidate`
+
+World 정책은 이 값을 사용해:
+
+- 특정 전략은 “백테스트만 반복”하거나,
+- 일정 조건을 만족하면 “paper까지 허용”하고,
+- 충분한 검증을 통과한 전략만 “live 후보 리스트”에 올릴 수 있다.
+
+live로의 실제 전환은 기본적으로 `/apply` 또는 별도 운영 승인 플로우에 남겨두되,  
+검증 계층은 “live 후보가 될 자격이 있는지”를 엄격히 필터링하는 역할을 한다.
+
+### 4.3 Validation Profile & Policy Versioning
+
+World 정책 DSL은 단일 `validation` 블록만 갖는 대신, **단계별 Validation Profile**과 **정책 버전** 개념을 도입할 수 있다.
+
+- 예시:
+
+  ```yaml
+  validation_profiles:
+    backtest:
+      # 매우 느슨한 컷 + 과적합 경고 위주
+    paper:
+      # data/sample/performance 강하게 + robustness는 warn
+    live:
+      # robustness/risk까지 blocking
+
+  default_profile_by_stage:
+    backtest_only: backtest
+    paper_only: paper
+    paper_ok_live_candidate: live
+  ```
+
+- WorldService는 `recommended_stage`와 `default_profile_by_stage` 매핑을 이용해  
+  어떤 프로파일을 적용할지 결정한다.
+- 각 Evaluation Run에는 `validation_policy_version` 및 `ruleset_hash`를 기록해,
+  정책 변경 전후 diff를 오프라인에서 시뮬레이션하고, 경고 모드 → fail 승격 과정을 안전하게 진행할 수 있다.
+
+---
+
+## 5. 실패 → 검증 강화 피드백 루프
+
+### 5.1 실패 케이스 수집
+
+운영상에서 다음과 같은 이벤트가 발생했을 때:
+
+- paper/live 전략이 예상보다 큰 손실을 내거나,
+- 검증 단계에서 통과시켰으나 “명백한 취약성”이 드러났을 때,
+
+WorldService는 해당 전략/월드/Run에 대한 다음 정보를 함께 기록·조회할 수 있어야 한다.
+
+- Evaluation Run 메트릭 스냅샷
+- 적용되었던 world policy 버전 및 validation 파라미터
+- Rule별 평가 결과(`RuleResult`)와 status/reason
+
+### 5.2 검증 강화 절차
+
+실패가 관찰되면:
+
+1. 어떤 Rule이 해당 실패를 잡을 수 있었는지, 또는 새 Rule이 필요한지를 분석한다.
+2. Runner/ValidationPipeline/WS에 새 지표 또는 Rule을 추가한다.
+3. 기존 Evaluation Run 히스토리에 대해 “새 Rule을 적용했을 때 어떻게 달라졌을지”를 오프라인으로 시뮬레이션한다.
+4. 일정 기간 경고 모드(`status=warn`)로만 운영해 보며 영향 범위를 관찰한 뒤,
+5. 최종적으로 해당 Rule을 `fail` 모드로 승격한다.
+
+이 절차를 지원하기 위해:
+
+- Evaluation Run 지표·Rule 결과는 **append-only 히스토리**로 보존하고,
+- policy 변경 전후의 diff를 비교하는 도구(스크립트/리포트)를 제공하는 것이 바람직하다.
+
+### 5.3 운영·거버넌스·Live 모니터링
+
+기술적 검증 설계 외에도, 업계 수준 신뢰도를 위해서는 운영·거버넌스·툴링이 함께 설계되어야 한다.
+
+- **독립 검증(Independent Validation)**
+  - validation 룰 구현과 World 정책 DSL 저장소를 전략 코드 저장소와 분리한다.
+  - 변경 워크플로:
+    - 전략 코드: 퀀트 팀 주도.
+    - validation 룰/정책: 리스크/검증 담당자만 merge 권한.
+  - 모든 룰/정책 변경 시, 영향 받는 World/전략 수와 대표 “나쁜 전략” 세트에 대한 regression test 결과를 CI에서 강제한다.
+
+- **Live 전략 상시 재검증(Live Monitoring)**
+  - 매일/매주 자동 “Live Evaluation Run”을 생성하고, 최근 30/60/90일 실현 PnL/Sharpe/DD/ES 및 backtest 대비 성과 드리프트를 측정한다.
+  - DSL에 `live_monitoring` 블록을 추가해, 일정 기간 동안의 실현 지표가 기준을 벗어나면 자동 demotion 후보로 태깅하거나 수동 검토 대상으로 올린다.
+
+- **Evaluation Store & 테스트 세트**
+  - Evaluation Run 전체를 하나의 불변 아티팩트(메트릭·Rule 결과·코드 hash·데이터 snapshot·policy 버전)를 담는 “Evaluation Store”로 관리한다.
+  - 대표적인 실패 모드별 “나쁜 전략” 세트를 만들어, validation 변경 시마다 이 세트에 대해 어떤 룰이 어떤 이유로 fail을 내는지 regression test를 수행한다.
+
+- **Fail‑closed 기본값**
+  - Validation 파이프라인에서 예외/에러 발생 시 기본값은 pass가 아니라 fail(또는 “검증 실패 – 재시도 필요”)로 처리한다.
+  - DSL에 다음과 같은 옵션을 두어 World별 보수성을 조정할 수 있다.
+
+    ```yaml
+    validation:
+      on_error: fail | warn
+      on_missing_metric: fail | warn | ignore
+    ```
+
+  - 특히 high‑tier world에서는 오류/누락 시 항상 fail‑closed 경로를 타도록 권장한다.
+
+- **Validation Report/Artefact**
+  - 각 World/전략에 대해 Evaluation Run·Rule 결과를 요약한 **Validation Report**를 표준 포맷(요약, 스코프, 사용 지표·룰, 결과, 한계, 권고사항 등)으로 생성·보관한다.
+  - 보고서 템플릿·배포 경로는 운영 문서(예: `operations/activation.md` 또는 별도 MRM 문서)에서 정의하되, 이 설계는 Validation Report가 Evaluation Store의 스냅샷을 사람이 읽을 수 있는 형태로 투영한 산출물임을 전제로 한다.
+
+---
+
+## 6. 로드맵 연계 및 다음 단계
+
+이 문서의 설계는 [Core Loop × World 로드맵](core_loop_world_roadmap.md)의 Phase 4–5와 직접 연결된다.
+
+- **Phase 4**:  
+  - 여기서 정의한 Evaluation Run 메트릭 블록 구조 및 캠페인 상태 모델을 사용해  
+    backtest/paper/live 캠페인 윈도우를 관리한다.
+- **Phase 5**:  
+  - `validation` 블록과 Rule 세트가 “충분히 신뢰할 수 있는 검증 단계”를 제공하도록 확장/튜닝한다.
+
+### 작업자용 다음 스텝 제안
+
+1. **코어 지표 세트 확정**  
+   - returns/sample/performance/risk/robustness 블록에 들어갈 “최소 필수 필드”를 일단 고정한다.
+2. **첫 번째 Rule 세트 구현**  
+   - DataCurrency/Sample/Performance/RiskConstraint 중심의 작은 Rule 세트를 구현하고,  
+     world policy 예제에 `validation` 블록을 추가한다.
+3. **Rule 결과/지표 리포트 형식 정의**  
+   - Evaluation Run API 혹은 별도 리포트에서 Rule별 결과와 사유를 어떻게 보여줄지 스케치한다.
+4. **실패 케이스를 반영한 반복 프로세스 설계**  
+   - 실패 → 새 지표/Rule 추가 → 경고 모드 → fail 승격까지의 워크플로를  
+     운영 문서(operations/activation.md 또는 신규 문서)에 요약해 둔다.
+
+이 문서는 의도적으로 “스케치 수준”으로 남겨 두고, 실제 구현이 진행되면서  
+구체적인 지표 목록, Rule 타입, DSL 스키마를 채워가는 것을 전제로 한다.
+
+---
+
+## 7. 참조 스키마 & DSL 예제 (v1 제안)
+
+이 섹션은 실제 구현·정책 작업자가 바로 참조할 수 있도록, 위에서 논의된 개념들을 **v1 기준으로 정리한 스케치 스키마**를 제공한다. 필드/타입은 초안이며, 구현 단계에서 세부 이름과 구조는 조정될 수 있다.
+
+### 7.1 EvaluationRun 스키마 (요약)
+
+```yaml
+EvaluationRun:
+  run_id: string
+  world_id: string
+  strategy_id: string
+  stage: backtest | paper | live
+  model_card_version: string | null
+  risk_tier: high | medium | low
+  metrics: EvaluationMetrics
+  validation:
+    policy_version: string
+    ruleset_hash: string
+    profile: backtest | paper | live
+    results:              # rule_name -> RuleResult
+      performance.sharpe_min: RuleResult
+      robustness.dsr_min: RuleResult
+    summary:
+      status: pass | warn | fail
+      recommended_stage: backtest_only | paper_only | paper_ok_live_candidate
+      override_status: none | approved | rejected
+      override_reason: string | null
+      override_actor: string | null
+      override_timestamp: string | null
+```
+
+### 7.2 EvaluationMetrics 스키마 (블록별 v1 필드)
+
+```yaml
+EvaluationMetrics:
+  returns:
+    sharpe: float                 # v1 core
+    sortino_ratio: float          # v1.5+
+    max_drawdown: float           # v1 core
+    gain_to_pain_ratio: float     # v1 core
+    var_p01: float                # v1.5+
+    es_p01: float                 # v1.5+
+    time_under_water_ratio: float # v1 core
+    max_time_under_water_days: int  # v1.5+
+  sample:
+    effective_history_years: float  # v1 core
+    n_trades_total: int             # v1 core
+    n_trades_per_year: float        # v1 core
+    regime_coverage:
+      low_vol: float               # v1.5+
+      mid_vol: float               # v1.5+
+      high_vol: float              # v1.5+
+  risk:
+    factor_exposures:              # factor_name -> exposure
+      mkt: float                   # v1.5+ (필요 시 'mkt'만 v1 core로 시작 가능)
+      value: float                 # v1.5+
+      momentum: float              # v1.5+
+    incremental_var_99: float      # v1.5+
+    incremental_es_99: float       # v1.5+
+    adv_utilization_p95: float     # v1 core
+    participation_rate_p95: float  # v1 core
+    capacity_estimate_base: float  # v1.5+
+  robustness:
+    probabilistic_sharpe_ratio: float  # v1.5+
+    deflated_sharpe_ratio: float       # v1 core
+    cv_folds: int                      # v1.5+
+    cv_sharpe_mean: float              # v1.5+
+    cv_sharpe_std: float               # v1.5+
+    sharpe_first_half: float           # v1 core
+    sharpe_second_half: float          # v1 core
+  diagnostics:
+    strategy_complexity: float         # v1 core
+    search_intensity: int              # v1 core
+    returns_source: string | null      # v1 core — "explicit:strategy", "ws:derived" 등 returns 생성 출처
+    validation_health:
+      metric_coverage_ratio: float     # v1 core
+      rules_executed_ratio: float      # v1 core
+      validation_error_count: int      # v1.5+
+```
+
+### 7.3 RuleResult 스키마
+
+```yaml
+RuleResult:
+  status: pass | fail | warn
+  severity: blocking | soft | info
+  owner: quant | risk | ops
+  reason_code: string              # 예: "sample_too_small"
+  reason: string                   # 사람 읽기용 메시지
+  tags:
+    - string                       # 예: ["sample", "tail"]
+  details:
+    # 추가 디버깅 정보 (임의의 key/value)
+    ...: ...
+```
+
+위 스키마는 Python/Pydantic 모델 또는 유사 구조로 구현되며, 필드는 **가능한 한 backwards-compatible** 하게만 추가하는 것을 기본 원칙으로 한다.
+
+### 7.4 Validation DSL 예제 (Tier × Stage × Profile)
+
+아래는 risk tier, stage, validation profile 개념을 결합한 World 정책 DSL 예시다. 실제 필드 이름·값 범위는 구현 시점에 맞게 조정한다.
+
+```yaml
+risk_profile:
+  tier: high
+  max_capital_at_risk_pct: 2.0
+  client_critical: true
+
+validation_profiles:
+  backtest:
+    data_currency:
+      max_lag: 5m              # v1 core
+      min_history: 180d        # v1 core
+    sample:
+      min_effective_years: 3.0 # v1 core
+      min_trades_total: 200    # v1 core
+      require_high_vol_regime: true  # v1.5+
+    performance:
+      sharpe_min: 0.6          # v1 core
+      max_dd_max: 0.30         # v1 core
+      gain_to_pain_min: 1.2    # v1 core
+    robustness:
+      dsr_min: 0.2             # v1 core
+      cv_sharpe_gap_max: 0.6   # v1.5+ (train/test gap)
+      severity: soft
+      owner: quant
+    risk:
+      incremental_var_99_max: 0.5     # v1.5+
+      adv_utilization_p95_max: 0.3    # v1 core
+      participation_rate_p95_max: 0.2 # v1 core
+
+  paper:
+    performance:
+      sharpe_min: 0.8          # v1 core
+      max_dd_max: 0.25         # v1 core
+      gain_to_pain_min: 1.4    # v1 core
+    robustness:
+      dsr_min: 0.3             # v1 core
+      cv_sharpe_gap_max: 0.4   # v1.5+
+      severity: blocking
+      owner: risk
+
+  live:                         # v1.5+
+    performance:
+      sharpe_min: 1.0
+      max_dd_max: 0.20
+      gain_to_pain_min: 1.5
+    risk:
+      incremental_var_99_max: 0.3
+      capacity_estimate_base_min: 5_000_000
+    portfolio:
+      max_incremental_var_99: 0.5
+      min_portfolio_sharpe_uplift: 0.1
+
+default_profile_by_stage:
+  backtest_only: backtest
+  paper_only: paper
+  paper_ok_live_candidate: live   # v1.5+ (v1에서는 사용하지 않음)
+
+validation:
+  on_error: fail              # v1 core
+  on_missing_metric: fail     # v1 core
+```
+
+이 예시는 “v1에서 현실적으로 가져갈 수 있는 최소/핵심 세트”를 그림으로 보여주는 용도이며, 실제 구현에서는 다음 원칙을 따른다.
+
+- 필드는 가능한 한 **optional + 안전한 기본값**을 갖도록 설계한다.
+- 새로운 지표·룰·프로파일을 추가할 때는, 기존 world 설정이 깨지지 않도록 **명시적 opt‑in**을 요구한다.
+- risk tier / stage / profile 매핑은 world별로 튜닝 가능한 기본값을 제공하되, high‑tier + client_critical world에 대해서는 가장 보수적인 조합을 권장한다.
+
+---
+
+## 8. SR 11‑7 / 모델 리스크 관리 관점 매핑 (요약)
+
+은행권 등 규제 환경에서 자주 인용되는 SR 11‑7 모델 리스크 관리 프레임워크는 검증을 대략 다음 세 축으로 나눈다.
+
+- **개념적 건전성(conceptual soundness)**  
+  - 본 문서에서는 1.1의 Model Card + risk tiering, 3장의 Rule 타입 분류, 4장의 validation/selection 역할 분리로 대응된다. 전략 아이디어/팩터의 이론적 타당성 자체는 별도 모델링 문서에서 다루되, 해당 가정·한계를 Model Card와 Evaluation Run에 연결해 추적 가능하게 한다.
+
+- **결과 분석·백테스트/벤치마킹(outcomes analysis & benchmarking)**  
+  - 2장의 Evaluation Metrics(returns/sample/risk/robustness), 3장의 PerformanceRule/RobustnessRule, 7.2의 v1 코어 지표 세트가 이 축을 담당한다. CohortRule/PortfolioRule, 벤치마크 전략(단순 Buy&Hold, cap‑weighted index, naive factor 등)을 통한 상대 비교는 결과 분석·벤치마킹 요구를 충족하는 확장 포인트다.
+
+- **지속 모니터링(ongoing monitoring) 및 거버넌스/독립성**  
+  - 5.3의 Live Monitoring, Evaluation Store·“나쁜 전략” 세트, fail‑closed(on_error/on_missing_metric) 정책과 validation_health 메트릭이 지속 모니터링 요구에 대응한다.
+  - 동일 섹션에서 제안한 **독립 검증(Repo 분리, merge 권한 분리)**, override 로깅, policy 버전 관리(`validation_policy_version`·`ruleset_hash`)는 거버넌스·독립성 요건을 뒷받침한다.
+
+이 문서와 연관된 조직/프로세스 문서에서 역할·책임(RACI), 벤치마크 모델 집합, Validation Report 템플릿만 추가로 정의하면, 소규모/중형 퀀트 운용사·브로커딜러 환경에서도 SR 11‑7 수준의 모델 검증·모니터링 체계와 구조적으로 잘 정렬된 검증 계층을 갖추게 된다.
+
+---
+
+## 9. 구현 갭 분석 및 주의사항 (검토 의견)
+
+!!! warning "검토 의견"
+    이 섹션은 현재 QMTL 코드베이스(2025-12-09 기준)와 본 설계 문서 간의 구조적 갭을 분석한 내용이다. 실제 구현 시 이질적으로 동작할 가능성이 높은 부분을 식별하고, 점진적 마이그레이션 전략을 제안한다.
+
+### 9.1 Validation 레이어 위치 문제
+
+**현재 구현:**
+
+```
+Runner.submit() → ValidationPipeline (SDK 레벨) → policy_engine.evaluate_policy() → WorldService.evaluate()
+```
+
+- `ValidationPipeline`은 **SDK/Runtime 레이어**(`qmtl/runtime/sdk/validation_pipeline.py`)에 위치
+- `policy_engine.py`는 **WorldService 하위**에 있지만, 실제로는 SDK에서 직접 import해서 사용
+- 검증 로직이 Runner → WS 사이에 분산되어 있음
+
+**본 설계 제안:**
+
+- WorldService가 검증의 **SSOT**
+- Rule 세트를 WS가 관리하고, Runner는 메트릭만 계산해서 전달
+- `validation` 블록이 정책 DSL의 일부로 WS에서 파싱/실행
+
+**갭:**
+
+- 현재는 **ValidationPipeline이 SDK에서 정책 평가를 직접 수행**하고, WS는 최종 activate/reject 결정만 내림
+- 설계처럼 "WS가 Rule 파이프라인 전체를 오케스트레이션"하려면 **SDK→WS 간 책임 재배치** 필요
+
+**권장 마이그레이션:**
+
+1. 단기: SDK의 ValidationPipeline이 계산한 RuleResult를 WS에 그대로 전달, WS는 이를 저장/조회만 담당
+2. 중기: WS에 Rule 실행 엔진 추가, SDK는 raw metrics만 전송
+3. 장기: SDK의 ValidationPipeline을 thin client로 전환
+
+---
+
+### 9.2 메트릭 스키마 확장성
+
+**현재 구현 (`PerformanceMetrics` in validation_pipeline.py):**
+
+```python
+@dataclass
+class PerformanceMetrics:
+    sharpe: float = 0.0
+    max_drawdown: float = 0.0
+    win_ratio: float = 0.0
+    profit_factor: float = 0.0
+    # ... 고정된 필드들
+```
+
+**본 설계 제안:**
+
+```yaml
+EvaluationMetrics:
+  returns: { sharpe, var_p01, es_p01, ... }
+  sample: { effective_history_years, n_trades_total, ... }
+  risk: { factor_exposures, incremental_var_99, ... }
+  robustness: { dsr, cv_sharpe_mean, ... }
+  diagnostics: { extra_metrics: {...} }  # 확장 슬롯
+```
+
+**갭:**
+
+- 현재 메트릭은 **flat한 dataclass**로, 블록별 구조화 없음
+- `diagnostics.extra_metrics` 같은 **확장 슬롯** 미존재
+- 새 지표 추가 시 dataclass 수정 필요 (OCP 위반 가능성)
+
+**권장 마이그레이션:**
+
+1. 기존 `PerformanceMetrics`에 `extra_metrics: Dict[str, Any] = field(default_factory=dict)` 필드 추가
+2. 점진적으로 블록별 서브모델(`ReturnsMetrics`, `SampleMetrics` 등) 도입
+3. 기존 flat 필드를 deprecated alias로 유지하며 하위 호환성 확보
+
+---
+
+### 9.3 Policy DSL 구조
+
+**현재 `Policy` 모델 (policy_engine.py):**
+
+```python
+class Policy(BaseModel):
+    thresholds: dict[str, ThresholdRule] = ...
+    top_k: TopKRule | None = ...
+    correlation: CorrelationRule | None = ...
+    hysteresis: HysteresisRule | None = ...
+```
+
+**본 설계 제안:**
+
+```yaml
+validation:
+  data_currency: { max_lag, min_history }
+  sample: { min_effective_years, min_trades_total }
+  performance: { sharpe_min, max_dd_max }
+  robustness: { dsr_min, severity: soft }
+  risk: { incremental_var_99_max }
+selection:
+  gates/score/topk/constraints/hysteresis
+```
+
+**갭:**
+
+- 현재는 `validation` vs `selection` 분리가 없음
+- `severity: blocking|soft|info`, `owner: quant|risk|ops` 메타데이터 미지원
+- 레이어별(Data/Sample/Performance/Risk/Robustness) 구조화 없음
+
+**권장 마이그레이션:**
+
+1. 현재 `thresholds`를 `selection.thresholds`로 alias 처리
+2. 새로운 `validation` 블록을 optional로 추가
+3. migration 기간(예: 2 릴리스) 후 구 스키마 deprecated 경고
+4. 기존 world policy 파일에 대한 자동 변환 스크립트 제공
+
+---
+
+### 9.4 Rule 모듈성과 RuleResult
+
+**현재 구현:**
+
+- `_apply_thresholds()`, `_apply_topk()` 등 **함수 기반** (Rule 객체 아님)
+- 결과는 단순히 `List[str]` (통과한 strategy ID 목록)
+- 실패 사유, severity, owner 등 메타데이터 없음
+
+**본 설계 제안:**
+
+```python
+class ValidationRule(Protocol):
+    name: str
+    def evaluate(self, metrics, context) -> RuleResult: ...
+
+class RuleResult(BaseModel):
+    status: Literal["pass", "fail", "warn"]
+    severity: Literal["blocking", "soft", "info"]
+    owner: Literal["quant", "risk", "ops"]
+    reason_code: str
+    reason: str
+    details: dict
+```
+
+**갭:**
+
+- Rule 단위 추적 불가 → "왜 떨어졌는지" 설명하기 어려움
+- fail-closed 정책, 경고 모드 운영 불가
+
+**권장 마이그레이션:**
+
+1. 기존 함수들을 **Rule 클래스로 래핑**하는 adapter 패턴 사용
+2. `evaluate_policy()` 반환 타입을 `List[str]` → `PolicyEvaluationResult` 확장
+   - `PolicyEvaluationResult`: selected IDs + `Dict[str, RuleResult]` 맵 포함
+3. 기존 호출자는 `.selected_ids` 속성으로 하위 호환 유지
+
+---
+
+### 9.5 Evaluation Run 모델
+
+**현재 구현:**
+
+- `ActivationEntry`, `ValidationCacheEntry` 등 **단편적인 저장 모델**
+- 명시적인 **Evaluation Run** 개념 미존재
+- 정책 버전, ruleset hash, model card 등 추적 메타데이터 없음
+
+**본 설계 제안:**
+
+- `EvaluationRun`: `(world_id, strategy_id, run_id)` 키로 전체 평가 이력 관리
+- `validation.policy_version`, `ruleset_hash`, `recommended_stage` 포함
+
+**갭:**
+
+- "이 전략이 어떤 정책 버전 아래 어떤 룰로 통과/실패했는지" 추적 불가
+- 정책 변경 전후 diff 시뮬레이션 불가
+
+**권장 마이그레이션:**
+
+1. 기존 `ValidationCacheEntry`를 `EvaluationRun`의 서브셋으로 취급
+2. WS storage layer에 `evaluation_runs` 테이블/컬렉션 추가
+3. 기존 API는 내부적으로 EvaluationRun을 생성하되, 응답 스키마는 점진적으로 확장
+
+---
+
+### 9.6 CohortRule / PortfolioRule / StressRule
+
+**현재 구현:**
+
+- 단일 전략 단위 평가만 지원
+- 캠페인(다중 전략 동시 제출) 개념 없음
+- 포트폴리오 레벨 incremental risk 평가 없음
+
+**본 설계 제안:**
+
+- `CohortRule`: 여러 전략을 함께 평가해 다중 테스트 통제
+- `PortfolioRule`: 기존 live 전략과 합쳐서 incremental VaR/ES 계산
+- `StressRule`: 사전 정의된 시나리오별 재시뮬레이션
+
+**갭:**
+
+- 현재 아키텍처에서 이 개념들을 도입하려면 **상당한 확장** 필요
+- WS가 "활성 전략 목록"을 알고 있어야 portfolio-level 평가 가능
+
+**권장 마이그레이션:**
+
+1. v1에서는 CohortRule/PortfolioRule/StressRule을 **optional extension**으로 분류
+2. 먼저 단일 전략 Rule 체계를 안정화
+3. 이후 WS에 "active portfolio snapshot" 개념 도입 후 portfolio-level rule 추가
+
+---
+
+### 9.7 구현 우선순위 제안
+
+| Phase | 범위 | 기존 코드 영향 | 예상 공수 |
+|-------|------|----------------|-----------|
+| **P1** | EvaluationMetrics 블록 구조화 + `extra_metrics` 확장 슬롯 | 낮음 (additive) | 1–2일 |
+| **P2** | RuleResult 스키마 도입 + 기존 함수들 Rule 래핑 | 중간 (adapter) | 3–5일 |
+| **P3** | Policy DSL에 `validation` 블록 추가 (selection과 분리) | 중간 (migration) | 3–5일 |
+| **P4** | EvaluationRun 모델 + policy_version/ruleset_hash 추적 | 높음 (storage 변경) | 5–7일 |
+| **P5** | Cohort/Portfolio/StressRule | 높음 (새 기능) | 7–14일 |
+
+---
+
+### 9.8 핵심 설계 결정 필요 사항
+
+본 설계를 구현하기 전에 다음 사항에 대한 명시적 결정이 필요하다:
+
+1. **검증 오케스트레이션 위치**  
+   SDK(`ValidationPipeline`)에서 계속할지, WS로 이전할지?  
+   → 현실적으로는 **하이브리드 접근**(SDK가 Rule 실행, WS가 결과 저장/정책 관리)이 마이그레이션 비용을 낮출 수 있다.
+
+2. **기존 Policy 스키마 호환성**  
+   마이그레이션 기간과 deprecated 정책은?  
+   → 최소 2 릴리스 동안 구 스키마 지원 권장.
+
+3. **fail-closed 기본값 적용 시점**  
+   프로덕션 적용 시점과 티어별 다른 정책?  
+   → `tier: high` world부터 단계적 적용, `tier: low`는 opt-in 방식 권장.
+
+4. **Rule 소유권 분리**  
+   `owner: quant|risk|ops` 메타데이터를 실제 권한 시스템과 어떻게 연결할지?  
+   → 초기에는 정보성 태그로만 사용, 이후 CI/approval workflow와 연동.
+
+5. **스트리밍 아키텍처와의 정렬**  
+   QMTL은 기본적으로 WorldService/Gateway/SDK가 **스트리밍 이벤트(ActivationUpdated, QueueUpdated, Commit Log 등)** 를 중심으로 동작한다. 검증 계층 구현 시에도 다음 원칙을 고려해야 한다.
+   - EvaluationRun과 validation 결과는 단발성 batch 산출물이 아니라, **시간에 따라 누적·갱신되는 스트림의 스냅샷**으로 취급한다.
+   - Runner.submit 경로에서 모든 검증을 동기적으로 처리하려 하지 말고,  
+     - “필수 최소 검증”만 submit 파이프라인 안에서 수행하고,  
+     - 나머지 심층 검증/캠페인/Cohort/Portfolio/Stress 룰은 **별도 스트리밍/배치 파이프라인**에서 EvaluationRun 스트림을 소비하는 형태로 분리한다.
+   - WorldService는 ControlBus/Commit Log 등 기존 이벤트 버스를 활용해  
+     - `EvaluationRunCreated`/`EvaluationRunUpdated`/`ValidationProfileChanged` 같은 이벤트를 발행하고,  
+     - 검증/리포트/모니터링 컴포넌트는 이를 구독하여 **비동기적으로 Rule을 실행**하도록 설계하는 것이 QMTL의 스트리밍 모델과 더 자연스럽게 맞는다.
+   - Core Loop E2E 경로와는 별도로, **검증 결과/상태를 스트리밍 대시보드(예: Prometheus/Grafana, Web UI)** 쪽으로 지속적으로 흘려보내는 것을 전제로 설계해야 한다.  
+     Runner/CLI가 “현재 검증 상태/추천 단계”를 조회할 때도 WS의 EvaluationRun 스냅샷을 읽는 대신, 스트림 기반 상태 저장소(캐시/뷰)를 조회하는 구조가 장기적으로 더 일관성 있다.
+
+---
+
+## 10. 품질 목표 및 SLO (초안)
+
+검증 계층이 “어느 정도까지 잘 작동하면 성공으로 볼 것인지”를 정량화하기 위해, 다음과 같은 품질 목표·SLO를 초안 수준으로 제안한다. 실제 수치는 조직/World별로 조정 가능하며, 본 문서는 지표 구조만 고정한다.
+
+### 10.1 기능적 목표 (Validation Effectiveness)
+
+- **False‑negative 제한 (고위험 World)**  
+  - `risk_profile.tier=high` 및 `client_critical=true`인 World에 대해,  
+    과거 실패 사례 유형(예: 과도한 레버리지, 극단적 DD, 유동성 붕괴)에 해당하는 synthetic 전략/히스토리를 재현했을 때:
+    - 최소 95% 이상의 테스트 케이스에서 하나 이상의 Rule이 `status=fail` 또는 `status=warn`를 반환해야 한다.
+- **Coverage 목표**  
+  - v1 코어 메트릭 세트에 대해 `validation_health.metric_coverage_ratio >= 0.98`를 유지하는 것을 목표로 한다.
+
+### 10.2 운영 목표 (Pipeline Reliability)
+
+- **단건 EvaluationRun 처리 지연**  
+  - p95 latency < 1초, p99 latency < 5초 (단일 World/전략 EvaluationRun 기준, v1 코어 룰 세트만 적용한 경우).
+- **에러/누락 이벤트 비율**  
+  - `validation.on_error in {fail,warn}` 또는 `on_missing_metric in {fail,warn}` 로 기록된 이벤트 비율이 전체 EvaluationRun의 X% 이하(예: 1% 이하)를 유지하도록 한다.
+
+### 10.3 리스크 관점 목표 (Ex‑post 실패율)
+
+- **검증 허용 후 ex‑post 실패 비율**  
+  - “검증 계층이 허용(passed)했으나, ex‑post 관점에서 명백히 피했어야 할 실패 케이스”로 분류된 live 전략 비율을  
+    - 연간 전체 live 전략 수의 Y% 이하(예: 2% 이하)로 유지하는 것을 목표로 한다.
+- 해당 지표는 Model Risk Management 문서(`model_risk_management_framework.md`)와 연동해 관리하며,  
+  검증 계층 개선의 우선순위를 정하는 기준으로 사용한다.
+
+---
+
+## 11. 검증 계층 테스트 전략 (초안)
+
+검증 계층은 일반 유닛 테스트 외에도 **정책/룰 변경이 기존 World/전략에 미치는 영향**을 검증할 수 있는 테스트 전략이 필요하다. 아래는 이를 위한 최소 구성 초안이다.
+
+### 11.1 단위 테스트 (Rule‑level)
+
+- 각 ValidationRule에 대해:
+  - 정상 입력에서 기대한 `status`/`reason_code`/`severity`가 나오는지 검증.
+  - 필수 메트릭 누락/에러 발생 시 `on_error`/`on_missing_metric` 정책을 준수하는지 확인.
+
+### 11.2 시나리오 테스트 (Good/Bad/Borderline 전략)
+
+- 대표적인 전략 샘플 또는 EvaluationRun 스냅샷 세트를 정의한다.
+  - Good: 안정적 Sharpe, 적절한 샘플, tail·유동성 리스크 양호.
+  - Bad: 극단적 레버리지, 지나치게 짧은 백테스트, 과도한 탐색 강도 등.
+  - Borderline: 기준 근처에 위치한 전략들.
+- 정책/룰 변경 시:
+  - 각 샘플에 대해 어떤 RuleResult가 발생하는지 자동으로 비교·리포트한다.
+
+### 11.3 회귀 테스트 (Policy Diff)
+
+- `validation_policy_version`/`ruleset_hash` 변경 시, 과거 N개월(예: 12개월)의 EvaluationRun 히스토리에 대해:
+  - 이전 정책 vs 새로운 정책을 적용했을 때의 `summary.status`·`recommended_stage` diff를 계산.
+  - 영향 범위가 특정 임계값(예: 전체 Run의 5% 초과)을 넘으면 경고 및 수동 검토를 요구한다.
+
+### 11.4 성능/부하 테스트
+
+- 다양한 World/전략 조합, 동시 EvaluationRun 수(N) 시나리오에 대해:
+  - Rule 평가 latency, 에러율, 스트림 처리 지연을 측정.
+  - 10.2에서 정의한 SLO를 만족하는지 확인.
+
+---
+
+## 12. 시스템 인바리언트 및 안전장치 (초안)
+
+운영/리스크 관점에서 “절대로 깨져서는 안 되는 조건”을 명시해 두면, 코드/구성 변경 시 검증·테스트의 기준이 명확해진다. 아래 인바리언트는 초안이며, 실제 적용 시 World tier 등에 따라 확장될 수 있다.
+
+### 12.1 실행 단계 관련 인바리언트
+
+- **Invariant 1 — live 단계 정합성**
+  - `stage=live` 또는 `effective_mode=live`인 전략에 대해서는:
+    - 최신 EvaluationRun의 `summary.status`가 반드시 `"pass"` 여야 한다.
+    - 최신 EvaluationRun의 `validation.policy_version`은 해당 World의 현재 WorldPolicy 버전과 호환되어야 한다(최소 버전 이상).
+
+### 12.2 고위험 World에 대한 강제 규칙
+
+- **Invariant 2 — high‑tier World의 fail‑closed 정책**
+  - `risk_profile.tier=high` 및 `client_critical=true`인 World에서는:
+    - `validation.on_error`와 `validation.on_missing_metric`은 항상 `"fail"`이어야 한다.
+    - 이 설정을 완화하려면 별도 승인 플로우 및 Change Log 기록이 필요하다.
+
+### 12.3 Override 관련 인바리언트
+
+- **Invariant 3 — override 관리**
+  - `override_status=approved`인 EvaluationRun(또는 전략/World 조합)은:
+    - 별도 목록으로 집계되어야 하며,
+    - 설정된 기간(예: 30일/90일) 내에 반드시 재검토 대상이 되어야 한다.
+  - Override 승인 시:
+    - `override_reason`, `override_actor`, `override_timestamp`는 필수 기록 필드다.
+
+이러한 인바리언트는 Core Loop E2E 테스트, CI 정책 체크, 운영 점검(checklist) 등에 반영되는 것을 전제로 한다.
+
+---
+
+## 13. E2E 시나리오 예제 (개략)
+
+검증 계층이 실제 QMTL Core Loop와 어떻게 상호작용하는지 이해를 돕기 위해, 대표적인 세 가지 흐름을 개략적으로 정리한다.
+
+### 13.1 새 전략의 최초 backtest 제출
+
+1. 개발자는 Model Card를 작성하고, 전략 코드를 준비한다.
+2. `Runner.submit(MyStrategy, world="demo", mode="backtest")` 호출:
+   - SDK가 히스토리 warmup → backtest → returns/metrics 추출.
+   - WorldService에 EvaluationRun이 생성되고, v1 코어 validation 프로파일이 적용된다.
+3. ValidationRule들이 EvaluationMetrics를 평가하여 `RuleResult` 집합과 `summary.status`/`recommended_stage`를 생성한다.
+4. SDK/CLI는 SubmitResult에 `evaluation_run_id`/`summary` 일부를 매핑해 사용자에게 보여준다.
+5. Risk/Validator는 Evaluation Store와 Model Card를 기반으로 Validation Report 초안을 작성한다.
+
+### 13.2 paper까지 승격되는 경우
+
+1. 여러 번의 backtest EvaluationRun에서 일관되게 `recommended_stage=paper_only` 또는 `paper_ok_live_candidate`가 나온다.
+2. Risk/Validator가 Validation Report를 승인하고, WorldPolicy에서 해당 전략/World에 대해 paper 프로파일을 활성화한다.
+3. PM/Ops가 합의 후, `/worlds/{id}/apply` 또는 CLI를 통해 paper 모드 실행을 허용한다.
+4. 이후 EvaluationRun은 paper 프로파일을 사용해 검증되며, Live Monitoring 지표(최근 30/60/90일 결과)가 누적된다.
+
+### 13.3 live 전략의 성능 악화로 인한 demotion
+
+1. live 전략에 대해 주기적으로 Live EvaluationRun이 생성되고, backtest 대비 성능 decay 및 risk breach가 감지된다.
+2. Live Monitoring 규칙에 따라:
+   - 특정 임계값을 초과하면 해당 전략은 자동 demotion 후보로 태깅된다.
+3. Risk/Ops/PM은 Validation Report 업데이트와 함께 전략 상태를 검토하고,
+   - `/apply` 플로우를 통해 `effective_mode`를 paper 또는 backtest로 강등하거나,
+   - override가 필요한 경우 `override_status=approved`로 승인하되, Invariant 3에 따라 재검토 일정과 사유를 기록한다.
+
+위 시나리오는 상세한 API/타임라인을 생략한 개략이며, 실제 구현 시에는 Core Loop 시퀀스 다이어그램 및 WorldService API 문서와 함께 보완된다.
+
+이러한 결정들을 먼저 정리한 후 구현에 들어가면, 설계와 실제 동작 사이의 이질성을 최소화할 수 있다.

--- a/docs/ko/design/world_validation_v1_implementation_plan.md
+++ b/docs/ko/design/world_validation_v1_implementation_plan.md
@@ -1,0 +1,163 @@
+---
+title: "World 검증 v1 구현 계획"
+tags: [design, world, validation, implementation-plan]
+author: "QMTL Team"
+last_modified: 2025-12-09
+status: draft
+---
+
+# World 검증 v1 구현 계획
+
+!!! abstract "역할"
+    이 문서는 `world_validation_architecture.md`와 `model_risk_management_framework.md`를 기반으로,  
+    **v1 단계에서 실제로 구현할 범위와 순서를 작업자 관점에서 정리한 구현 계획서**다.  
+    설계 문서 그 자체를 수정하기보다는, 이 계획서를 TODO/체크리스트로 사용해 “설계를 잃지 않고 큰 변경”을 수행하는 것이 목적이다.
+
+관련 설계 문서:
+
+- World 검증 계층 설계: [world_validation_architecture.md](world_validation_architecture.md)
+- 모델 리스크 관리 프레임워크: [model_risk_management_framework.md](model_risk_management_framework.md)
+
+---
+
+## 1. v1 구현 스코프 요약
+
+v1은 **“단일 전략 + 단일 World에 대한 기본 검증”**을 안정적으로 도입하는 것을 목표로 한다.  
+다음 항목만 실제 구현 대상으로 포함하고, 그 외(코호트/포트폴리오/Stress/Live 프로파일 등)는 v1.5+로 남겨둔다.
+
+### 1.1 EvaluationRun / Metrics
+
+- EvaluationRun (WS 쪽)
+  - 필수 필드: `run_id`, `world_id`, `strategy_id`, `stage`, `risk_tier`
+  - validation 메타: `validation.policy_version`, `validation.ruleset_hash`, `validation.profile`, `summary.status`, `summary.recommended_stage`
+- EvaluationMetrics (v1 core 필드만)
+  - returns: `sharpe`, `max_drawdown`, `gain_to_pain_ratio`, `time_under_water_ratio`
+  - sample: `effective_history_years`, `n_trades_total`, `n_trades_per_year`
+  - risk: `adv_utilization_p95`, `participation_rate_p95` (factor_exposures 등은 v1.5+)
+  - robustness: `deflated_sharpe_ratio`, `sharpe_first_half`, `sharpe_second_half`
+  - diagnostics: `strategy_complexity`, `search_intensity`, `validation_health.metric_coverage_ratio`, `validation_health.rules_executed_ratio`, `returns_source`
+
+### 1.2 Rule / DSL
+
+- Rule 타입 (v1)
+  - DataCurrencyRule, SampleRule, PerformanceRule, RiskConstraintRule
+  - 단일 EvaluationRun(단일 전략)만 평가 (Cohort/Portfolio/StressRule은 v1.5+)
+- RuleResult (필수 필드)
+  - `status`, `severity`, `owner`, `reason_code`, `reason`, `tags`, `details`
+- World policy DSL (v1)
+  - `validation_profiles.backtest` / `validation_profiles.paper`의 v1 core 필드
+  - `default_profile_by_stage.backtest_only/paper_only`
+  - `validation.on_error=fail`, `validation.on_missing_metric=fail`
+  - `live` 프로파일, portfolio 섹션은 정의만 두고 v1에서는 사용하지 않는다.
+
+### 1.3 MRM / 아티팩트
+
+- Model Card
+  - 최소 필수 필드: ID/버전, 목적, 데이터 개요, 핵심 가정/한계
+- Validation Report (초안 포맷)
+  - Summary, Scope/Objective, Model 요약, 사용한 프로파일/룰/지표, 결과, 한계/권고사항
+- Override 로깅
+  - `override_status`, `override_reason`, `override_actor`, `override_timestamp` 필드만 구현
+
+---
+
+## 2. 설계 섹션 ↔ 코드 모듈 매핑
+
+구현 중 설계를 잃지 않기 위해, 주요 문서 섹션을 예상 코드 위치와 매핑해 둔다. (실제 모듈명/경로는 구현 시점에 조정 가능)
+
+| 설계 섹션 | 개념 | 예상 코드 위치 예시 |
+|----------|------|----------------------|
+| §7.1 EvaluationRun | EvaluationRun 모델/저장소 | `qmtl/services/worldservice/models/evaluation_run.py` |
+| §7.2 EvaluationMetrics | 메트릭 스키마 | `qmtl/services/worldservice/schemas/evaluation_metrics.py` |
+| §7.3 RuleResult | 룰 평가 결과 | `qmtl/services/worldservice/policy_engine.py` 내 새 모델 |
+| §7.4 validation_profiles DSL | World policy validation 블록 | `qmtl/services/worldservice/policy_engine.py` DSL 파서 |
+| §3 ValidationRule 인터페이스 | 룰 구현/adapter | `policy_engine.py` 또는 `validation_rules.py` |
+| §10 품질 목표/SLO | 모니터링 지표 정의 | `docs/ko/operations/*` / alert_rules.yml 연계 |
+| §12 인바리언트 | CI/E2E 체크 조건 | `tests/e2e/core_loop` / 신규 validation 테스트 |
+
+이 표를 작업 초기에 한 번 확정해 두고, 실제 코드 경로가 바뀌면 이 문서를 함께 업데이트한다.
+
+---
+
+## 3. Vertical Slice 기반 단계별 계획
+
+### 3.1 P1 — EvaluationRun 저장/조회 (스키마만)
+
+목표:
+- WorldService에 EvaluationRun 모델/저장소를 추가하고, Runner.submit에서 `run_id` 생성·조회까지 연결한다.
+
+범위:
+- `evaluation_runs` 테이블/컬렉션 추가 (필수 메타만)
+- WS API에 EvaluationRun 조회 endpoint (internal 용) 추가
+- Runner.submit → WS로 EvaluationRun 생성/링크 수신 (SubmitResult.evaluation_run_id)
+
+비범위:
+- Rule 평가/validation_profiles 적용은 아직 하지 않는다 (status 등은 placeholder).
+
+### 3.2 P2 — RuleResult 도입 & 단일 전략 Rule 엔진
+
+목표:
+- 기존 policy_engine 로직을 Rule 클래스로 래핑하고, RuleResult를 생성해 EvaluationRun.validation.results에 저장한다.
+
+범위:
+- ValidationRule 인터페이스 구현
+- DataCurrency/Sample/Performance/RiskConstraint 룰을 Rule 클래스로 포장
+- RuleResult 스키마 도입
+- EvaluationRun.validation.results에 RuleResult 맵 저장
+
+비범위:
+- Cohort/Portfolio/StressRule, live_monitoring, 캠페인 수준 평가는 포함하지 않는다.
+
+### 3.3 P3 — validation_profiles DSL(v1) 적용
+
+목표:
+- World policy에 `validation_profiles.backtest/paper` 블록을 추가하고, v1 core 필드만 적용한다.
+
+범위:
+- DSL 파서 확장 (기존 thresholds를 selection으로 alias 처리)
+- 몇 개 샘플 World YAML을 새 DSL로 마이그레이션
+- v1 validation_profile에 따라 어떤 Rule이 어떤 파라미터로 구성되는지 결정
+
+비범위:
+- 전체 World 파일 일괄 변환, live 프로파일, portfolio 섹션 적용은 v1.5+.
+
+### 3.4 P4 — Validation Report/아티팩트 최소 구현
+
+목표:
+- EvaluationRun + Model Card 정보를 바탕으로 기계 생성 가능한 Validation Report 초안을 만들 수 있게 한다.
+
+범위:
+- Report 생성 헬퍼/스크립트 (예: `scripts/generate_validation_report.py`)
+- 최소 Summary/Scope/Result/Key Rules 섹션만 포함
+
+비범위:
+- 리치 포맷팅, UI 통합, 자동 배포는 v1.5+.
+
+---
+
+## 4. 설계 변경 시 문서 업데이트 규칙
+
+구현 중 설계 일부를 바꾸고 싶어질 때는, 코드부터 바꾸지 말고 다음 순서를 따른다.
+
+1. 해당 설계 문서 섹션 옆에 짧은 note를 추가한다.
+   - 예: `!!! note "v1 구현 예정 변경"` 형태로 “여기서 말하는 X는 v1에서는 Y로 단순화된다” 식으로 주석.
+2. 이 구현 계획 문서에 “영향 받는 섹션 ↔ 코드 모듈”을 한 줄 메모한다.
+3. 코드 변경 후, 다시 설계 문서를 훑으며 거짓이 된 문장을 수정하거나 “v1.5+ 예정”으로 명시한다.
+
+이 규칙을 통해 “문서가 오래된 설계 스냅샷으로 남는 것”을 방지한다.
+
+---
+
+## 5. 체크리스트 (v1 완료 기준)
+
+v1 구현이 완료되었다고 주장하기 위한 최소 체크리스트:
+
+- [ ] WS에 EvaluationRun 모델/저장소가 추가되었고, Runner.submit 결과로 run_id를 확인할 수 있다.
+- [ ] EvaluationMetrics v1 core 필드가 채워지고, WorldService에서 이를 조회할 수 있다.
+- [ ] DataCurrency/Sample/Performance/RiskConstraint Rule이 RuleResult를 반환하며, EvaluationRun.validation.results에 저장된다.
+- [ ] World policy에 validation_profiles.backtest/paper 블록이 존재하고, v1 core 필드만으로도 go/no‑go 판단을 할 수 있다.
+- [ ] 최소 한 개 World/전략에 대해 Validation Report 초안을 자동 생성할 수 있다.
+- [ ] §12의 인바리언트(특히 Invariant 1/2/3)에 대한 테스트/체크가 CI 또는 e2e 테스트로 구현되었다.
+
+이 체크리스트를 모두 만족한 시점을 v1 “검증 계층 구현 완료”로 간주하고, 이후 Cohort/Portfolio/StressRule, live 프로파일, 포트폴리오 리스크, capacity, advanced robustness 지표 등 v1.5+ 범위를 별도 계획으로 확장해 나간다.
+

--- a/docs/ko/design/worldservice_evaluation_runs_and_metrics_api.md
+++ b/docs/ko/design/worldservice_evaluation_runs_and_metrics_api.md
@@ -27,7 +27,7 @@ related_issue: "hyophyop/qmtl#1750"
 관련 문서:
 
 - [아키텍처 개요](../architecture/architecture.md), [WorldService](../architecture/worldservice.md)
-- [auto_returns 통합 설계](auto_returns_unified_design.md)
+- [auto_returns 통합 설계](../archive/auto_returns_unified_design.md)
 - Core Loop 합의 요약: [architecture.md](../architecture/architecture.md#core-loop-summary)
 
 여기서 제안하는 API/스키마는 **초안(draft)** 이며, 실제 적용 전에 worldservice/gateway/SDK 팀과 함께 구체화·축소·분할해야 한다.

--- a/docs_archive/ko/archive/seamless_materialize_jobs.md
+++ b/docs_archive/ko/archive/seamless_materialize_jobs.md
@@ -1,0 +1,127 @@
+# Seamless 데이터 물질화 설계: DAG 격리 실행
+
+!!! warning "Status: draft"
+    이 문서는 초안 상태입니다. 구현 과정에서 세부 동작과 API가 변경될 수 있습니다.
+
+## 핵심 아이디어
+
+**DAG를 Core Loop에서 격리하여 실행**하는 것이 본 설계의 핵심이다.
+
+- **Core Loop (live/paper)**: `Runner.submit` → World/activation 흐름, `as_of = now` (실시간)
+- **Materialize**: DAG를 격리된 환경에서 **지정된 범위(start/end)** 로 replay
+
+```
+┌─────────────────────────────────────────────────────────┐
+│              SeamlessDataProvider (공통 엔진)            │
+└─────────────────────────┬───────────────────────────────┘
+                          │
+          ┌───────────────┴───────────────┐
+          │                               │
+   Core Loop 실행                  격리 실행 (Materialize)
+   Runner.submit(...)              MaterializeSeamlessJob(...)
+   as_of = now                     as_of = start..end
+          │                               │
+          ▼                               ▼
+   WS/activation/allocations       노드별 물질화 저장
+```
+
+### 왜 start/end가 필요한가?
+
+DAG에 wiring된 `SeamlessDataProvider`는 **start/end를 저장하지 않는다**:
+
+- `SeamlessDataProvider.fetch(start, end, ...)` — 파라미터로 받음
+- `DataPresetSpec` — interval_ms, sla_preset만 있고 범위 없음
+- Core Loop에서는 Runner가 `as_of = now`를 암묵적으로 결정
+
+따라서 **과거 데이터 사전 계산(물질화)**이 목적이라면 범위는 외부에서 제공해야 한다.
+
+## API
+
+```python
+# DAG + 범위만 입력
+job = MaterializeSeamlessJob(
+    strategy=MyStrategy,   # DAG (모든 설정 자동 추출)
+    start=1700000000,      # 범위 시작
+    end=1700100000,        # 범위 종료
+)
+report = await job.run()
+```
+
+### 자동 추출 항목
+
+| 항목 | 추출 소스 |
+|------|-----------|
+| `interval` | 각 노드의 `node.interval` |
+| `period` | 각 노드의 `node.period` |
+| `preset` | `StreamInput.history_provider.preset` |
+| `history_provider` | `StreamInput.history_provider` |
+
+### 입력
+
+| 입력 | 설명 |
+|------|------|
+| `strategy` | 물질화할 DAG |
+| `start` | 시작 타임스탬프 |
+| `end` | 종료 타임스탬프 |
+
+## 실행 흐름
+
+```
+1. Strategy 인스턴스화 → 노드 그래프 구성
+2. Compute-only 컨텍스트 (live 구독/WS 호출 차단)
+3. 토폴로지 정렬 → 실행 순서 결정
+4. StreamInput 워밍업 → SeamlessDataProvider.fetch(start, end)
+5. 노드 순차 실행 → compute_fn 호출 및 저장
+6. 리포트 생성 → fingerprint/coverage 통합
+```
+
+## 출력
+
+```python
+@dataclass
+class MaterializeReport:
+    coverage_bounds: tuple[int, int]  # 물질화된 범위
+    node_count: int                   # 물질화된 노드 수
+```
+
+> fingerprint 등 내부 구현 세부사항은 자동 캐시에서 사용되며 사용자가 직접 다룰 필요 없음.
+
+## 자동 캐시
+
+**동일 DAG + 동일 범위 = 캐시 히트** (재계산 없이 로드)
+
+```python
+# 첫 실행: 계산 후 저장
+job = MaterializeSeamlessJob(MyStrategy, start=T0, end=T1)
+await job.run()
+
+# 재실행: 자동 캐시 히트 (재계산 없음)
+job = MaterializeSeamlessJob(MyStrategy, start=T0, end=T1)
+await job.run()  # 즉시 완료
+```
+
+사용자는 fingerprint나 storage 경로를 관리할 필요 없음.
+
+## 비교
+
+| 항목 | Core Loop | Materialize |
+|------|-----------|-------------|
+| 입력 | Strategy + world | Strategy + start/end |
+| 범위 | `as_of = now` | 명시적 start/end |
+| 모드 | live/backtest | compute-only |
+| 출력 | WS/activation | fingerprint/coverage 리포트 |
+| 저장 | 런타임 캐시 | 영구 저장 |
+
+## 테스트
+
+```python
+def test_materialize_and_cache():
+    # 첫 실행
+    job = MaterializeSeamlessJob(MyStrategy, start=T0, end=T1)
+    r1 = await job.run()
+    assert r1.node_count > 0
+    
+    # 재실행: 캐시 히트
+    r2 = await MaterializeSeamlessJob(MyStrategy, start=T0, end=T1).run()
+    assert r2.coverage_bounds == r1.coverage_bounds
+```

--- a/docs_archive/rewrite_architecture_docs.md
+++ b/docs_archive/rewrite_architecture_docs.md
@@ -23,7 +23,7 @@ status: archived
   - 아키텍처 개요: `docs/ko/architecture/architecture.md`
   - 월드/정책: `docs/ko/world/world.md`
   - 단순화 제안: `docs/ko/architecture/architecture.md#core-loop-합의-요약-편입` 편입
-  - Auto Returns: `./auto_returns_unified_design.md` (통합안)
+- Auto Returns: `../docs/ko/archive/auto_returns_unified_design.md` (통합안)
   - SR 통합: `./sr_integration_proposal.md`
 
 이 가이드는 **완전한 구현이 아직 없는 상태에서도**,  
@@ -109,7 +109,7 @@ status: archived
 
 - **핵심 부족/불연결**
   - **auto_returns 미구현**
-    - 설계 문서(`./auto_returns_unified_design.md`)의 `AutoReturnsConfig`, `auto_returns` 파라미터, `returns_derive.py`는 코드에 없다.
+    - 설계 문서(`../docs/ko/archive/auto_returns_unified_design.md`)의 `AutoReturnsConfig`, `auto_returns` 파라미터, `returns_derive.py`는 코드에 없다.
     - 실제 `submit_async`는
       - 인자로 받은 `returns`, 또는
       - `_extract_returns_from_strategy`로 `strategy.returns / equity / pnl`만 본다.
@@ -177,7 +177,7 @@ As‑Is 분석을 바탕으로, 핵심 복잡도 요인은 다음 세 가지로 
        - 실패 시에는 “파생 실패”를 improvement_hint로 남기고, 기존 동작(returns 없음)에 맞춰 거절
 
 - **문서 반영**
-  - `./auto_returns_unified_design.md`를 업데이트해:
+- `../docs/ko/archive/auto_returns_unified_design.md`를 업데이트해:
     - Runner.submit 전처리 레이어만 확장하고
     - ValidationPipeline 계약은 그대로 유지한다는 점을 명시
     - SR 통합 설계(`./sr_integration_proposal.md`)와 auto_returns 연결 지점을 Core Loop 기준으로 설명
@@ -272,7 +272,7 @@ As‑Is 분석을 바탕으로, 핵심 복잡도 요인은 다음 세 가지로 
 
 ### 4.4 Auto Returns / SR 관련 설계 문서들
 
-- `./auto_returns_unified_design.md`  
+- `../docs/ko/archive/auto_returns_unified_design.md`  
   `./sr_integration_proposal.md`
 
 - **As‑Is**
@@ -284,7 +284,7 @@ As‑Is 분석을 바탕으로, 핵심 복잡도 요인은 다음 세 가지로 
     - `목적:` Core Loop의 어느 단계를 단순화/자동화하기 위한 설계인지 한 줄로 설명
     - `As‑Is:` 현재 구현/사용 경험에서 사용자가 겪는 문제 요약
     - `To‑Be:` 이 설계가 성공했을 때 사용자가 얻게 될 경험(전략 작성/제출/평가 관점) 요약
-  - `./auto_returns_unified_design.md`의 경우:
+  - `../docs/ko/archive/auto_returns_unified_design.md`의 경우:
     - 구현/체크리스트 상태를 상단에서 계속 갱신해  
       Runner 전처리/returns_source/파생 헬퍼의 정합성을 추적 가능하게 한다.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,10 @@ nav:
       - CI: operations/ci.md
   - Design:
       - QMTL UI: design/qmtl_ui.md
+      - Core Loop × World Roadmap: design/core_loop_world_roadmap.md
+      - World Validation Architecture: design/world_validation_architecture.md
+      - World Validation v1 Implementation Plan: design/world_validation_v1_implementation_plan.md
+      - Model Risk Management Framework: design/model_risk_management_framework.md
       - WorldService Evaluation Runs & Metrics API: design/worldservice_evaluation_runs_and_metrics_api.md
       - YAML-Only Configuration Overhaul: design/yaml_config_overhaul.md
       - Seamless Materialize/Verify Surface: design/seamless_materialize_jobs.md
@@ -184,6 +188,10 @@ plugins:
             "Rebalancing Schema Coordination": "리밸런싱 스키마 조율"
             Design: 설계
             QMTL UI: QMTL UI
+            "Core Loop × World Roadmap": "Core Loop × World 로드맵"
+            "World Validation Architecture": "World 검증 계층 설계"
+            "Model Risk Management Framework": "모델 리스크 관리 프레임워크"
+            "World Validation v1 Implementation Plan": "World 검증 v1 구현 계획"
             Seamless Full-Stack Bundle: 심리스 풀스택 번들
             Reference: 레퍼런스
             World: 월드

--- a/qmtl/runtime/sdk/__init__.py
+++ b/qmtl/runtime/sdk/__init__.py
@@ -157,6 +157,8 @@ _EXTENDED_API: Mapping[str, tuple[str, str | None]] = {
     "SeamlessPresetRegistry": ("qmtl.runtime.sdk.seamless", "SeamlessPresetRegistry"),
     "hydrate_builder": ("qmtl.runtime.sdk.seamless", "hydrate_builder"),
     "build_seamless_assembly": ("qmtl.runtime.sdk.seamless", "build_assembly"),
+    "MaterializeSeamlessJob": ("qmtl.runtime.sdk.materialize_job", "MaterializeSeamlessJob"),
+    "MaterializeReport": ("qmtl.runtime.sdk.materialize_job", "MaterializeReport"),
 }
 
 _ALL_API = {**_PUBLIC_API, **_EXTENDED_API}

--- a/qmtl/services/worldservice/validation_checks.py
+++ b/qmtl/services/worldservice/validation_checks.py
@@ -1,0 +1,251 @@
+"""Invariant and validation-health helpers for WorldService."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable, Mapping
+
+from .metrics import parse_timestamp
+
+V1_CORE_METRIC_PATHS: tuple[tuple[str, str], ...] = (
+    ("returns", "sharpe"),
+    ("returns", "max_drawdown"),
+    ("returns", "gain_to_pain_ratio"),
+    ("returns", "time_under_water_ratio"),
+    ("sample", "effective_history_years"),
+    ("sample", "n_trades_total"),
+    ("sample", "n_trades_per_year"),
+    ("risk", "adv_utilization_p95"),
+    ("risk", "participation_rate_p95"),
+    ("robustness", "deflated_sharpe_ratio"),
+    ("robustness", "sharpe_first_half"),
+    ("robustness", "sharpe_second_half"),
+)
+
+# v1 core rule set: DataCurrency, Sample, Performance, RiskConstraint
+DEFAULT_RULE_COUNT = 4
+
+
+@dataclass
+class InvariantReport:
+    """Container for validation invariant results."""
+
+    live_status_failures: list[dict[str, Any]]
+    fail_closed_violations: list[dict[str, Any]]
+    approved_overrides: list[dict[str, Any]]
+    validation_health_gaps: list[dict[str, Any]]
+
+    @property
+    def ok(self) -> bool:
+        return not (
+            self.live_status_failures
+            or self.fail_closed_violations
+            or self.approved_overrides
+            or self.validation_health_gaps
+        )
+
+
+def _metric_coverage_ratio(metrics: Mapping[str, Any] | None) -> float:
+    if not metrics:
+        return 0.0
+    present = 0
+    for section, name in V1_CORE_METRIC_PATHS:
+        slot = metrics.get(section)
+        if isinstance(slot, Mapping) and slot.get(name) is not None:
+            present += 1
+    total = len(V1_CORE_METRIC_PATHS)
+    return present / total if total else 0.0
+
+
+def _rules_executed_ratio(
+    rule_results: Mapping[str, Any] | None,
+    expected_rules: int = DEFAULT_RULE_COUNT,
+) -> float:
+    if expected_rules <= 0:
+        return 0.0
+    executed = len(rule_results or {})
+    return min(1.0, executed / expected_rules)
+
+
+def compute_validation_health(
+    metrics: Mapping[str, Any] | None,
+    rule_results: Mapping[str, Any] | None,
+    *,
+    expected_rules: int = DEFAULT_RULE_COUNT,
+) -> dict[str, float]:
+    """Derive validation health ratios from metrics and executed rules."""
+
+    return {
+        "metric_coverage_ratio": _metric_coverage_ratio(metrics),
+        "rules_executed_ratio": _rules_executed_ratio(rule_results, expected_rules),
+    }
+
+
+def ensure_validation_health(
+    metrics: Mapping[str, Any] | None,
+    rule_results: Mapping[str, Any] | None,
+    *,
+    expected_rules: int = DEFAULT_RULE_COUNT,
+) -> dict[str, Any]:
+    """Attach validation_health metrics to an EvaluationMetrics mapping.
+
+    Returns a deep-copied metrics mapping with diagnostics.validation_health filled.
+    """
+
+    base = deepcopy(metrics) if metrics else {}
+    diagnostics = base.setdefault("diagnostics", {})
+    health = dict(diagnostics.get("validation_health") or {})
+    derived = compute_validation_health(base, rule_results, expected_rules=expected_rules)
+    health.update(derived)
+    diagnostics["validation_health"] = health
+    base["diagnostics"] = diagnostics
+    return base
+
+
+def _world_is_high_tier_and_critical(world: Mapping[str, Any]) -> bool:
+    profile = world.get("risk_profile") or {}
+    tier = str(profile.get("tier", "")).lower()
+    critical = bool(profile.get("client_critical") or world.get("client_critical"))
+    return tier == "high" and critical
+
+
+def _validation_policy(world: Mapping[str, Any]) -> Mapping[str, Any]:
+    validation = world.get("validation")
+    return validation if isinstance(validation, Mapping) else {}
+
+
+def _timestamp_key(run: Mapping[str, Any], index: int) -> tuple[datetime, int]:
+    ts = parse_timestamp(run.get("created_at") or run.get("updated_at"))
+    return (ts or datetime.min, index)
+
+
+def _latest_live_runs(runs: list[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    per_strategy: dict[Any, tuple[tuple[datetime, int], Mapping[str, Any]]] = {}
+    for idx, run in enumerate(runs):
+        strategy_id = run.get("strategy_id")
+        key = _timestamp_key(run, idx)
+        if strategy_id not in per_strategy or key > per_strategy[strategy_id][0]:
+            per_strategy[strategy_id] = (key, run)
+    return [entry[1] for entry in per_strategy.values()]
+
+
+def _recorded_health(metrics: Mapping[str, Any] | None) -> dict[str, float | None]:
+    diagnostics = metrics.get("diagnostics") if isinstance(metrics, Mapping) else None
+    health = diagnostics.get("validation_health") if isinstance(diagnostics, Mapping) else None
+    if not isinstance(health, Mapping):
+        return {"metric_coverage_ratio": None, "rules_executed_ratio": None}
+    return {
+        "metric_coverage_ratio": health.get("metric_coverage_ratio"),
+        "rules_executed_ratio": health.get("rules_executed_ratio"),
+    }
+
+
+def _close(a: float | None, b: float | None, *, tol: float = 1e-6) -> bool:
+    if a is None or b is None:
+        return False
+    return abs(a - b) <= tol
+
+
+def check_validation_invariants(
+    world: Mapping[str, Any],
+    evaluation_runs: Iterable[Mapping[str, Any]],
+) -> InvariantReport:
+    """Evaluate validation invariants for a world and its evaluation runs."""
+
+    runs = list(evaluation_runs)
+    world_id = world.get("id") or world.get("world_id")
+
+    live_runs = [
+        run for run in runs if str(run.get("stage", "")).lower() == "live"
+    ]
+    latest_live = _latest_live_runs(live_runs)
+
+    live_failures: list[dict[str, Any]] = []
+    for run in latest_live:
+        summary = run.get("summary") or {}
+        status = str(summary.get("status", "")).lower()
+        if status != "pass":
+            live_failures.append(
+                {
+                    "world_id": world_id or run.get("world_id"),
+                    "strategy_id": run.get("strategy_id"),
+                    "run_id": run.get("run_id"),
+                    "status": summary.get("status"),
+                }
+            )
+
+    fail_closed_violations: list[dict[str, Any]] = []
+    if _world_is_high_tier_and_critical(world):
+        validation = _validation_policy(world)
+        on_error = str(validation.get("on_error", "")).lower() or None
+        on_missing = str(validation.get("on_missing_metric", "")).lower() or None
+        if on_error != "fail" or on_missing != "fail":
+            fail_closed_violations.append(
+                {
+                    "world_id": world_id,
+                    "on_error": on_error or "<unset>",
+                    "on_missing_metric": on_missing or "<unset>",
+                }
+            )
+
+    approved_overrides: list[dict[str, Any]] = []
+    validation_health_gaps: list[dict[str, Any]] = []
+    for run in runs:
+        summary = run.get("summary") or {}
+        if str(summary.get("override_status", "")).lower() == "approved":
+            approved_overrides.append(
+                {
+                    "world_id": world_id or run.get("world_id"),
+                    "strategy_id": run.get("strategy_id"),
+                    "run_id": run.get("run_id"),
+                    "override_reason": summary.get("override_reason"),
+                    "override_timestamp": summary.get("override_timestamp"),
+                }
+            )
+
+        validation = run.get("validation") if isinstance(run, Mapping) else {}
+        rule_results = validation.get("results") if isinstance(validation, Mapping) else {}
+        expected = compute_validation_health(run.get("metrics"), rule_results)
+        recorded = _recorded_health(run.get("metrics"))
+
+        if not _close(recorded["metric_coverage_ratio"], expected["metric_coverage_ratio"]):
+            validation_health_gaps.append(
+                {
+                    "world_id": world_id or run.get("world_id"),
+                    "strategy_id": run.get("strategy_id"),
+                    "run_id": run.get("run_id"),
+                    "metric": "metric_coverage_ratio",
+                    "expected": expected["metric_coverage_ratio"],
+                    "recorded": recorded["metric_coverage_ratio"],
+                }
+            )
+        if not _close(recorded["rules_executed_ratio"], expected["rules_executed_ratio"]):
+            validation_health_gaps.append(
+                {
+                    "world_id": world_id or run.get("world_id"),
+                    "strategy_id": run.get("strategy_id"),
+                    "run_id": run.get("run_id"),
+                    "metric": "rules_executed_ratio",
+                    "expected": expected["rules_executed_ratio"],
+                    "recorded": recorded["rules_executed_ratio"],
+                }
+            )
+
+    return InvariantReport(
+        live_status_failures=live_failures,
+        fail_closed_violations=fail_closed_violations,
+        approved_overrides=approved_overrides,
+        validation_health_gaps=validation_health_gaps,
+    )
+
+
+__all__ = [
+    "InvariantReport",
+    "DEFAULT_RULE_COUNT",
+    "V1_CORE_METRIC_PATHS",
+    "check_validation_invariants",
+    "compute_validation_health",
+    "ensure_validation_health",
+]

--- a/tests/qmtl/runtime/sdk/test_materialize_job.py
+++ b/tests/qmtl/runtime/sdk/test_materialize_job.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from qmtl.runtime.sdk.conformance import ConformanceReport
+from qmtl.runtime.sdk.materialize_job import MaterializeReport, MaterializeSeamlessJob
+from qmtl.runtime.sdk.seamless_data_provider import SeamlessFetchMetadata, SeamlessFetchResult
+
+
+class _StubProvider:
+    def __init__(self, *, fingerprint: str | None = None, live_feed: object | None = None):
+        self.live_feed = live_feed
+        self._fingerprint = fingerprint
+        self._report = ConformanceReport()
+
+    @property
+    def last_conformance_report(self) -> ConformanceReport:
+        return self._report
+
+    async def fetch(self, start: int, end: int, *, node_id: str, interval: int, **_: object) -> SeamlessFetchResult:
+        frame = pd.DataFrame({"ts": [start, end]})
+        metadata = SeamlessFetchMetadata(
+            node_id=node_id,
+            interval=interval,
+            requested_range=(start, end),
+            rows=len(frame),
+            coverage_bounds=(start, end),
+            conformance_flags=dict(self._report.flags_counts),
+            conformance_warnings=self._report.warnings,
+            dataset_fingerprint=self._fingerprint,
+        )
+        return SeamlessFetchResult(frame, metadata)
+
+
+@pytest.mark.asyncio
+async def test_materialize_job_returns_report(tmp_path) -> None:
+    provider = _StubProvider(fingerprint="v1:demo")
+    job = MaterializeSeamlessJob(
+        provider=provider,
+        start=0,
+        end=10,
+        interval=5,
+        contract_version="v1",
+        checkpoint_dir=tmp_path,
+        retention_class="research-short",
+        retention_ttl_seconds=3600,
+        priority="low",
+        max_attempts=2,
+    )
+
+    report = await job.run()
+
+    assert isinstance(report, MaterializeReport)
+    assert report.dataset_fingerprint == "v1:demo"
+    assert report.coverage_bounds == (0, 10)
+    assert report.requested_range == (0, 10)
+    assert report.contract_version == "v1"
+    assert report.retention_class == "research-short"
+    assert report.retention_ttl_seconds == 3600
+    assert report.priority == "low"
+    assert report.checkpoint_key.startswith("materialize:")
+    assert report.resumed is False
+    assert report.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_materialize_job_requires_live_when_flagged() -> None:
+    provider = _StubProvider(live_feed=None)
+    job = MaterializeSeamlessJob(provider=provider, start=0, end=1, interval=1, require_live=True)
+
+    with pytest.raises(ValueError):
+        await job.run()
+
+
+@pytest.mark.asyncio
+async def test_materialize_job_contract_version_mismatch() -> None:
+    provider = _StubProvider(fingerprint="v1:data")
+    job = MaterializeSeamlessJob(provider=provider, start=0, end=1, interval=1, contract_version="v2")
+
+    with pytest.raises(ValueError):
+        await job.run()
+
+
+@pytest.mark.asyncio
+async def test_materialize_job_resume(tmp_path) -> None:
+    provider = _StubProvider(fingerprint="v1:demo")
+    job = MaterializeSeamlessJob(
+        provider=provider,
+        start=0,
+        end=2,
+        interval=1,
+        contract_version="v1",
+        checkpoint_dir=tmp_path,
+    )
+
+    first = await job.run()
+    second = await job.run()
+
+    assert first.checkpoint_key == second.checkpoint_key
+    assert second.resumed is True
+    assert second.dataset_fingerprint == "v1:demo"
+
+
+class _FlakyProvider(_StubProvider):
+    def __init__(self, fail_times: int, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._remaining = fail_times
+
+    async def fetch(self, start: int, end: int, *, node_id: str, interval: int, **_: object) -> SeamlessFetchResult:
+        if self._remaining > 0:
+            self._remaining -= 1
+            raise RuntimeError("flaky")
+        return await super().fetch(start, end, node_id=node_id, interval=interval)
+
+
+@pytest.mark.asyncio
+async def test_materialize_job_retries() -> None:
+    provider = _FlakyProvider(fail_times=1, fingerprint="v1:demo")
+    job = MaterializeSeamlessJob(provider=provider, start=0, end=1, interval=1, contract_version="v1", max_attempts=2)
+
+    report = await job.run()
+
+    assert report.attempts == 2

--- a/tests/qmtl/services/worldservice/test_validation_invariants.py
+++ b/tests/qmtl/services/worldservice/test_validation_invariants.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.services.worldservice.validation_checks import (
+    DEFAULT_RULE_COUNT,
+    check_validation_invariants,
+    ensure_validation_health,
+)
+
+
+def _full_metrics() -> dict:
+    return {
+        "returns": {
+            "sharpe": 1.2,
+            "max_drawdown": -0.1,
+            "gain_to_pain_ratio": 1.5,
+            "time_under_water_ratio": 0.2,
+        },
+        "sample": {
+            "effective_history_years": 3.5,
+            "n_trades_total": 210,
+            "n_trades_per_year": 70.0,
+        },
+        "risk": {
+            "adv_utilization_p95": 0.2,
+            "participation_rate_p95": 0.15,
+        },
+        "robustness": {
+            "deflated_sharpe_ratio": 0.3,
+            "sharpe_first_half": 0.4,
+            "sharpe_second_half": 0.5,
+        },
+    }
+
+
+def test_ensure_validation_health_computes_ratios_without_mutation():
+    metrics = _full_metrics()
+    rule_results = {
+        "sample": {"status": "pass"},
+        "performance": {"status": "pass"},
+        "risk": {"status": "warn"},
+    }
+
+    enriched = ensure_validation_health(metrics, rule_results)
+
+    assert "diagnostics" not in metrics  # original untouched
+    health = enriched["diagnostics"]["validation_health"]
+    assert health["metric_coverage_ratio"] == pytest.approx(1.0)
+    assert health["rules_executed_ratio"] == pytest.approx(len(rule_results) / DEFAULT_RULE_COUNT)
+
+
+def test_check_invariants_flags_latest_live_failure():
+    metrics = ensure_validation_health(
+        _full_metrics(),
+        {"performance": {"status": "pass"}, "risk": {"status": "pass"}},
+    )
+    runs = [
+        {
+            "world_id": "world-live",
+            "strategy_id": "strat-a",
+            "run_id": "live-pass",
+            "stage": "live",
+            "summary": {"status": "pass"},
+            "metrics": metrics,
+            "validation": {"results": {"performance": {"status": "pass"}}},
+            "created_at": "2025-01-01T00:00:00+00:00",
+        },
+        {
+            "world_id": "world-live",
+            "strategy_id": "strat-a",
+            "run_id": "live-fail",
+            "stage": "live",
+            "summary": {"status": "fail"},
+            "metrics": metrics,
+            "validation": {"results": {"performance": {"status": "fail"}}},
+            "created_at": "2025-02-01T00:00:00+00:00",
+        },
+    ]
+
+    report = check_validation_invariants({"id": "world-live"}, runs)
+
+    assert any(v["run_id"] == "live-fail" for v in report.live_status_failures)
+
+
+def test_check_invariants_enforces_fail_closed_and_collects_overrides():
+    world = {
+        "id": "world-risky",
+        "risk_profile": {"tier": "high", "client_critical": True},
+        "validation": {"on_error": "warn", "on_missing_metric": "fail"},
+    }
+    override_run = {
+        "world_id": "world-risky",
+        "strategy_id": "strat-b",
+        "run_id": "override-run",
+        "stage": "paper",
+        "summary": {"status": "warn", "override_status": "approved"},
+        "validation": {"results": {}},
+        "metrics": {"returns": {"sharpe": 1.0}},
+        "created_at": "2025-01-10T00:00:00+00:00",
+    }
+    healthy_run = {
+        "world_id": "world-risky",
+        "strategy_id": "strat-c",
+        "run_id": "healthy-run",
+        "stage": "paper",
+        "summary": {"status": "pass"},
+        "validation": {"results": {"performance": {"status": "pass"}}},
+        "metrics": ensure_validation_health(
+            _full_metrics(),
+            {"performance": {"status": "pass"}},
+        ),
+        "created_at": "2025-01-05T00:00:00+00:00",
+    }
+
+    report = check_validation_invariants(world, [override_run, healthy_run])
+
+    assert report.fail_closed_violations and report.fail_closed_violations[0]["world_id"] == "world-risky"
+    assert any(item["run_id"] == "override-run" for item in report.approved_overrides)
+    assert any(gap["run_id"] == "override-run" for gap in report.validation_health_gaps)
+    assert not any(gap["run_id"] == "healthy-run" for gap in report.validation_health_gaps)


### PR DESCRIPTION
Summary:\n- ensure evaluation runs persist validation_health coverage/exec ratios and add invariant checker helpers for live status, fail-closed policy, and approved overrides\n- add regression tests for invariants plus materialize job coverage; include design docs updates already in branch\n\nTesting:\n- uv run --with mypy -m mypy\n- uv run mkdocs build --strict\n- uv run python scripts/check_design_drift.py\n- uv run python scripts/lint_dsn_keys.py\n- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json\n- uv run --with grimp python scripts/check_sdk_layers.py\n- uv run python scripts/check_docs_links.py\n- uv run -m pytest --collect-only -q\n- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'\n- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests\n- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q\n\nFixes #1869