### PR TITLE
Fixes #1909: producer contract tests + rehearsal docs

### DIFF
--- a/docs/en/operations/risk_signal_hub_runbook.md
+++ b/docs/en/operations/risk_signal_hub_runbook.md
@@ -49,6 +49,16 @@ status: draft
 - Backfill:  
   `python scripts/backfill_risk_snapshots.py --dsn $DB --redis $REDIS --world w1`
 
+### Producer rehearsal (publishing snapshots)
+
+You can rehearse a producer path (e.g., gateway/risk engine) that publishes snapshots containing **realized returns / stress** to the WS hub under the same contract used in production.
+
+- Sample payload: `operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json`
+- Publisher script:
+  - `uv run python scripts/publish_risk_hub_snapshot.py --base-url $WS_URL --world <world_id> --snapshot operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json --token $HUB_TOKEN --actor gateway --stage paper`
+
+`scripts/publish_risk_hub_snapshot.py` validates the shared contract (`qmtl/services/risk_hub_contract.py`) for **weights sum≈1, ttl_sec>0, actor/stage, and hash consistency**, and offloads large payloads to a blob-store when needed (producing refs like `realized_returns_ref`, `stress_ref`, and `covariance_ref`).
+
 ## 6. Tests / validation
 - Unit: `tests/qmtl/services/worldservice/test_risk_hub_*`, `test_risk_snapshot_publisher.py`.
 - E2E (recommended): gateway→hub→ControlBus→WS worker, include large covariance ref and TTL-expired/delayed cases.

--- a/docs/ko/operations/risk_signal_hub_runbook.md
+++ b/docs/ko/operations/risk_signal_hub_runbook.md
@@ -50,6 +50,16 @@ status: draft
 - Backfill:  
   `python scripts/backfill_risk_snapshots.py --dsn $DB --redis $REDIS --world w1`
 
+### 프로듀서 리허설(스냅샷 발행)
+
+프로듀서(예: gateway/리스크 엔진)에서 **realized returns / stress**를 포함한 스냅샷을 WS hub로 발행하는 경로를, 로컬/운영 환경에서 동일한 계약으로 리허설할 수 있습니다.
+
+- 샘플 페이로드: `operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json`
+- 발행 스크립트:
+  - `uv run python scripts/publish_risk_hub_snapshot.py --base-url $WS_URL --world <world_id> --snapshot operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json --token $HUB_TOKEN --actor gateway --stage paper`
+
+`scripts/publish_risk_hub_snapshot.py`는 공통 계약(`qmtl/services/risk_hub_contract.py`)으로 **weights 합≈1, ttl_sec>0, actor/stage, hash 정합성**을 검증하고, 필요 시 blob-store로 offload 후 ref(`realized_returns_ref`, `stress_ref`, `covariance_ref`)를 생성합니다.
+
 ## 6. 테스트/검증
 - 단위: `tests/qmtl/services/worldservice/test_risk_hub_*`, `test_risk_snapshot_publisher.py`.
 - e2e(추천): gateway→hub→ControlBus→WS worker 경로, 큰 공분산 ref 포함, TTL 만료/지연 시나리오.

--- a/operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json
+++ b/operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json
@@ -1,0 +1,16 @@
+{
+  "as_of": "2025-01-01T00:00:00Z",
+  "version": "v1",
+  "weights": {
+    "strategy_a": 0.6,
+    "strategy_b": 0.4
+  },
+  "realized_returns": {
+    "strategy_a": [0.01, -0.005, 0.002],
+    "strategy_b": [0.008, -0.004, 0.001]
+  },
+  "stress": {
+    "crash": {"max_drawdown": 0.25},
+    "slowdown": {"max_drawdown": 0.12}
+  }
+}

--- a/tests/qmtl/services/test_risk_hub_contract.py
+++ b/tests/qmtl/services/test_risk_hub_contract.py
@@ -110,3 +110,58 @@ def test_normalize_and_validate_snapshot_enforces_stage_allowlist():
             payload,
             allowed_stages=["staging"],
         )
+
+
+def test_normalize_and_validate_snapshot_rejects_header_actor_mismatch():
+    payload = {
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+        "provenance": {"actor": "gateway", "stage": "paper"},
+    }
+    with pytest.raises(ValueError, match="actor mismatch"):
+        normalize_and_validate_snapshot(
+            "w",
+            payload,
+            actor="risk-engine",
+        )
+
+
+def test_normalize_and_validate_snapshot_rejects_header_stage_mismatch():
+    payload = {
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+        "provenance": {"actor": "gateway", "stage": "paper"},
+    }
+    with pytest.raises(ValueError, match="stage mismatch"):
+        normalize_and_validate_snapshot(
+            "w",
+            payload,
+            actor="gateway",
+            stage="live",
+        )
+
+
+def test_normalize_and_validate_snapshot_rejects_non_positive_ttl():
+    payload = {
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+        "ttl_sec": 0,
+        "provenance": {"actor": "gateway", "stage": "paper"},
+    }
+    with pytest.raises(ValueError, match="ttl_sec must be positive"):
+        normalize_and_validate_snapshot("w", payload)
+
+
+def test_normalize_and_validate_snapshot_rejects_hash_mismatch():
+    payload = {
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+        "hash": "not-a-real-hash",
+        "provenance": {"actor": "gateway", "stage": "paper"},
+    }
+    with pytest.raises(ValueError, match="hash mismatch"):
+        normalize_and_validate_snapshot("w", payload)


### PR DESCRIPTION
Summary:
- Expand RiskHub snapshot contract tests (header mismatch, ttl, hash consistency).
- Add a producer rehearsal section to the Risk Signal Hub runbook (ko/en) with a sample payload and publishing command.

Fixes #1909
Refs #1934
