### PR TITLE
Fix provenance override for allowlisted actors in risk hub snapshots

### DIFF
--- a/qmtl/services/risk_hub_contract.py
+++ b/qmtl/services/risk_hub_contract.py
@@ -128,9 +128,9 @@ def normalize_and_validate_snapshot(
         _validate_stage(str(stage_value), allowed_stages=None)
 
     if actor_value:
-        provenance_map.setdefault("actor", str(actor_value))
+        provenance_map["actor"] = str(actor_value)
     if stage_value:
-        provenance_map.setdefault("stage", str(stage_value))
+        provenance_map["stage"] = str(stage_value)
     if provenance_map:
         data["provenance"] = provenance_map
 

--- a/tests/qmtl/services/test_risk_hub_contract.py
+++ b/tests/qmtl/services/test_risk_hub_contract.py
@@ -111,3 +111,23 @@ def test_normalize_and_validate_snapshot_enforces_stage_allowlist():
             allowed_stages=["staging"],
         )
 
+
+def test_normalize_and_validate_snapshot_overrides_payload_provenance_with_validated_values():
+    payload = {
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+        "provenance": {"actor": "evil", "stage": "prod"},
+    }
+    out = normalize_and_validate_snapshot(
+        "w",
+        payload,
+        actor="gateway",
+        stage="staging",
+        allowed_actors=["gateway"],
+        allowed_stages=["staging"],
+    )
+
+    assert out["provenance"]["actor"] == "gateway"
+    assert out["provenance"]["stage"] == "staging"
+


### PR DESCRIPTION
## Summary
- override payload provenance actor/stage with the validated values so allowlists cannot be bypassed by pre-populated payloads
- add regression coverage ensuring payload provenance is rewritten to the validated actor and stage

## Testing
- python -m pytest tests/qmtl/services/test_risk_hub_contract.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ccdd5a44883299348c70a1795fcc8)