### PR TITLE
Fixes #1910: WS SSOT contract tests + deprecation guide

### DIFF
--- a/docs/en/guides/sdk_deprecation.md
+++ b/docs/en/guides/sdk_deprecation.md
@@ -1,0 +1,26 @@
+# SDK ValidationPipeline Deprecation Guide
+
+The SDK `ValidationPipeline` is kept only for local precheck (metrics) purposes. WorldService is the single source of truth (SSOT) for policy evaluation and gating. This guide describes the post-migration behavior and emergency bypass steps.
+
+## Default behavior
+- v1.5+: `ValidationPipeline` computes **metrics only** (local policy evaluation/gating removed).
+- The WS evaluation outcome is the final decision; the SDK `precheck` section is informational only.
+
+## Emergency bypass / rollback
+- If WS is unstable (outage/deploy issues), use `Runner.submit(..., auto_validate=False)` to submit without validation and re-evaluate after WS stabilizes.
+- For a hard rollback, pin the SDK version to a known-good release prior to the change.
+
+## Recommended usage
+- In submission/test pipelines, surface WS results (`SubmitResult.ws.*`) as the primary output; keep `precheck` in a separate section.
+- If SDK vs WS results diverge, prioritize WS logs/metrics; use `precheck` only as a debugging hint.
+
+## Rollout (recommended)
+- Order: **Backtest → Paper → Live**
+- Validate at each stage:
+  - `SubmitResult.ws.*` is populated (decision/activation/evaluation_run_url)
+  - `/worlds/{id}/evaluate` 4xx/5xx, latency, and fail-closed rate
+  - Alerts for WS/ControlBus/worker paths (operations dashboards)
+
+## Checklist (DoD)
+- The WS single-entry contract is locked by tests (rule execution/error handling, etc.).
+- This deprecation guide ships together with clear rollout/rollback guidance.

--- a/docs/ko/guides/sdk_deprecation.md
+++ b/docs/ko/guides/sdk_deprecation.md
@@ -14,5 +14,13 @@ SDK의 `ValidationPipeline`은 로컬 사전 점검(precheck) 용도로만 유�
 - 제출/테스트 파이프라인에서는 WS 결과(`SubmitResult.ws.*`)를 사용자에게 표준 출력으로 노출하고, `precheck`는 별도 섹션으로 분리합니다.
 - SDK→WS 불일치가 있을 경우 WS 로그/메트릭을 우선 확인하고, `precheck`는 디버그 힌트로만 사용합니다.
 
-## 추가 단계(예정)
-- WS 단일 오케스트레이션 테스트(룰 실행/오류/오프로드)와 SDK 디프리케이션 알림을 순차적으로 배포합니다.
+## 운영 롤아웃(권장)
+- 순서: **Backtest → Paper → Live**
+- 각 단계에서 확인할 것:
+  - `SubmitResult.ws.*`가 정상 채워지는지(결정/activation/evaluation_run_url)
+  - `/worlds/{id}/evaluate` 4xx/5xx, latency, fail-closed 증가 여부
+  - WS/ControlBus/worker 경로의 알람(운영 대시보드) 이상 유무
+
+## 체크리스트(DoD)
+- WS 단일 진입 계약이 테스트로 고정됨(룰 실행/오류 처리 등).
+- 디프리케이션 가이드가 배포되고, 롤아웃/롤백 가이드가 문서화됨.

--- a/tests/qmtl/runtime/sdk/test_worldservice_eval_contract.py
+++ b/tests/qmtl/runtime/sdk/test_worldservice_eval_contract.py
@@ -1,0 +1,89 @@
+import pytest
+
+from qmtl.runtime.sdk.submit import StrategyMetrics, _evaluate_with_worldservice
+
+
+class _DummyGatewayClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.response: dict[str, object] = {"active": []}
+
+    async def evaluate_strategy(
+        self,
+        *,
+        gateway_url: str,
+        world_id: str,
+        strategy_id: str,
+        metrics: dict,
+        returns: list[float],
+        policy_payload: dict | None,
+        evaluation_run_id: str | None,
+        stage: str | None,
+        risk_tier: str | None,
+    ) -> dict:
+        self.calls.append(
+            {
+                "gateway_url": gateway_url,
+                "world_id": world_id,
+                "strategy_id": strategy_id,
+                "metrics": metrics,
+                "returns": returns,
+                "policy_payload": policy_payload,
+                "evaluation_run_id": evaluation_run_id,
+                "stage": stage,
+                "risk_tier": risk_tier,
+            }
+        )
+        return dict(self.response)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_with_worldservice_uses_gateway_client_and_includes_risk_metrics():
+    client = _DummyGatewayClient()
+    client.response = {"active": ["s1"], "evaluation_run_id": "run-1"}
+    metrics = StrategyMetrics(adv_utilization_p95=0.12, participation_rate_p95=0.34)
+
+    result = await _evaluate_with_worldservice(
+        gateway_url="http://gw",
+        world_id="w",
+        strategy_id="s1",
+        metrics=metrics,
+        returns=[0.01, -0.02, 0.03],
+        preset=None,
+        client=client,  # type: ignore[arg-type]
+        evaluation_run_id="run-1",
+        stage="paper",
+        risk_tier="high",
+    )
+
+    assert result.error is None
+    assert result.evaluation_run_id == "run-1"
+    assert client.calls
+    call = client.calls[0]
+    payload_metrics = call["metrics"]
+    assert payload_metrics["risk"]["adv_utilization_p95"] == 0.12
+    assert payload_metrics["risk"]["participation_rate_p95"] == 0.34
+    assert call["stage"] == "paper"
+    assert call["risk_tier"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_with_worldservice_maps_gateway_error_to_ws_eval_error():
+    client = _DummyGatewayClient()
+    client.response = {"error": "boom"}
+
+    result = await _evaluate_with_worldservice(
+        gateway_url="http://gw",
+        world_id="w",
+        strategy_id="s1",
+        metrics=StrategyMetrics(),
+        returns=[0.01, 0.02],
+        preset=None,
+        client=client,  # type: ignore[arg-type]
+        evaluation_run_id="run-err",
+        stage=None,
+        risk_tier=None,
+    )
+
+    assert result.error == "boom"
+    assert result.evaluation_run_id == "run-err"


### PR DESCRIPTION
Summary:
- Add a contract-style test for the SDK → WS /evaluate integration path (including risk metrics forwarding and error mapping).
- Extend the SDK deprecation guide with rollout guidance and add an English mirror page.

Fixes #1910
Refs #1934
