### PR TITLE
[Epic] Close out World Validation follow-ups

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -184,3 +184,19 @@ prometheus:
           annotations:
             summary: Risk hub snapshots routed to DLQ
             runbook: docs/operations/risk_signal_hub_runbook.html
+        - alert: LiveMonitoringNoRuns
+          expr: (sum(increase(live_monitoring_run_total[6h])) or vector(0)) < 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: No live monitoring runs observed for 6 hours
+            runbook: docs/operations/world_validation_observability.html
+        - alert: LiveMonitoringFailures
+          expr: sum(increase(live_monitoring_run_total{status="failure"}[10m])) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: Live monitoring worker failures detected
+            runbook: docs/operations/world_validation_observability.html

--- a/docs/en/operations/validation_report.md
+++ b/docs/en/operations/validation_report.md
@@ -1,0 +1,34 @@
+# Validation Report (Standard Template)
+
+To share and retain World Validation outcomes from an ops/risk perspective, generate a **standard Validation Report** from an `EvaluationRun` payload and a Model Card.
+
+## How to generate
+
+- Inputs: EvaluationRun payload (JSON/YAML), Model Card payload (JSON/YAML)
+- Output: Markdown (`.md`)
+
+Example:
+
+```bash
+uv run python scripts/generate_validation_report.py \
+  --evaluation-run artifacts/evaluation_run.json \
+  --model-card model_cards/my_strategy.json \
+  --output validation_report.md
+```
+
+## What the report includes (summary)
+
+The generator (`scripts/generate_validation_report.py`) emits:
+
+- Summary (status/recommended stage/policy_version/ruleset_hash)
+- Scope & Objective (from Model Card)
+- Rule outcomes (core + extended layers)
+- Metrics snapshot (selected metrics summary)
+- Override information (when present)
+- Limitations & recommendations
+
+## Related
+
+- Evaluation Store: `operations/evaluation_store.md`
+- Observability (SLO/alerts): `operations/world_validation_observability.md`
+

--- a/docs/en/operations/world_validation_governance.md
+++ b/docs/en/operations/world_validation_governance.md
@@ -1,0 +1,42 @@
+# World Validation Governance (Override Re-review)
+
+This document operationalizes `world_validation_architecture.md` §12.3 (Invariant 3) by standardizing the **approved override re-review queue, deadlines, and SLA**.
+
+## Concepts (Summary)
+
+- **Override (approved)**: An operational/risk-approved exception where `summary.status` is not `"pass"`.
+- **Invariant 3**: Approved overrides must be aggregated into a dedicated list and re-reviewed within a fixed window (e.g., 30/90 days).
+
+## Required fields
+
+Approved overrides must record the following fields.
+
+- `override_reason`: approval reason
+- `override_actor`: approver identity
+- `override_timestamp`: approval timestamp (UTC ISO8601)
+
+## Re-review window (defaults)
+
+Current defaults in code:
+
+- `stage=live`: **30 days**
+- `risk_profile.tier=high` AND `client_critical=true`: **30 days**
+- Otherwise: **90 days**
+
+## Queue generation (entrypoints)
+
+- Storage-based (recommended):  
+  `uv run python scripts/generate_override_rereview_report.py --output override_queue.md`
+- API-based (per world):  
+  `GET /worlds/{world_id}/validations/invariants` → inspect `approved_overrides`
+
+Each `approved_overrides` entry includes `review_due_at`, `review_overdue`, and `missing_fields`.
+
+## Operational workflow (brief)
+
+1) Generate the queue daily/weekly and triage entries with `review_overdue=true` or non-empty `missing_fields`.  
+2) Apply a decision:
+   - remove the override (normalize), or
+   - renew the override (update reason/actor/timestamp) and record follow-ups
+3) For recurring overrides, feed back into policy/rules and investigate root causes (data, rebalancing, risk signals, rule design).
+

