### PR TITLE
ControlBus/queue standards + defaults

### DIFF
--- a/docs/en/operations/controlbus_queue_standards.md
+++ b/docs/en/operations/controlbus_queue_standards.md
@@ -1,0 +1,60 @@
+# ControlBus / Queue Operational Standards
+
+This document defines topic naming, consumer groups, retry/DLQ behavior, and idempotency rules so ControlBus (Kafka) producers/consumers remain **idempotent, observable, and re-playable** at operational scale.
+
+## Topic and Event Types
+
+- WorldService publishes/consumes CloudEvents on `worldservice.server.controlbus_topic` (default: `policy`).
+- Multiple event types may share the same topic; consumers must filter on CloudEvents `type`.
+  - Examples: `risk_snapshot_updated`, `policy_updated`, `activation_updated`, `evaluation_run_created`, `evaluation_run_updated`
+
+## Consumer Groups (Recommended)
+
+- RiskHub snapshot consumer: `worldservice-risk-hub`
+  - Processes only `risk_snapshot_updated` events.
+
+## Retry / Backoff / DLQ Defaults
+
+### Consumer (RiskHubControlBusConsumer)
+- `max_attempts`: 3
+- `retry_backoff_sec`: 0.5
+- `dlq_topic`: enable explicitly in operations when needed (e.g., `${controlbus_topic}.dlq`)
+  - DLQ event type: `risk_snapshot_updated_dlq`
+
+### Producers (ControlBusProducer / RiskHubClient)
+- Producers should implement retries/backoff and expose failures via logs/metrics.
+- For large RiskHub snapshot payloads (above the offload threshold), prefer ref-based offload:
+  - `covariance_ref`, `realized_returns_ref`, `stress_ref`
+
+## Idempotency / Dedupe Rules
+
+### RiskHub snapshots
+- Consumer dedupe key: `risk_snapshot_dedupe_key(payload)`
+  - Built from `(world_id, version, hash, actor, stage)`
+- Producers must enforce:
+  - `provenance.actor` (or `X-Actor`) is required
+  - `provenance.stage` (or `X-Stage`) is strongly recommended (backtest/paper/live separation)
+  - `hash` must follow stable hashing rules so retries produce the same digest
+
+### ControlBus events (general)
+- CloudEvents `correlation_id` groups retries and related events (e.g., the same EvaluationRun).
+- If `data.idempotency_key` is present, consumers should use it to prevent duplicate side effects.
+
+## Observability Checklist
+
+Example WorldService Prometheus metrics:
+
+- `risk_hub_snapshot_processed_total{world_id,stage}`
+- `risk_hub_snapshot_failed_total{world_id,stage}`
+- `risk_hub_snapshot_retry_total{world_id,stage}`
+- `risk_hub_snapshot_dlq_total{world_id,stage}`
+- `risk_hub_snapshot_dedupe_total{world_id,stage}`
+- `risk_hub_snapshot_expired_total{world_id,stage}`
+
+## Required Rehearsal Scenarios
+
+- Re-processing duplicate events (dedupe hit) increases counters
+- Dropping expired snapshots (TTL) is observable
+- Fail → retry(backoff) → success, or fail → DLQ routing
+- Stage labels (backtest/paper/live) remain separated in metrics
+

--- a/docs/en/operations/risk_signal_hub_runbook.md
+++ b/docs/en/operations/risk_signal_hub_runbook.md
@@ -8,10 +8,10 @@ status: draft
 # Risk Signal Hub Runbook
 
 ## 1. Topology
-- **WorldService**: `risk_hub` router (Bearer-protected), Redis cache, Postgres `risk_snapshots`, ControlBus consumer (`risk_snapshot_updated`), activation updates push snapshots.
+- **WorldService**: `risk_hub` router (Bearer-protected), Redis cache, Postgres `risk_snapshots`, ControlBus consumer (CloudEvents type `risk_snapshot_updated`), activation updates push snapshots.
 - **Gateway**: pushes after rebalance/fills/position sync with retry/backoff; large covariance/returns offloaded to blob-store (S3/Redis/file) and referenced via `covariance_ref`.
 - **Blob store**: dev=file(`JsonBlobStore`), prod=S3 (option: Redis).
-- **Events**: shared ControlBus/Kafka topic `risk_snapshot_updated`; WS consumes to trigger ExtendedValidation/stress/live workers.
+- **Events**: published on ControlBus/Kafka topic (`worldservice.server.controlbus_topic`) as CloudEvents with type `risk_snapshot_updated`; WS consumes to trigger ExtendedValidation/stress/live workers.
 - **Headers**: `Authorization: Bearer <token>` (prod), `X-Actor` required, `X-Stage` (backtest/paper/live) strongly recommended for dedupe/alert labels.
 
 ## 2. Deployment checklist
