### PR TITLE
[WV] Cohort/Campaign 평가 모델 + CohortRule 고도화

### DIFF
--- a/qmtl/services/worldservice/routers/activation.py
+++ b/qmtl/services/worldservice/routers/activation.py
@@ -12,6 +12,8 @@ from ..schemas import (
     ApplyAck,
     ApplyRequest,
     ApplyResponse,
+    CohortEvaluateRequest,
+    CohortEvaluateResponse,
     EvaluateRequest,
 )
 from ..services import WorldService
@@ -48,6 +50,12 @@ def create_activation_router(service: WorldService) -> APIRouter:
     @router.post('/worlds/{world_id}/evaluate', response_model=ApplyResponse)
     async def post_evaluate(world_id: str, payload: EvaluateRequest) -> ApplyResponse:
         return await service.evaluate(world_id, payload)
+
+    @router.post('/worlds/{world_id}/evaluate-cohort', response_model=CohortEvaluateResponse)
+    async def post_evaluate_cohort(
+        world_id: str, payload: CohortEvaluateRequest
+    ) -> CohortEvaluateResponse:
+        return await service.evaluate_cohort(world_id, payload)
 
     @router.post('/worlds/{world_id}/apply', response_model=ApplyAck)
     async def post_apply(world_id: str, payload: ApplyRequest) -> ApplyAck:

--- a/scripts/generate_validation_report.py
+++ b/scripts/generate_validation_report.py
@@ -227,6 +227,8 @@ def generate_markdown_report(evaluation_run: Mapping[str, Any], model_card: Mapp
     summary = summary_raw if isinstance(summary_raw, Mapping) else {}
     summary_status = _coerce_str(summary.get("status"), "unknown")
     recommended_stage = _coerce_str(summary.get("recommended_stage"), "")
+    campaign_id = _coerce_str(summary.get("campaign_id"), "")
+    campaign_candidates = _string_list(summary.get("campaign_candidates"))
     model_card_version = _coerce_str(
         evaluation_run.get("model_card_version") or model_card.get("model_card_version"),
         "",
@@ -270,6 +272,10 @@ def generate_markdown_report(evaluation_run: Mapping[str, Any], model_card: Mapp
     lines.append(_summary_line("World", world_id))
     lines.append(_summary_line("Strategy", strategy_id))
     lines.append(_summary_line("Run ID", run_id))
+    if campaign_id:
+        lines.append(_summary_line("Campaign ID", campaign_id))
+    if campaign_candidates:
+        lines.append(_summary_line("Campaign candidates", ", ".join(campaign_candidates)))
     lines.append(_summary_line("Stage", stage))
     lines.append(_summary_line("Risk tier", risk_tier))
     lines.append(_summary_line("Model card version", model_card_version or "(not provided)"))

--- a/tests/scripts/test_generate_validation_report.py
+++ b/tests/scripts/test_generate_validation_report.py
@@ -15,7 +15,12 @@ def _sample_evaluation_run() -> dict:
         "run_id": "eval-123",
         "stage": "backtest",
         "risk_tier": "medium",
-        "summary": {"status": "warn", "recommended_stage": "paper_only"},
+        "summary": {
+            "status": "warn",
+            "recommended_stage": "paper_only",
+            "campaign_id": "camp-1",
+            "campaign_candidates": ["strat-a", "strat-b"],
+        },
         "validation": {
             "policy_version": "v1",
             "ruleset_hash": "abc123",
@@ -73,6 +78,8 @@ def test_generate_markdown_report_includes_core_fields() -> None:
 
     assert "Validation Report — strat-a @ world-demo" in report
     assert "- Run ID: eval-123" in report
+    assert "- Campaign ID: camp-1" in report
+    assert "- Campaign candidates: strat-a, strat-b" in report
     assert "- Stage: backtest" in report
     assert "- Recommended stage: paper_only" in report
     assert "- Extended revision: 2" in report
@@ -111,5 +118,6 @@ def test_cli_writes_report_file(tmp_path: Path, monkeypatch, capsys) -> None:
     report = out_path.read_text(encoding="utf-8")
     captured = capsys.readouterr()
     assert "Validation Report — strat-a @ world-demo" in report
+    assert "- Campaign ID: camp-1" in report
     assert "written to" in captured.out
     assert "Extended validation" in report


### PR DESCRIPTION
Summary:
- /worlds/{id}/evaluate-cohort 엔드포인트 추가(campaign_id + multi-strategy 평가)
- 캠페인 컨텍스트(campaign_id/candidates)를 EvaluationRun.summary로 저장 + API/리포트 노출
- 회귀/계약 테스트 추가

Fixes #1945
Refs #1941
