### PR TITLE
[G5] SDK ValidationPipeline → WS SSOT (remove policy_engine import)

### DIFF
--- a/docs/ko/guides/sdk_deprecation.md
+++ b/docs/ko/guides/sdk_deprecation.md
@@ -1,14 +1,14 @@
 # SDK ValidationPipeline 디프리케이션 가이드
 
-SDK의 `ValidationPipeline`은 로컬 사전 점검(precheck) 용도로만 유지되고, 정책 평가/게이팅의 단일 출처(SSOT)는 WorldService 입니다. 이 가이드는 전환 플래그와 롤백 절차를 안내합니다.
+SDK의 `ValidationPipeline`은 로컬 사전 점검(precheck) 용도로만 유지되고, 정책 평가/게이팅의 단일 출처(SSOT)는 WorldService 입니다. 이 가이드는 전환 이후의 동작과 우회(긴급) 절차를 안내합니다.
 
 ## 기본 동작
-- v1.5+: 환경변수 `QMTL_SDK_METRICS_ONLY=1`가 기본값이며, ValidationPipeline은 정책 게이팅을 건너뛰고 **metrics만 산출**합니다.
+- v1.5+: ValidationPipeline은 **metrics만 산출**합니다(로컬 정책 평가/게이팅 제거).
 - WS 평가 결과가 최종 결정이며, SDK `precheck` 섹션은 참고용입니다.
 
-## 플래그/롤백
-- 비활성화(임시 롤백): `QMTL_SDK_METRICS_ONLY=0` (또는 false/no)로 설정하면 기존 SDK 게이팅 동작을 사용합니다.
-- 문제 발생 시 플래그를 끄고 WS 평가/오케스트레이션만 신뢰하도록 설정을 유지합니다.
+## 우회/롤백(긴급)
+- WS 장애/배포 이슈로 평가가 불안정할 때는 `Runner.submit(..., auto_validate=False)`로 제출만 수행하고, WS 안정화 후 재평가합니다.
+- 강한 롤백이 필요하면 해당 변경 이전 SDK 버전으로 pin하여 복구합니다.
 
 ## 권장 사용
 - 제출/테스트 파이프라인에서는 WS 결과(`SubmitResult.ws.*`)를 사용자에게 표준 출력으로 노출하고, `precheck`는 별도 섹션으로 분리합니다.

--- a/tests/qmtl/runtime/sdk/test_submit.py
+++ b/tests/qmtl/runtime/sdk/test_submit.py
@@ -437,6 +437,51 @@ class TestSubmitResult:
         assert result.precheck is not None
         assert result.precheck.status == ValidationStatus.FAILED.value
 
+    def test_offline_submission_stays_pending_without_ws_decision(self):
+        class DummyMetrics:
+            sharpe = 1.0
+            max_drawdown = 0.1
+            win_ratio = 0.6
+            profit_factor = 1.2
+            car_mdd = 0.0
+            rar_mdd = 0.0
+            total_return = 0.05
+            num_trades = 10
+            correlation_avg = 0.3
+
+        class DummyValidation:
+            def __init__(self):
+                self.status = ValidationStatus.PASSED
+                self.weight = 0.11
+                self.rank = 7
+                self.contribution = 0.02
+                self.activated = False
+                self.metrics = DummyMetrics()
+                self.violations = []
+                self.improvement_hints = []
+                self.correlation_avg = 0.3
+
+        validation = DummyValidation()
+        strategy = SimpleStrategy()
+
+        result = _build_submit_result_from_validation(
+            strategy=strategy,
+            strategy_class_name="SimpleStrategy",
+            strategy_id="sid-offline",
+            resolved_world="world-offline",
+            mode=Mode.BACKTEST,
+            world_notice=[],
+            validation_result=validation,
+            ws_eval=None,
+            gateway_available=False,
+        )
+
+        assert result.status == "pending"
+        assert result.decision is None
+        assert result.activation is None
+        assert result.precheck is not None
+        assert result.precheck.status == ValidationStatus.PASSED.value
+
     def test_submit_result_to_dict_includes_ws_and_precheck(self):
         precheck = PrecheckResult(
             status="passed",


### PR DESCRIPTION
Summary:
- Remove SDK import of qmtl.services.worldservice.policy_engine
- Keep SDK ValidationPipeline as metrics-only precheck; WS /evaluate is SSOT
- Update docs to reflect the new responsibility split

Fixes #1881
