### PR TITLE
Enforce override metadata + invariants endpoint

### DIFF
--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -216,6 +216,14 @@ class ValidationCacheResponse(BaseModel):
     timestamp: str | None = None
 
 
+class ValidationInvariantsReport(BaseModel):
+    ok: bool
+    live_status_failures: List[Dict[str, Any]] = Field(default_factory=list)
+    fail_closed_violations: List[Dict[str, Any]] = Field(default_factory=list)
+    approved_overrides: List[Dict[str, Any]] = Field(default_factory=list)
+    validation_health_gaps: List[Dict[str, Any]] = Field(default_factory=list)
+
+
 class SeamlessHistoryRequest(BaseModel):
     strategy_id: str
     node_id: str
@@ -504,6 +512,7 @@ __all__ = [
     'ValidationCacheLookupRequest',
     'ValidationCacheResponse',
     'ValidationCacheStoreRequest',
+    'ValidationInvariantsReport',
     'SeamlessArtifactPayload',
     'SeamlessHistoryRequest',
     'World',

--- a/tests/qmtl/services/worldservice/test_shared_schemas.py
+++ b/tests/qmtl/services/worldservice/test_shared_schemas.py
@@ -1,3 +1,5 @@
+import pytest
+
 from qmtl.services.worldservice import schemas, shared_schemas
 
 
@@ -18,3 +20,16 @@ def test_evaluate_request_and_series_shared():
     assert schemas.StrategySeries is shared_schemas.StrategySeries
     payload = shared_schemas.EvaluateRequest()
     assert payload.metrics == {}
+
+
+def test_override_schema_requires_metadata_for_approved():
+    with pytest.raises(ValueError):
+        shared_schemas.EvaluationOverride(status="approved", reason="ok", actor="risk", timestamp=None)
+
+    payload = shared_schemas.EvaluationOverride(
+        status="approved",
+        reason="ok",
+        actor="risk",
+        timestamp="2025-01-01T00:00:00Z",
+    )
+    assert payload.status == "approved"


### PR DESCRIPTION
Summary:
- Require reason/actor/timestamp when posting an approved evaluation override.
- Add `/worlds/{world_id}/validations/invariants` to surface SR 11-7 invariant reports.
- Update/extend API + schema tests.

Fixes #1883