### PR TITLE
Fixes #1923: Policy diff regression automation

### DIFF
--- a/.github/workflows/policy-diff-regression.yml
+++ b/.github/workflows/policy-diff-regression.yml
@@ -1,0 +1,106 @@
+name: policy-diff-regression
+
+on:
+  workflow_dispatch:
+    inputs:
+      fail_impact_ratio:
+        description: "Fail if impacted ratio >= threshold (0~1)"
+        required: false
+        default: "0.05"
+      stage:
+        description: "Validation stage (backtest/paper/live)"
+        required: false
+        default: "backtest"
+  schedule:
+    - cron: "41 2 * * 1" # Mondays 02:41 UTC
+  pull_request:
+    paths:
+      - "docs/**/world/sample_policy.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  policy-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]"
+
+      - name: Materialize policy inputs
+        id: policies
+        shell: bash
+        run: |
+          set -euo pipefail
+          stage="${{ inputs.stage || 'backtest' }}"
+          echo "stage=$stage" >> "$GITHUB_OUTPUT"
+
+          policy_path="docs/ko/world/sample_policy.yml"
+          if [[ ! -f "$policy_path" ]]; then
+            echo "Missing $policy_path; nothing to diff."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_ref="${{ github.base_ref }}"
+            git fetch origin "$base_ref" --depth=1
+            git show "origin/$base_ref:$policy_path" > old_policy.yml
+            cp "$policy_path" new_policy.yml
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            if git rev-parse HEAD~1 >/dev/null 2>&1; then
+              git show "HEAD~1:$policy_path" > old_policy.yml || cp "$policy_path" old_policy.yml
+              cp "$policy_path" new_policy.yml
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # workflow_dispatch: compare HEAD~1 to HEAD (best-effort)
+          if git rev-parse HEAD~1 >/dev/null 2>&1; then
+            git show "HEAD~1:$policy_path" > old_policy.yml || cp "$policy_path" old_policy.yml
+          else
+            cp "$policy_path" old_policy.yml
+          fi
+          cp "$policy_path" new_policy.yml
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Run policy diff batch
+        if: ${{ steps.policies.outputs.skip != 'true' }}
+        run: |
+          fail_ratio="${{ inputs.fail_impact_ratio || '0.05' }}"
+          stage="${{ steps.policies.outputs.stage }}"
+          uv run -m scripts.policy_diff_batch \
+            --old old_policy.yml \
+            --new new_policy.yml \
+            --runs-dir operations/policy_diff/bad_strategies_runs \
+            --runs-pattern '*.json' \
+            --stage "$stage" \
+            --output policy_diff_report.json \
+            --fail-impact-ratio "$fail_ratio"
+
+      - name: Write skip report
+        if: ${{ steps.policies.outputs.skip == 'true' }}
+        run: |
+          cat > policy_diff_report.json <<'JSON'
+          {"skipped": true}
+          JSON
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: policy-diff-report
+          path: policy_diff_report.json

--- a/docs/en/operations/ci.md
+++ b/docs/en/operations/ci.md
@@ -65,6 +65,27 @@ def test_long_running_case():
 - Mark long/external tests as `slow` and, if needed, exclude them from preflight with `-k 'not slow'`.
 - Avoid unbounded network waits; always set client timeouts in tests.
 
+## Policy Diff Regression (CI/Cron)
+
+- Goal: automatically monitor the impact ratio of policy changes against the “bad strategies” regression set.
+- Example command:
+
+```
+uv run -m scripts.policy_diff_batch \
+  --old docs/ko/world/sample_policy.yml \
+  --new docs/ko/world/sample_policy.yml \
+  --runs-dir operations/policy_diff/bad_strategies_runs \
+  --runs-pattern '*.json' \
+  --stage backtest \
+  --output policy_diff_report.json \
+  --fail-impact-ratio 0.05
+```
+
+- Artifact: upload `policy_diff_report.json`, and fail the workflow when the impact ratio exceeds the threshold.
+- GitHub Actions workflow: `.github/workflows/policy-diff-regression.yml`
+  - Runs automatically when `docs/**/world/sample_policy.yml` changes in a PR and uploads the report artifact
+  - Also supports scheduled/manual triggers (default threshold `0.05`)
+
 ## Architecture Invariants (advisory checks)
 
 Add lightweight checks (unit/integration) that fail fast when core invariants are violated:

--- a/docs/ko/operations/ci.md
+++ b/docs/ko/operations/ci.md
@@ -67,44 +67,19 @@ def test_long_running_case():
 - 목적: 정책 변경이 “나쁜 전략” 회귀 세트에 미치는 영향 비율을 자동 감시.
 - 명령 예시:
   ```bash
-  uv run python scripts/policy_diff_batch.py \
-    --old policies/baseline.yml \
-    --new policies/candidate.yml \
-    --runs-dir artifacts/bad_strategies_runs \
+  uv run -m scripts.policy_diff_batch \
+    --old docs/ko/world/sample_policy.yml \
+    --new docs/ko/world/sample_policy.yml \
+    --runs-dir operations/policy_diff/bad_strategies_runs \
     --runs-pattern '*.json' \
     --stage backtest \
     --output policy_diff_report.json \
     --fail-impact-ratio 0.05
   ```
 - 아티팩트: `policy_diff_report.json` 을 업로드하고, 임팩트 비율이 임계 초과 시 워크플로를 실패 처리.