--- a/docs/ko/design/world_validation_v1.5_implementation.md
+++ b/docs/ko/design/world_validation_v1.5_implementation.md
@@ -28,12 +28,12 @@
 | §4 DSL 구조 | validation vs selection, profiles, recommended_stage | 충족 | `qmtl/services/worldservice/policy_engine.py` | - |
 | §4/5 저장 | EvaluationRun에 policy_version/ruleset_hash/override 추적 | 충족 | `qmtl/services/worldservice/storage`, `qmtl/services/worldservice/services.py` | - |
 | §5 피드백 루프 | policy diff/회귀 자동화 도구 | 부분 | `scripts/policy_diff_batch.py`, `docs/ko/operations/evaluation_store.md` | “나쁜 전략” 세트/CI 임계 플래그 운영 정착 (G3) |
-| §5.3 Live Monitoring | live 결과 상시 재검증(run/report) | 부분 | `qmtl/services/worldservice/routers/live_monitoring.py`, `qmtl/services/worldservice/live_monitoring_worker.py` | 주기적 생성(스케줄러/워커) 운영 경로 연결 (G2) |
+| §5.3 Live Monitoring | live 결과 상시 재검증(run/report) | 충족 | `qmtl/services/worldservice/routers/live_monitoring.py`, `qmtl/services/worldservice/live_monitoring_worker.py`, `scripts/live_monitoring_worker.py`, `scripts/generate_live_monitoring_report.py` | - |
 | §5.3 Fail-closed | on_error/on_missing_metric 기본값/강제 | 충족 | `qmtl/services/worldservice/policy_engine.py`, `qmtl/services/worldservice/decision.py` | - |
 | §5.3 Evaluation Store | append-only 보존/운영 가이드 | 부분 | `docs/ko/operations/evaluation_store.md` | 삽입/조회 API + 보존 정책을 코드/CI로 고정 (G3) |
-| §5.3 Validation Report | 표준 리포트 산출물/보관 | 미구현 | - | 템플릿/생성·배포 경로 정의 + 샘플 산출 (G6) |
-| §8/§12 Invariants | SR 11-7 인바리언트 점검 API | 부분 | `qmtl/services/worldservice/routers/validations.py`, `qmtl/services/worldservice/validation_checks.py` | Invariant 1의 “policy_version 호환” 체크 추가, override 재검토 기한/큐 운영 (G6) |
-| §10 SLO/관측성 | 핵심 SLO/알람/대시보드 표준화 | 부분 | `qmtl/services/worldservice/metrics.py`, `docs/ko/operations/world_validation_observability.md` | 실제 운영 대시보드/알람 캡처 증빙 및 룰 튜닝 (G6) |
+| §5.3 Validation Report | 표준 리포트 산출물/보관 | 충족 | `scripts/generate_validation_report.py`, `docs/ko/operations/validation_report.md` | - |
+| §8/§12 Invariants | SR 11-7 인바리언트 점검 API | 충족 | `qmtl/services/worldservice/routers/validations.py`, `qmtl/services/worldservice/validation_checks.py`, `scripts/generate_override_rereview_report.py`, `docs/ko/operations/world_validation_governance.md` | - |
+| §10 SLO/관측성 | 핵심 SLO/알람/대시보드 표준화 | 부분 | `alert_rules.yml`, `docs/ko/operations/world_validation_observability.md` | 대시보드 스냅샷/임계 튜닝은 운영에서 지속(증빙 링크 첨부 권장) |
 | 스트리밍 정착 | ControlBus/큐 토픽·그룹·재시도·DLQ 표준화 | 부분 | `docs/ko/operations/controlbus_queue_standards.md`, `qmtl/services/worldservice/controlbus_*` | 워커/프로듀서까지 템플릿 공통 적용 + 리허설/증빙 (G1) |
 
 ## 차기 이슈 번들(제안)

--- a/docs/ko/operations/validation_report.md
+++ b/docs/ko/operations/validation_report.md
@@ -1,0 +1,34 @@
+# Validation Report (표준 템플릿)
+
+World Validation의 결과를 운영/리스크 관점에서 공유·보관하기 위해, `EvaluationRun`과 Model Card를 기반으로 **표준 Validation Report**를 생성합니다.
+
+## 생성 방법
+
+- 입력: EvaluationRun payload(JSON/YAML), Model Card payload(JSON/YAML)
+- 출력: Markdown(`.md`)
+
+예시:
+
+```bash
+uv run python scripts/generate_validation_report.py \
+  --evaluation-run artifacts/evaluation_run.json \
+  --model-card model_cards/my_strategy.json \
+  --output validation_report.md
+```
+
+## 포함 내용(요약)
+
+스크립트(`scripts/generate_validation_report.py`)가 생성하는 리포트는 아래 섹션을 포함합니다.
+
+- Summary(상태/추천 스테이지/policy_version/ruleset_hash)
+- Scope & Objective(모델 카드 기반)
+- Rule outcomes(코어 + 확장 레이어 결과)
+- Metrics snapshot(대표 메트릭 요약)
+- Override 정보(존재 시)
+- Limitations & recommendations(한계/권고사항)
+
+## 관련
+
+- Evaluation Store: `operations/evaluation_store.md`
+- 운영 가시성(SLO/알람): `operations/world_validation_observability.md`
+

