### PR TITLE
Fix RiskHub realized_returns persistence + override event versioning

### DIFF
--- a/qmtl/services/worldservice/risk_hub.py
+++ b/qmtl/services/worldservice/risk_hub.py
@@ -29,6 +29,7 @@ class PortfolioSnapshot:
     weights: Dict[str, float]
     covariance: Dict[str, float] | None = None
     covariance_ref: str | None = None
+    realized_returns: Any | None = None
     realized_returns_ref: str | None = None
     stress_ref: str | None = None
     stress: Dict[str, Any] | None = None
@@ -51,6 +52,14 @@ class PortfolioSnapshot:
             payload["covariance"] = dict(self.covariance)
         if self.covariance_ref:
             payload["covariance_ref"] = self.covariance_ref
+        if self.realized_returns is not None:
+            realized = self.realized_returns
+            if isinstance(realized, Mapping):
+                payload["realized_returns"] = dict(realized)
+            elif isinstance(realized, (list, tuple)):
+                payload["realized_returns"] = list(realized)
+            else:
+                payload["realized_returns"] = realized
         if self.realized_returns_ref:
             payload["realized_returns_ref"] = self.realized_returns_ref
         if self.stress_ref:
@@ -67,6 +76,14 @@ class PortfolioSnapshot:
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "PortfolioSnapshot":
+        realized = payload.get("realized_returns")
+        realized_payload: Any | None
+        if isinstance(realized, Mapping):
+            realized_payload = dict(realized)
+        elif isinstance(realized, (list, tuple)):
+            realized_payload = list(realized)
+        else:
+            realized_payload = realized
         return cls(
             world_id=str(payload["world_id"]),
             as_of=str(payload["as_of"]),
@@ -74,6 +91,7 @@ class PortfolioSnapshot:
             weights=dict(payload.get("weights") or {}),
             covariance=dict(payload.get("covariance") or {}) or None,
             covariance_ref=payload.get("covariance_ref"),
+            realized_returns=realized_payload,
             realized_returns_ref=payload.get("realized_returns_ref"),
             stress_ref=payload.get("stress_ref"),
             stress=dict(payload.get("stress") or {}) or None,

--- a/qmtl/services/worldservice/services.py
+++ b/qmtl/services/worldservice/services.py
@@ -490,6 +490,16 @@ class WorldService:
             if self.bus is not None:
                 try:
                     summary = record.get("summary") if isinstance(record, Mapping) else {}
+                    revision = None
+                    if isinstance(record, Mapping):
+                        rev = record.get("revision")
+                        if isinstance(rev, int):
+                            revision = rev
+                        elif isinstance(rev, str):
+                            try:
+                                revision = int(rev)
+                            except Exception:
+                                revision = None
                     await self.bus.publish_evaluation_run_updated(
                         world_id,
                         strategy_id=strategy_id,
@@ -501,6 +511,7 @@ class WorldService:
                             summary.get("recommended_stage") if isinstance(summary, Mapping) else None
                         ),
                         change_type="override",
+                        version=revision or 1,
                     )
                 except Exception:  # pragma: no cover - best-effort observability
                     logger.exception(

--- a/qmtl/services/worldservice/storage/facade.py
+++ b/qmtl/services/worldservice/storage/facade.py
@@ -440,7 +440,9 @@ class Storage:
                 "timestamp": override_timestamp,
             },
         )
-        return updated.to_dict()
+        payload = updated.to_dict()
+        payload["revision"] = revision
+        return payload
 
     async def list_evaluation_runs(
         self, *, world_id: str | None = None, strategy_id: str | None = None

--- a/qmtl/services/worldservice/storage/persistent.py
+++ b/qmtl/services/worldservice/storage/persistent.py
@@ -900,7 +900,19 @@ class PersistentStorage:
                 "timestamp": override_timestamp,
             },
         )
-        return record.to_dict()
+        revision_row = await self._driver.fetchone(
+            "SELECT MAX(revision) FROM evaluation_run_history WHERE world_id = ? AND strategy_id = ? AND run_id = ?",
+            world_id,
+            strategy_id,
+            run_id,
+        )
+        try:
+            revision = int(revision_row[0]) if revision_row and revision_row[0] is not None else 0
+        except Exception:
+            revision = 0
+        payload = record.to_dict()
+        payload["revision"] = revision
+        return payload
 
     async def get_evaluation_run(
         self, world_id: str, strategy_id: str, run_id: str

--- a/tests/qmtl/services/worldservice/test_risk_hub_validations.py
+++ b/tests/qmtl/services/worldservice/test_risk_hub_validations.py
@@ -30,3 +30,16 @@ async def test_ttl_filters_expired_snapshot():
     await hub.upsert_snapshot(snap)
     latest = await hub.latest_snapshot("w")
     assert latest is None
+
+
+def test_snapshot_round_trip_preserves_inline_realized_returns():
+    payload = {
+        "world_id": "w",
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+        "realized_returns": {"s1": [0.01, -0.005]},
+    }
+    snapshot = PortfolioSnapshot.from_payload(payload)
+    encoded = snapshot.to_dict()
+    assert encoded.get("realized_returns") == payload["realized_returns"]


### PR DESCRIPTION
Summary:
- Persist inline `realized_returns` in RiskHub snapshots so downstream consumers see them even when no `realized_returns_ref` is created.
- Publish override `evaluation_run_updated` events with monotonic `version` (evaluation run history revision) to keep idempotency keys unique.
- Docs: add a KO architecture satisfaction matrix section.

Tests:
- `uv run -m pytest -q tests/qmtl/services/worldservice/test_risk_hub_validations.py tests/qmtl/services/worldservice/test_worldservice_api.py::test_risk_hub_persists_snapshots_with_persistent_storage tests/qmtl/services/worldservice/test_worldservice_api.py::test_evaluation_and_overrides_emit_controlbus_events tests/qmtl/services/worldservice/test_live_monitoring_worker.py tests/qmtl/services/worldservice/test_extended_validation_worker.py`