@@ -25,7 +25,7 @@ status: draft
   - Offload large covariance/returns to blob-store with shared ref schema.
   - Enable hub push after rebalance/fills/position sync.
 - ControlBus/Queue:
-  - Create Kafka topic `risk_snapshot_updated`, size/retention checked.
+  - Create Kafka topic `${controlbus_topic}` (route by CloudEvents `type`), size/retention checked.
   - WS consumer group `worldservice-risk-hub` alive.
 
 ## 3. Monitoring / alerts

--- a/docs/ko/operations/controlbus_queue_standards.md
+++ b/docs/ko/operations/controlbus_queue_standards.md
@@ -1,0 +1,60 @@
+# ControlBus/큐 운영 표준
+
+이 문서는 ControlBus(Kafka) 기반 워커/프로듀서가 **idempotent + 관측 가능 + 재처리 가능**하도록 토픽·컨슈머 그룹·재시도/DLQ·dedupe 규칙을 운영 표준으로 정리합니다.
+
+## 토픽/이벤트 타입
+
+- WorldService는 `worldservice.server.controlbus_topic`(기본값: `policy`)에 **CloudEvents** 메시지를 발행/소비합니다.
+- 동일 토픽에 여러 이벤트 타입이 공존할 수 있으며, 필터링 기준은 CloudEvents의 `type` 입니다.
+  - 예: `risk_snapshot_updated`, `policy_updated`, `activation_updated`, `evaluation_run_created`, `evaluation_run_updated`
+
+## 컨슈머 그룹 (권장)
+
+- RiskHub 스냅샷 소비자: `worldservice-risk-hub`
+  - 이벤트 타입 `risk_snapshot_updated`만 처리합니다.
+
+## 재시도/백오프/DLQ (권장 기본값)
+
+### 소비자(RiskHubControlBusConsumer)
+- `max_attempts`: 3
+- `retry_backoff_sec`: 0.5
+- `dlq_topic`: 운영에서 필요 시 명시적으로 활성화(예: `${controlbus_topic}.dlq`)
+  - DLQ 이벤트 타입: `risk_snapshot_updated_dlq`
+
+### 프로듀서(ControlBusProducer/RiskHubClient)
+- 프로듀서는 재시도/백오프를 내장하고, 실패 시 로깅/메트릭으로 노출해야 합니다.
+- RiskHub snapshot payload가 큰 경우(offload 기준 초과):
+  - `covariance_ref`, `realized_returns_ref`, `stress_ref` 형태의 **ref 기반 오프로드**를 우선합니다.
+
+## Idempotency / Dedupe 규칙
+
+### RiskHub 스냅샷
+- consumer dedupe 키: `risk_snapshot_dedupe_key(payload)`
+  - 구성: `(world_id, version, hash, actor, stage)`
+- producer는 아래를 반드시 준수합니다.
+  - `provenance.actor`(또는 `X-Actor`) 필수
+  - `provenance.stage`(또는 `X-Stage`) 강력 권장(backtest/paper/live 분리)
+  - `hash`는 stable hash 규칙으로 계산(재시도 시 동일)
+
+### ControlBus 이벤트(일반)
+- CloudEvents `correlation_id`는 동일 작업 단위(예: 동일 EvaluationRun)의 재시도/연쇄 이벤트를 묶는 데 사용합니다.
+- 이벤트 `data.idempotency_key`가 제공되면, 소비자는 이를 기준으로 중복 처리를 방지할 수 있어야 합니다.
+
+## 관측(메트릭) 체크리스트
+
+WorldService 내 Prometheus 메트릭(예):
+
+- `risk_hub_snapshot_processed_total{world_id,stage}`
+- `risk_hub_snapshot_failed_total{world_id,stage}`
+- `risk_hub_snapshot_retry_total{world_id,stage}`
+- `risk_hub_snapshot_dlq_total{world_id,stage}`
+- `risk_hub_snapshot_dedupe_total{world_id,stage}`
+- `risk_hub_snapshot_expired_total{world_id,stage}`
+
+## 리허설 시나리오(필수)
+
+- 중복 이벤트 재처리(dedupe hit) 시 메트릭 증가 확인
+- TTL 만료 스냅샷 드롭(expired) 확인
+- 처리 실패 → 재시도(backoff) 후 성공/또는 DLQ 라우팅 확인
+- stage별(backtest/paper/live)로 메트릭 라벨 분리가 유지되는지 확인
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - Seamless Stack Templates: operations/seamless_stack.md
       - WS Load & Endurance: operations/ws_load_testing.md
       - Evaluation Store: operations/evaluation_store.md
+      - ControlBus/Queue Standards: operations/controlbus_queue_standards.md
       - World Activation Runbook: operations/activation.md
       - Determinism Runbook: operations/determinism.md
       - Rebalancing Execution: operations/rebalancing_execution.md

