### PR TITLE
Add policy version guard to validation invariants

### DIFF
--- a/qmtl/services/worldservice/routers/validations.py
+++ b/qmtl/services/worldservice/routers/validations.py
@@ -97,6 +97,7 @@ def create_validations_router(service: WorldService) -> APIRouter:
         return ValidationInvariantsReport(
             ok=report.ok,
             live_status_failures=report.live_status_failures,
+            live_policy_version_mismatches=report.live_policy_version_mismatches,
             fail_closed_violations=report.fail_closed_violations,
             approved_overrides=report.approved_overrides,
             validation_health_gaps=report.validation_health_gaps,

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -219,6 +219,7 @@ class ValidationCacheResponse(BaseModel):
 class ValidationInvariantsReport(BaseModel):
     ok: bool
     live_status_failures: List[Dict[str, Any]] = Field(default_factory=list)
+    live_policy_version_mismatches: List[Dict[str, Any]] = Field(default_factory=list)
     fail_closed_violations: List[Dict[str, Any]] = Field(default_factory=list)
     approved_overrides: List[Dict[str, Any]] = Field(default_factory=list)
     validation_health_gaps: List[Dict[str, Any]] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- enforce policy version compatibility for latest live runs in validation invariant checks
- surface live policy version mismatches in the validation invariants API response
- add regression coverage for policy version handling across live invariant scenarios

## Testing
- pytest tests/qmtl/services/worldservice/test_validation_invariants.py -q

Fixes #1911

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ccd17300483298531bcb67da61eba)