### PR TITLE
Respect WS SSOT when WS evaluation is missing

### DIFF
--- a/qmtl/runtime/sdk/submit.py
+++ b/qmtl/runtime/sdk/submit.py
@@ -1369,9 +1369,6 @@ def _resolved_status(validation_result: Any, ws_eval: WsEvalResult | None) -> st
         # WS response didn't include an explicit decision; treat as pending.
         return "pending"
 
-    if getattr(validation_result, "activated", False):
-        return "active"
-
     if getattr(validation_result, "status", None) == ValidationStatus.FAILED:
         return "rejected"
 

--- a/tests/qmtl/runtime/sdk/test_submit.py
+++ b/tests/qmtl/runtime/sdk/test_submit.py
@@ -437,6 +437,50 @@ class TestSubmitResult:
         assert result.precheck is not None
         assert result.precheck.status == ValidationStatus.FAILED.value
 
+    def test_missing_ws_result_does_not_promote_local_activation(self):
+        class DummyMetrics:
+            sharpe = 1.3
+            max_drawdown = 0.05
+            win_ratio = 0.65
+            profit_factor = 1.4
+            car_mdd = 0.0
+            rar_mdd = 0.0
+            total_return = 0.12
+            num_trades = 15
+            correlation_avg = 0.18
+
+        class DummyValidation:
+            def __init__(self):
+                self.status = ValidationStatus.PASSED
+                self.weight = 0.15
+                self.rank = 3
+                self.contribution = 0.06
+                self.activated = True
+                self.metrics = DummyMetrics()
+                self.violations = []
+                self.improvement_hints = []
+                self.correlation_avg = 0.18
+
+        validation = DummyValidation()
+        strategy = SimpleStrategy()
+
+        result = _build_submit_result_from_validation(
+            strategy=strategy,
+            strategy_class_name="SimpleStrategy",
+            strategy_id="sid-missing-ws",
+            resolved_world="world-missing-ws",
+            mode=Mode.BACKTEST,
+            world_notice=[],
+            validation_result=validation,
+            ws_eval=None,
+            gateway_available=False,
+        )
+
+        assert result.status == "pending"
+        assert result.precheck is not None
+        assert result.precheck.activated is True
+        assert result.precheck.status == ValidationStatus.PASSED.value
+
     def test_offline_submission_stays_pending_without_ws_decision(self):
         class DummyMetrics:
             sharpe = 1.0


### PR DESCRIPTION
## Summary
- ensure local validation cannot mark submissions active when WorldService evaluation is missing
- cover missing WorldService evaluation path with a precheck-preserving regression test

## Testing
- pytest tests/qmtl/runtime/sdk/test_submit.py::TestSubmitResult::test_missing_ws_result_does_not_promote_local_activation -q

Fixes #1910

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cced15d608329b1b9a3220ddb0fd0)