### PR TITLE
Fixes #1922: v1 core risk metrics persistence

### DIFF
--- a/docs/ko/design/world_validation_v1.5_implementation.md
+++ b/docs/ko/design/world_validation_v1.5_implementation.md
@@ -23,7 +23,7 @@
 | 설계 섹션 | 요구(요약) | 상태 | 구현 근거(대표) | 남은 갭 / 후속(G*) |
 | --- | --- | --- | --- | --- |
 | §1 원칙 | WS가 검증 SSOT, 레이어드 검증 | 충족 | `qmtl/services/worldservice/services.py`, `qmtl/services/worldservice/policy_engine.py` | - |
-| §2 Metrics 블록 | returns/sample/risk/robustness/diagnostics + 확장 슬롯 | 부분 | `qmtl/runtime/sdk/world_validation_metrics.py`, `qmtl/services/worldservice/schemas.py` | v1 코어 risk 메트릭 일부(예: `adv_utilization_p95`) 산출 경로 보강 (G4) |
+| §2 Metrics 블록 | returns/sample/risk/robustness/diagnostics + 확장 슬롯 | 충족 | `qmtl/runtime/sdk/world_validation_metrics.py`, `qmtl/services/worldservice/schemas.py` | - |
 | §3 Rule 모듈성 | RuleResult(status/severity/owner/reason/details) | 충족 | `qmtl/services/worldservice/policy_engine.py` | - |
 | §4 DSL 구조 | validation vs selection, profiles, recommended_stage | 충족 | `qmtl/services/worldservice/policy_engine.py` | - |
 | §4/5 저장 | EvaluationRun에 policy_version/ruleset_hash/override 추적 | 충족 | `qmtl/services/worldservice/storage`, `qmtl/services/worldservice/services.py` | - |

--- a/qmtl/runtime/sdk/submit.py
+++ b/qmtl/runtime/sdk/submit.py
@@ -71,6 +71,8 @@ class StrategyMetrics:
     rar_mdd: float | None = None
     total_return: float | None = None
     num_trades: int | None = None
+    adv_utilization_p95: float | None = None
+    participation_rate_p95: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -83,6 +85,8 @@ class StrategyMetrics:
             "rar_mdd": self.rar_mdd,
             "total_return": self.total_return,
             "num_trades": self.num_trades,
+            "adv_utilization_p95": self.adv_utilization_p95,
+            "participation_rate_p95": self.participation_rate_p95,
         }
 
 
@@ -1704,6 +1708,8 @@ def _clone_metrics_with_corr(metrics: StrategyMetrics, correlation_avg: float | 
         rar_mdd=metrics.rar_mdd,
         total_return=metrics.total_return,
         num_trades=metrics.num_trades,
+        adv_utilization_p95=metrics.adv_utilization_p95,
+        participation_rate_p95=metrics.participation_rate_p95,
     )
 
 
@@ -2066,9 +2072,15 @@ async def _evaluate_with_worldservice(
         value = getattr(metrics, key, None)
         if value is not None:
             extra[key] = value
+    risk_metrics: dict[str, Any] = {}
+    for key in ("adv_utilization_p95", "participation_rate_p95"):
+        value = getattr(metrics, key, None)
+        if value is not None:
+            risk_metrics[key] = value
     payload_metrics: dict[str, Any] = build_v1_evaluation_metrics(
         returns,
         extra_metrics=extra or None,
+        risk_metrics=risk_metrics or None,
     )
     policy_payload: dict[str, Any] | None = None
     if preset:

--- a/tests/qmtl/services/worldservice/test_worldservice_api.py
+++ b/tests/qmtl/services/worldservice/test_worldservice_api.py
@@ -376,7 +376,15 @@ async def test_evaluation_run_creation_and_fetch():
             assert default_resp.status_code == 200
             payload = {
                 "strategy_id": "s-eval",
-                "metrics": {"s-eval": {"sharpe": 1.5}},
+                "metrics": {
+                    "s-eval": {
+                        "returns": {"sharpe": 1.5},
+                        "risk": {
+                            "adv_utilization_p95": 0.2,
+                            "participation_rate_p95": 0.15,
+                        },
+                    }
+                },
                 "run_id": "run-eval-1",
                 "stage": "backtest",
                 "risk_tier": "medium",
@@ -395,6 +403,8 @@ async def test_evaluation_run_creation_and_fetch():
             assert record["stage"] == "backtest"
             assert record["model_card_version"] == "v1.0"
             assert record["metrics"]["returns"]["sharpe"] == 1.5
+            assert record["metrics"]["risk"]["adv_utilization_p95"] == 0.2
+            assert record["metrics"]["risk"]["participation_rate_p95"] == 0.15
             assert record["summary"]["status"] == "warn"
             assert record["summary"]["recommended_stage"] == "backtest_only"
             assert record["validation"]["results"]


### PR DESCRIPTION
Summary: Ensure v1 core risk metrics (adv_utilization_p95, participation_rate_p95) can be carried through SDK->WS payload and persisted in EvaluationRun.

Fixes #1922