### PR TITLE
Fixes #1925: World Validation observability tuning

### DIFF
--- a/alert_rules.yml
+++ b/alert_rules.yml
@@ -144,6 +144,14 @@ prometheus:
           annotations:
             summary: Risk hub snapshots are older than 10 minutes
             runbook: docs/operations/risk_signal_hub_runbook.html
+        - alert: RiskHubSnapshotLagCritical
+          expr: max_over_time(risk_hub_snapshot_lag_seconds[5m]) > 1800
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Risk hub snapshots are older than 30 minutes
+            runbook: docs/operations/risk_signal_hub_runbook.html
         - alert: RiskHubSnapshotMissing
           expr: sum(increase(risk_hub_snapshot_missing_total[5m])) > 0
           for: 5m
@@ -199,4 +207,20 @@ prometheus:
             severity: warning
           annotations:
             summary: Live monitoring worker failures detected
+            runbook: docs/operations/world_validation_observability.html
+        - alert: ExtendedValidationFailures
+          expr: sum(increase(extended_validation_run_total{status=~"failure|enqueue_failed"}[10m])) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: Extended validation failures detected
+            runbook: docs/operations/world_validation_observability.html
+        - alert: ExtendedValidationLatencyHigh
+          expr: histogram_quantile(0.95, sum by (le, world_id, stage) (rate(extended_validation_run_latency_seconds_bucket[10m]))) > 60
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Extended validation p95 latency is high
             runbook: docs/operations/world_validation_observability.html

--- a/docs/en/operations/world_validation_observability.md
+++ b/docs/en/operations/world_validation_observability.md
@@ -109,3 +109,11 @@ groups:
 - Extended validation: success/failure, p95 latency
 - Live monitoring: run success/failure, updated strategies
 - Invariants/health: `/validations/invariants` results (recommended to collect periodically via an ops script/external poller)
+
+### Dashboard spec (stored in repo)
+
+- Grafana panel spec (text): `operations/monitoring/world_validation_v1.jsonnet`
+
+### Operational evidence (recommended)
+
+- Evidence template: `operations/monitoring/samples/world_validation_observability_evidence.md`

--- a/docs/ko/design/world_validation_v1.5_implementation.md
+++ b/docs/ko/design/world_validation_v1.5_implementation.md
@@ -33,7 +33,7 @@
 | §5.3 Evaluation Store | append-only 보존/운영 가이드 | 충족 | `docs/ko/operations/evaluation_store.md`, `scripts/purge_evaluation_run_history.py`, `.github/workflows/evaluation-store-retention.yml` | - |
 | §5.3 Validation Report | 표준 리포트 산출물/보관 | 충족 | `scripts/generate_validation_report.py`, `docs/ko/operations/validation_report.md` | - |
 | §8/§12 Invariants | SR 11-7 인바리언트 점검 API | 충족 | `qmtl/services/worldservice/routers/validations.py`, `qmtl/services/worldservice/validation_checks.py`, `scripts/generate_override_rereview_report.py`, `docs/ko/operations/world_validation_governance.md` | - |
-| §10 SLO/관측성 | 핵심 SLO/알람/대시보드 표준화 | 부분 | `alert_rules.yml`, `docs/ko/operations/world_validation_observability.md` | 대시보드 스냅샷/임계 튜닝은 운영에서 지속(증빙 링크 첨부 권장) |
+| §10 SLO/관측성 | 핵심 SLO/알람/대시보드 표준화 | 충족 | `alert_rules.yml`, `docs/ko/operations/world_validation_observability.md`, `operations/monitoring/world_validation_v1.jsonnet` | - |
 | 스트리밍 정착 | ControlBus/큐 토픽·그룹·재시도·DLQ 표준화 | 충족 | `docs/ko/operations/controlbus_queue_standards.md`, `qmtl/services/worldservice/controlbus_*`, `qmtl/services/dagmanager/controlbus_producer.py`, `qmtl/services/gateway/controlbus_ack.py` | - |
 
 ## 차기 이슈 번들(제안)

--- a/docs/ko/operations/world_validation_observability.md
+++ b/docs/ko/operations/world_validation_observability.md
@@ -109,3 +109,11 @@ groups:
 - Extended validation: success/failure, p95 latency
 - Live monitoring: run success/failure, updated strategies
 - Invariants/Health: `/validations/invariants` 결과(운영 스크립트/외부 폴러로 주기 수집 권장)
+
+### 대시보드 스펙(Repo 내 텍스트)
+
+- Grafana 패널 스펙(텍스트): `operations/monitoring/world_validation_v1.jsonnet`
+
+### 운영 증빙(권장)
+
+- 증빙 템플릿: `operations/monitoring/samples/world_validation_observability_evidence.md`