-- 스케줄 샘플(GitHub Actions):
-  ```yaml
-  on:
-    schedule:
-      - cron: "0 */6 * * *"  # 6시간마다
-  jobs:
-    policy-diff:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - name: Install deps
-          run: uv pip install -e .[dev]
-        - name: Run policy diff batch
-          run: |
-            uv run python scripts/policy_diff_batch.py \
-              --old policies/baseline.yml \
-              --new policies/candidate.yml \
-              --runs-dir artifacts/bad_strategies_runs \
-              --runs-pattern '*.json' \
-              --stage backtest \
-              --output policy_diff_report.json \
-              --fail-impact-ratio 0.05
-        - name: Upload report
-          uses: actions/upload-artifact@v4
-          with:
-            name: policy-diff-report
-            path: policy_diff_report.json
-  ```
+- GitHub Actions 워크플로: `.github/workflows/policy-diff-regression.yml`
+  - PR에서 `docs/**/world/sample_policy.yml` 변경 시 자동 실행 + 리포트 아티팩트 업로드
+  - 스케줄/수동 트리거로도 실행 가능(기본 임계값 `0.05`)
 ## 아키텍처 불변 조건(권장 검사)
 
 핵심 불변 조건이 깨지면 즉시 실패하도록 가벼운 검사(단위/통합)를 추가하세요.

--- a/operations/policy_diff/bad_strategies_runs/bad_strategies_runs.json
+++ b/operations/policy_diff/bad_strategies_runs/bad_strategies_runs.json
@@ -1,0 +1,168 @@
+[
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "good_stable_1",
+    "run_id": "bad-set-001",
+    "metrics": {
+      "returns": {
+        "sharpe": 1.2,
+        "max_drawdown": 0.12,
+        "gain_to_pain_ratio": 1.8,
+        "time_under_water_ratio": 0.2
+      },
+      "sample": {
+        "effective_history_years": 5.0,
+        "n_trades_total": 500,
+        "n_trades_per_year": 100.0
+      },
+      "risk": {
+        "adv_utilization_p95": 0.1,
+        "participation_rate_p95": 0.05
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.8,
+        "sharpe_first_half": 1.1,
+        "sharpe_second_half": 1.3
+      },
+      "diagnostics": {
+        "returns_source": "explicit:strategy"
+      }
+    }
+  },
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "good_stable_2",
+    "run_id": "bad-set-002",
+    "metrics": {
+      "returns": {
+        "sharpe": 0.9,
+        "max_drawdown": 0.18,
+        "gain_to_pain_ratio": 1.4,
+        "time_under_water_ratio": 0.3
+      },
+      "sample": {
+        "effective_history_years": 3.5,
+        "n_trades_total": 220,
+        "n_trades_per_year": 80.0
+      },
+      "risk": {
+        "adv_utilization_p95": 0.2,
+        "participation_rate_p95": 0.1
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.5,
+        "sharpe_first_half": 0.85,
+        "sharpe_second_half": 0.95
+      }
+    }
+  },
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "bad_short_history",
+    "run_id": "bad-set-003",
+    "metrics": {
+      "returns": {
+        "sharpe": 2.5,
+        "max_drawdown": 0.05,
+        "gain_to_pain_ratio": 3.0,
+        "time_under_water_ratio": 0.1
+      },
+      "sample": {
+        "effective_history_years": 0.5,
+        "n_trades_total": 20,
+        "n_trades_per_year": 40.0
+      },
+      "risk": {
+        "adv_utilization_p95": 0.05,
+        "participation_rate_p95": 0.02
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.3,
+        "sharpe_first_half": 2.8,
+        "sharpe_second_half": 2.2
+      }
+    }
+  },
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "bad_high_drawdown",
+    "run_id": "bad-set-004",
+    "metrics": {
+      "returns": {
+        "sharpe": 0.9,
+        "max_drawdown": 0.45,
+        "gain_to_pain_ratio": 1.2,
+        "time_under_water_ratio": 0.6
+      },
+      "sample": {
+        "effective_history_years": 3.0,
+        "n_trades_total": 200,
+        "n_trades_per_year": 67.0
+      },
+      "risk": {
+        "adv_utilization_p95": 0.2,
+        "participation_rate_p95": 0.1
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.5,
+        "sharpe_first_half": 1.2,
+        "sharpe_second_half": 0.6
+      }
+    }
+  },
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "bad_low_sharpe",
+    "run_id": "bad-set-005",
+    "metrics": {
+      "returns": {
+        "sharpe": 0.3,
+        "max_drawdown": 0.2,
+        "gain_to_pain_ratio": 1.1,
+        "time_under_water_ratio": 0.4
+      },
+      "sample": {
+        "effective_history_years": 4.0,
+        "n_trades_total": 300,
+        "n_trades_per_year": 75.0
+      },
+      "risk": {
+        "adv_utilization_p95": 0.15,
+        "participation_rate_p95": 0.1
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.2,
+        "sharpe_first_half": 0.4,
+        "sharpe_second_half": 0.2
+      }
+    }
+  },
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "bad_liquidity_risk",
+    "run_id": "bad-set-006",
+    "metrics": {
+      "returns": {
+        "sharpe": 0.9,
+        "max_drawdown": 0.2,
+        "gain_to_pain_ratio": 1.1,
+        "time_under_water_ratio": 0.35
+      },
+      "sample": {
+        "effective_history_years": 3.0,
+        "n_trades_total": 250,
+        "n_trades_per_year": 90.0
+      },
+      "risk": {
+        "adv_utilization_p95": 0.8,
+        "participation_rate_p95": 0.5
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.4,
+        "sharpe_first_half": 1.0,
+        "sharpe_second_half": 0.8
+      }
+    }
+  }
+]
+


### PR DESCRIPTION
Summary: Standardize the 'bad strategies' regression run set, add a scheduled/manual GitHub Actions workflow, and document the default impact threshold.

Fixes #1923