### PR TITLE
docs(ops): world validation v1.5 문서/런북

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -136,3 +136,51 @@ prometheus:
           annotations:
             summary: Surge in Seamless conformance flags over the last 15 minutes
             runbook: docs/operations/seamless_sla_dashboards.html#validation-tooling
+        - alert: RiskHubSnapshotStale
+          expr: max_over_time(risk_hub_snapshot_lag_seconds[5m]) > 600
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Risk hub snapshots are older than 10 minutes
+            runbook: docs/operations/risk_signal_hub_runbook.html
+        - alert: RiskHubSnapshotMissing
+          expr: sum(increase(risk_hub_snapshot_missing_total[5m])) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Failed or missing risk snapshots observed
+            runbook: docs/operations/risk_signal_hub_runbook.html
+        - alert: RiskHubSnapshotDedupeSpike
+          expr: sum(rate(risk_hub_snapshot_dedupe_total[5m])) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Risk hub snapshots dropped due to dedupe keys
+            runbook: docs/operations/risk_signal_hub_runbook.html
+        - alert: RiskHubSnapshotExpiredSpike
+          expr: sum(rate(risk_hub_snapshot_expired_total[5m])) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Risk hub snapshots dropped due to expired TTL
+            runbook: docs/operations/risk_signal_hub_runbook.html
+        - alert: RiskHubSnapshotRetrySpike
+          expr: sum(rate(risk_hub_snapshot_retry_total[5m])) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Risk hub snapshot processing retries observed
+            runbook: docs/operations/risk_signal_hub_runbook.html
+        - alert: RiskHubSnapshotDLQ
+          expr: sum(increase(risk_hub_snapshot_dlq_total[5m])) > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Risk hub snapshots routed to DLQ
+            runbook: docs/operations/risk_signal_hub_runbook.html

--- a/docs/en/architecture/README.md
+++ b/docs/en/architecture/README.md
@@ -25,6 +25,7 @@ See also: Architecture Glossary (../architecture/glossary.md) for canonical term
 - [WorldService](worldservice.md): World policy, decisions, activation.
 - [ControlBus](controlbus.md): Internal control bus (opaque to SDK).
 - [Lean Brokerage Model](lean_brokerage_model.md): Brokerage integration details.
+- [Risk Signal Hub](risk_signal_hub.md): Portfolio/risk snapshot SSOT.
 
 ## Architectural Layers at a Glance
 

--- a/docs/en/architecture/architecture.md
+++ b/docs/en/architecture/architecture.md
@@ -22,6 +22,7 @@ last_modified: 2025-12-06
 - [WorldService](worldservice.md)
 - [ControlBus](controlbus.md)
 - [Exchange Node Sets](exchange_node_sets.md)
+- Risk Signal Hub: [Risk Signal Hub Architecture](risk_signal_hub.md)
 
 ---
 

--- a/docs/en/architecture/risk_signal_hub.md
+++ b/docs/en/architecture/risk_signal_hub.md
@@ -1,0 +1,77 @@
+---
+title: "Risk Signal Hub — Portfolio/Risk Snapshot SSOT"
+tags: [architecture, risk, hub, world]
+author: "QMTL Team"
+last_modified: 2025-12-10
+---
+
+{{ nav_links() }}
+
+# Risk Signal Hub — Portfolio/Risk Snapshot SSOT
+
+!!! abstract "Role"
+    Collect and normalize portfolio/risk snapshots (weights, covariance_ref/matrix, stress, realized returns) produced by Gateway and store them as a **single source of truth**.  
+    WorldService, Exit Engine, and monitoring consumers read from the hub API/events to compute Var/ES, stress, and exit signals, and to monitor freshness/missing data.
+
+Related documents:
+- Design details: [design/risk_signal_hub.md](../design/risk_signal_hub.md)
+- Validation architecture: [design/world_validation_architecture.md](../design/world_validation_architecture.md)
+- Operations runbook: [operations/risk_signal_hub_runbook.md](../operations/risk_signal_hub_runbook.md)
+
+---
+
+## 1. System Boundary and Flow
+
+```mermaid
+flowchart LR
+    GW[Gateway\n(rebalance/fill producers)] -->|HTTP POST /risk-hub| HUB[(Risk Signal Hub\nWS router + Storage)]
+    HUB -->|PortfolioSnapshotUpdated\nControlBus event| WS[WorldService\n(ExtendedValidation / Stress / Live workers)]
+    HUB --> EXIT[Exit Engine\n(future)]
+    HUB --> MON[Monitoring/Dashboards]
+```
+
+- **Producers**: Gateway rebalance/fill paths POST snapshots into the hub; large covariance payloads can be offloaded as refs.
+- **Consumers**: WS ExtendedValidation/stress/live workers use hub lookups/events to compute Var/ES and stress. Exit Engine can subscribe to hub events to emit additional exit signals.
+- **Events**: `PortfolioSnapshotUpdated` on ControlBus triggers workers/monitoring downstream.
+
+---
+
+## 2. Config/Deployment Profiles
+
+- **dev**: Inline + fakeredis/in-memory cache only (covariance offload disabled). No persistent blob/file/S3 in dev; focus on functionality/minimal verification.
+- **prod**: Postgres `risk_snapshots` + Redis cache; optional S3/Redis blob offload. ControlBus events required.
+- The `risk_hub` block in `qmtl.yml` injects the same token/inline thresholds/blob store config into both Gateway (producer) and WS (consumer) to avoid drift.
+
+---
+
+## 3. Data Contract (Summary)
+
+- Required: `world_id`, `as_of` (ISO), `version`, `weights` (sum≈1.0)
+- Optional: `covariance` (inline when small) or `covariance_ref`, `realized_returns_ref`, `stress`, `constraints`, `ttl_sec`, `provenance`, `hash`
+- Validation: weight sum > 0 and within 1.0±1e-3, ISO `as_of`, TTL expiration excludes stale snapshots from cache/lookups.
+
+---
+
+## 4. Storage and Cache
+
+- **Meta/versions**: Postgres/SQLite (`risk_snapshots`) with indexes on `(world_id, as_of/version)`.
+- **Cache**: Redis (or fakeredis in dev) for latest snapshot hot path.
+- **Blob offload**: Redis/S3 in prod only; dev keeps everything inline. Gateway and WS share `inline_cov_threshold`.
+
+---
+
+## 5. Security and Operations
+
+- Auth: Hub router bearer token (`risk_hub.token`) shared only with Gateway producers.
+- Observability: `risk_hub_snapshot_lag_seconds`, `risk_hub_snapshot_missing_total` metrics and Alertmanager rules (RiskHubSnapshotStale/Missing).
+- Background workers: ControlBus consumer example `scripts/risk_hub_worker.py`; health checker `scripts/risk_hub_monitor.py`.
+
+---
+
+## 6. Future Extensions
+
+- Exit Engine: derive and emit additional exit signals from hub events.
+- Stress/live re-simulation: schedule via hub events → queue/ControlBus workers.
+- Standardize large returns/covariance refs and retention policies (prod only).
+
+{{ nav_links() }}

