### PR TITLE
Fixes #1926: ControlBus standard templates

### DIFF
--- a/docs/en/operations/controlbus_queue_standards.md
+++ b/docs/en/operations/controlbus_queue_standards.md
@@ -7,6 +7,7 @@ This document defines topic naming, consumer groups, retry/DLQ behavior, and ide
 - WorldService publishes/consumes CloudEvents on `worldservice.server.controlbus_topic` (default: `policy`).
 - Multiple event types may share the same topic; consumers must filter on CloudEvents `type`.
   - Examples: `risk_snapshot_updated`, `policy_updated`, `activation_updated`, `evaluation_run_created`, `evaluation_run_updated`
+  - Examples (ops/bridge): `queue_updated`, `sentinel_weight_updated`, `activation_ack`
 
 ## Consumer Groups (Recommended)
 
@@ -57,4 +58,3 @@ Example WorldService Prometheus metrics:
 - Dropping expired snapshots (TTL) is observable
 - Fail → retry(backoff) → success, or fail → DLQ routing
 - Stage labels (backtest/paper/live) remain separated in metrics
-

--- a/docs/ko/design/world_validation_v1.5_implementation.md
+++ b/docs/ko/design/world_validation_v1.5_implementation.md
@@ -34,7 +34,7 @@
 | §5.3 Validation Report | 표준 리포트 산출물/보관 | 충족 | `scripts/generate_validation_report.py`, `docs/ko/operations/validation_report.md` | - |
 | §8/§12 Invariants | SR 11-7 인바리언트 점검 API | 충족 | `qmtl/services/worldservice/routers/validations.py`, `qmtl/services/worldservice/validation_checks.py`, `scripts/generate_override_rereview_report.py`, `docs/ko/operations/world_validation_governance.md` | - |
 | §10 SLO/관측성 | 핵심 SLO/알람/대시보드 표준화 | 부분 | `alert_rules.yml`, `docs/ko/operations/world_validation_observability.md` | 대시보드 스냅샷/임계 튜닝은 운영에서 지속(증빙 링크 첨부 권장) |
-| 스트리밍 정착 | ControlBus/큐 토픽·그룹·재시도·DLQ 표준화 | 부분 | `docs/ko/operations/controlbus_queue_standards.md`, `qmtl/services/worldservice/controlbus_*` | 워커/프로듀서까지 템플릿 공통 적용 + 리허설/증빙 (G1) |
+| 스트리밍 정착 | ControlBus/큐 토픽·그룹·재시도·DLQ 표준화 | 충족 | `docs/ko/operations/controlbus_queue_standards.md`, `qmtl/services/worldservice/controlbus_*`, `qmtl/services/dagmanager/controlbus_producer.py`, `qmtl/services/gateway/controlbus_ack.py` | - |
 
 ## 차기 이슈 번들(제안)
 

--- a/docs/ko/operations/controlbus_queue_standards.md
+++ b/docs/ko/operations/controlbus_queue_standards.md
@@ -7,6 +7,7 @@
 - WorldService는 `worldservice.server.controlbus_topic`(기본값: `policy`)에 **CloudEvents** 메시지를 발행/소비합니다.
 - 동일 토픽에 여러 이벤트 타입이 공존할 수 있으며, 필터링 기준은 CloudEvents의 `type` 입니다.
   - 예: `risk_snapshot_updated`, `policy_updated`, `activation_updated`, `evaluation_run_created`, `evaluation_run_updated`
+  - 예(운영/브리지): `queue_updated`, `sentinel_weight_updated`, `activation_ack`
 
 ## 컨슈머 그룹 (권장)
 
@@ -57,4 +58,3 @@ WorldService 내 Prometheus 메트릭(예):
 - TTL 만료 스냅샷 드롭(expired) 확인
 - 처리 실패 → 재시도(backoff) 후 성공/또는 DLQ 라우팅 확인
 - stage별(backtest/paper/live)로 메트릭 라벨 분리가 유지되는지 확인
