### PR TITLE
WorldService: expose /metrics and fix risk-hub timestamp parsing

### DIFF
--- a/qmtl/services/worldservice/api.py
+++ b/qmtl/services/worldservice/api.py
@@ -28,6 +28,7 @@ from .routers import (
     create_bindings_router,
     create_evaluation_runs_router,
     create_live_monitoring_router,
+    create_observability_router,
     create_risk_hub_router,
     create_policies_router,
     create_rebalancing_router,
@@ -459,6 +460,7 @@ def create_app(
     app.include_router(create_allocations_router(service))
     app.include_router(create_evaluation_runs_router(service))
     app.include_router(create_live_monitoring_router(service))
+    app.include_router(create_observability_router())
     app.include_router(
         create_risk_hub_router(
             risk_hub,

--- a/qmtl/services/worldservice/routers/__init__.py
+++ b/qmtl/services/worldservice/routers/__init__.py
@@ -8,6 +8,7 @@ from .validations import create_validations_router
 from .worlds import create_worlds_router
 from .risk_hub import create_risk_hub_router
 from .live_monitoring import create_live_monitoring_router
+from .observability import create_observability_router
 
 __all__ = [
     'create_activation_router',
@@ -20,4 +21,5 @@ __all__ = [
     'create_worlds_router',
     'create_risk_hub_router',
     'create_live_monitoring_router',
+    'create_observability_router',
 ]

--- a/qmtl/services/worldservice/routers/observability.py
+++ b/qmtl/services/worldservice/routers/observability.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Response
+
+from qmtl.services.worldservice import metrics as ws_metrics
+
+
+def create_observability_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/metrics")
+    async def metrics_endpoint() -> Response:
+        return Response(ws_metrics.collect_metrics(), media_type="text/plain")
+
+    return router
+
+
+__all__ = ["create_observability_router"]

--- a/tests/qmtl/services/worldservice/test_metrics.py
+++ b/tests/qmtl/services/worldservice/test_metrics.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
+import httpx
+import pytest
 from pytest import approx
 
 from qmtl.foundation.common.metrics_factory import get_metric_value
+from qmtl.services.worldservice.api import create_app
 from qmtl.services.worldservice import metrics
+from qmtl.services.worldservice.storage import Storage
 
 
 def test_allocation_snapshot_ratio_reflects_counter_values() -> None:
@@ -40,3 +46,29 @@ def test_allocation_snapshot_ratio_reflects_counter_values() -> None:
         metrics.world_allocation_snapshot_stale_ratio, {"world_id": world_id}
     ) == approx(0.5)
 
+
+def test_parse_timestamp_supports_z_suffix() -> None:
+    ts = metrics.parse_timestamp("2025-01-01T00:00:00Z")
+    assert ts == datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_timestamp_normalizes_timezone_offsets() -> None:
+    ts = metrics.parse_timestamp("2025-01-01T09:00:00+09:00")
+    assert ts == datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_exports_risk_hub_snapshot_metrics() -> None:
+    app = create_app(storage=Storage())
+    async with httpx.ASGITransport(app=app) as asgi:
+        async with httpx.AsyncClient(transport=asgi, base_url="http://test") as client:
+            resp = await client.get("/metrics")
+            assert resp.status_code == 200
+            payload = resp.text
+
+    assert "risk_hub_snapshot_lag_seconds" in payload
+    assert "risk_hub_snapshot_missing_total" in payload
+    assert "risk_hub_snapshot_dedupe_total" in payload
+    assert "risk_hub_snapshot_expired_total" in payload
+    assert "risk_hub_snapshot_retry_total" in payload
+    assert "risk_hub_snapshot_dlq_total" in payload


### PR DESCRIPTION
- Add WorldService /metrics endpoint so Prometheus can scrape WS-emitted metrics (including risk_hub_snapshot_*).
- Ensure risk hub health metrics are registered during export.
- Fix ISO8601 'Z' timestamp parsing used for risk_hub_snapshot_lag_seconds.
- Add tests for /metrics output + timestamp parsing.