--- a/docs/ko/operations/world_validation_governance.md
+++ b/docs/ko/operations/world_validation_governance.md
@@ -1,0 +1,42 @@
+# World Validation 거버넌스 (Override 재검토)
+
+이 문서는 `world_validation_architecture.md` §12.3(Invariant 3)를 운영 관점에서 재현 가능하도록, **approved override 재검토 큐·기한·SLA**를 표준화합니다.
+
+## 개념(요약)
+
+- **Override(approved)**: 검증 결과(`summary.status`)가 `"pass"`가 아니더라도 운영/리스크 판단으로 예외를 승인한 상태.
+- **Invariant 3**: approved override는 별도 목록으로 집계되고, 정해진 기간(예: 30/90일) 내 반드시 재검토되어야 합니다.
+
+## 필수 기록 필드
+
+approved override에는 아래 필드를 반드시 기록합니다.
+
+- `override_reason`: 승인 사유
+- `override_actor`: 승인자(주체)
+- `override_timestamp`: 승인 시각(UTC ISO8601)
+
+## 재검토 윈도우(기본값)
+
+현재 코드 기준 기본 재검토 기한은 다음과 같습니다.
+
+- `stage=live`: **30일**
+- `risk_profile.tier=high` AND `client_critical=true`: **30일**
+- 그 외: **90일**
+
+## 큐 생성(운영 엔트리포인트)
+
+- 스토리지 기반(권장):  
+  `uv run python scripts/generate_override_rereview_report.py --output override_queue.md`
+- API 기반(월드별):  
+  `GET /worlds/{world_id}/validations/invariants` → `approved_overrides` 확인
+
+`approved_overrides` 항목에는 `review_due_at`, `review_overdue`, `missing_fields` 가 포함됩니다.
+
+## 운영 절차(간단)
+
+1) **매일/매주** 큐를 생성하고 `review_overdue=true` 또는 `missing_fields` 가 있는 항목을 우선 triage 합니다.  
+2) 재검토 결과에 따라:
+   - override 해제(정상화) 또는
+   - override 갱신(사유/승인자/시각 갱신) 및 추가 조치 기록
+3) 반복 발생 전략/월드는 원인 분석(룰/데이터/리밸런스/리스크 신호) 및 정책/룰 보강으로 연결합니다.
+

--- a/docs/ko/operations/world_validation_observability.md
+++ b/docs/ko/operations/world_validation_observability.md
@@ -37,6 +37,9 @@
 - SLI:
   - 실행 성공/실패: `rate(live_monitoring_run_total{status="success"}[5m])`, `rate(live_monitoring_run_total{status="failure"}[5m])`
   - 업데이트된 전략 수: `increase(live_monitoring_run_updated_strategies_total[1h])`
+- 운영 엔트리포인트(예시):
+  - Live run 생성(크론/데몬): `uv run python scripts/live_monitoring_worker.py --interval-seconds 3600`
+  - 리포트 생성(Markdown/JSON): `uv run python scripts/generate_live_monitoring_report.py --world <world_id> --output live_report.md`
 
 ### 5) Validation Health / Invariants
 
@@ -78,6 +81,24 @@ groups:
         annotations:
           summary: "Extended validation failures"
           description: "world={{ $labels.world_id }} stage={{ $labels.stage }}"
