### PR TITLE
Capture ruleset hashes in policy diff batch output

### DIFF
--- a/scripts/policy_diff_batch.py
+++ b/scripts/policy_diff_batch.py
@@ -83,8 +83,8 @@ def run_diff(
     report = PolicyDiffReport(
         old_policy_version=str(getattr(old_policy, "version", None) or old_policy.model_dump().get("version")),
         new_policy_version=str(getattr(new_policy, "version", None) or new_policy.model_dump().get("version")),
-        old_ruleset_hash=None,
-        new_ruleset_hash=None,
+        old_ruleset_hash=result_old.ruleset_hash,
+        new_ruleset_hash=result_new.ruleset_hash,
         total_strategies=len(strategies),
         strategies_affected=sum(1 for d in diffs if d.has_changes),
         selection_changes=selection_changes,

--- a/tests/scripts/test_policy_diff_batch.py
+++ b/tests/scripts/test_policy_diff_batch.py
@@ -53,6 +53,9 @@ def test_policy_diff_batch_generates_report(tmp_path: Path):
     assert data["strategies_affected"] == 1
     assert any(diff["strategy_id"] == "s2" for diff in data["diffs"])
     assert report.impact_ratio > 0
+    assert report.old_ruleset_hash and report.old_ruleset_hash.startswith("blake3:")
+    assert report.new_ruleset_hash and report.new_ruleset_hash.startswith("blake3:")
+    assert report.old_ruleset_hash != report.new_ruleset_hash
 
 
 def test_policy_diff_batch_loads_runs_dir(tmp_path: Path):
@@ -77,3 +80,4 @@ def test_policy_diff_batch_loads_runs_dir(tmp_path: Path):
 
     assert report.total_strategies == 3
     assert any(d.strategy_id == "s3" for d in report.diffs)
+    assert report.old_ruleset_hash and report.new_ruleset_hash


### PR DESCRIPTION
## Summary
- include the evaluated ruleset hashes in `scripts/policy_diff_batch.py` reports
- extend batch diff tests to assert the hashes are present and distinct

## Testing
- uv run -m pytest tests/scripts/test_policy_diff_batch.py -q

Fixes #1908

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cc829b9c08329ac77157b145dc680)