### PR TITLE
Fixes #1924: Evaluation Store retention purge job

### DIFF
--- a/.github/workflows/evaluation-store-retention.yml
+++ b/.github/workflows/evaluation-store-retention.yml
@@ -1,0 +1,58 @@
+name: evaluation-store-retention
+
+on:
+  workflow_dispatch:
+    inputs:
+      retention_days:
+        description: "History retention window in days"
+        required: false
+        default: "180"
+      dry_run:
+        description: "If true, do not delete rows"
+        required: false
+        default: "true"
+  schedule:
+    - cron: "17 3 * * 1" # Mondays 03:17 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    env:
+      WORLDS_DB_DSN: ${{ secrets.WORLDS_DB_DSN }}
+      WORLDS_REDIS_DSN: ${{ secrets.WORLDS_REDIS_DSN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip if secrets missing
+        if: ${{ env.WORLDS_DB_DSN == '' || env.WORLDS_REDIS_DSN == '' }}
+        run: |
+          echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping retention job."
+          exit 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]"
+
+      - name: Run purge (dry-run by default)
+        run: |
+          retention_days="${{ inputs.retention_days || '180' }}"
+          dry_run="${{ inputs.dry_run || 'true' }}"
+          args=(--retention-days "$retention_days" --output purge_report.json)
+          if [[ "$dry_run" == "true" ]]; then
+            :
+          else
+            args+=(--execute)
+          fi
+          uv run python scripts/purge_evaluation_run_history.py "${args[@]}"
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: purge_report
+          path: purge_report.json
+

--- a/docs/en/operations/evaluation_store.md
+++ b/docs/en/operations/evaluation_store.md
@@ -45,6 +45,14 @@ Purge guidance:
 - Only purge history records that are beyond the retention period (as required for capacity/PII/compliance).
 - Purging can weaken auditability of an append-only store, so require an operational approval process.
 
+### Retention job (code + operations)
+
+- Script: `scripts/purge_evaluation_run_history.py`
+  - Dry-run (default): `WORLDS_DB_DSN=... WORLDS_REDIS_DSN=... uv run python scripts/purge_evaluation_run_history.py --retention-days 180`
+  - Execute: `WORLDS_DB_DSN=... WORLDS_REDIS_DSN=... uv run python scripts/purge_evaluation_run_history.py --retention-days 180 --execute --output purge_report.json`
+- GitHub Actions (scheduled/manual): `.github/workflows/evaluation-store-retention.yml`
+  - Runs only when `WORLDS_DB_DSN` and `WORLDS_REDIS_DSN` secrets are configured (skips otherwise).
+
 ## Operational Playbook (Examples)
 
 - Regression / audit:
@@ -53,4 +61,3 @@ Purge guidance:
 - Overrides:
   - Approved overrides must include reason/actor/timestamp, and
     keep the run’s `/history` for later review.
-

--- a/docs/ko/operations/evaluation_store.md
+++ b/docs/ko/operations/evaluation_store.md
@@ -45,6 +45,14 @@ WorldService의 Evaluation Store는 `EvaluationRun`과 그 변경 이력을 **�
 - 용량/PII/규정 요구에 따라, 보존 기간이 지난 history 레코드만 정리합니다.
 - 정리 작업은 **append-only 불변성(감사 가능성)** 을 훼손할 수 있으므로, 운영 승인을 거쳐 수행합니다.
 
+### Retention 잡(코드/운영) 고정
+
+- 스크립트: `scripts/purge_evaluation_run_history.py`
+  - dry-run(기본): `WORLDS_DB_DSN=... WORLDS_REDIS_DSN=... uv run python scripts/purge_evaluation_run_history.py --retention-days 180`
+  - 실행: `WORLDS_DB_DSN=... WORLDS_REDIS_DSN=... uv run python scripts/purge_evaluation_run_history.py --retention-days 180 --execute --output purge_report.json`
+- GitHub Actions(스케줄/수동): `.github/workflows/evaluation-store-retention.yml`
+  - `WORLDS_DB_DSN`, `WORLDS_REDIS_DSN` 시크릿이 설정된 경우에만 실행됩니다(미설정 시 skip).
+
 ## 운영 절차 (예시)
 
 - 회귀/감사:
@@ -53,4 +61,3 @@ WorldService의 Evaluation Store는 `EvaluationRun`과 그 변경 이력을 **�
 - 오버라이드:
   - 승인(approved)은 사유/승인자/타임스탬프를 포함해야 하며,
     추후 재검토를 위해 관련 run의 `/history`를 함께 보관합니다.
-

--- a/scripts/purge_evaluation_run_history.py
+++ b/scripts/purge_evaluation_run_history.py
@@ -1,0 +1,99 @@
+"""Purge EvaluationRun history entries older than a retention cutoff.
+
+Usage:
+  WORLDS_DB_DSN=sqlite:///... WORLDS_REDIS_DSN=redis://... \\
+    uv run python scripts/purge_evaluation_run_history.py --retention-days 180 --dry-run
+
+  WORLDS_DB_DSN=... WORLDS_REDIS_DSN=... \\
+    uv run python scripts/purge_evaluation_run_history.py --retention-days 180 --execute --output purge_report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import redis.asyncio as redis
+
+from qmtl.services.worldservice.storage import PersistentStorage
+
+
+def _iso_utc(ts: datetime) -> str:
+    return ts.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+async def _build_storage() -> tuple[PersistentStorage, Any]:
+    dsn = os.environ.get("WORLDS_DB_DSN")
+    redis_dsn = os.environ.get("WORLDS_REDIS_DSN")
+    if not dsn or not redis_dsn:
+        raise SystemExit("Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN")
+    redis_client = redis.from_url(redis_dsn, decode_responses=True)
+    storage = await PersistentStorage.create(db_dsn=dsn, redis_client=redis_client)
+    return storage, redis_client
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Purge evaluation_run_history rows older than a cutoff")
+    parser.add_argument("--world", action="append", help="world id(s); default=all")
+    parser.add_argument("--retention-days", type=int, default=180)
+    parser.add_argument("--older-than", help="override cutoff timestamp (ISO-8601, e.g. 2025-01-01T00:00:00Z)")
+    parser.add_argument("--execute", action="store_true", help="actually delete rows (default: dry-run)")
+    parser.add_argument("--vacuum", action="store_true", help="run VACUUM after deletion (sqlite only; best-effort)")
+    parser.add_argument("--output", help="write JSON report to path (default: stdout)")
+    args = parser.parse_args()
+
+    now = datetime.now(timezone.utc)
+    older_than = args.older_than
+    if not older_than:
+        older_than = _iso_utc(now - timedelta(days=int(args.retention_days)))
+
+    storage, redis_client = await _build_storage()
+    try:
+        worlds = args.world
+        if not worlds:
+            worlds = [w["id"] for w in await storage.list_worlds() if w.get("id")]
+
+        per_world: list[dict[str, Any]] = []
+        total_candidates = 0
+        total_deleted = 0
+        for wid in worlds:
+            result = await storage.purge_evaluation_run_history(
+                older_than=older_than,
+                world_id=wid,
+                dry_run=not args.execute,
+                vacuum=bool(args.vacuum and args.execute),
+            )
+            per_world.append(dict(result))
+            total_candidates += int(result.get("candidates") or 0)
+            total_deleted += int(result.get("deleted") or 0)
+
+        report = {
+            "generated_at": _iso_utc(now),
+            "older_than": older_than,
+            "execute": bool(args.execute),
+            "worlds": worlds,
+            "summary": {
+                "candidates": total_candidates,
+                "deleted": total_deleted,
+            },
+            "results": per_world,
+        }
+
+        text = json.dumps(report, indent=2)
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write(text + "\n")
+        else:
+            print(text)
+    finally:
+        await storage.close()
+        await redis_client.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+


### PR DESCRIPTION
Summary: Add code+ops path for evaluation_run_history retention (purge script, storage API, and scheduled workflow).

Fixes #1924