+
+      - alert: LiveMonitoringNoRuns
+        expr: (sum(increase(live_monitoring_run_total[6h])) or vector(0)) < 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Live monitoring job not running"
+          description: "No live monitoring runs observed for 6 hours"
+
+      - alert: LiveMonitoringFailures
+        expr: sum(increase(live_monitoring_run_total{status=\"failure\"}[10m])) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Live monitoring failures detected"
+          description: "Live monitoring worker failures observed"
 ```
 {% endraw %}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,8 @@ nav:
       - Neo4j Migrations: operations/neo4j_migrations.md
       - Monitoring: operations/monitoring.md
       - World Validation Observability: operations/world_validation_observability.md
+      - World Validation Governance: operations/world_validation_governance.md
+      - Validation Report: operations/validation_report.md
       - Core Loop Golden Signals: operations/core_loop_golden_signals.md
       - Seamless SLA Dashboards: operations/seamless_sla_dashboards.md
       - Seamless Stack Templates: operations/seamless_stack.md
@@ -196,6 +198,8 @@ plugins:
             Operations: 운영
             "Core Loop Golden Signals": "Core Loop 골든 시그널"
             "World Validation Observability": "World Validation 운영 가시성"
+            "World Validation Governance": "World Validation 거버넌스"
+            "Validation Report": "Validation Report"
             "Rebalancing Schema Coordination": "리밸런싱 스키마 조율"
             Design: 설계
             QMTL UI: QMTL UI

--- a/qmtl/foundation/config.py
+++ b/qmtl/foundation/config.py
@@ -284,6 +284,9 @@ class RiskHubConfig:
     token: str | None = None
     inline_cov_threshold: int | None = 100
     stage: str | None = None  # optional default stage for producers
+    ttl_sec_default: int = 10
+    allowed_actors: list[str] | None = None
+    allowed_stages: list[str] | None = None
     blob_store: RiskHubBlobStoreConfig = field(default_factory=RiskHubBlobStoreConfig)
 
 CONFIG_SECTION_NAMES: tuple[str, ...] = (

--- a/qmtl/services/gateway/api.py
+++ b/qmtl/services/gateway/api.py
@@ -102,6 +102,9 @@ def _build_risk_hub_client(
     inline_threshold = _resolve_risk_hub_inline(cfg)
     token = cfg.token if cfg else None
     stage = cfg.stage if cfg else None
+    ttl_sec_default = int(cfg.ttl_sec_default) if cfg else 10
+    allowed_actors = list(cfg.allowed_actors) if cfg and cfg.allowed_actors is not None else None
+    allowed_stages = list(cfg.allowed_stages) if cfg and cfg.allowed_stages is not None else None
     return RiskHubClient(
         world_client.base_url,
         timeout=3.0,
@@ -111,6 +114,9 @@ def _build_risk_hub_client(
         blob_store=blob_store,
         inline_cov_threshold=inline_threshold if inline_threshold is not None else 100,
         stage=stage,
+        ttl_sec=ttl_sec_default,
+        allowed_actors=allowed_actors,
+        allowed_stages=allowed_stages,
     )
 
 

--- a/qmtl/services/gateway/risk_hub_client.py
+++ b/qmtl/services/gateway/risk_hub_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from collections.abc import Sequence
 from typing import Any, Mapping, cast
 
 import httpx
@@ -28,6 +29,8 @@ class RiskHubClient:
     actor: str = "gateway"
     stage: str | None = None
     ttl_sec: int = 10
+    allowed_actors: Sequence[str] | None = None
+    allowed_stages: Sequence[str] | None = None
 
     async def publish_snapshot(self, world_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         """POST a snapshot to /risk-hub/worlds/{world_id}/snapshots."""
@@ -126,6 +129,8 @@ class RiskHubClient:
                 actor=self.actor,
                 stage=self.stage,
                 ttl_sec_default=self.ttl_sec,
+                allowed_actors=self.allowed_actors,
+                allowed_stages=self.allowed_stages,
             )
         except TypeError:
             # Preserve legacy fallback only for non-JSON-serializable payloads.

--- a/qmtl/services/worldservice/activation.py
+++ b/qmtl/services/worldservice/activation.py
@@ -213,6 +213,7 @@ class ActivationEventPublisher:
             provenance={
                 "source": "worldservice",
                 "reason": "activation_update",
+                "actor": "worldservice",
                 "stage": "live",
             },
         )

--- a/qmtl/services/worldservice/api.py
+++ b/qmtl/services/worldservice/api.py
@@ -297,6 +297,21 @@ def create_app(
     risk_hub_token = risk_hub_token or (
         resolved_risk_hub_config.token if resolved_risk_hub_config else None
     )
+    risk_hub_ttl_default = (
+        int(resolved_risk_hub_config.ttl_sec_default)
+        if resolved_risk_hub_config is not None
+        else 10
+    )
+    risk_hub_allowed_actors = (
+        list(resolved_risk_hub_config.allowed_actors)
+        if resolved_risk_hub_config is not None and resolved_risk_hub_config.allowed_actors is not None
+        else None
+    )
+    risk_hub_allowed_stages = (
+        list(resolved_risk_hub_config.allowed_stages)
+        if resolved_risk_hub_config is not None and resolved_risk_hub_config.allowed_stages is not None
+        else None
+    )
 
     if risk_hub is None:
         risk_hub = RiskSignalHub(
@@ -383,6 +398,9 @@ def create_app(
                             policy_payload=None,
                         ),
                         dedupe_cache=getattr(risk_hub, "_cache", None),
+                        ttl_sec_default=risk_hub_ttl_default,
+                        allowed_actors=risk_hub_allowed_actors,
+                        allowed_stages=risk_hub_allowed_stages,
                         brokers=brokers,
                         topic=topic,
                     )
@@ -466,6 +484,9 @@ def create_app(
             risk_hub,
             bus=bus_instance,
             expected_token=risk_hub_token,
+            ttl_sec_default=risk_hub_ttl_default,
+            allowed_actors=risk_hub_allowed_actors,
+            allowed_stages=risk_hub_allowed_stages,
             schedule_extended_validation=lambda world_id: service._apply_extended_validation(  # type: ignore[attr-defined]
                 world_id=world_id,
                 stage=None,

--- a/scripts/generate_override_rereview_report.py
+++ b/scripts/generate_override_rereview_report.py
@@ -1,0 +1,133 @@
+"""Generate an override re-review queue report from stored EvaluationRuns.
+
+This script aggregates Invariant 3 ("approved override management") signals across
+worlds and renders a concise Markdown/JSON report for operations.
+
+Usage:
+  WORLDS_DB_DSN=sqlite:///... WORLDS_REDIS_DSN=redis://... \\
+    uv run python scripts/generate_override_rereview_report.py --output override_queue.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import redis.asyncio as redis
+
+from qmtl.services.worldservice.storage import PersistentStorage
+from qmtl.services.worldservice.validation_checks import check_validation_invariants
+
+
+def _iso_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _render_markdown(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append("# Override Re-review Queue")
+    lines.append("")
+    lines.append(f"- Generated at: {report['generated_at']}")
+    lines.append(f"- Worlds scanned: {report['summary'].get('worlds_scanned', 0)}")
+    lines.append(f"- Overrides found: {report['summary'].get('overrides_total', 0)}")
+    lines.append(f"- Overdue overrides: {report['summary'].get('overrides_overdue', 0)}")
+    lines.append("")
+
+    lines.append(
+        "| World | Strategy | Run ID | Stage | Override at | Due at | Overdue | Missing fields | Reason |"
+    )
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- | --- |")
+    for item in report.get("overrides", []):
+        missing = item.get("missing_fields") or []
+        lines.append(
+            "| {world} | {strategy} | {run_id} | {stage} | {ts} | {due} | {overdue} | {missing} | {reason} |".format(
+                world=item.get("world_id", ""),
+                strategy=item.get("strategy_id", ""),
+                run_id=item.get("run_id", ""),
+                stage=item.get("stage", ""),
+                ts=item.get("override_timestamp") or "",
+                due=item.get("review_due_at") or "",
+                overdue=str(bool(item.get("review_overdue"))).lower()
+                if item.get("review_overdue") is not None
+                else "",
+                missing=",".join(str(m) for m in missing) if missing else "",
+                reason=item.get("override_reason") or "",
+            )
+        )
+    return "\n".join(lines).strip() + "\n"
+
+
+async def _build_storage() -> tuple[PersistentStorage, Any]:
+    dsn = os.environ.get("WORLDS_DB_DSN")
+    redis_dsn = os.environ.get("WORLDS_REDIS_DSN")
+    if not dsn or not redis_dsn:
+        raise SystemExit("Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN")
+    redis_client = redis.from_url(redis_dsn, decode_responses=True)
+    storage = await PersistentStorage.create(db_dsn=dsn, redis_client=redis_client)
+    return storage, redis_client
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate override re-review queue report")
+    parser.add_argument("--world", action="append", help="world id(s); default=all")
+    parser.add_argument("--format", choices=["md", "json"], default="md")
+    parser.add_argument("--output", help="output path; default=stdout")
+    args = parser.parse_args()
+
+    storage, redis_client = await _build_storage()
+    try:
+        worlds = args.world
+        if not worlds:
+            worlds = [w["id"] for w in await storage.list_worlds() if w.get("id")]
+
+        overrides: list[dict[str, Any]] = []
+        overdue_count = 0
+        for wid in worlds:
+            world = await storage.get_world(wid) or {"id": wid}
+            runs = await storage.list_evaluation_runs(world_id=wid)
+            report = check_validation_invariants(world, runs)
+            for item in report.approved_overrides:
+                overrides.append(dict(item))
+                if item.get("review_overdue") is True:
+                    overdue_count += 1
+
+        report_payload = {
+            "generated_at": _iso_now(),
+            "summary": {
+                "worlds_scanned": len(worlds),
+                "overrides_total": len(overrides),
+                "overrides_overdue": overdue_count,
+            },
+            "overrides": overrides,
+        }
+
+        if args.format == "json":
+            output_text = json.dumps(report_payload, indent=2)
+        else:
+            output_text = _render_markdown(report_payload)
+
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write(output_text)
+        else:
+            print(output_text)
+    finally:
+        await storage.close()
+        try:
+            await redis_client.aclose()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/tests/qmtl/services/test_risk_hub_contract.py
+++ b/tests/qmtl/services/test_risk_hub_contract.py
@@ -50,7 +50,7 @@ def test_normalize_and_validate_snapshot_rejects_bad_weights():
         "weights": {"s1": 0.5, "s2": 0.4},
     }
     with pytest.raises(ValueError, match="sum"):
-        normalize_and_validate_snapshot("w", payload)
+        normalize_and_validate_snapshot("w", payload, actor="gateway")
 
 
 def test_normalize_and_validate_snapshot_enforces_allowlist():
@@ -102,7 +102,7 @@ def test_normalize_and_validate_snapshot_enforces_stage_allowlist():
         "as_of": "2025-01-01T00:00:00Z",
         "version": "v1",
         "weights": {"s1": 1.0},
-        "provenance": {"stage": "prod"},
+        "provenance": {"actor": "gateway", "stage": "prod"},
     }
     with pytest.raises(ValueError, match="not allowed"):
         normalize_and_validate_snapshot(
@@ -110,4 +110,3 @@ def test_normalize_and_validate_snapshot_enforces_stage_allowlist():
             payload,
             allowed_stages=["staging"],
         )
-

--- a/tests/qmtl/services/worldservice/test_controlbus_consumer.py
+++ b/tests/qmtl/services/worldservice/test_controlbus_consumer.py
@@ -78,6 +78,7 @@ async def test_controlbus_consumer_hydrates_hub_and_triggers_callback():
             "as_of": "2025-01-01T00:00:00Z",
             "version": "v1",
             "weights": {"a": 1.0},
+            "provenance": {"actor": "gateway"},
         },
     }
     msg = SimpleNamespace(value=json.dumps(data))
@@ -116,7 +117,6 @@ async def test_controlbus_consumer_dedupes_by_hash_and_actor():
         "as_of": "2025-01-01T00:00:00Z",
         "version": "v1",
         "weights": {"a": 1.0},
-        "hash": "sha256:test",
         "provenance": {"actor": "gateway", "stage": "paper"},
     }
     data = {"type": "risk_snapshot_updated", "data": payload}


### PR DESCRIPTION
Summary:\n- Enforce RiskHub snapshot contract end-to-end (actor required, hash stability, allowlists via config)\n- Add override re-review queue + validation report docs/tooling\n- Add live monitoring no-run/failure alerts and document scheduler entrypoints\n\nFixes #1905