-

--- a/qmtl/services/gateway/controlbus_ack.py
+++ b/qmtl/services/gateway/controlbus_ack.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 """ControlBus ACK publisher for activation freeze/unfreeze events."""
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
 from typing import Iterable
 
+from qmtl.foundation.common.cloudevents import format_event
 from qmtl.services.kafka import KafkaProducerLike, create_kafka_producer
 
 
@@ -22,11 +24,15 @@ class ActivationAckProducer:
         brokers: Iterable[str] | None = None,
         topic: str = "control.activation.ack",
         required: bool = False,
+        retries: int = 2,
+        backoff: float = 0.5,
     ) -> None:
         self.brokers = list(brokers or [])
         self.topic = topic
         self._producer: KafkaProducerLike | None = None
         self._required = required
+        self._retries = int(retries)
+        self._backoff = float(backoff)
 
     async def start(self) -> None:
         if self._producer is not None:
@@ -69,7 +75,6 @@ class ActivationAckProducer:
             return
         now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         payload = {
-            "type": "ActivationAck",
             "version": 1,
             "world_id": world_id,
             "run_id": run_id,
@@ -77,10 +82,29 @@ class ActivationAckProducer:
             "phase": phase,
             "etag": etag,
             "ack_ts": now,
+            "idempotency_key": f"activation_ack:{world_id}:{run_id}:{sequence or 0}:{phase or 'unknown'}:1",
         }
-        data = json.dumps(payload).encode()
+        corr = f"activation:{world_id}:{run_id}"
+        event = format_event(
+            "qmtl.services.gateway",
+            "activation_ack",
+            payload,
+            correlation_id=corr,
+        )
+        data = json.dumps(event).encode()
         key = (world_id or "").encode() or b""
-        await producer.send_and_wait(self.topic, data, key=key)
+        last_exc: Exception | None = None
+        for attempt in range(self._retries + 1):
+            try:
+                await producer.send_and_wait(self.topic, data, key=key)
+                return
+            except Exception as exc:  # pragma: no cover - best-effort reliability
+                last_exc = exc
+                if attempt >= self._retries:
+                    break
+                await asyncio.sleep(self._backoff * (attempt + 1))
+        if last_exc:
+            raise last_exc
 
 
 __all__ = ["ActivationAckProducer"]

--- a/tests/qmtl/services/dagmanager/test_controlbus_producer.py
+++ b/tests/qmtl/services/dagmanager/test_controlbus_producer.py
@@ -1,21 +1,65 @@
+import json
+
 import pytest
 
 from qmtl.services.dagmanager.controlbus_producer import ControlBusProducer
 
 
+class DummyProducer:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, bytes, bytes | None]] = []
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def send_and_wait(self, topic: str, data: bytes, key: bytes | None = None) -> None:
+        self.sent.append((topic, data, key))
+
+
 @pytest.mark.asyncio
-async def test_start_warns_when_optional_controlbus_missing(caplog):
-    producer = ControlBusProducer(brokers=[], required=False)
+async def test_controlbus_producer_emits_queue_update_as_cloudevent():
+    dummy = DummyProducer()
+    producer = ControlBusProducer(producer=dummy, topic="queue", sentinel_topic="sentinel_weight")
 
-    with caplog.at_level("WARNING"):
-        await producer.start()
+    await producer.publish_queue_update(
+        tags=["a", "b"],
+        interval=60,
+        queues=[{"queue": "q1", "global": True}],
+        match_mode="any",
+        version=1,
+    )
 
-    assert "ControlBus disabled" in caplog.text
+    topic, data, key = dummy.sent[0]
+    evt = json.loads(data.decode())
+    assert evt["type"] == "queue_updated"
+    assert evt["correlation_id"].startswith("queue:")
+    assert evt["data"]["etag"].startswith("q:")
+    assert "idempotency_key" in evt["data"]
+    assert topic == "queue"
+    assert key == b"a,b"
 
 
 @pytest.mark.asyncio