--- a/qmtl/services/worldservice/controlbus_consumer.py
+++ b/qmtl/services/worldservice/controlbus_consumer.py
@@ -18,6 +18,13 @@ from qmtl.services.kafka import KafkaProducerLike, create_kafka_producer
 from qmtl.services.risk_hub_contract import risk_snapshot_dedupe_key
 
 from . import metrics as ws_metrics
+from .controlbus_defaults import (
+    DEFAULT_RISK_HUB_CONSUMER_GROUP_ID,
+    DEFAULT_RISK_HUB_DEDUPE_TTL_SEC,
+    DEFAULT_RISK_HUB_DLQ_TOPIC,
+    DEFAULT_RISK_HUB_MAX_ATTEMPTS,
+    DEFAULT_RISK_HUB_RETRY_BACKOFF_SEC,
+)
 from .risk_hub import PortfolioSnapshot, RiskSignalHub
 
 
@@ -58,15 +65,15 @@ class RiskHubControlBusConsumer:
         hub: RiskSignalHub,
         on_snapshot: Callable[[PortfolioSnapshot], Awaitable[Any]] | None = None,
         dedupe_cache: Any | None = None,
-        dedupe_ttl_sec: int | None = None,
-        max_attempts: int = 3,
-        retry_backoff_sec: float = 0.5,
-        dlq_topic: str | None = None,
+        dedupe_ttl_sec: int | None = DEFAULT_RISK_HUB_DEDUPE_TTL_SEC,
+        max_attempts: int = DEFAULT_RISK_HUB_MAX_ATTEMPTS,
+        retry_backoff_sec: float = DEFAULT_RISK_HUB_RETRY_BACKOFF_SEC,
+        dlq_topic: str | None = DEFAULT_RISK_HUB_DLQ_TOPIC,
         dlq_producer: KafkaProducerLike | None = None,
         brokers: Iterable[str] | None = None,
         topic: str | None = None,
         consumer: KafkaConsumerLike | None = None,
-        group_id: str = "worldservice-risk-hub",
+        group_id: str = DEFAULT_RISK_HUB_CONSUMER_GROUP_ID,
     ) -> None:
         self._hub = hub
         self._on_snapshot = on_snapshot

--- a/qmtl/services/worldservice/controlbus_defaults.py
+++ b/qmtl/services/worldservice/controlbus_defaults.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Defaults and naming conventions for ControlBus integrations.
+
+These values are intended to be shared across WorldService producers/consumers
+so that retries/DLQ/idempotency behaviors are consistent by default.
+"""
+
+DEFAULT_CONTROLBUS_TOPIC = "policy"
+
+# RiskHub snapshot consumer defaults.
+DEFAULT_RISK_HUB_CONSUMER_GROUP_ID = "worldservice-risk-hub"
+DEFAULT_RISK_HUB_MAX_ATTEMPTS = 3
+DEFAULT_RISK_HUB_RETRY_BACKOFF_SEC = 0.5
+DEFAULT_RISK_HUB_DEDUPE_TTL_SEC: int | None = None
+DEFAULT_RISK_HUB_DLQ_TOPIC: str | None = None
+
+
+def default_dlq_topic(topic: str) -> str:
+    return f"{topic}.dlq"
+
+
+__all__ = [
+    "DEFAULT_CONTROLBUS_TOPIC",
+    "DEFAULT_RISK_HUB_CONSUMER_GROUP_ID",
+    "DEFAULT_RISK_HUB_MAX_ATTEMPTS",
+    "DEFAULT_RISK_HUB_RETRY_BACKOFF_SEC",
+    "DEFAULT_RISK_HUB_DEDUPE_TTL_SEC",
+    "DEFAULT_RISK_HUB_DLQ_TOPIC",
+    "default_dlq_topic",
+]
+

--- a/qmtl/services/worldservice/controlbus_producer.py
+++ b/qmtl/services/worldservice/controlbus_producer.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, Iterable
 from qmtl.foundation.common.cloudevents import format_event
 from qmtl.services.kafka import KafkaProducerLike, create_kafka_producer
 
+from .controlbus_defaults import DEFAULT_CONTROLBUS_TOPIC
+
 
 class ControlBusProducer:
     """Publish updates to the internal ControlBus."""
@@ -17,7 +19,7 @@ class ControlBusProducer:
         self,
         *,
         brokers: Iterable[str] | None = None,
-        topic: str = "policy",
+        topic: str = DEFAULT_CONTROLBUS_TOPIC,
         producer: KafkaProducerLike | None = None,
         required: bool = False,
         retries: int = 2,


### PR DESCRIPTION
Summary:
- Add shared defaults for ControlBus topic and RiskHub consumer settings.
- Document ControlBus/queue operational standards (ko/en) and fix RiskHub runbook topic wording.
- Wire defaults into ControlBusProducer and RiskHubControlBusConsumer.

Fixes #1889