### PR TITLE
Enforce risk hub snapshot provenance allowlists

### DIFF
--- a/qmtl/services/risk_hub_contract.py
+++ b/qmtl/services/risk_hub_contract.py
@@ -113,12 +113,24 @@ def normalize_and_validate_snapshot(
 
     provenance = data.get("provenance")
     provenance_map: dict[str, Any] = dict(provenance) if isinstance(provenance, Mapping) else {}
-    if actor:
-        _validate_actor(actor, allowed_actors=allowed_actors)
-        provenance_map.setdefault("actor", actor)
-    if stage:
-        _validate_stage(stage, allowed_stages=allowed_stages)
-        provenance_map.setdefault("stage", stage)
+
+    actor_value = actor or provenance_map.get("actor")
+    stage_value = stage or provenance_map.get("stage")
+
+    if allowed_actors is not None:
+        _validate_actor(str(actor_value or ""), allowed_actors=allowed_actors)
+    elif actor_value:
+        _validate_actor(str(actor_value), allowed_actors=None)
+
+    if allowed_stages is not None:
+        _validate_stage(str(stage_value or ""), allowed_stages=allowed_stages)
+    elif stage_value:
+        _validate_stage(str(stage_value), allowed_stages=None)
+
+    if actor_value:
+        provenance_map.setdefault("actor", str(actor_value))
+    if stage_value:
+        provenance_map.setdefault("stage", str(stage_value))
     if provenance_map:
         data["provenance"] = provenance_map
 

--- a/tests/qmtl/services/test_risk_hub_contract.py
+++ b/tests/qmtl/services/test_risk_hub_contract.py
@@ -67,3 +67,47 @@ def test_normalize_and_validate_snapshot_enforces_allowlist():
             allowed_actors=["gateway"],
         )
 
+
+def test_normalize_and_validate_snapshot_enforces_payload_actor_allowlist():
+    payload = {
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+        "provenance": {"actor": "evil"},
+    }
+    with pytest.raises(ValueError, match="not allowed"):
+        normalize_and_validate_snapshot(
+            "w",
+            payload,
+            allowed_actors=["gateway"],
+        )
+
+
+def test_normalize_and_validate_snapshot_requires_actor_when_acl_present():
+    payload = {
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+    }
+    with pytest.raises(ValueError, match="actor is required"):
+        normalize_and_validate_snapshot(
+            "w",
+            payload,
+            allowed_actors=["gateway"],
+        )
+
+
+def test_normalize_and_validate_snapshot_enforces_stage_allowlist():
+    payload = {
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+        "provenance": {"stage": "prod"},
+    }
+    with pytest.raises(ValueError, match="not allowed"):
+        normalize_and_validate_snapshot(
+            "w",
+            payload,
+            allowed_stages=["staging"],
+        )
+


### PR DESCRIPTION
## Summary
- enforce actor/stage allowlists when present in risk hub snapshot payloads and require actor when an allowlist is configured
- normalize provenance injection using the validated actor/stage values
- add coverage for payload provenance ACL enforcement

## Testing
- python -m pytest tests/qmtl/services/test_risk_hub_contract.py -q

Fixes #1909

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cc8358d18832993d5f7d9481bf60e)