### PR TITLE
[WV] Stress scenario contract/룰 고도화 (stress_ref)

### DIFF
--- a/docs/en/operations/risk_signal_hub_runbook.md
+++ b/docs/en/operations/risk_signal_hub_runbook.md
@@ -54,6 +54,9 @@ status: draft
 You can rehearse a producer path (e.g., gateway/risk engine) that publishes snapshots containing **realized returns / stress** to the WS hub under the same contract used in production.
 
 - Sample payload: `operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json`
+- Stress ref rehearsal (force offload):
+  - Sample payload: `operations/risk_hub/samples/risk_snapshot_with_stress_ref.json`
+  - Command: `uv run python scripts/publish_risk_hub_snapshot.py --base-url $WS_URL --world <world_id> --snapshot operations/risk_hub/samples/risk_snapshot_with_stress_ref.json --token $HUB_TOKEN --actor gateway --stage paper --inline-threshold 1`
 - Publisher script:
   - `uv run python scripts/publish_risk_hub_snapshot.py --base-url $WS_URL --world <world_id> --snapshot operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json --token $HUB_TOKEN --actor gateway --stage paper`
 

--- a/docs/ko/operations/risk_signal_hub_runbook.md
+++ b/docs/ko/operations/risk_signal_hub_runbook.md
@@ -55,6 +55,9 @@ status: draft
 프로듀서(예: gateway/리스크 엔진)에서 **realized returns / stress**를 포함한 스냅샷을 WS hub로 발행하는 경로를, 로컬/운영 환경에서 동일한 계약으로 리허설할 수 있습니다.
 
 - 샘플 페이로드: `operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json`
+- Stress ref 리허설(오프로드 강제):
+  - 샘플 페이로드: `operations/risk_hub/samples/risk_snapshot_with_stress_ref.json`
+  - 실행: `uv run python scripts/publish_risk_hub_snapshot.py --base-url $WS_URL --world <world_id> --snapshot operations/risk_hub/samples/risk_snapshot_with_stress_ref.json --token $HUB_TOKEN --actor gateway --stage paper --inline-threshold 1`
 - 발행 스크립트:
   - `uv run python scripts/publish_risk_hub_snapshot.py --base-url $WS_URL --world <world_id> --snapshot operations/risk_hub/samples/risk_snapshot_with_realized_and_stress.json --token $HUB_TOKEN --actor gateway --stage paper`
 

--- a/operations/risk_hub/samples/risk_snapshot_with_stress_ref.json
+++ b/operations/risk_hub/samples/risk_snapshot_with_stress_ref.json
@@ -1,0 +1,20 @@
+{
+  "as_of": "2025-01-01T00:00:00Z",
+  "version": "v1",
+  "weights": {
+    "strategy_a": 0.6,
+    "strategy_b": 0.4
+  },
+  "stress": {
+    "crash": {
+      "max_drawdown": 0.25,
+      "var_99": 0.12,
+      "es_99": 0.15
+    },
+    "slowdown": {
+      "max_drawdown": 0.12,
+      "var_99": 0.05,
+      "es_99": 0.07
+    }
+  }
+}

--- a/tests/qmtl/services/worldservice/test_extended_validation_worker.py
+++ b/tests/qmtl/services/worldservice/test_extended_validation_worker.py
@@ -256,7 +256,7 @@ async def test_extended_worker_injects_stress_from_hub_ref(tmp_path):
     storage = Storage()
     await storage.create_world({"id": "wstress"})
     policy_payload = {
-        "stress": {"scenarios": {"crash": {"dd_max": 0.3}}, "severity": "soft"},
+        "stress": {"scenarios": {"crash": {"dd_max": 0.3, "var_99": 0.01}}, "severity": "soft"},
     }
     policy = parse_policy(policy_payload)
     version = await storage.add_policy("wstress", policy)
@@ -277,7 +277,7 @@ async def test_extended_worker_injects_stress_from_hub_ref(tmp_path):
     hub = RiskSignalHub(blob_store=blob_store)
     stress_ref = blob_store.write(
         "stress",
-        {"s-stress": {"crash": {"max_drawdown": 0.2}}},
+        {"s-stress": {"crash": {"var_99": 0.02}}},
     )
     snap = PortfolioSnapshot(
         world_id="wstress",
@@ -297,4 +297,5 @@ async def test_extended_worker_injects_stress_from_hub_ref(tmp_path):
     assert record is not None
     results = record["validation"]["results"]
     assert "stress" in results
-    assert results["stress"]["reason_code"] != "crash_dd_missing"
+    assert results["stress"]["status"] == "fail"
+    assert results["stress"]["reason_code"] == "crash_var_exceeds_max"


### PR DESCRIPTION
Summary:
- StressRule 평가를 monotonic(fail>warn) + reason_code 우선순위로 고정
- stress_ref(오프로드) 경로를 var_99 케이스까지 포함해 회귀 테스트로 고정
- RiskHub 런북에 stress_ref 리허설/샘플 추가(ko/en)

Fixes #1947
Refs #1941
