### PR TITLE
Honor live monitoring window configuration

### DIFF
--- a/qmtl/services/worldservice/live_monitoring_worker.py
+++ b/qmtl/services/worldservice/live_monitoring_worker.py
@@ -110,7 +110,7 @@ class LiveMonitoringWorker:
             if backtest_sharpe is not None:
                 metrics["returns"]["sharpe"] = backtest_sharpe
 
-            metrics = augment_live_metrics(metrics)
+            metrics = augment_live_metrics(metrics, windows=self.windows)
 
             run_id = _safe_run_id("live", world_id, sid, as_of)
             try:
@@ -136,7 +136,9 @@ class LiveMonitoringWorker:
 
         if updated and self.risk_hub is not None:
             try:
-                worker = ExtendedValidationWorker(self.store, risk_hub=self.risk_hub)
+                worker = ExtendedValidationWorker(
+                    self.store, risk_hub=self.risk_hub, windows=self.windows
+                )
                 await worker.run(world_id, stage="live", policy_payload=None)
             except Exception:
                 logger.exception("Failed to apply extended validation for live runs in %s", world_id)

--- a/qmtl/services/worldservice/validation_metrics.py
+++ b/qmtl/services/worldservice/validation_metrics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from typing import Any, Dict
 
@@ -19,7 +19,9 @@ def _coerce_returns(source: Any) -> list[float] | None:
     return None
 
 
-def augment_live_metrics(metrics: Mapping[str, Any] | None) -> dict[str, Any]:
+def augment_live_metrics(
+    metrics: Mapping[str, Any] | None, *, windows: Iterable[int] = (30, 60, 90)
+) -> dict[str, Any]:
     """Attach live monitoring aggregates if realized returns are present."""
 
     if not metrics:
@@ -44,6 +46,7 @@ def augment_live_metrics(metrics: Mapping[str, Any] | None) -> dict[str, Any]:
 
     aggregates = aggregate_live_metrics(
         [float(r) for r in live_returns],
+        windows=windows,
         backtest_sharpe=backtest_sharpe,
     )
     diagnostics.update(aggregates)

--- a/tests/qmtl/services/worldservice/test_live_monitoring_worker.py
+++ b/tests/qmtl/services/worldservice/test_live_monitoring_worker.py
@@ -49,3 +49,49 @@ async def test_live_monitoring_worker_creates_live_runs_and_evaluates(tmp_path):
     diagnostics = live_runs[0]["metrics"]["diagnostics"]
     assert diagnostics.get("live_sharpe") is not None
     assert "live_monitoring" in (live_runs[0]["validation"].get("results") or {})
+
+
+@pytest.mark.asyncio
+async def test_live_monitoring_worker_respects_windows(tmp_path):
+    storage = Storage()
+    await storage.create_world({"id": "wlive", "name": "Live World"})
+    policy = parse_policy({"live_monitoring": {"sharpe_min": 0.0, "dd_max": 10.0}})
+    version = await storage.add_policy("wlive", policy)
+    await storage.set_default_policy("wlive", version=version)
+
+    await storage.set_decisions("wlive", ["s1"])
+    await storage.record_evaluation_run(
+        "wlive",
+        "s1",
+        "run-backtest",
+        stage="paper",
+        risk_tier="medium",
+        metrics={"returns": {"sharpe": 1.0}},
+        summary={"status": "pass"},
+    )
+
+    blob_store = JsonBlobStore(tmp_path / "blobs")
+    hub = RiskSignalHub(blob_store=blob_store)
+    ref = blob_store.write("realized", {"s1": [0.01, -0.005, 0.02, 0.0]})
+    snap = PortfolioSnapshot(
+        world_id="wlive",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"s1": 1.0},
+        realized_returns_ref=ref,
+        provenance={"actor": "gateway", "stage": "live"},
+    )
+    await hub.upsert_snapshot(snap)
+
+    worker = LiveMonitoringWorker(storage, risk_hub=hub, windows=(2,))
+    updated = await worker.run_world("wlive")
+    assert updated == 1
+
+    runs = await storage.list_evaluation_runs(world_id="wlive", strategy_id="s1")
+    live_runs = [r for r in runs if r.get("stage") == "live"]
+    assert len(live_runs) == 1
+    diagnostics = live_runs[0]["metrics"].get("diagnostics") or {}
+
+    assert "live_sharpe_p2" in diagnostics
+    assert diagnostics.get("live_sharpe") == diagnostics.get("live_sharpe_p2")
+    assert "live_sharpe_p30" not in diagnostics


### PR DESCRIPTION
## Summary
- allow live monitoring metric aggregation to respect configurable window inputs
- propagate window configuration through ExtendedValidationWorker and live monitoring worker
- add coverage to ensure custom windows shape diagnostic outputs

## Testing
- uv run -m pytest tests/qmtl/services/worldservice/test_live_monitoring_worker.py -q

Fixes #1907

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ccbe6de38832981c959412dbf7842)