### PR TITLE
[WV] Benchmark metrics 저장 + 상대평가 룰

### DIFF
--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -402,6 +402,12 @@ class RobustnessMetrics(BaseModel):
     sharpe_second_half: float | None = None
 
 
+class BenchmarkMetrics(BaseModel):
+    sharpe: float | None = None
+    max_drawdown: float | None = None
+    volatility: float | None = None
+
+
 class ValidationHealth(BaseModel):
     metric_coverage_ratio: float | None = None
     rules_executed_ratio: float | None = None
@@ -423,6 +429,7 @@ class EvaluationMetrics(BaseModel):
     risk: RiskMetrics | None = None
     robustness: RobustnessMetrics | None = None
     diagnostics: DiagnosticsMetrics | None = None
+    benchmark: BenchmarkMetrics | None = None
 
 
 class RuleResultModel(BaseModel):


### PR DESCRIPTION
Summary:
- EvaluationRun에 benchmark 메트릭 블록을 저장(based schema)
- challenger vs benchmark 비교 지표(vs_benchmark_sharpe) 주입 + 정책 룰 지원
- API 계약/회귀 테스트 추가

Fixes #1944
Refs #1941