-async def test_start_raises_when_controlbus_required_and_missing():
-    producer = ControlBusProducer(brokers=[], required=True)
+async def test_controlbus_producer_emits_sentinel_weight_as_cloudevent():
+    dummy = DummyProducer()
+    producer = ControlBusProducer(producer=dummy, topic="queue", sentinel_topic="sentinel_weight")
 
-    with pytest.raises(RuntimeError, match="ControlBus unavailable"):
-        await producer.start()
+    await producer.publish_sentinel_weight(
+        sentinel_id="s1",
+        weight=0.25,
+        world_id="w1",
+        version=1,
+    )
+
+    topic, data, key = dummy.sent[0]
+    evt = json.loads(data.decode())
+    assert evt["type"] == "sentinel_weight_updated"
+    assert evt["data"]["sentinel_id"] == "s1"
+    assert evt["data"]["weight"] == 0.25
+    assert "idempotency_key" in evt["data"]
+    assert topic == "sentinel_weight"
+    assert key == b"s1"
+

--- a/tests/qmtl/services/dagmanager/test_grpc_server.py
+++ b/tests/qmtl/services/dagmanager/test_grpc_server.py
@@ -583,7 +583,8 @@ async def test_grpc_diff_publishes_controlbus():
     assert producer.sent
     topic, data, key = producer.sent[0]
     assert topic == "queue"
-    payload = json.loads(data.decode())
+    event = json.loads(data.decode())
+    payload = event.get("data", event)
     assert payload["tags"] == ["x"]
 
 
@@ -650,7 +651,8 @@ async def test_grpc_diff_emits_sentinel_weight_and_gateway_consumes():
     topic, data, key = sentinel_msgs[-1]
     assert topic == "sentinel_weight"
     assert key == b"s-sentinel"
-    payload = json.loads(data.decode())
+    event = json.loads(data.decode())
+    payload = event.get("data", event)
     assert payload["sentinel_id"] == "s-sentinel"
     assert payload["weight"] == pytest.approx(0.75)
     assert payload["version"] == 1

--- a/tests/qmtl/services/gateway/test_controlbus_ack.py
+++ b/tests/qmtl/services/gateway/test_controlbus_ack.py
@@ -1,0 +1,48 @@
+import json
+
+import pytest
+
+from qmtl.services.gateway.controlbus_ack import ActivationAckProducer
+
+
+class DummyProducer:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, bytes, bytes | None]] = []
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def send_and_wait(self, topic: str, data: bytes, key: bytes | None = None) -> None:
+        self.sent.append((topic, data, key))
+
+
+@pytest.mark.asyncio
+async def test_activation_ack_publisher_emits_cloudevent_with_idempotency_key():
+    ack = ActivationAckProducer(brokers=["kafka:9092"], topic="control.activation.ack")
+    dummy = DummyProducer()
+    ack._producer = dummy  # test seam
+
+    await ack.publish_ack(
+        world_id="w1",
+        run_id="r1",
+        sequence=3,
+        phase="apply",
+        etag="e1",
+    )
+
+    topic, data, key = dummy.sent[0]
+    evt = json.loads(data.decode())
+    assert evt["type"] == "activation_ack"
+    assert evt["correlation_id"] == "activation:w1:r1"
+    assert evt["data"]["world_id"] == "w1"
+    assert evt["data"]["run_id"] == "r1"
+    assert evt["data"]["sequence"] == 3
+    assert evt["data"]["phase"] == "apply"
+    assert evt["data"]["etag"] == "e1"
+    assert "idempotency_key" in evt["data"]
+    assert topic == "control.activation.ack"
+    assert key == b"w1"
+


### PR DESCRIPTION
Summary: Apply ControlBus CloudEvents/idempotency templates across producers (worldservice/dagmanager/gateway ack), add tests, and update runbooks.

Fixes #1926