--- a/docs/en/operations/monitoring.md
+++ b/docs/en/operations/monitoring.md
@@ -38,11 +38,17 @@ The following alerts are available for inspiration when extending `alert_rules.y
 - **WorldApplyFailureDetected/RateHigh** – detect apply failures by `world_apply_failure_total` and failure rate via `world_apply_run_total`.
 - **WorldAllocationSnapshotStale** – raises when `world_allocation_snapshot_stale_ratio` exceeds 10% (5‑minute freshness window).
 - **ControlBusApplyAckLatencyHigh** – warns when `controlbus_apply_ack_latency_ms{phase="freeze"}` stays above 5s.
+- **RiskHubSnapshotDedupe/Expired** – watch `risk_hub_snapshot_dedupe_total{world_id,stage}` and `risk_hub_snapshot_expired_total{world_id,stage}` (stage-labeled; runbook: operations/risk_signal_hub_runbook.md).
 
 WorldService emits `world_apply_run_total`/`world_apply_failure_total` per `world_id`/`run_id`, while `world_allocation_snapshot_stale_ratio`
 tracks the fraction of snapshots whose `updated_at` is older than five minutes. Gateway captures freeze/unfreeze ControlBus
 acknowledgements via `controlbus_apply_ack_total` and `controlbus_apply_ack_latency_ms` (milliseconds). Add Grafana panels for
 apply success rate, allocation freshness, and apply ACK latency to give operators real-time visibility into apply health.
+
+Risk Hub stage-aware panels:
+- Stage labels (backtest/paper/live) are exposed on `risk_hub_snapshot_*` metrics for stacking/filtering in Grafana.
+- Example stacked query: `sum by(stage) (rate(risk_hub_snapshot_dedupe_total[5m]))`
+- TTL failures by stage/world: `sum by(world_id,stage) (increase(risk_hub_snapshot_expired_total[30m]))`
 
 ## Grafana Dashboards
 

--- a/docs/en/operations/risk_signal_hub_runbook.md
+++ b/docs/en/operations/risk_signal_hub_runbook.md
@@ -1,0 +1,59 @@
+---
+title: "Risk Signal Hub Runbook"
+tags: [operations, risk, snapshots]
+last_modified: 2025-12-10
+status: draft
+---
+
+# Risk Signal Hub Runbook
+
+## 1. Topology
+- **WorldService**: `risk_hub` router (Bearer-protected), Redis cache, Postgres `risk_snapshots`, ControlBus consumer (`risk_snapshot_updated`), activation updates push snapshots.
+- **Gateway**: pushes after rebalance/fills/position sync with retry/backoff; large covariance/returns offloaded to blob-store (S3/Redis/file) and referenced via `covariance_ref`.
+- **Blob store**: dev=file(`JsonBlobStore`), prod=S3 (option: Redis).
+- **Events**: shared ControlBus/Kafka topic `risk_snapshot_updated`; WS consumes to trigger ExtendedValidation/stress/live workers.
+- **Headers**: `Authorization: Bearer <token>` (prod), `X-Actor` required, `X-Stage` (backtest/paper/live) strongly recommended for dedupe/alert labels.
+
+## 2. Deployment checklist
+- WS:
+  - Configure `worldservice.server.controlbus_brokers/controlbus_topic`.
+  - Redis DSN required (activation cache + hub cache).
+  - Provide hub token (`risk_hub_token`) and share only with Gateway.
+  - Blob store: dev `JsonBlobStore`; prod S3 bucket/prefix.
+- Gateway:
+  - `RiskHubClient` with token/retries/backoff/inline_cov_threshold.
+  - Offload large covariance/returns to blob-store with shared ref schema.
+  - Enable hub push after rebalance/fills/position sync.
+- ControlBus/Queue:
+  - Create Kafka topic `risk_snapshot_updated`, size/retention checked.
+  - WS consumer group `worldservice-risk-hub` alive.
+
+## 3. Monitoring / alerts
+- Freshness: latest snapshot `as_of` lag (warn ~10m, crit ~30m).
+  - Script: `python scripts/risk_hub_monitor.py --base-url ... --world ... --warn-seconds 600`
+- Duplicate/TTL: watch `risk_hub_snapshot_dedupe_total{world_id,stage}` and `risk_hub_snapshot_expired_total{world_id,stage}` spikes → validate producer headers/TTL.
+- Producer validation: ensure gateway/risk-engine producers set `X-Actor`/`X-Stage` and enforce weights sum≈1, positive TTL, and hash before publishing.
+- Events: ControlBus consumer errors/lag, retry rate.
+- Blob-store: S3 4xx/5xx, Redis miss ratio.
+- Hub HTTP: 401/5xx bursts.
+
+## 4. Incident response
+- Snapshot lag: check Gateway push retries, ControlBus lag; apply conservative fallback (corr/σ) if needed.
+- Data corruption: re-download/refetch refs, re-emit on hash mismatch.
+- Kafka outage: temporarily run with HTTP push only, resume consumer after lag catch-up.
+- Producer violations: if weights/TTL/header are missing, inspect producer logs/metrics first and cross-check stage-specific dedupe/expired spikes on dashboards.
+
+## 5. Handy commands
+- Freshness (one-off):  
+  `python scripts/risk_hub_monitor.py --base-url $WS_URL --world w1 --world w2 --token $HUB_TOKEN`
+- Backfill:  
+  `python scripts/backfill_risk_snapshots.py --dsn $DB --redis $REDIS --world w1`
+
+## 6. Tests / validation
+- Unit: `tests/qmtl/services/worldservice/test_risk_hub_*`, `test_risk_snapshot_publisher.py`.
+- E2E (recommended): gateway→hub→ControlBus→WS worker, include large covariance ref and TTL-expired/delayed cases.
+- Load: multi-world/strategy latest-hit ratio, ControlBus consumer lag.
+
+## 7. Security
+- Hub router: Bearer token required; network ACL limited to Gateway/infra subnets.
+- Blob store: S3 IAM least privilege; Redis namespace/prefix (`risk-blobs:`); rotate tokens/keys.

--- a/docs/ko/architecture/README.md
+++ b/docs/ko/architecture/README.md
@@ -26,6 +26,7 @@ EventStreamDescriptor와 같은 표준 명칭을 확인할 수 있습니다.
 - [WorldService](worldservice.md): 월드 정책, 결정, 활성화.
 - [ControlBus](controlbus.md): SDK에서는 보이지 않는 내부 제어 버스.
 - [Lean Brokerage Model](lean_brokerage_model.md): 브로커리지 통합 세부 사항.
+- [Risk Signal Hub](risk_signal_hub.md): 포트폴리오/리스크 스냅샷 SSOT.
 
 ## 아키텍처 계층 한눈에 보기
 

--- a/docs/ko/architecture/architecture.md
+++ b/docs/ko/architecture/architecture.md
@@ -22,6 +22,7 @@ last_modified: 2025-12-06
 - [WorldService](worldservice.md)
 - [ControlBus](controlbus.md)
 - [Exchange Node Sets](exchange_node_sets.md)
+- Risk Signal Hub: [Risk Signal Hub 아키텍처](risk_signal_hub.md)
 - Core Loop 계약 테스트: `tests/e2e/core_loop/README.md`
 
 ---

--- a/docs/ko/architecture/gateway.md
+++ b/docs/ko/architecture/gateway.md
@@ -34,6 +34,12 @@ spec_version: v1.2
     `profile: dev`에서는 Redis/ControlBus/Commit‑Log 설정이 비어 있으면 인메모리 대체 구현을 사용합니다. `profile: prod`에서는 `gateway.redis_dsn`, `gateway.database_backend=postgres` + `gateway.database_dsn`, `gateway.controlbus_brokers`/`controlbus_topics`, `gateway.commitlog_bootstrap`/`commitlog_topic`이 모두 채워져 있지 않으면 Gateway가 기동 전에 실패합니다.
     `profile: dev`에서 커밋 로그 필드를 비우면 게이트웨이는 단순히 커밋 로그 라이터를 비활성화하고 정보 로그를 남깁니다.
 
+!!! note "Risk Signal Hub 연동"
+- 게이트웨이는 리밸런스/체결 이후 포트폴리오 스냅샷(weights, covariance_ref/행렬, as_of)을 hub에 push 하는 생산자 역할만 수행합니다.  
+- 설정: `qmtl.yml` `risk_hub` 블록으로 토큰/inline offload 기준을 주입하고, dev 프로파일에서는 inline+fakeredis만 사용하며 offload(blob/file/S3)는 비활성입니다. prod 프로파일에서만 Redis/S3 offload를 사용합니다.  
+- 소비자 역할(Var/ES 계산, 스트레스 재시뮬레이션)은 WorldService 측에서 hub 이벤트/조회로 수행하며, Gateway는 hub를 직접 읽지 않습니다.  
+- ControlBus/큐 경로는 기존 활성/결정 스트림과 동일하게 유지되며, hub 이벤트는 WS/Exit 엔진이 구독합니다.
+
 > 이 확장판은 기존 문서 대비 약 75% 분량이 늘었으며, 연구 중심의 엄밀한 기술 명세 형식을 채택했습니다. 모든 위협 모델, 공식 API 계약, 지연 분포, CI/CD 의미론을 완전하게 기술합니다.
 > 표기: **Sx** = 섹션, **Rx** = 요구사항, **Ax** = 가정.
 

--- a/docs/ko/architecture/risk_signal_hub.md
+++ b/docs/ko/architecture/risk_signal_hub.md
@@ -1,0 +1,77 @@
+---
+title: "Risk Signal Hub — 포트폴리오/리스크 스냅샷 SSOT"
+tags: [architecture, risk, hub, world]
+author: "QMTL Team"
+last_modified: 2025-12-10
+---
+
+{{ nav_links() }}
+
+# Risk Signal Hub — 포트폴리오/리스크 스냅샷 SSOT
+
+!!! abstract "역할"
+    Gateway가 생성하는 포트폴리오/리스크 스냅샷(weights, covariance_ref/행렬, stress, realized returns)을 수집·표준화해 **단일 진실 소스(SSOT)**로 보관한다.  
+    WorldService·Exit Engine·모니터링은 허브의 API/이벤트만 소비해 Var/ES·stress·exit 신호를 계산하고, 스냅샷 신선도/결측 여부를 모니터링한다.
+
+관련 문서:
+- 설계 세부: [design/risk_signal_hub.md](../design/risk_signal_hub.md)
+- 검증 아키텍처: [design/world_validation_architecture.md](../design/world_validation_architecture.md)
+- 운영 런북: [operations/risk_signal_hub_runbook.md](../operations/risk_signal_hub_runbook.md)
+
+---
+
+## 1. 시스템 경계와 데이터 흐름
+
+```mermaid
+flowchart LR
+    GW[Gateway\n(rebalance/fill producers)] -->|HTTP POST /risk-hub| HUB[(Risk Signal Hub\nWS 라우터 + Storage)]
+    HUB -->|PortfolioSnapshotUpdated\nControlBus event| WS[WorldService\n(ExtendedValidation / Stress / Live workers)]
+    HUB --> EXIT[Exit Engine\n(향후)]
+    HUB --> MON[Monitoring/Dashboards]
+```
+
+- **생산자**: Gateway 리밸런스/체결 경로가 스냅샷을 Hub에 POST, 필요 시 큰 공분산은 ref로 offload.
+- **소비자**: WS ExtendedValidation/스트레스/라이브 워커가 Hub 조회/이벤트를 통해 Var/ES·stress 계산. Exit 엔진은 Hub 이벤트만 구독해 별도 exit 신호를 낼 수 있다.
+- **이벤트**: `PortfolioSnapshotUpdated`를 ControlBus로 발행, 워커/모니터링이 구독해 후속 작업을 트리거.
+
+---
+
+## 2. 구성/배포 프로필
+
+- **dev**: inline + fakeredis/인메모리 캐시만 사용(공분산 offload 비활성). 영속 스토리지(file/S3/Redis) 없이 “동작/검증”에 집중한 경량 경로.
+- **prod**: Postgres `risk_snapshots` 테이블 + Redis 캐시, 필요 시 S3/Redis blob offload 활성화. ControlBus 이벤트 필수.
+- `qmtl.yml` `risk_hub` 블록으로 Gateway(생산자)와 WS(소비자) 양쪽에 동일한 토큰/inline 기준/BlobStore 설정을 주입해 설정 드리프트를 방지한다.
+
+---
+
+## 3. 데이터 계약 (요약)
+
+- 필수: `world_id`, `as_of`(ISO), `version`, `weights`(합≈1.0)
+- 선택: `covariance`(작을 때 inline) 또는 `covariance_ref`, `realized_returns_ref`, `stress`, `constraints`, `ttl_sec`, `provenance`, `hash`
+- 검증: 가중치 합>0 및 1.0±1e-3, `as_of` ISO, TTL 만료시 캐시/조회에서 제외
+
+---
+
+## 4. 저장·캐시 계층
+
+- **메타/버전**: Postgres/SQLite(`risk_snapshots`)에 `(world_id, as_of/version)` 인덱스.
+- **캐시**: Redis(또는 dev의 fakeredis)로 최신 스냅샷 hot path.
+- **Blob offload**: prod에서만 Redis/S3; dev는 비활성. inline 기준 `inline_cov_threshold`를 Gateway/WS가 공유.
+
+---
+
+## 5. 보안/운영
+
+- 인증: Hub 라우터 Bearer 토큰(`risk_hub.token`) — Gateway에만 공유.
+- 가시성: `risk_hub_snapshot_lag_seconds`, `risk_hub_snapshot_missing_total` 메트릭 및 Alertmanager 룰(RiskHubSnapshotStale/Missing).
+- 백그라운드 워커: ControlBus 소비자 예시 `scripts/risk_hub_worker.py`, 헬스 체크 `scripts/risk_hub_monitor.py`.
+
+---
+
+## 6. 향후 확장
+
+- Exit Engine: Hub 이벤트만으로 추가 exit 신호를 생성/발행.
+- Stress/라이브 재시뮬레이션: Hub 이벤트→큐/ControlBus 워커로 스케줄링.
+- 대용량 리턴/공분산 ref 표준화 및 보존 정책(Prod 전용) 세분화.
+
+{{ nav_links() }}

--- a/docs/ko/architecture/worldservice.md
+++ b/docs/ko/architecture/worldservice.md
@@ -23,6 +23,12 @@ WorldService는 월드의 단일 진실 소스(SSOT)입니다. 다음을 소유�
 !!! note "배포 프로필"
     `profile: dev`에서는 활성화 캐시 Redis가 비어 있으면 인메모리 저장소를 사용합니다. `profile: prod`에서는 `worldservice.server.redis`가 비어 있으면 프로세스가 기동 전에 실패하며, 인메모리 모드는 지원하지 않습니다.
 
+!!! note "Risk Signal Hub 연동"
+- WS는 `/risk-hub/*` 라우터로 포트폴리오/리스크 스냅샷을 수신·저장하며, ExtendedValidation/스트레스/라이브 워커가 hub 조회/이벤트를 통해 Var/ES·stress 계산을 수행합니다.  
+- dev 프로파일: in-memory/SQLite+fakeredis 캐시만 사용하며 공분산 등은 inline(ref offload 비활성).  
+- prod 프로파일: Postgres `risk_snapshots` + Redis 캐시, 필요 시 S3/Redis blob offload를 hub 설정으로 활성화합니다.  
+- gateway는 hub에 스냅샷을 push만 하고, hub 소비자는 WS(및 exit 엔진)입니다.
+
 !!! warning "안전 기본값"
 - 입력이 모호하거나 부족하면 live로 기본 설정하지 않고 compute-only(backtest)로 강등해야 합니다. `execution_domain`을 비우거나 생략한 WS API 호출이 live로 저장되면 안 됩니다.
 - `allow_live=false`(기본)일 때는 운영자가 요청하더라도 활성/도메인이 live로 전환되지 않습니다. 정책 검증(필수 지표, 히스테리시스, dataset_fingerprint 고정)이 통과될 때에만 승격을 허용하세요.

--- a/docs/ko/design/exit_engine_overview.md
+++ b/docs/ko/design/exit_engine_overview.md
@@ -1,0 +1,59 @@
+---
+title: "Exit Engine 개요 (초안)"
+tags: [design, exit, risk, signals]
+author: "QMTL Team"
+last_modified: 2025-12-09
+status: draft
+---
+
+# Exit Engine 개요 (초안)
+
+!!! abstract "목적"
+    이 문서는 **전략 진입 신호와 별개로 리스크 기반 추가 Exit 신호**를 생성하는 `Exit Engine`의 목적과 역할을 개략적으로 정의한다.  
+    구현/연결은 `risk_signal_hub`가 안정화된 이후 진행하며, 현 단계에서는 **목적과 인터페이스 방향성**만을 공유한다.
+
+관련 문서:
+- World 검증 계층 설계: [world_validation_architecture.md](world_validation_architecture.md)
+- 모델 리스크 관리 프레임워크: [model_risk_management_framework.md](model_risk_management_framework.md)
+- World 검증 v1 구현 계획: [world_validation_v1_implementation_plan.md](world_validation_v1_implementation_plan.md)
+- Risk Signal Hub 설계: §6 of [world_validation_v1_implementation_plan.md](world_validation_v1_implementation_plan.md#6-risk-signal-hub-exit)
+
+---
+
+## 0. 목적과 비범위
+
+- 목적: 시장 상태, 리스크 한계, 이론적 제약을 근거로 **전략의 내부 exit 신호와 독립적인 추가 exit/감축 신호**를 생성해, 과도한 손실/리스크 노출을 사전에 완화한다.
+- 비범위: 전략 자체의 진입/익절/손절 로직 변경, 실행/체결 엔진 구현, 신규 리스크 모델 개발(별도 리스크 엔진 문서 참조).
+
+---
+
+## 1. 역할 정의 (초안)
+
+- 입력: `risk_signal_hub`가 제공하는 포트폴리오 스냅샷(가중치, 공분산/상관, 실현 리턴), 시장/마켓 스냅샷, 사전 정의된 리스크 규칙 세트.
+- 처리: 규칙 기반(or 모델 기반)으로 **추가 exit/감축** 신호 계산 (예: VaR/ES 초과, 스트레스 DD 초과, 시장 구조 붕괴 지표 감지).
+- 출력: `ExitSignalEmitted` 이벤트(전략별/월드별 exit 권고, 감축 비율, 사유/지표 포함)를 발행하여 gateway/WS가 소비할 수 있도록 한다.
+- 속성: 읽기 전용 소비자이며, 포지션 변경/체결은 gateway가 수행한다.
+
+---
+
+## 2. 데이터 연결 (risk_signal_hub 기반)
+
+- **소스**: `risk_signal_hub`의 스냅샷/이벤트(`PortfolioSnapshotUpdated`, `CovarianceUpdated`, `RealizedReturnsIngested`, `StressResultsUpdated` 등).
+- **소비**: Exit Engine은 hub를 통해 필요한 지표만 읽고, 추가로 시장/마켓 지표(예: VIX, 스프레드, 유동성 지표)를 참조한다.
+- **배포**: 결과 신호는 `ExitSignalEmitted` 이벤트로 발행하여 gateway/WS가 적용/검증할 수 있게 한다. 적용 우선순위/충돌 정책은 별도 운영 문서에서 정의.
+
+---
+
+## 3. 향후 계획 (연결 시점에 조정)
+
+1. Hub 계약 확정 후, Exit Engine 입력 스키마 정의 (필수: weights, covariance/상관, as_of; 선택: stress 결과, realized returns ref).
+2. 규칙 세트 초안: VaR/ES 한계 초과, 스트레스 DD 초과, 마켓 스트럭처 붕괴 지표, 롤링 유동성 악화 등.
+3. 이벤트 통합: ControlBus/Kafka로 ExitSignal 발행 → gateway 적용/WS 로그.
+4. 운영 가드: 신호 우선순위, 승인/override 경로, 감사 로그(신호 근거 지표 포함).
+
+---
+
+## 4. 참고
+
+- 구현/스케줄링: risk_signal_hub 이벤트를 트리거로 백그라운드 워커에서 실행(동기 WS/SDK 변경 없음).
+- 보안/권한: exit 신호는 읽기/발행 권한을 분리하고, 포지션 변경은 gateway에서만 허용.

--- a/docs/ko/design/risk_signal_hub.md
+++ b/docs/ko/design/risk_signal_hub.md
@@ -1,0 +1,208 @@
+---
+title: "Risk Signal Hub 설계 (초안)"
+tags: [design, risk, signals, snapshots]
+author: "QMTL Team"
+last_modified: 2025-12-09
+status: draft
+---
+
+# Risk Signal Hub 설계 (초안)
+
+!!! abstract "목적"
+    `risk_signal_hub`은 **포트폴리오/리스크 스냅샷과 리스크·exit 신호의 단일 진실 소스**를 제공한다.  
+    실행/배분(gateway)에서 생성되는 가중치·공분산·실현 리턴·스트레스 결과를 표준화해 저장하고,  
+    WorldService/Exit Engine/모니터링이 동일한 스냅샷을 읽어 **일관된 검증·exit·모니터링**을 수행하도록 한다.
+
+연관 문서:
+- World 검증 v1 구현 계획: [world_validation_v1_implementation_plan.md](world_validation_v1_implementation_plan.md) §6
+- Exit Engine 개요: [exit_engine_overview.md](exit_engine_overview.md)
+- World 검증 계층 설계: [world_validation_architecture.md](world_validation_architecture.md)
+
+---
+
+## 0. 요구사항 요약
+
+- **SSOT**: 포트폴리오 상태(가중치/공분산/스트레스/실현 리턴)와 리스크 신호를 한 곳에서 관리.
+- **느슨한 결합**: 실행(gateway)은 스냅샷을 기록/발행만, 소비자(WS, exit 엔진)는 읽기 전용.
+- **재현성**: as_of/version/hash로 동일 스냅샷을 재현 가능.
+- **성능/확장성**: 이벤트 + 머티리얼라이즈드 뷰 형태, 큰 데이터는 ref/id로 전달.
+- **보안/감사**: 쓰기 주체 제한, 모든 변경에 감사/서명 가능하도록 메타 포함.
+
+---
+
+## 1. 스키마/계약 (v1 초안)
+
+### 1.1 스냅샷 페이로드
+```json
+{
+  "world_id": "world-1",
+  "as_of": "2025-01-15T00:00:00Z",
+  "version": "v20250115T0000Z",
+  "weights": {"strat_a": 0.35, "strat_b": 0.25, "strat_c": 0.40},
+  "covariance_ref": "cov/2025-01-15",
+  "covariance": {"strat_a,strat_b": 0.12, "strat_b,strat_c": 0.15},
+  "realized_returns_ref": "s3://.../realized/2025-01-15.parquet",
+  "stress": {"crash": {"dd_max": 0.30, "es_99": 0.25}},
+  "constraints": {"max_leverage": 3.0, "adv_util_p95": 0.25},
+  "provenance": {"source": "gateway", "cov_version": "v42"},
+  "hash": "blake3:...",
+  "ttl_sec": 900
+}
+```
+
+- 필수: `world_id`, `as_of`, `version`, `weights`
+- 선택: `covariance_ref`(권장), `covariance`(작을 때 inline), `realized_returns_ref`, `stress`, `constraints`
+- 메타: `provenance.source/cov_version`, `hash`, `ttl_sec`
+
+### 1.1.1 헤더·메타 계약
+- 쓰기 요청 헤더:
+  - `Authorization: Bearer <token>` (prod 필수)
+  - `X-Actor`: 작성 주체(필수)
+  - `X-Stage`: 검증/배포 스테이지(backtest/paper/live 등, 가능하면 필수)
+- 스냅샷 `provenance` 채우기:
+  - `provenance.actor` ← `X-Actor`
+  - `provenance.stage` ← `X-Stage` (없으면 `unknown` 취급, dedupe/메트릭 분리 불가)
+  - `provenance.reason/source/schema_version` 등은 프로듀서에서 설정
+- TTL: `ttl_sec` 기본 10초, 만료 스냅샷은 소비자가 거부하고 `risk_hub_snapshot_expired_total`에 계수.
+- Idempotency: `(world_id, version, hash, actor, stage)` 조합으로 dedupe 처리(`risk_hub_snapshot_dedupe_total`에 계수).
+
+### 1.2 이벤트 목록
+- `PortfolioSnapshotUpdated` (필수 필드: world_id, version, as_of, weights, covariance_ref/hash, ttl)
+- `CovarianceUpdated` (covariance_ref/hash, as_of, version)
+- `RealizedReturnsIngested` (ref, as_of, horizon)
+- `StressResultsUpdated` (stress payload 또는 ref)
+- `ExitSignalEmitted` (exit 엔진이 발행; 전략/월드별 exit 권고, 사유/지표)
+
+페이로드는 큰 데이터(리턴/공분산)를 ref/id로 전달하고, 소비자는 ref로 원본 스토리지를 조회.
+
+---
+
+## 2. 저장/조회 뷰
+
+- 저장소(템플릿):
+  - Dev/경량: 인메모리/SQLite에 메타·버전 저장, 캐시/오프로드는 fakeredis/인메모리만 사용(실 Redis/S3/File 영속 스토리지는 dev에서 비활성). 공분산 등은 inline(또는 fakeredis ref)으로만 검증용 최소 구성.
+  - Prod: Postgres(메타/버전/감사) + Redis/KeyDB(최신 스냅샷 캐시) + 오브젝트 스토리지(S3/OBS/GCS; 공분산/리턴 시계열 ref) + Kafka/ControlBus(이벤트).
+  - 선택: ClickHouse/BigQuery 등 컬럼형 DB에 시계열을 적재하고 ref로 연결.
+  키: `(world_id, version)` 또는 `(world_id, as_of)`; 큰 데이터는 ref/id로 저장.
+- 조회 API(내부):
+  - `get_snapshot(world_id, version=None, as_of=None)` → 최신 또는 특정 버전 반환
+  - `list_snapshots(world_id, limit=N, since=ts)`
+- 데이터 크기 이슈: 공분산/리턴 시계열은 object storage/DB에 저장, 스냅샷에는 `ref`만 포함. 조회 시 ref를 따라가거나 WS/exit 엔진은 요약(σ, ρ)만 사용.
+
+---
+
+## 3. 접근 제어/감사
+
+- 쓰기: gateway/리스크 엔진 계정만 허용.
+- 읽기: WS, exit 엔진, 모니터링.
+- 감사: 모든 이벤트/쓰기 연산에 `actor`, `ts`, `hash` 기록. 필요 시 서명/체크섬 검증.
+
+---
+
+## 4. 소비자 통합 포인트
+
+- WS ExtendedValidationWorker: `get_snapshot`으로 weights/covariance/stress를 읽어 Var/ES/Sharpe 베이스라인 계산.
+- Exit Engine: hub 이벤트(`PortfolioSnapshotUpdated`, `StressResultsUpdated`)를 트리거로 exit 신호 계산 후 `ExitSignalEmitted`.
+- 대시보드/모니터링: 최신 스냅샷 뷰를 읽어 리스크 상태를 시각화.
+
+---
+
+## 5. 장애/운영 가드
+
+- 신선도: `as_of` 지연 상한(예: 5m) 초과 시 보수적 fallback(기본 상관 0.5, 이전 버전 스냅샷).
+- 리트라이/알람: 이벤트 처리 실패 시 재시도 + 알림(Prometheus/Sentry).
+- TTL: `ttl_sec` 만료 시 경고/폐기 처리.
+
+---
+
+## 6. 단계별 도입 계획 (초안)
+
+1. **스냅샷 저장소 + 조회 API**: gateway가 스냅샷을 기록, WS/exit 엔진이 수동 조회.
+2. **이벤트 발행/구독**: ControlBus/Kafka에 이벤트 발행, WS/exit 엔진 워커가 구독하여 자동 갱신/트리거.
+3. **리스크/exit 신호 통합**: Exit Engine이 hub 이벤트를 기반으로 신호를 발행, WS/gateway가 적용/검증 경로를 통합.
+
+---
+
+## 7. 보완 작업(구현 계획)
+
+- **스키마/데이터 계약**
+  - 필수 필드 검증: 가중치 합≈1, `as_of` 지연 한도, `ttl_sec` 만료 처리.
+  - 대용량 필드 분리: 공분산/실현 리턴은 inline 대신 `ref`(+hash/version)로 저장, 스냅샷에는 요약/참조만 포함.
+  - Idempotency: `(world_id, version)` 충돌 정책 정의(덮어쓰기 vs 거절), hash 검증.
+- **영속·캐시 계층**
+  - Postgres/SQLite 인덱스(as_of, world_id) 및 최신/히스토리 조회 최적화.
+  - Redis 캐시 또는 materialized view로 핫월드 지연 최소화.
+  - 백필 스크립트: 기존 결정/포지션에서 초기 스냅샷 생성.
+- **생산자 경로**
+  - Rebalance 외 체결/포지션 싱크/alloc 스냅샷 후에도 hub push, 실패 시 재시도·DLQ.
+  - ControlBus 토픽/키/재시도 설정 표준화(`risk_snapshot_updated`), gateway 쓰기 ACL(토큰/네트워크).
+- **소비자 경로**
+  - WS: ControlBus/큐 구독 워커 → 스냅샷 이벤트를 받아 ExtendedValidation/스트레스/라이브 워커 트리거(idempotent 실행 포함).
+  - Exit 엔진: 이벤트 구독 후 추가 exit 신호 산출, 신호 스키마 정의.
+  - 큐/스케줄러 표준화: Celery/Arq/ControlBus 핸들러 공통 모듈, 중복 방지.
+- **운영/가시성**
+- 모니터링: 최신 스냅샷 `as_of` 지연, 결측률, 이벤트 실패/재시도 메트릭, 알람.
+- 감사/보안: actor/source/reason/cov_ref 서명/감사 로그, 민감 필드 마스킹 정책.
+- 장애 대응: fail-closed 정책(스냅샷 오래되면 보수적 상관/σ), 재시도/백오프, DLQ 소비기.
+- **테스트/문서**
+- e2e: gateway→hub→ControlBus→WS 워커 경로, TTL/지연/손상 스냅샷 시나리오, 공분산 없는 fallback.
+- 부하 테스트: 다수 전략/스냅샷에서 조회/캐시 hit 비율 확인.
+- 운영 문서: 토픽/큐 설정, 권한 모델, 스키마/TTL 정책, runbook.
+
+### 7.1 현재 코드 상태 대비 잔여 갭
+- 구현됨: 필수 검증/TTL/hash, Redis 캐시 최신 조회, Postgres 인덱스, blob-store(offload/ref) 지원, ControlBus 이벤트 소비/발행, bearer token 보호, gateway push 재시도/backoff.
+- 미구현/남은 것:
+  - 대용량 필드 표준 ref 스키마(s3/oss/redis)와 저장소 선택지 정의, 업로드 헬퍼.
+  - 생산자 전면 적용: 체결/포지션 싱크·alloc 스냅샷 push + 재시도/ACL 일관화(리밸런스/activation 경로는 완료).
+  - 운영 모니터링/알람: Prometheus 규칙 추가(`alert_rules.yml`에 RiskHubSnapshotStale/Missing), 런북 완성(`operations/risk_signal_hub_runbook.md`), metrics 노출(`risk_hub_snapshot_lag_seconds`, `risk_hub_snapshot_missing_total`), 헬스 스크립트(`scripts/risk_hub_monitor.py`).
+  - 큐/ControlBus 워커 배포 예시와 idempotency 키: 미니멀 워커(`scripts/risk_hub_worker.py`) 제공, Celery/Arq 예시와 키 규칙은 운영 환경에 맞춰 확정 필요.
+  - e2e/부하 테스트 시나리오 구현, CI 포함 여부 결정.
+
+운영 런북: [operations/risk_signal_hub_runbook.md](../operations/risk_signal_hub_runbook.md) 참고.
+
+---
+
+## 8. 남은 결정/오픈 이슈
+
+- 공분산/상관 추정 소스와 해상도(자산 vs 전략) 확정.
+- 대용량 리턴/공분산의 ref 포맷(s3/redis/DB) 및 수명 관리.
+- exit 신호 우선순위/override 정책(운영 문서와 정렬).
+- 스냅샷 해시/서명 적용 여부(감사 요구 수준에 따라).
+
+### 8.1 모니터링/알람 지표 (v1.5)
+- `risk_hub_snapshot_dedupe_total{world_id,stage}`: dedupe 키 충돌로 스킵된 건수
+- `risk_hub_snapshot_expired_total{world_id,stage}`: TTL 만료로 거부된 건수
+- `risk_hub_snapshot_lag_seconds`(추가 예정): 최신 스냅샷 `as_of` 지연
+- Alert 예시: dedupe/expired 급증, lag 초과 시 경고 → runbook으로 재처리/프로듀서 점검
+
+## 9. 환경 구성(dev/prod 템플릿)
+
+- `qmtl.yml`에 `risk_hub` 블록을 추가해 gateway/WS가 동일 설정을 공유한다.  
+  `token`은 WS `risk_hub` 라우터 bearer 검증과 gateway `RiskHubClient` 양쪽에 주입된다.  
+  `inline_cov_threshold`/`blob_store.inline_cov_threshold`는 hub와 gateway가 동일 기준으로 공분산을 offload/ref 처리하도록 맞춘다.
+- Dev 템플릿(경량, fakeredis/인메모리 전용):
+  ```yaml
+  risk_hub:
+    token: dev-hub-token           # 선택
+    stage: paper                   # 기본 stage 헤더 (선택, 미지정 시 컨슈머 dedupe/알람이 unknown 라벨)
+    inline_cov_threshold: 100      # dev는 공분산 inline 기본, offload 비활성
+  ```
+  - WS: in-memory/SQLite 메타 저장, 캐시/오프로드는 fakeredis(또는 순수 인메모리)만 사용한다. 별도 파일/S3 영속 스토리지는 dev에서 사용하지 않는다.
+  - Gateway: 동일 토큰/threshold로 hub에 push. dev에서는 fakeredis 캐시/참조만 사용하고, 재시작 시 스냅샷이 사라져도 문제없는 최소 검증 흐름을 전제로 한다.
+- Prod 템플릿(정식):
+  ```yaml
+  risk_hub:
+    token: ${HUB_TOKEN}             # 필수, gateway에만 공유
+    stage: live                     # 기본 stage 헤더 (backtest/paper/live 등)
+    inline_cov_threshold: 50        # 큰 공분산은 ref로 강제
+    blob_store:
+      type: s3                      # 또는 redis
+      bucket: qmtl-risk-snapshots
+      prefix: risk/portfolios/
+      inline_cov_threshold: 100
+      cache_ttl: 900                # redis blob일 때 TTL
+      redis_prefix: "risk-blobs:"
+  ```
+  - WS: Postgres `risk_snapshots` 테이블 + Redis 캐시, blob은 S3/OBS/GCS(또는 redis)로 offload.
+  - Gateway: 동일 blob 스토어/threshold로 스냅샷을 push, WS는 `risk_hub.token`으로 보호.
+  - dev/prod 전역 프로파일과 일관: 다른 모듈(WS/gateway/dagmanager/controlbus)과 동일 qmtl.yml을 사용하므로 환경 전환 시 hub 설정도 함께 적용된다.

--- a/docs/ko/design/world_strategy_weighting_v1.5_design.md
+++ b/docs/ko/design/world_strategy_weighting_v1.5_design.md
@@ -1,0 +1,326 @@
+---
+title: "World 전략 비중 조절(Weighting) v1.5 설계 초안"
+tags: [design, world, allocation, weighting, portfolio]
+author: "QMTL Team"
+last_modified: 2025-12-11
+status: draft
+---
+
+# World 전략 비중 조절(Weighting) v1.5 설계 초안
+
+본 문서는 QMTL **WorldService(WS)** 가 월드 내부의 전략 비중을 **이론 기반 포트폴리오 최적화 기법**으로 자동 조절하는 기능을 추가하기 위한 설계 초안이다.  
+월드 내 전략을 “자산(슬리브)”으로 보고, **성과/리스크/레짐 정보를 입력으로 받아 전략 가중치(=strategy_alloc_total, activation.weight)를 산출·적용**한다.
+
+관련 문서:
+- World/전략 생애주기 사양: [world/world.md](../world/world.md)
+- WorldService SSOT/Activation/Apply: [architecture/worldservice.md](../architecture/worldservice.md)
+- 리밸런싱 계약/캐스케이드: [world/rebalancing.md](../world/rebalancing.md)
+- World 검증 v1.5 진행 현황: [design/world_validation_v1.5_implementation.md](world_validation_v1.5_implementation.md)
+- Risk Signal Hub(실현 리스크/공분산 입력): [architecture/risk_signal_hub.md](../architecture/risk_signal_hub.md)
+
+---
+
+## 0. 배경 & 문제 정의
+
+현재 WS는 정책 엔진으로 **전략 선정(top‑k/상관/히스테리시스)** 까지는 수행하지만,  
+선정된 전략들의 **상대 비중(리스크/기대수익 기반 weight)** 은 다음 두 경로로만 갱신된다:
+1) 외부 “성과 기반 가중치 모듈”이 산출해 `/allocations`에 전달  
+2) 월드 비중 리밸런싱의 캐스케이드(전략 상대비율 유지)
+
+즉, WS 내부에는 **전략 비중을 체계적으로 산출·적용하는 1급 모듈**이 아직 없다.  
+특히 1m 선물/퍼프 환경에서는 평균수익 추정이 불안정하고 레짐 전환이 잦아,
+**단순 Sharpe 비례 가중치**로는 월드 리스크가 특정 전략에 쏠리거나
+레짐 변화 시 과도한 레버리지/턴오버가 발생할 수 있다.
+
+따라서 WS에 **“월드 내 전략 비중 조절 엔진”을 내장**해,
+아래 업계/학계 검증 기법들을 정책적으로 선택·조합하고
+안전 제약 하에서 자동 리밸런싱을 수행할 수 있도록 한다.
+
+---
+
+## 1. 목표 & 비범위
+
+### 1.1 목표
+- WS가 월드 내부 전략을 입력 시계열 기반 “자산”으로 보고
+  **전략 상대 비중 벡터 `w_world(strategy_id)`** 를 산출한다.
+- 산출된 비중을
+  - **Activation weight**(주문 스케일링, side‑level)과
+  - **strategy_alloc_total**(총자산 대비 비중, rebalancer 입력)
+  로 저장·전파한다.
+- 정책(YAML)로 기법/윈도우/제약/스무딩/턴오버 상한을 선언하고,
+  WS는 동일 계약으로 plan/apply를 제공한다.
+- 데이터 부족/불안정/제약 실패 시 **fail‑safe 폴백**으로 수렴한다.
+
+### 1.2 비범위
+- 월드 간 자본 배분(world_alloc) 최적화(별도 allocator 범위).
+- 레짐 탐지 자체의 신규 백엔드 서비스 도입(입력 제공자만 정의).
+- 전략(알파) 로직을 `qmtl/`에 추가하는 일(전략은 `strategies/` 범위).
+
+---
+
+## 2. 시스템 개요 (WS 전략 비중 엔진)
+
+WS는 기존 Core Loop 흐름을 유지하면서, **선정 이후 “비중 산출 단계”를 추가**한다.
+
+```mermaid
+sequenceDiagram
+    participant Runner as SDK/Runner
+    participant GW as Gateway
+    participant WS as WorldService
+    participant RH as Risk Signal Hub
+    participant CB as ControlBus
+
+    Runner->>GW: submit(world_id, mode)
+    GW->>WS: /worlds/{id}/evaluate (metrics, series)
+    WS->>WS: 정책 평가 → selected_ids
+    WS->>WS: WeightingEngine.plan(selected_ids, series, metrics, regime)
+    WS-->>GW: ApplyResponse(selected_ids, weights_preview)
+    WS->>WS: WeightingEngine.apply(run_id)
+    WS->>RH: (optional) weights/cov snapshot store
+    WS-->>CB: activation_updated (weights)
+    WS-->>CB: rebalancing_planned (strategy_alloc_total changed)
+    GW-->>Runner: WS stream relay (ActivationUpdated)
+```
+
+핵심 SSOT 경계:
+- **전략 선정/가중치/활성화/할당**의 SSOT는 WS.
+- Gateway는 프록시/중계만 수행하며, 가중치 계산을 하지 않는다.
+
+---
+
+## 3. 입력 데이터 계약
+
+### 3.1 전략 시계열 입력(필수)
+WeightingEngine은 아래 중 하나를 전략별로 입력받는다.
+- `StrategySeries.returns`: 일별(또는 바‑집계 후 일 단위) 수익률 시계열
+- `StrategySeries.pnl`: 일별 PnL 시계열
+- `StrategySeries.equity`: 일별 equity curve
+
+입력 경로:
+- backtest/paper: Runner가 `EvaluateRequest.series`로 전달  
+  (현재 reports/*backtest*.json에서 추출 가능)
+- live: Risk Signal Hub의 realized snapshot 또는 Live EvaluationRun
+  (`live_metrics` 워커가 30/60/90일 realized Sharpe/DD/ES 생성)
+
+### 3.2 메트릭 입력(선택)
+기법/제약에 따라 아래 메트릭을 참조한다.
+- `returns.*`: Sharpe, Sortino, MDD, VaR/ES 등 (`EvaluationMetrics`)
+- `sample.*`: 최소 거래수/유효 연수
+- `robustness.*`: DSR, CV gap 등
+- `risk.*`: incremental VaR/ES, exposure 등
+
+### 3.3 레짐 입력(선택)
+Mixture‑of‑Experts(MoE)용.
+- `diagnostics.extra_metrics.regime_posterior`: `{regime: prob}` (시점별 or 최근값)
+- 또는 `diagnostics.extra_metrics.regime_metrics`: `{regime: {strategy_id: sharpe/pf/...}}`
+
+레짐 산출은 **외부 RegimeProvider(전략/노드/워커)** 가 담당하고,
+WS는 제공된 확률/조건부 성과만 소비한다.
+
+---
+
+## 4. WeightingEngine 설계
+
+### 4.1 플러그형 인터페이스
+`qmtl/services/worldservice/weighting/`에 아래 인터페이스를 추가한다.
+
+- `StrategyWeightingEngine.plan(ctx) -> WeightPlan`
+  - 입력: `world_id`, `strategy_ids`, `series`, `metrics`, `regime_payload`, `policy.weighting`
+  - 출력: `weights_by_strategy`, `diagnostics`, `warnings`
+- `StrategyWeightingEngine.apply(plan, execute=False) -> WeightApplyResult`
+  - Activation/allocations 저장, ControlBus 이벤트 발행, 선택적 리밸런싱 execute
+
+### 4.2 공통 전처리
+- **일 단위 정규화**: bar‑PnL/returns는 일별로 리샘플링.
+- **윈도우 선택**: `lookback_days` 또는 stage‑별 기본값(backtest=전체, live=60d).
+- **클린/필터링**: NaN/inf 제거, 최소 표본수(`min_history_days`, `min_trades_total`) 미달 전략 제외.
+- **공분산 추정(필요 시)**:
+  - EWMA 또는 Ledoit‑Wolf shrinkage 기본.
+  - 표본 부족 시 diagonal‑only로 축소(=독립 가정).
+
+### 4.3 공통 제약/스무딩
+- `max_weight`, `min_weight`(0 허용), `max_leverage`(총합 또는 per‑strategy)
+- `max_dd`, `max_var_es` 등 리스크 컷 미달 전략은 weight=0
+- **턴오버 상한**: `||w_t - w_{t-1}||_1 ≤ max_turnover`
+- **EWMA 스무딩**: `w_t = α w_plan + (1-α) w_{t-1}`
+- 제약 불만족/해결 실패 시 폴백(§9).
+
+---
+
+## 5. 지원 기법(알고리즘) 상세
+
+각 기법은 `method`로 선택하며, 공통 전처리/제약을 공유한다.
+
+### 5.1 Constrained Mean‑Variance / Max‑Sharpe
+**입력:** 전략별 일 수익률(또는 PnL), 공분산.  
+**특징:** 1m 선물의 평균추정 불안정성을 고려해 **기대수익을 Sharpe/Sortino 기반으로 대체**하고 강한 제약을 둔다.
+
+- 기대수익 벡터:
+  - `μ_i := Sharpe_i × σ_i` (또는 Sortino 기반)
+- 최적화:
+  - 목적: `min w^T Σ w` (risk‑min) 또는 `max (w·μ)/sqrt(w^T Σ w)` (max‑Sharpe)
+  - 제약: `Σ w_i = 1`, `0 ≤ w_i ≤ max_weight`,  
+    `n_active ≥ min_active_strategies`,  
+    `DD_i ≤ max_dd`, `n_trades_i ≥ min_trades_total`
+- 구현:
+  - v1.5: cvxpy/OSQP 기반 QP(선택), 실패 시 휴리스틱 폴백.
+
+### 5.2 Risk Parity / Volatility Targeting
+**입력:** 최근 실현 변동성(30‑60d).  
+**특징:** 기대수익 추정 없이도 안정적.
+
+- inverse‑vol 기본:
+  - `w_i ∝ 1/σ_i`, 정규화
+- (옵션) marginal risk parity:
+  - `RC_i = w_i (Σ w)_i` 가 동일하도록 반복 갱신
+- vol target:
+  - 월드 목표 변동성 `σ_target`에 맞춰  
+    `scale = σ_target / σ_portfolio` 를 별도 출력(세계 레버리지 계층에서 사용)
+
+### 5.3 HRP (Hierarchical Risk Parity)
+**입력:** 상관 행렬.  
+**특징:** 상관 구조 기반 클러스터링 → 추정 오차에 강함.
+
+1) 상관→거리 변환 `d_ij = sqrt((1-ρ_ij)/2)`  
+2) 계층적 클러스터링(linkage=`single|ward`)  
+3) quasi‑diagonalization으로 순서 재배치  
+4) recursive bisection으로 클러스터 분산 역비례 배분  
+5) 공통 제약/턴오버 적용 후 정규화
+
+### 5.4 Fractional Kelly Scaling
+**입력:** 전략별 edge(PF, Sharpe, mean/var).  
+**특징:** 고레버리지 선물 환경에서 **레버리지 최적화에 정합적**. 과최적화 방지를 위해 fractional 사용.
+
+- 근사 Kelly:
+  - `f_i = μ_i / σ_i^2` 또는 `f_i = (PF_i-1)/Var_i`
+- fractional 적용:
+  - `f_i' = k × f_i`, `k ∈ [0.25, 0.5]`
+- 최종 weight:
+  - base weight(예: HRP/RP/MV) × `f_i'` 로 스케일 → cap → 정규화
+
+### 5.5 레짐‑컨디셔널 Mixture‑of‑Experts(MoE)
+**입력:** 레짐별 조건부 성과 + 레짐 posterior.  
+**특징:** on/off 라벨 대신 **soft weight**로 레짐 전환에 부드럽게 적응.
+
+- 레짐 r에서:
+  - `w_i(r) ∝ max(0, Sharpe_i(r))` (또는 PF/Sortino)
+  - softmax 온도 `τ`로 완만화:  
+    `w_i(r)=softmax( max(0,m_i(r))/τ )`
+- 시점 t 최종 weight:
+  - `w_i(t) = Σ_r p_t(r) w_i(r)`
+- 이후 공통 스무딩/턴오버/제약 적용.
+
+---
+
+## 6. 정책(YAML) 스키마 확장
+
+`Policy`에 `strategy_weighting` 블록을 추가한다(역호환: 미지정 시 Sharpe‑비례 폴백).
+
+```yaml
+strategy_weighting:
+  method: constrained_mv        # constrained_mv | risk_parity | hrp | fractional_kelly | moe
+  lookback_days: 60
+  rebalance_interval: "1d"      # or cron, stage별 override 가능
+  constraints:
+    max_weight: 0.40
+    min_weight: 0.02
+    min_active_strategies: 3
+    min_trades_total: 30
+    max_dd: 0.30
+    max_turnover: 0.20
+  mv:
+    objective: max_sharpe       # max_sharpe | min_var
+    expected_return_source: sortino
+    cov_estimator: ewma         # ewma | shrinkage | diagonal
+  risk_parity:
+    vol_target: 0.15
+  hrp:
+    linkage: ward
+  kelly:
+    fraction: 0.25
+    edge_source: profit_factor
+  moe:
+    regimes: [low_vol, mid_vol, high_vol]
+    temperature: 1.0
+    smoothing_half_life_days: 7
+```
+
+---
+
+## 7. WS API 설계
+
+### 7.1 Plan
+`POST /worlds/{world_id}/strategy-weights/plan`
+- 입력: `EvaluateRequest` 호환 payload(series/metrics/stage/previous/override) + 선택적 `run_id`
+- 출력:
+  ```json
+  {
+    "world_id": "...",
+    "run_id": "...",
+    "method": "hrp",
+    "weights_by_strategy": {"s1": 0.4, "s2": 0.35, "s3": 0.25},
+    "leverage_by_strategy": null,
+    "diagnostics": {"window_days": 60, "cov_estimator": "ewma"},
+    "warnings": ["insufficient_history:s4"]
+  }
+  ```
+
+### 7.2 Apply
+`POST /worlds/{world_id}/strategy-weights/apply`
+- 입력: plan 입력 + `execute: bool=false`
+- 동작:
+  1) weights 산출(idempotent `run_id`)
+  2) Activation 테이블의 `(strategy_id, side)` weight 갱신
+  3) 최신 world_alloc을 읽어 `strategy_alloc_total = world_alloc × weights` 저장
+  4) ControlBus:
+     - `activation_updated` 발행
+     - 전략 비중 변화가 있으면 `rebalancing_planned` 발행(+execute 시 executor 호출)
+
+### 7.3 CLI(후속)
+- `qmtl world weights plan --world <id>`
+- `qmtl world weights apply --world <id> [--execute]`
+
+---
+
+## 8. 저장·이벤트·관측성
+
+- 저장:
+  - Activation SSOT: Redis/DB activation table(기존)
+  - Allocation SSOT: `world_allocations.strategy_alloc_total`(기존 컬럼)
+  - Weighting audit: `WorldAuditLog`에 plan/apply 입력·출력 저장
+- 이벤트:
+  - 기존 `activation_updated`, `rebalancing_planned` 재사용
+  - 필요 시 v2에서 `weights_updated` 타입 추가(분리 스트림)
+- 메트릭:
+  - `ws_weighting_plan_total{world_id,method,stage}`
+  - `ws_weighting_apply_total{world_id,method,stage,ok}`
+  - `ws_weighting_turnover{world_id}` p95
+
+---
+
+## 9. 안전 기본값 & 폴백
+
+- 데이터 부족/레짐 입력 부재/공분산 추정 실패/제약 불만족 시:
+  1) **Sharpe‑비례(현재 ValidationPipeline과 동일)**
+  2) Sharpe 합=0이면 **균등 가중치**
+  3) 그래도 실패하면 **기존 weight 유지**
+- high‑tier & client‑critical 월드는 fail‑closed 원칙에 따라
+  plan/apply 실패 시 weight 변경을 금지하고 경고만 남긴다.
+
+---
+
+## 10. 단계적 롤아웃(v1.5)
+
+1) **P0: HRP/RiskParity 우선 도입**
+   - 기대수익 추정 없이 안정적인 기법부터 WS 내부 플러그인으로 제공.
+   - live 모드에서는 60d realized window 기본.
+2) **P1: Constrained MV + Fractional Kelly**
+   - cvxpy 기반 QP 및 Kelly 스케일링 추가.
+   - 강한 제약/턴오버 상한 검증.
+3) **P2: Regime‑conditional MoE**
+   - RegimeProvider 계약 확정 후 soft weight 적용.
+   - weak_off 실험 실패 원인(라벨 이분화) 개선 검증.
+
+각 단계는 `strategy_weighting.method` 플래그로 opt‑in하며,
+기본값은 현행 Sharpe‑비례를 유지한다.
+

--- a/docs/ko/design/world_validation_architecture.md
+++ b/docs/ko/design/world_validation_architecture.md
@@ -22,6 +22,12 @@ status: draft
 - 모델 리스크 관리 프레임워크: [design/model_risk_management_framework.md](model_risk_management_framework.md)
 - 과거 SDK auto_returns 설계(보관용): [archive/auto_returns_unified_design.md](../archive/auto_returns_unified_design.md)
 
+> 최근 변경 요약 (risk_signal_hub 연계)
+> - Hub 최소 구현: WS에 `risk_hub` 라우터를 추가하고 dev(in-memory/SQLite+fakeredis 캐시, offload 비활성)·prod(Postgres+Redis+S3/redis)에서 스냅샷 메타를 영속화하도록 바인딩.
+> - 소비자 전환: `ExtendedValidationWorker`가 hub 스냅샷(가중치/공분산) 기반으로 Var/ES 베이스라인을 계산하도록 수정하여 gateway 직접 의존을 제거.
+> - 생산자 연결 준비: gateway/alloc이 리밸런스·체결 이후 스냅샷을 push 할 수 있도록 HTTP 헬퍼(`services/gateway/risk_hub_client.py`)를 추가. ControlBus/큐 이벤트 연동은 후속 단계로 남김.
+> - 환경 설정 일원화: `qmtl.yml` `risk_hub` 블록(dev=inline+fakeredis 캐시만, prod=Postgres+Redis+S3/redis)으로 WS 라우터 토큰/inline offload/blob 스토어와 gateway push 클라이언트를 동시에 구성하도록 연결.
+
 ---
 
 ## 0. 배경 & 문제 정의

--- a/docs/ko/design/world_validation_v1.5_implementation.md
+++ b/docs/ko/design/world_validation_v1.5_implementation.md
@@ -1,0 +1,178 @@
+# World 검증 v1.5 진행 현황 및 잔여 작업
+
+본 문서는 `world_validation_architecture.md`·`world_validation_v1_implementation_plan.md`의 v1.5 범위를 마무리하기 위해 **현재 구현 상태**와 **남은 작업**을 정리한 체크포인트다.
+
+## 진행 현황 (요약)
+- **핵심 검증 경로**: EvaluationRun/metrics 블록, RuleResult 메타(severity/owner/tags), validation_profiles(backtest/paper), recommended_stage·policy_version·ruleset_hash 저장까지 구현 완료.
+- **확장 레이어**: cohort/portfolio/stress/live 평가·append-only 기록, risk hub 스냅샷 소비/베이스라인 파생치, ControlBus 소비자(dedupe 포함) 연동, TTL(10s)·hash(sha256)·actor 헤더 강제.
+- **Blob/offload**: redis/file/s3 BlobStore 팩토리 제공, redis TTL 기본 10초, covariance offload 기준 적용.
+- **게이트웨이 생산자**: 리밸런스 경로에서 risk hub 스냅샷 push(+offload) 적용, RiskHubClient가 TTL/actor 헤더를 포함하도록 보강.
+- **회귀/도구**: `scripts/policy_diff_batch.py` 추가로 정책 변경 영향 리포트 CI/배치 실행 가능, extended validation 워커 부하 시나리오 테스트 추가.
+- **문서/내비게이션**: Risk Signal Hub/Exit Engine 문서를 mkdocs nav에 추가.
+- **품질**: 풀 CI 스위트, mypy, mkdocs, 링크/사이클 검사 모두 통과.
+
+## 남은 주요 갭
+1) **스트리밍·운영 배포 정착**
+   - ControlBus/큐 → ExtendedValidation/라이브·스트레스 워커를 운영 스케일에서 idempotent하게 트리거하도록 토픽/그룹/재시도·DLQ·헬스 메트릭을 표준화해야 함.
+   - risk snapshot 프로듀서(gateway/리스크 엔진) 측 재시도·알람·dedupe 키 규칙 문서화/코드 반영 필요.
+
+2) **Live 모니터링 자동 생성**
+   - 주기적 Live EvaluationRun 생산(30/60/90일 realized Sharpe/DD/ES, decay 지표)을 스케줄러/워커로 운영 경로에 연결해야 함.
+   - 라이브 리포트 템플릿/노출 경로 정의 필요.
+
+3) **Evaluation Store & 회귀 자동화**
+   - EvaluationRun/override/정책 버전 히스토리를 불변 스토어로 관리하는 정책 명문화.
+   - “나쁜 전략” 회귀 세트 + `scripts/policy_diff.py`를 주기 배치/CI 옵션으로 연결하고, 영향 임계치 초과 시 경고/실패 플래그화.
+
+4) **Portfolio/Stress 입력 소스 강화**
+   - realized_returns_ref/stress ref를 생성하는 프로듀서(gateway/리스크 엔진) 연결과 해시 검증/ACL 경로를 표준화.
+   - risk hub 스냅샷 계약(가중치 합≈1, TTL, hash, actor, offload 기준) 검증을 프로듀서에도 강제.
+
+5) **SDK 얇게 만들기 & WS SSOT 전환**
+   - Runner ValidationPipeline을 metrics-only로 축소하고, 룰 실행·오케스트레이션을 WS 단일 진입으로 이관하는 단계적 플랜 필요.
+
+6) **거버넌스/운영 가시성**
+   - 독립 검증(Repo/권한 분리), override 재검토 큐, SR 11-7 인바리언트 운영 체크/대시보드 정착.
+   - risk hub freshness/누락, extended validation 워커 성공/실패 메트릭 + Alertmanager 룰 보완.
+
+## 다음 실행 우선순위 제안
+1. ControlBus/큐 운영 패키징: 토픽·그룹·재시도/백오프·DLQ·헬스 메트릭 템플릿 확정 후 워커/프로듀서에 적용.
+2. Live 모니터링 스케줄러 배포: live run 생성 워커 + 리포트 경로 연결, 기본 주기/타임아웃 정의.
+3. Policy diff 회귀 배치: “나쁜 전략” 샘플 세트 마련 → `scripts/policy_diff.py` 크론/CI 옵션화 → 영향 임계 플래그 도입.
+4. realized/stress 프로듀서 연결: gateway/리스크 엔진에서 realized_returns_ref·stress ref를 hub로 push, 해시/actor 검증 강제.
+5. SDK→WS 오케스트레이션 전환 계획 수립: ValidationPipeline 축소, WS 룰 실행/오류 처리 중심으로 마이그레이션 단계 정의.
+6. 운영 가시성: risk hub freshness, extended validation 성공률, snapshot dedupe hit 등 메트릭 노출 + Alertmanager 룰 추가.
+
+## 갭별 상세 실행 계획
+- G1 ControlBus/큐 운영 표준화
+  - 토픽/컨슈머 그룹/재시도·DLQ·백오프·idempotency 키 템플릿 정의 → gateway·ExtendedValidation 워커·RiskHub 컨슈머에 공통 적용.
+  - dedupe 키 규칙(스냅샷 해시+actor+stage), 재시도/알람 정책을 프로듀서 코드와 운영 문서에 반영.
+  - 헬스 메트릭(큐 적체, 재시도·DLQ 카운트, dedupe hit, 처리 지연)과 Alertmanager 룰 초안 배포.
+  - DoD: 템플릿이 코드/런북에 반영되고, 재처리·중복 시나리오 리허설 로그/메트릭이 확보.
+
+- G2 Live 모니터링 자동 생성
+  - 스케줄러(30/60/90일) → Live EvaluationRun 생성 워커 연결, decay 지표 계산 파이프라인을 metrics-only 경로로 연결.
+  - 라이브 리포트 템플릿(요약·추세·임계 경고) 정의, 노출 경로(대시보드/API) 확정 및 샘플 출력 검증.
+  - 지연/실패 알림(스케줄 미실행, 워커 실패, 지표 계산 에러) 룰 추가.
+  - DoD: 정해진 주기마다 Live run이 기록되고, 리포트/알림이 운영 환경에서 확인 가능.
+
+- G3 Evaluation Store & 회귀 자동화
+  - EvaluationRun/override/정책 버전 불변 스토어 스키마/보존 정책 명문화, 삽입/조회 API 정리.
+  - “나쁜 전략” 회귀 세트 큐레이션 → `scripts/policy_diff.py` 크론/CI 옵션화 → 임계 초과 시 경고/실패 플래그 설정.
+  - 회귀 결과/히스토리 리포트(주간) 생성 경로 정의.
+  - DoD: 스토어에 정책 버전별 기록이 남고, 회귀 배치가 임계 초과 시 실패 신호를 내며 리포트가 생성.
+
+- G4 Portfolio/Stress 입력 소스 강화
+  - gateway/리스크 엔진 프로듀서가 realized_returns_ref·stress ref를 risk hub에 push하도록 연결, 해시/actor/ACL 검증을 공통 모듈로 강제.
+  - risk hub 스냅샷 계약(TTL 10s, sha256 hash, actor 헤더, offload 기준, 가중치 합≈1) 프로듀서·컨슈머 모두에 린터/테스트 추가.
+  - DoD: 계약 위반 시 프로듀서 단계에서 거부/로깅되고, hub 컨슈머에서도 동일 기준으로 차단·알림.
+
+- G5 SDK 얇게 만들기 & WS SSOT 전환
+  - ValidationPipeline을 metrics-only 경로로 축소, 룰 실행·오케스트레이션을 WS 단일 진입으로 단계 전환(플래그/롤백 경로 포함).
+  - WS 기반 통합 테스트(룰 실행·오류 처리·오프로드) 추가, SDK 호출부에는 디프리케이션 가이드 삽입.
+  - DoD: 신규 경로가 기본값, SDK 경로는 metrics-only로 남고, 전환 실패 시 롤백 플래그로 복구 가능.
+
+- G6 거버넌스/운영 가시성
+  - 독립 검증(Repo/권한 분리) 경로와 override 재검토 큐 운영 모델 정의, 승인 SLA 명시.
+  - SR 11-7 인바리언트, risk hub freshness/누락, extended validation 성공률·dedupe hit 메트릭 대시보드와 Alertmanager 룰 보강.
+  - DoD: 승인/재검토 흐름이 런북에 반영되고, 메트릭/알람이 운영 환경에서 확인 가능.
+
+## 공통 일정·추적 프레임
+- 순서: G1 → G2 → G3/G4 병행 → G5 → G6(지속)으로 추진, 각 단계 종료 시 런북/알람/테스트 업데이트.
+- 증빙: 리허설 로그, 대시보드 스냅샷, 알람 트리거 캡처, 회귀 리포트 샘플을 문서에 첨부.
+- 검증: 코드 변경 시 CI 전체(uv mypy, mkdocs, docs 링크, 사이클, pytest -n auto, e2e world_smoke) 실행을 기본으로 하고, 큐/워커는 재시도·중복·TTL 초과 시나리오 수동 리허설 포함.
+
+## 이번 사이클(2주) 실행 항목
+- Week 1 — G1·G2 토대
+  - ControlBus 템플릿 초안: 토픽/컨슈머 그룹/백오프·재시도/DLQ/헬스 메트릭 정의를 문서+코드에 반영, gateway·ExtendedValidation 워커에 적용 PR 착수.
+  - Risk snapshot dedupe·알람: dedupe 키(해시+actor+stage) 공용 헬퍼 추가, 재시도/Alertmanager 룰 PR, 재처리/중복 리허설 로그 확보.
+  - Live 스케줄러 골격: 30/60/90일 스케줄러 잡 생성, Live EvaluationRun 워커 엔드포인트 연결, decay 지표 계산 파이프라인 스텁 배치.
+  - 증빙/검증: 큐 리허설 캡처, 스케줄러 dry-run 결과, mkdocs 링크·CI 기본 세트 실행 로그.
+
+- Week 2 — G2 운영화 + G3/G4 착수
+  - Live 리포트 템플릿/노출: 대시보드/API 초안과 샘플 출력 확정, 스케줄 지연/실패 알람 튜닝.
+  - Evaluation Store 정책: 불변 스토어 스키마·보존 정책 결정, 삽입/조회 API 초안 문서화, “나쁜 전략” 회귀 세트 목록 작성.
+  - Realized/Stress 프로듀서 연결: gateway/리스크 엔진에서 realized_returns_ref·stress ref push 경로와 해시/ACL 검증 헬퍼 추가 PR.
+  - 증빙/검증: 회귀 세트 목록·스토어 스키마 리뷰 기록, 프로듀서 계약 위반 테스트 로그, CI 기본 세트 재실행.
+
+## 실행 체크리스트 (담당/마감/증빙)
+- G1 ControlBus 표준화
+  - [ ] 토픽·그룹·백오프·DLQ 템플릿 PR (담당/마감/PR 링크)
+  - [ ] dedupe 키 헬퍼 + 재시도·알람 규칙 PR (담당/마감/PR 링크)
+  - [ ] 재처리/중복 리허설 로그·메트릭 캡처 첨부
+- G2 Live 모니터링
+  - [ ] 스케줄러 잡 배포 + dry-run 로그
+  - [ ] Live EvaluationRun 워커/decay 계산 파이프라인 연결 PR
+  - [ ] 리포트 템플릿·노출 경로 샘플 출력, 지연/실패 알람 캡처
+- G3 Evaluation Store·회귀
+  - [ ] 불변 스토어 스키마/보존 정책 확정 문서
+  - [ ] 삽입/조회 API 초안 PR
+  - [ ] “나쁜 전략” 회귀 세트 목록 + `scripts/policy_diff.py` 크론/CI 옵션 PR + 임계 초과 실패 플래그 검증 로그
+- G4 Portfolio/Stress 입력
+  - [ ] realized_returns_ref·stress ref 프로듀서 연결 PR
+  - [ ] 해시/actor/ACL 검증 공용 모듈 + 린터/테스트 PR
+  - [ ] 계약 위반 차단 로그·알람 캡처
+- G5 SDK→WS 전환
+  - [ ] ValidationPipeline metrics-only 축소 PR + 플래그/롤백 경로 문서
+  - [ ] WS 통합 테스트(룰 실행·오류·오프로드) 추가 PR
+  - [ ] SDK 디프리케이션 가이드 배포
+- G6 거버넌스/가시성
+  - [ ] override 재검토 큐·승인 SLA 문서
+  - [ ] SR 11-7/메트릭 대시보드·Alertmanager 룰 PR
+  - [ ] 런북 업데이트 및 대시보드/알람 스냅샷 첨부
+
+## 최근 진행 업데이트
+- ControlBus 경로 dedupe/TTL 계측: `risk_hub_snapshot_dedupe_total{world_id,stage}`·`risk_hub_snapshot_expired_total{world_id,stage}` 추가, 소비자에서 stage-aware 집계.
+- Stage 헤더 전파: gateway 리밸런스→RiskHubClient `X-Stage` 전달, activation 스냅샷도 `stage=live` 부여, WS 라우터가 provenance.stage 기록.
+- 런북/알림: ko/en Risk Signal Hub 런북에 헤더/TTL/dedupe 대응 추가, Alertmanager 룰에 dedupe/expired 스파이크 감지 룰 포함.
+- 회귀 자동화(G3): `scripts/policy_diff_batch.py`가 stage 지정(`--stage`)과 runs 디렉터리 glob(`--runs-dir/--runs-pattern`)를 지원하여 “나쁜 전략” 세트+최신 runs를 묶어 크론/CI에서 임팩트 비율 임계(`--fail-impact-ratio`)로 실패 플래그를 낼 수 있음.
+
+## G3 실행 가이드 (회귀/스토어)
+- 크론/CI 스니펫: `uv run python scripts/policy_diff_batch.py --old baseline.yml --new candidate.yml --runs-dir artifacts/bad_strategies_runs --runs-pattern '*.json' --stage backtest --output policy_diff_report.json --fail-impact-ratio 0.05`
+- 아티팩트: `policy_diff_report.json` 업로드, 임팩트 비율 초과 시 워크플로 실패 처리.
+- 스토어/보존: EvaluationRun/override 불변 저장, 정책 버전별 히스토리 유지(최소 90일) → API/문서로 스키마 고정 필요(추후 PR).
+
+## G5 전환 스텝 (SDK→WS)
+- SDK metrics-only 플래그: `QMTL_SDK_METRICS_ONLY=1` 시 ValidationPipeline이 정책 게이팅을 건너뛰고 metrics만 산출, 최종 결정은 WS 평가/오케스트레이션 결과를 신뢰.
+- 전환/롤백: 플래그 기본 off(기존 동작), 단계적 on → 문제 시 환경변수 제거로 즉시 롤백.
+- 추가 TODO: WS 오케스트레이션 기본값 전환 및 SDK 디프리케이션 가이드/테스트는 후속 PR에서 완성.
+
+## G5 전환 체크리스트 (추가)
+- [ ] SDK metrics-only를 기본값(on)으로 전환하는 플래그/디폴트 결정 및 배포 계획 수립.
+- [ ] WS 통합 테스트: 룰 실행/오류 처리/오프로드 경로를 WS 단일 진입으로 검증.
+- [ ] SDK 디프리케이션 가이드: precheck/WS SSOT 관계 명시, `QMTL_SDK_METRICS_ONLY` 플래그 사용법, 롤백 절차 포함.
+- [ ] 모드별(Backtest/Paper/Live) WS 오케스트레이션 플래그 롤아웃 순서 합의 및 알림.
+
+### 모드별 롤아웃 가이드
+- Backtest → Paper → Live 순으로 단계 적용, 각 단계에서 수집/재시도율/알람을 모니터링 후 다음 단계 진행.
+- 롤백: 특정 스테이지에서 문제 발생 시 `QMTL_SDK_METRICS_ONLY=0`으로 즉시 복구하고 WS 로그/메트릭으로 원인 파악.
+- 커뮤니케이션: 롤아웃 전/후 changelog+런북 업데이트, 제출/파이프라인 소유자 대상 공지.
+
+## 리허설/검증 시나리오 (필수)
+- 큐/워커: 중복 메시지, 재시도 백오프, DLQ 전송, TTL 만료 후 처리 거부, dedupe hit/미스 메트릭.
+- Risk snapshot: TTL 10s 초과, 해시 불일치, actor 누락, 가중치 합≠1, offload 기준 위반 시 거부·알림.
+- Live 스케줄러: 잡 미실행/지연/워커 실패 알람 트리거, decay 계산 오류 처리.
+- Evaluation Store: 이력 조회/override 적용/정책 버전 추적 쿼리 정상 동작.
+- 회귀 배치: “나쁜 전략” 세트에서 정책 변경 시 임계 초과 실패 플래그 확인.
+
+## 작업 배정 템플릿 (작성용)
+| 갭 | 담당 | 마감 | PR/문서 링크 | 증빙 링크(로그/알람/대시보드/샘플) |
+| --- | --- | --- | --- | --- |
+| G1 ControlBus 표준화 |  |  |  |  |
+| G2 Live 모니터링 |  |  |  |  |
+| G3 Evaluation Store·회귀 |  |  |  |  |
+| G4 Portfolio/Stress 입력 |  |  |  |  |
+| G5 SDK→WS 전환 |  |  |  |  |
+| G6 거버넌스/가시성 |  |  |  |  |
+
+## 주간 리포트 포맷 (채워서 공유)
+- 진행: 이번 주 완료 항목(체크리스트 참조)과 주요 증빙 링크.
+- 리스크/차단: 의존 서비스, 인프라, 권한, 설계 결정 대기 등.
+- 다음 주 계획: 체크리스트 중 이어서 진행할 항목, 추가 리허설 필요 리스트.
+- 의사결정 요청: SLA·임계값·스키마 변경 등 합의가 필요한 사항.
+
+## 참고 링크
+- 설계: [world_validation_architecture.md](world_validation_architecture.md)
+- v1 계획: [world_validation_v1_implementation_plan.md](world_validation_v1_implementation_plan.md)
+- Risk Hub 설계: [risk_signal_hub.md](risk_signal_hub.md)
+- 운영 런북: [../operations/risk_signal_hub_runbook.md](../operations/risk_signal_hub_runbook.md)

--- a/docs/ko/design/world_validation_v1_implementation_plan.md
+++ b/docs/ko/design/world_validation_v1_implementation_plan.md
@@ -25,6 +25,32 @@ status: draft
 v1은 **“단일 전략 + 단일 World에 대한 기본 검증”**을 안정적으로 도입하는 것을 목표로 한다.  
 다음 항목만 실제 구현 대상으로 포함하고, 그 외(코호트/포트폴리오/Stress/Live 프로파일 등)는 v1.5+로 남겨둔다.
 
+## 진행 현황 (작업 체크인용)
+
+| Phase | 범위 | 상태 | 코드 레퍼런스 / 테스트 |
+|-------|------|------|------------------------|
+| P1 | EvaluationRun 저장/조회 + v1 core Metrics 블록 | 완료 | `qmtl/services/worldservice/storage/*evaluation*`, `tests/qmtl/services/worldservice/test_worldservice_api.py::test_evaluation_run_creation_and_fetch` |
+| P2 | RuleResult 스키마 + Rule 래핑 | 완료 | `qmtl/services/worldservice/policy_engine.py`, `tests/qmtl/services/worldservice/test_policy_engine.py` |
+| P3 | validation_profiles DSL(v1) 적용 | 완료 (backtest/paper 프로파일 + severity/owner override 반영) | `policy_engine._materialize_policy`, `tests/qmtl/services/worldservice/test_policy_engine.py::{test_validation_profiles_switch_by_stage,test_validation_profile_overrides_severity_and_owner}` |
+| P4 | EvaluationRun에 policy_version / ruleset_hash / recommended_stage 기록 | 완료 | `decision.py`·`services.py` 메타 전파, `policy_engine.recommended_stage`, `tests/qmtl/services/worldservice/test_worldservice_api.py::test_evaluation_run_creation_and_fetch` |
+| P5 | Cohort/Portfolio/StressRule, live_monitoring | 완료 (extended_layers + append-only history + live/stress/portfolio 지표 파이프라인 + risk_hub 스냅샷 기반 베이스라인 + ControlBus consumer/모니터링 스크립트) | `policy_engine` P5 evaluators + `evaluate_extended_layers`, `worldservice.services._apply_extended_validation`, `extended_validation_worker.py`, `validation_metrics.py`, `risk_hub.py`/`routers/risk_hub.py`/`controlbus_consumer.py`, 리포트(`scripts/generate_validation_report.py`), 모니터/워커(`scripts/risk_hub_monitor.py`,`scripts/risk_hub_worker.py`), `tests/qmtl/services/worldservice/test_policy_engine.py::{test_parse_policy_with_p5_sections,test_stub_cohort_portfolio_stress_and_live_monitoring,test_evaluate_extended_layers_over_runs}`, `tests/qmtl/services/worldservice/{test_extended_validation_worker.py,test_extended_validation_worker_cov_ref.py,test_live_metrics.py,test_stress_metrics.py,test_risk_hub_validations.py,test_controlbus_consumer.py}`, `tests/qmtl/services/gateway/{test_risk_hub_publish.py,test_risk_snapshot_publisher.py}`, `tests/scripts/test_generate_validation_report.py` |
+
+테스트 커버리지 메모:
+- 정책/룰 메타데이터: `uv run -m pytest tests/qmtl/services/worldservice/test_policy_engine.py tests/qmtl/services/worldservice/test_worldservice_api.py::test_evaluation_run_creation_and_fetch`
+- 추가로 전체 WS/GW 스모크/통합은 실행 시 여기에 기록
+
+## 다음 단계 제안 (v1.5+ 하드닝)
+
+- 이벤트/운영: ControlBus/큐 기반 risk snapshot 이벤트를 WS 워커로 트리거하는 운영 배포(현재 워커/모니터 스크립트 제공, 운영 큐 연결은 환경별 설정 필요).
+- 리스크 허브 운영: gateway 전면 생산자 전환(체결/포지션 싱크 포함), blob-store ref 포맷(S3/Redis) 표준 확정, Alertmanager 룰/런북 지속 개선.
+- 회귀/성능: policy diff 시뮬레이터를 “나쁜 전략” 세트와 함께 CI나 배치로 돌리는 옵션 도입, extended validation 워커 부하/성능 테스트 추가.
+- SDK/문서: SDK 예제·CLI 도움말에 cohort/portfolio/stress/live 결과 조회 안내를 추가하고, 운영자용 health 체크 스크립트(`risk_signal_hub_runbook.md`)와 연결.
+
+### 새 TODO (v1.5+)
+- risk snapshot 이벤트를 ControlBus/Celery/Arq 등 운영 큐에 연결해 `ExtendedValidationWorker`/라이브·스트레스 워커가 idempotent하게 실행되도록 환경별 헬름/서비스 스크립트 추가.
+- blob-store ref(s3/redis/file) 스키마와 TTL/해시/ACL 규칙을 운영 문서와 CI에 반영하고, 대용량 공분산/리턴 업로드 헬퍼를 배포.
+- policy diff / “나쁜 전략” 회귀 세트를 주기 배치로 돌려 정책 변경 영향 보고서를 생성하는 스크립트(scripts/policy_diff.py 기반) 확대 적용.
+
 ### 1.1 EvaluationRun / Metrics
 
 - EvaluationRun (WS 쪽)
@@ -152,12 +178,71 @@ v1은 **“단일 전략 + 단일 World에 대한 기본 검증”**을 안정�
 
 v1 구현이 완료되었다고 주장하기 위한 최소 체크리스트:
 
-- [ ] WS에 EvaluationRun 모델/저장소가 추가되었고, Runner.submit 결과로 run_id를 확인할 수 있다.
-- [ ] EvaluationMetrics v1 core 필드가 채워지고, WorldService에서 이를 조회할 수 있다.
-- [ ] DataCurrency/Sample/Performance/RiskConstraint Rule이 RuleResult를 반환하며, EvaluationRun.validation.results에 저장된다.
-- [ ] World policy에 validation_profiles.backtest/paper 블록이 존재하고, v1 core 필드만으로도 go/no‑go 판단을 할 수 있다.
-- [ ] 최소 한 개 World/전략에 대해 Validation Report 초안을 자동 생성할 수 있다.
-- [ ] §12의 인바리언트(특히 Invariant 1/2/3)에 대한 테스트/체크가 CI 또는 e2e 테스트로 구현되었다.
+- [x] WS에 EvaluationRun 모델/저장소가 추가되었고, Runner.submit 결과로 run_id를 확인할 수 있다.
+- [x] EvaluationMetrics v1 core 필드가 채워지고, WorldService에서 이를 조회할 수 있다.
+- [x] DataCurrency/Sample/Performance/RiskConstraint Rule이 RuleResult를 반환하며, EvaluationRun.validation.results에 저장된다.
+- [x] World policy에 validation_profiles.backtest/paper 블록이 존재하고, v1 core 필드만으로도 go/no‑go 판단을 할 수 있다.
+- [x] 최소 한 개 World/전략에 대해 Validation Report 초안을 자동 생성할 수 있다.
+- [x] §12의 인바리언트(특히 Invariant 1/2/3)에 대한 테스트/체크가 CI 또는 e2e 테스트로 구현되었다.
 
 이 체크리스트를 모두 만족한 시점을 v1 “검증 계층 구현 완료”로 간주하고, 이후 Cohort/Portfolio/StressRule, live 프로파일, 포트폴리오 리스크, capacity, advanced robustness 지표 등 v1.5+ 범위를 별도 계획으로 확장해 나간다.
 
+---
+
+## 6. Risk Signal Hub (exit 엔진/리스크 신호 허브) 설계 추가
+
+`risk_signal_hub`은 실행/배분(gateway)과 검증/exit(WS, exit engine) 사이에서 **포트폴리오 스냅샷·리스크 지표·추가 exit 신호**를 SSOT로 제공하는 모듈이다. 목표는 “실행”과 “검증/리스크 신호”를 느슨하게 결합시키고, exit 엔진 같은 신규 소비자가 SDK/WS를 건드리지 않고 붙을 수 있게 하는 것.
+
+### 6.1 역할/데이터 스코프
+- 입력(생산자): gateway/alloc(실제 가중치/포지션), 리스크 엔진(공분산/상관, 스트레스 결과), 실현 리턴 파이프라인.
+- 출력(소비자): WS(Var/ES/샤프 베이스라인, live 모니터링), exit engine(추가 exit 신호 판단), 모니터링 대시보드.
+- 보관 데이터(예시 스냅샷 스키마):
+  ```json
+  {
+    "as_of": "2025-01-15T00:00:00Z",
+    "weights": {"strat_a": 0.35, "strat_b": 0.25, "strat_c": 0.40},
+    "covariance_ref": "cov/2025-01-15",
+    "covariance": {"strat_a,strat_b": 0.12, "strat_b,strat_c": 0.15},
+    "realized_returns_ref": "s3://.../realized/2025-01-15.parquet",
+    "stress": {"crash": {"dd_max": 0.3, "es_99": 0.25}},
+    "constraints": {"max_leverage": 3.0, "adv_util_p95": 0.25},
+    "provenance": {"source": "gateway", "cov_version": "v42"}
+  }
+  ```
+
+### 6.2 인터페이스/배포 형태
+- **이벤트**: `PortfolioSnapshotUpdated`, `CovarianceUpdated`, `RealizedReturnsIngested`, `ExitSignalEmitted` 등을 ControlBus/Kafka로 발행. WS/exit engine은 구독자로 동작.
+- **조회 뷰**: KV/DB/캐시(머티리얼라이즈드 뷰)에서 `get_snapshot(world_id, as_of/version)` 형태로 읽기 전용 제공. 큰 덩어리는 ref/id만 전달하고 원본은 저장소에 둔다.
+- **접근 제어**: 쓰기 주체는 gateway/리스크 엔진으로 한정, 읽기는 WS/exit engine/모니터링. 모든 업데이트에 version/hash/audit 로그를 남긴다.
+
+### 6.3 소비자 통합 포인트
+- WS: ExtendedValidationWorker가 스냅샷을 읽어 Var/ES/Sharpe 베이스라인, 포트폴리오 제약 위반 여부를 계산.
+- Exit engine: 동일 스냅샷 + market/risk 지표를 사용해 전략 exit 신호를 생성하고, `ExitSignalEmitted`로 발행.
+- SDK: 변경 없음. WS/exit 엔진이 hub를 통해 필요한 데이터만 읽는다.
+
+### 6.4 운영/품질 가드
+- SLA: 스냅샷 `as_of` 지연 한도(예: 5m), 실패 시 fallback(이전 버전 + 보수적 상관/σ).
+- 데이터 계약: 필수 필드(weights, as_of), 선택 필드(covariance, realized_returns_ref, stress) 명시. 결측 시 정책(보수 상관=0.5 등) 정의.
+- 보안: 리스크/포지션 스냅샷은 별도 권한 도메인, 감사 필수.
+
+### 6.5 단계별 적용
+1. Minimal: gateway가 스냅샷을 KV/DB에 기록, WS/exit 엔진이 조회만 수행.
+2. 이벤트화: ControlBus/Kafka 이벤트 발행 + 구독 워커로 자동 갱신/트리거.
+3. 확장: 공분산/스트레스 엔진 결과를 ref/id로 결합, exit 신호 발행까지 동일 허브로 관리.
+
+### 6.6 기존/향후 작업에 대한 허브 연계 리워크
+- 포트폴리오 Var/ES 계산: ExtendedValidationWorker가 gateway에서 직접 받아오던 가중치·상관/공분산을 `risk_signal_hub`의 스냅샷 조회로 대체한다. 스냅샷에 weights, covariance_ref/행렬을 포함하도록 계약을 정의한 뒤, WS는 hub에서 최신 버전만 읽는다.
+- 스트레스/라이브 재시뮬레이션 워커: hub가 발행하는 `PortfolioSnapshotUpdated`/`RealizedReturnsIngested` 이벤트를 트리거로 삼아 ControlBus/백그라운드 워커에서 실행하도록 스케줄링 훅을 연결한다.
+- extended_validation_scheduler: 현재 asyncio fire-and-forget 훅을 운영 큐(Celery/Arq 등)나 ControlBus 이벤트 핸들러로 교체해, hub 이벤트 → 큐 → WS 워커 실행 흐름을 구성한다.
+- CI/운영 체크리스트 업데이트: hub 계약(필수 필드, as_of/버전, TTL) 준수 여부와 fail-closed 정책을 고위험 world에서 강제하는 항목을 추가한다.
+- Exit Engine 연계: exit 신호는 `risk_signal_hub` 이벤트를 기반으로 생성해 ControlBus/Kafka로 발행하되, 적용 우선순위/override 정책은 별도 운영 문서에서 정의한다(초안은 [exit_engine_overview.md](exit_engine_overview.md) 참조).
+- Dev/Prod 템플릿 연결: dev에서는 in-memory/SQLite에 메타를 두고 캐시/오프로드는 fakeredis 또는 순수 인메모리만 사용하며(파일/S3 영속 스토리지는 dev에서 비활성), prod에서는 Postgres+Redis 캐시+오브젝트 스토리지(S3/OBS/GCS)+Kafka/ControlBus 조합으로 hub를 운영한다. WS/exit 엔진은 동일 API/이벤트 인터페이스를 사용해 환경 차이를 흡수한다.
+  - `qmtl.yml` `risk_hub` 블록을 통해 WS 라우터 토큰/inline offload 기준/BlobStore(file|redis|s3)와 gateway 생산자 클라이언트를 함께 구성해 dev↔prod 전환 시 설정 드리프트를 방지한다(단, dev 프로파일에서는 blob_store 영속형을 사용하지 않는다).
+- 단계별 작업 흐름 고정:
+  1) **Hub 최소 구현**: 스냅샷 저장/조회 API + `PortfolioSnapshotUpdated` 이벤트 발행.
+  2) **Gateway 생산자 전환**: 리밸런스/체결 이후 hub에 weights+covariance_ref/행렬+as_of 기록(WS 직접 의존 제거).
+  3) **WS 소비자 전환**: ExtendedValidationWorker/라이브·스트레스 워커가 hub 조회/이벤트 구독 기반으로 Var/ES·live/stress 계산.
+  4) **Exit/모니터링 확장**: exit 엔진·대시보드가 hub 이벤트만 구독해 신호/뷰 생성, WS/SDK 변경 없이 확장.
+  - 현재 구현 상태: WS는 `risk_hub` 라우터+`ExtendedValidationWorker`에 hub 조회를 연결했고, dev(인메모리/SQLite)·prod(Postgres/Redis) 환경에서 `risk_snapshots` 테이블을 통해 스냅샷을 영속화하도록 바인딩했다. 이벤트 발행/큐 연동과 gateway 생산자 전환은 후속 단계로 남겨둔다.
+  - 보완 계획(요약): ControlBus/큐 구독 워커로 스냅샷 이벤트를 받아 ExtendedValidation/스트레스/라이브 워커를 idempotent 실행; gateway는 리밸런스·체결·포지션 싱크 시 스냅샷 push + ControlBus 재시도/ACL; 스냅샷 스키마에 ref/hash/TTL/idempotency 규칙을 추가하고 Redis 캐시·모니터링/알람(runbook)·e2e/부하 테스트까지 포함해 운영 완성도를 높인다.
+  - 운영 가시성: risk hub freshness/누락 메트릭(`risk_hub_snapshot_lag_seconds`, `risk_hub_snapshot_missing_total`)과 Alertmanager 룰 추가, 런북/헬스 스크립트(`risk_signal_hub_runbook.md`, `scripts/risk_hub_monitor.py`) 정리, ControlBus 워커 예시(`scripts/risk_hub_worker.py`) 제공.

--- a/docs/ko/guides/sdk_deprecation.md
+++ b/docs/ko/guides/sdk_deprecation.md
@@ -1,0 +1,18 @@
+# SDK ValidationPipeline 디프리케이션 가이드
+
+SDK의 `ValidationPipeline`은 로컬 사전 점검(precheck) 용도로만 유지되고, 정책 평가/게이팅의 단일 출처(SSOT)는 WorldService 입니다. 이 가이드는 전환 플래그와 롤백 절차를 안내합니다.
+
+## 기본 동작
+- v1.5+: 환경변수 `QMTL_SDK_METRICS_ONLY=1`가 기본값이며, ValidationPipeline은 정책 게이팅을 건너뛰고 **metrics만 산출**합니다.
+- WS 평가 결과가 최종 결정이며, SDK `precheck` 섹션은 참고용입니다.
+
+## 플래그/롤백
+- 비활성화(임시 롤백): `QMTL_SDK_METRICS_ONLY=0` (또는 false/no)로 설정하면 기존 SDK 게이팅 동작을 사용합니다.
+- 문제 발생 시 플래그를 끄고 WS 평가/오케스트레이션만 신뢰하도록 설정을 유지합니다.
+
+## 권장 사용
+- 제출/테스트 파이프라인에서는 WS 결과(`SubmitResult.ws.*`)를 사용자에게 표준 출력으로 노출하고, `precheck`는 별도 섹션으로 분리합니다.
+- SDK→WS 불일치가 있을 경우 WS 로그/메트릭을 우선 확인하고, `precheck`는 디버그 힌트로만 사용합니다.
+
+## 추가 단계(예정)
+- WS 단일 오케스트레이션 테스트(룰 실행/오류/오프로드)와 SDK 디프리케이션 알림을 순차적으로 배포합니다.

--- a/docs/ko/operations/monitoring.md
+++ b/docs/ko/operations/monitoring.md
@@ -38,11 +38,17 @@ Prometheus는 `alert_rules.yml`을 로드해 DAG Manager와 Gateway용 경보를
 - **WorldApplyFailureDetected/RateHigh** – `world_apply_failure_total`/`world_apply_run_total`로 run_id별 적용 실패 감지
 - **WorldAllocationSnapshotStale** – `world_allocation_snapshot_stale_ratio` 10% 초과 시 스냅샷 갱신 지연 알림(5분 신선도 기준)
 - **ControlBusApplyAckLatencyHigh** – `controlbus_apply_ack_latency_ms{phase="freeze"}` 5초 초과 시 게이트 해제 지연 감지
+- **RiskHubSnapshotDedupe/Expired** – `risk_hub_snapshot_dedupe_total{world_id,stage}` 또는 `risk_hub_snapshot_expired_total{world_id,stage}` 증가 감지(스테이지별 분리, 런북: operations/risk_signal_hub_runbook.md)
 
 WorldService는 `world_apply_run_total`/`world_apply_failure_total`을 world_id·run_id별로 기록하고, `world_allocation_snapshot_stale_ratio`
 는 `updated_at`이 5분 이상 지난 스냅샷 비율을 world 단위로 추적합니다. Gateway는 freeze/unfreeze ControlBus 이벤트의 ACK를
 `controlbus_apply_ack_total`과 `controlbus_apply_ack_latency_ms`(ms)로 노출합니다. Grafana 대시보드에 world별 apply 성공률,
 스냅샷 신선도, freeze/unfreeze ACK 지연 패널을 추가해 운영자가 apply 진행 상황을 실시간으로 확인할 수 있도록 구성하세요.
+
+Risk Hub 스테이지별 관측 팁:
+- Stage 라벨(backtest/paper/live)을 `risk_hub_snapshot_*` 계열 메트릭에 함께 노출하므로 Grafana에서 스택/필터 구성.
+- 예시 쿼리(스택): `sum by(stage) (rate(risk_hub_snapshot_dedupe_total[5m]))`
+- 스테이지별 TTL 실패 추적: `sum by(world_id,stage) (increase(risk_hub_snapshot_expired_total[30m]))`
 
 ## Grafana 대시보드
 

--- a/docs/ko/operations/risk_signal_hub_runbook.md
+++ b/docs/ko/operations/risk_signal_hub_runbook.md
@@ -1,0 +1,60 @@
+---
+title: "Risk Signal Hub 운영 런북"
+tags: [operations, risk, snapshots]
+author: "QMTL Team"
+last_modified: 2025-12-10
+status: draft
+---
+
+# Risk Signal Hub 운영 런북
+
+## 1. 구성 요약
+- **WS**: `risk_hub` 라우터(토큰 보호), Redis 캐시, Postgres `risk_snapshots` 테이블, ControlBus 이벤트 소비(`risk_snapshot_updated`), activation 변경 시 스냅샷 push.
+- **Gateway**: 리밸런스/체결 후 hub push(재시도/backoff), 대용량 공분산은 blob-store(S3/Redis/file)로 offload → `covariance_ref`.
+- **Blob store**: dev=file(`JsonBlobStore`), prod=S3(+옵션: Redis).
+- **이벤트**: ControlBus/Kafka 토픽 공통(`risk_snapshot_updated`); WS 소비 → ExtendedValidation/스트레스/라이브 워커 트리거.
+  - 헤더 계약: `Authorization: Bearer <token>`(prod), `X-Actor`(필수), `X-Stage`(backtest/paper/live 등 — dedupe/알람 분리용).
+
+## 2. 배포 체크리스트
+- WS:
+  - `worldservice.server.controlbus_brokers/controlbus_topic` 설정.
+  - Redis DSN 필수(activation cache + hub 캐시).
+  - Hub 토큰(`risk_hub_token`) 주입, gateway에만 공유.
+  - Blob store: dev는 `JsonBlobStore`, prod는 S3 bucket/prefix 지정.
+- Gateway:
+  - `RiskHubClient`에 토큰/재시도/backoff/inline_cov_threshold 설정.
+  - Offload 대상 공분산/returns를 blob-store 업로드(동일 ref 스키마).
+  - 리밸런스·체결·포지션 싱크 후 hub push 경로 활성화.
+- ControlBus/Queue:
+  - Kafka 토픽 `risk_snapshot_updated` 생성, 파티션/보존일 확인.
+  - WS `RiskHubControlBusConsumer` 그룹 생성(`worldservice-risk-hub`).
+
+## 3. 모니터링/알람
+- Freshness: 최신 스냅샷 `as_of` 지연(예: 10m) 초과 시 WARNING, 30m 초과 CRITICAL.
+  - 스크립트: `scripts/risk_hub_monitor.py --base-url ... --world ... --warn-seconds 600`.
+- 중복/TTL: `risk_hub_snapshot_dedupe_total{world_id,stage}`·`risk_hub_snapshot_expired_total{world_id,stage}` 급증 시 프로듀서 헤더/TTL 규칙 점검.
+- 프로듀서 밸리데이션: 게이트웨이/리스크 엔진 프로듀서가 `X-Actor`/`X-Stage` 헤더를 넣고, weights 합≈1·TTL>0·hash 설정이 선행되는지 확인.
+- 이벤트 실패: ControlBus 소비 오류/지연 카운터, 재시도율.
+- Blob-store 접근: S3 4xx/5xx, Redis miss율.
+- Hub 라우터 401/5xx 급증 모니터링.
+
+## 4. 장애 대응
+- 스냅샷 지연: gateway push 재시도 확인, ControlBus lag 확인 → 임시 fallback(보수적 상관/σ) 적용.
+- 데이터 손상: ref 재다운로드/재생성, hash 불일치 시 재발행.
+- Kafka 장애: hub 라우터 HTTP push만으로 임시 운영, lag 해소 후 소비 재개.
+- 프로듀서 위반: weights 합/TTL/헤더 누락 시 producer 로그·메트릭을 우선 확인하고, 동일 스테이지의 dedupe/expired 급증 여부를 대시보드에서 교차 확인.
+
+## 5. 운영 명령 모음
+- Freshness 체크(once):  
+  `python scripts/risk_hub_monitor.py --base-url $WS_URL --world w1 --world w2 --token $HUB_TOKEN`
+- Backfill:  
+  `python scripts/backfill_risk_snapshots.py --dsn $DB --redis $REDIS --world w1`
+
+## 6. 테스트/검증
+- 단위: `tests/qmtl/services/worldservice/test_risk_hub_*`, `test_risk_snapshot_publisher.py`.
+- e2e(추천): gateway→hub→ControlBus→WS worker 경로, 큰 공분산 ref 포함, TTL 만료/지연 시나리오.
+- 부하: 다수 world/전략 기준 latest 조회 hit율, ControlBus 소비 lag.
+
+## 7. 보안
+- Hub 라우터: Bearer 토큰 필수, 네트워크 ACL로 gateway/infra 서브넷만 허용.
+- Blob store: S3 IAM 최소 권한, Redis 분리 네임스페이스/키 프리픽스(`risk-blobs:`), 토큰/키 rotation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Glossary: architecture/glossary.md
       - DAG Manager: architecture/dag-manager.md
       - Gateway: architecture/gateway.md
+      - Risk Signal Hub: architecture/risk_signal_hub.md
       - WorldService: architecture/worldservice.md
       - ControlBus: architecture/controlbus.md
       - Lean Brokerage Model: architecture/lean_brokerage_model.md
@@ -35,6 +36,7 @@ nav:
       - Ergonomic compute_fn patterns: guides/ergonomic_compute_fn_patterns.md
       - Strategy Workflow: guides/strategy_workflow.md
       - Strategy Submission & Gating: guides/strategy_submission_gating.md
+      - SDK Deprecation (ValidationPipeline): guides/sdk_deprecation.md
       - Shadow Execution E2E: guides/shadow_end_to_end.md
       - Multi-Asset Factor Patterns: guides/multi_asset_factor_patterns.md
       - Microstructure Signals: guides/microstructure_signals.md
@@ -83,6 +85,7 @@ nav:
       - Rebalancing Schema Coordination: operations/rebalancing_schema_coordination.md
       - Schema Registry Governance: operations/schema_registry_governance.md
       - Risk Management: operations/risk_management.md
+      - Risk Signal Hub Runbook: operations/risk_signal_hub_runbook.md
       - Timing Controls: operations/timing_controls.md
       - Exchange Calendars: operations/exchange_calendars.md
       - DAG Snapshot: operations/dag_snapshot.md
@@ -93,6 +96,10 @@ nav:
       - Core Loop × World Roadmap: design/core_loop_world_roadmap.md
       - World Validation Architecture: design/world_validation_architecture.md
       - World Validation v1 Implementation Plan: design/world_validation_v1_implementation_plan.md
+      - World Validation v1.5 Implementation: design/world_validation_v1.5_implementation.md
+      - World Strategy Weighting v1.5 Design: design/world_strategy_weighting_v1.5_design.md
+      - Risk Signal Hub Design: design/risk_signal_hub.md
+      - Exit Engine Overview: design/exit_engine_overview.md
       - Model Risk Management Framework: design/model_risk_management_framework.md
       - WorldService Evaluation Runs & Metrics API: design/worldservice_evaluation_runs_and_metrics_api.md
       - YAML-Only Configuration Overhaul: design/yaml_config_overhaul.md


### PR DESCRIPTION
## 요약
- World validation v1.5 관련 설계/진행 현황 문서 및 Risk Signal Hub/운영 런북 추가
- 아키텍처/운영 문서 업데이트 및 mkdocs nav 갱신
- Alertmanager 룰(alert_rules.yml) 보강(리스크 허브/워커 관측)

## 테스트
- `uv run mkdocs build --strict`
- `uv run python scripts/check_docs_links.py`
- (CI parity 전체도 로컬에서 통과)

## Refs
- Refs #1888
- Refs #1890
