### PR TITLE
Fixes #1911: override re-review queue workflow

### DIFF
--- a/.github/workflows/override-rereview-queue.yml
+++ b/.github/workflows/override-rereview-queue.yml
@@ -1,0 +1,62 @@
+name: override-rereview-queue
+
+on:
+  workflow_dispatch:
+    inputs:
+      worlds:
+        description: "Comma-separated world ids (empty = all worlds)"
+        required: false
+        default: ""
+  schedule:
+    - cron: "5 4 * * *" # Daily 04:05 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  queue:
+    runs-on: ubuntu-latest
+    env:
+      WORLDS_DB_DSN: ${{ secrets.WORLDS_DB_DSN }}
+      WORLDS_REDIS_DSN: ${{ secrets.WORLDS_REDIS_DSN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip if secrets missing
+        if: ${{ env.WORLDS_DB_DSN == '' || env.WORLDS_REDIS_DSN == '' }}
+        run: |
+          echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping override re-review job."
+          exit 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]"
+
+      - name: Generate override re-review queue
+        shell: bash
+        run: |
+          set -euo pipefail
+          worlds="${{ inputs.worlds || '' }}"
+          args=()
+          if [[ -n "$worlds" ]]; then
+            IFS=',' read -r -a world_list <<< "$worlds"
+            for w in "${world_list[@]}"; do
+              w_trim="$(echo "$w" | xargs)"
+              if [[ -n "$w_trim" ]]; then
+                args+=(--world "$w_trim")
+              fi
+            done
+          fi
+          uv run python scripts/generate_override_rereview_report.py "${args[@]}" --format md --output override_queue.md
+          uv run python scripts/generate_override_rereview_report.py "${args[@]}" --format json --output override_queue.json
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: override-rereview-queue
+          path: |
+            override_queue.md
+            override_queue.json
+

--- a/docs/en/operations/world_validation_governance.md
+++ b/docs/en/operations/world_validation_governance.md
@@ -27,6 +27,8 @@ Current defaults in code:
 
 - Storage-based (recommended):  
   `uv run python scripts/generate_override_rereview_report.py --output override_queue.md`
+- GitHub Actions schedule (recommended):  
+  `.github/workflows/override-rereview-queue.yml` (auto-skips if secrets are missing + uploads report artifacts)
 - API-based (per world):  
   `GET /worlds/{world_id}/validations/invariants` → inspect `approved_overrides`
 
@@ -39,4 +41,3 @@ Each `approved_overrides` entry includes `review_due_at`, `review_overdue`, and 
    - remove the override (normalize), or
    - renew the override (update reason/actor/timestamp) and record follow-ups
 3) For recurring overrides, feed back into policy/rules and investigate root causes (data, rebalancing, risk signals, rule design).
-

--- a/docs/ko/operations/world_validation_governance.md
+++ b/docs/ko/operations/world_validation_governance.md
@@ -27,6 +27,8 @@ approved override에는 아래 필드를 반드시 기록합니다.
 
 - 스토리지 기반(권장):  
   `uv run python scripts/generate_override_rereview_report.py --output override_queue.md`
+- GitHub Actions 스케줄(권장):  
+  `.github/workflows/override-rereview-queue.yml` (secrets 미설정 시 자동 skip + 리포트 아티팩트 업로드)
 - API 기반(월드별):  
   `GET /worlds/{world_id}/validations/invariants` → `approved_overrides` 확인
 
@@ -39,4 +41,3 @@ approved override에는 아래 필드를 반드시 기록합니다.
    - override 해제(정상화) 또는
    - override 갱신(사유/승인자/시각 갱신) 및 추가 조치 기록
 3) 반복 발생 전략/월드는 원인 분석(룰/데이터/리밸런스/리스크 신호) 및 정책/룰 보강으로 연결합니다.
-


### PR DESCRIPTION
Summary:
- Add scheduled GitHub Actions workflow to generate the override re-review queue report and upload artifacts.
- Document the workflow in the governance runbook (ko/en).

Fixes #1911
Refs #1934