--- a/operations/monitoring/samples/world_validation_observability_evidence.md
+++ b/operations/monitoring/samples/world_validation_observability_evidence.md
@@ -1,0 +1,22 @@
+# World Validation 관측성 증빙 템플릿
+
+이 파일은 World Validation 관측성(SLO/알람/대시보드) 운영 증빙을 남기기 위한 템플릿입니다.
+
+## 1) 대시보드
+
+- Grafana 대시보드 UID/링크:
+- 스냅샷(캡처) 링크:
+- 적용된 대시보드 스펙 파일: `operations/monitoring/world_validation_v1.jsonnet`
+
+## 2) 알람 트리거 증빙
+
+- 알람명:
+- 트리거 시각(UTC):
+- Alertmanager 링크:
+- 원인/조치 요약:
+
+## 3) 런북/후속
+
+- 런북 링크: `docs/ko/operations/world_validation_observability.md`
+- 후속 작업/티켓:
+

--- a/operations/monitoring/world_validation_v1.jsonnet
+++ b/operations/monitoring/world_validation_v1.jsonnet
@@ -1,0 +1,126 @@
+{
+  "bundle": "world_validation_observability",
+  "version": 1,
+  "dashboards": [
+    {
+      "uid": "world-validation-overview",
+      "title": "World Validation Overview",
+      "tags": ["world", "validation", "observability"],
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "RiskHub Snapshot Lag (seconds)",
+          "description": "Freshness of the latest RiskHub snapshot per world.",
+          "targets": [
+            {
+              "expr": "risk_hub_snapshot_lag_seconds",
+              "legendFormat": "{{world_id}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "RiskHub Snapshot Processing (rate)",
+          "description": "Processed vs failed snapshot events per world/stage.",
+          "targets": [
+            {
+              "expr": "sum by (world_id, stage) (rate(risk_hub_snapshot_processed_total[5m]))",
+              "legendFormat": "processed {{world_id}}/{{stage}}"
+            },
+            {
+              "expr": "sum by (world_id, stage) (rate(risk_hub_snapshot_failed_total[5m]))",
+              "legendFormat": "failed {{world_id}}/{{stage}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "RiskHub DLQ / Retry / Dedupe / Expired",
+          "description": "Operational signals for snapshot ingestion.",
+          "targets": [
+            {
+              "expr": "sum by (world_id, stage) (increase(risk_hub_snapshot_dlq_total[10m]))",
+              "legendFormat": "dlq {{world_id}}/{{stage}}"
+            },
+            {
+              "expr": "sum by (world_id, stage) (rate(risk_hub_snapshot_retry_total[5m]))",
+              "legendFormat": "retry {{world_id}}/{{stage}}"
+            },
+            {
+              "expr": "sum by (world_id, stage) (rate(risk_hub_snapshot_dedupe_total[5m]))",
+              "legendFormat": "dedupe {{world_id}}/{{stage}}"
+            },
+            {
+              "expr": "sum by (world_id, stage) (rate(risk_hub_snapshot_expired_total[5m]))",
+              "legendFormat": "expired {{world_id}}/{{stage}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "RiskHub Snapshot Processing Latency (p95 seconds)",
+          "description": "p95 time from snapshot creation to WS processing.",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, world_id, stage) (rate(risk_hub_snapshot_processing_latency_seconds_bucket[5m])))",
+              "legendFormat": "{{world_id}}/{{stage}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Extended Validation Runs (rate)",
+          "description": "Success/failure rate for extended validation workers.",
+          "targets": [
+            {
+              "expr": "sum by (world_id, stage) (rate(extended_validation_run_total{status=\"success\"}[5m]))",
+              "legendFormat": "success {{world_id}}/{{stage}}"
+            },
+            {
+              "expr": "sum by (world_id, stage) (rate(extended_validation_run_total{status=~\"failure|enqueue_failed\"}[5m]))",
+              "legendFormat": "failure {{world_id}}/{{stage}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Extended Validation Latency (p95 seconds)",
+          "description": "p95 latency of extended validation runs.",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, world_id, stage) (rate(extended_validation_run_latency_seconds_bucket[5m])))",
+              "legendFormat": "{{world_id}}/{{stage}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Live Monitoring Runs (rate)",
+          "description": "Success/failure rate for live monitoring materialization.",
+          "targets": [
+            {
+              "expr": "sum by (world_id) (rate(live_monitoring_run_total{status=\"success\"}[5m]))",
+              "legendFormat": "success {{world_id}}"
+            },
+            {
+              "expr": "sum by (world_id) (rate(live_monitoring_run_total{status=\"failure\"}[5m]))",
+              "legendFormat": "failure {{world_id}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Live Monitoring Updated Strategies",
+          "description": "Total number of strategies updated by LiveMonitoringWorker.",
+          "targets": [
+            {
+              "expr": "sum by (world_id) (increase(live_monitoring_run_updated_strategies_total[1h]))",
+              "legendFormat": "{{world_id}}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+

--- a/qmtl/services/gateway/dagmanager_client.py
+++ b/qmtl/services/gateway/dagmanager_client.py
@@ -213,6 +213,7 @@ class DagManagerClient:
                     await asyncio.sleep(0.1)
                     continue
                 return False
+        return False
 
     def _infer_namespace(
         self, dag_json: str, world_id: str | None


### PR DESCRIPTION
Summary: Add repo-stored dashboard spec, tune Alertmanager rules for extended validation and lag, and provide an ops evidence template.

Fixes #1925