### PR TITLE
[WV] Validation SLO scenarios + CI gate

### DIFF
--- a/.github/workflows/policy-diff-regression.yml
+++ b/.github/workflows/policy-diff-regression.yml
@@ -98,32 +98,74 @@ jobs:
           head_sha="$(git rev-parse HEAD)"
 
           policy_path="docs/ko/world/sample_policy.yml"
-          runs_dir="operations/policy_diff/bad_strategies_runs"
+          scenarios=(
+            "good:operations/policy_diff/good_strategies_runs"
+            "borderline:operations/policy_diff/borderline_strategies_runs"
+            "bad:operations/policy_diff/bad_strategies_runs"
+          )
 
-          PYTHONPATH="$PWD/baseline" uv run python scripts/policy_snapshot.py \
-            --policy "baseline/$policy_path" \
-            --runs-dir "baseline/$runs_dir" \
-            --runs-pattern '*.json' \
-            --stage "$stage" \
-            --revision "$base_sha" \
-            --policy-version "baseline:$base_sha" \
-            --output baseline_snapshot.json
+          for entry in "${scenarios[@]}"; do
+            name="${entry%%:*}"
+            runs_dir="${entry#*:}"
 
-          uv run python scripts/policy_snapshot.py \
-            --policy "$policy_path" \
-            --runs-dir "$runs_dir" \
-            --runs-pattern '*.json' \
-            --stage "$stage" \
-            --revision "$head_sha" \
-            --policy-version "head:$head_sha" \
-            --output head_snapshot.json
+            baseline_runs_dir="baseline/$runs_dir"
+            if [[ ! -d "$baseline_runs_dir" ]]; then
+              baseline_runs_dir="$runs_dir"
+            fi
 
-          uv run python scripts/policy_snapshot_diff.py \
-            --old baseline_snapshot.json \
-            --new head_snapshot.json \
-            --fail-impact-ratio "$fail_ratio" \
-            --output policy_diff_report.json \
-            --output-md policy_diff_report.md
+            PYTHONPATH="$PWD/baseline" uv run python scripts/policy_snapshot.py \
+              --policy "baseline/$policy_path" \
+              --runs-dir "$baseline_runs_dir" \
+              --runs-pattern '*.json' \
+              --stage "$stage" \
+              --revision "$base_sha" \
+              --policy-version "baseline:$base_sha" \
+              --output "baseline_snapshot_${name}.json"
+
+            uv run python scripts/policy_snapshot.py \
+              --policy "$policy_path" \
+              --runs-dir "$runs_dir" \
+              --runs-pattern '*.json' \
+              --stage "$stage" \
+              --revision "$head_sha" \
+              --policy-version "head:$head_sha" \
+              --output "head_snapshot_${name}.json"
+
+            uv run python scripts/policy_snapshot_diff.py \
+              --old "baseline_snapshot_${name}.json" \
+              --new "head_snapshot_${name}.json" \
+              --fail-impact-ratio "$fail_ratio" \
+              --output "policy_diff_report_${name}.json" \
+              --output-md "policy_diff_report_${name}.md"
+
+            case "$name" in
+              good)
+                uv run python scripts/policy_scenario_check.py \
+                  --snapshot "head_snapshot_${name}.json" \
+                  --output "scenario_summary_${name}.json" \
+                  --min-pass-ratio 1.0 \
+                  --max-fail-ratio 0.0 \
+                  --max-unknown-ratio 0.0
+                ;;
+              bad)
+                uv run python scripts/policy_scenario_check.py \
+                  --snapshot "head_snapshot_${name}.json" \
+                  --output "scenario_summary_${name}.json" \
+                  --min-fail-ratio 0.5 \
+                  --max-unknown-ratio 0.0
+                ;;
+              borderline)
+                uv run python scripts/policy_scenario_check.py \
+                  --snapshot "head_snapshot_${name}.json" \
+                  --output "scenario_summary_${name}.json" \
+                  --min-pass-ratio 0.1 \
+                  --max-pass-ratio 0.9 \
+                  --min-fail-ratio 0.1 \
+                  --max-fail-ratio 0.9 \
+                  --max-unknown-ratio 0.0
+                ;;
+            esac
+          done
 
       - name: Write skip report
         if: ${{ steps.baseline.outputs.skip == 'true' }}
@@ -134,11 +176,13 @@ jobs:
           echo "# Policy Regression Report (Skipped)" > policy_diff_report.md
 
       - name: Upload report
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: policy-diff-report
           path: |
-            policy_diff_report.json
-            policy_diff_report.md
-            baseline_snapshot.json
-            head_snapshot.json
+            policy_diff_report*.json
+            policy_diff_report*.md
+            baseline_snapshot_*.json
+            head_snapshot_*.json
+            scenario_summary_*.json

--- a/docs/ko/operations/independent_validation.md
+++ b/docs/ko/operations/independent_validation.md
@@ -43,18 +43,27 @@
 
 - `.github/workflows/policy-diff-regression.yml`
 
-기본 시나리오 세트:
+기본 시나리오 세트(Good/Borderline/Bad):
 
+- `operations/policy_diff/good_strategies_runs/*.json`
+- `operations/policy_diff/borderline_strategies_runs/*.json`
 - `operations/policy_diff/bad_strategies_runs/*.json`
 
 산출물(artifact):
 
-- base/head 스냅샷
-- diff 리포트(JSON/Markdown)
+- base/head 스냅샷(시나리오별)
+- diff 리포트(JSON/Markdown, 시나리오별)
+- 시나리오 SLO 요약(JSON, head 기준)
 
 임계 초과 시 실패(기본값 5%):
 
 - `fail_impact_ratio` (0~1)
+
+시나리오 SLO 게이트(기본값):
+
+- good: `pass_ratio=1.0`, `fail_ratio=0.0`, `unknown_ratio=0.0`
+- borderline: `pass_ratio`/`fail_ratio` 모두 `0.1~0.9`, `unknown_ratio=0.0`
+- bad: `fail_ratio>=0.5`, `unknown_ratio=0.0`
 
 ## 변경 로그(최소 포맷)
 
@@ -73,11 +82,16 @@ uv run python scripts/policy_snapshot.py \
   --policy docs/ko/world/sample_policy.yml \
   --runs-dir operations/policy_diff/bad_strategies_runs \
   --stage backtest \
-  --output head_snapshot.json
+  --output head_snapshot_bad.json
+
+uv run python scripts/policy_scenario_check.py \
+  --snapshot head_snapshot_bad.json \
+  --min-fail-ratio 0.5 \
+  --max-unknown-ratio 0.0
 
 uv run python scripts/policy_snapshot_diff.py \
   --old base_snapshot.json \
-  --new head_snapshot.json \
+  --new head_snapshot_bad.json \
   --fail-impact-ratio 0.05 \
   --output policy_regression_report.json \
   --output-md policy_regression_report.md

--- a/operations/policy_diff/borderline_strategies_runs/borderline_strategies_runs.json
+++ b/operations/policy_diff/borderline_strategies_runs/borderline_strategies_runs.json
@@ -1,0 +1,71 @@
+[
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "borderline_floor",
+    "run_id": "borderline-set-001",
+    "metrics": {
+      "returns": {
+        "sharpe": 0.6,
+        "max_drawdown": 0.25,
+        "gain_to_pain_ratio": 1.0
+      },
+      "sample": {
+        "effective_history_years": 2.0,
+        "n_trades_total": 50
+      },
+      "risk": {
+        "adv_utilization_p95": 0.5,
+        "participation_rate_p95": 0.4
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.15
+      }
+    }
+  },
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "borderline_hysteresis_blocked",
+    "run_id": "borderline-set-002",
+    "metrics": {
+      "returns": {
+        "sharpe": 0.59,
+        "max_drawdown": 0.2,
+        "gain_to_pain_ratio": 1.2
+      },
+      "sample": {
+        "effective_history_years": 3.0,
+        "n_trades_total": 100
+      },
+      "risk": {
+        "adv_utilization_p95": 0.2,
+        "participation_rate_p95": 0.1
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.2
+      }
+    }
+  },
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "borderline_close",
+    "run_id": "borderline-set-003",
+    "metrics": {
+      "returns": {
+        "sharpe": 0.61,
+        "max_drawdown": 0.249,
+        "gain_to_pain_ratio": 1.01
+      },
+      "sample": {
+        "effective_history_years": 2.01,
+        "n_trades_total": 55
+      },
+      "risk": {
+        "adv_utilization_p95": 0.49,
+        "participation_rate_p95": 0.39
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.151
+      }
+    }
+  }
+]

--- a/operations/policy_diff/good_strategies_runs/good_strategies_runs.json
+++ b/operations/policy_diff/good_strategies_runs/good_strategies_runs.json
@@ -1,0 +1,71 @@
+[
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "good_set_1",
+    "run_id": "good-set-001",
+    "metrics": {
+      "returns": {
+        "sharpe": 1.2,
+        "max_drawdown": 0.12,
+        "gain_to_pain_ratio": 1.8
+      },
+      "sample": {
+        "effective_history_years": 5.0,
+        "n_trades_total": 500
+      },
+      "risk": {
+        "adv_utilization_p95": 0.1,
+        "participation_rate_p95": 0.05
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.8
+      }
+    }
+  },
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "good_set_2",
+    "run_id": "good-set-002",
+    "metrics": {
+      "returns": {
+        "sharpe": 0.9,
+        "max_drawdown": 0.18,
+        "gain_to_pain_ratio": 1.4
+      },
+      "sample": {
+        "effective_history_years": 3.5,
+        "n_trades_total": 220
+      },
+      "risk": {
+        "adv_utilization_p95": 0.2,
+        "participation_rate_p95": 0.1
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.5
+      }
+    }
+  },
+  {
+    "world_id": "policy-diff",
+    "strategy_id": "good_set_3",
+    "run_id": "good-set-003",
+    "metrics": {
+      "returns": {
+        "sharpe": 0.7,
+        "max_drawdown": 0.2,
+        "gain_to_pain_ratio": 1.2
+      },
+      "sample": {
+        "effective_history_years": 2.5,
+        "n_trades_total": 120
+      },
+      "risk": {
+        "adv_utilization_p95": 0.3,
+        "participation_rate_p95": 0.2
+      },
+      "robustness": {
+        "deflated_sharpe_ratio": 0.2
+      }
+    }
+  }
+]

--- a/scripts/policy_scenario_check.py
+++ b/scripts/policy_scenario_check.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Scenario SLO guardrails for policy snapshots.
+
+This tool consumes a JSON snapshot produced by ``scripts/policy_snapshot.py`` and
+enforces simple ratio-based constraints (e.g., good set should have 0 fails).
+
+Intended for CI gating on validation policy/rule changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ScenarioSummary:
+    total: int
+    passed: int
+    warned: int
+    failed: int
+    unknown: int
+
+    @property
+    def pass_ratio(self) -> float:
+        return self.passed / self.total if self.total else 0.0
+
+    @property
+    def warn_ratio(self) -> float:
+        return self.warned / self.total if self.total else 0.0
+
+    @property
+    def fail_ratio(self) -> float:
+        return self.failed / self.total if self.total else 0.0
+
+    @property
+    def unknown_ratio(self) -> float:
+        return self.unknown / self.total if self.total else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total": self.total,
+            "passed": self.passed,
+            "warned": self.warned,
+            "failed": self.failed,
+            "unknown": self.unknown,
+            "pass_ratio": self.pass_ratio,
+            "warn_ratio": self.warn_ratio,
+            "fail_ratio": self.fail_ratio,
+            "unknown_ratio": self.unknown_ratio,
+        }
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def summarize_snapshot(snapshot: Mapping[str, Any]) -> ScenarioSummary:
+    strategies = snapshot.get("strategies") if isinstance(snapshot.get("strategies"), Mapping) else {}
+    passed = warned = failed = unknown = 0
+    for entry in strategies.values():
+        status = entry.get("status") if isinstance(entry, Mapping) else None
+        if status == "pass":
+            passed += 1
+        elif status == "warn":
+            warned += 1
+        elif status == "fail":
+            failed += 1
+        else:
+            unknown += 1
+    total = len(strategies)
+    return ScenarioSummary(total=total, passed=passed, warned=warned, failed=failed, unknown=unknown)
+
+
+def _check_ratio(name: str, value: float, *, min_value: float | None, max_value: float | None) -> list[str]:
+    errors: list[str] = []
+    if min_value is not None and value < min_value:
+        errors.append(f"{name} {value:.3f} < min {min_value:.3f}")
+    if max_value is not None and value > max_value:
+        errors.append(f"{name} {value:.3f} > max {max_value:.3f}")
+    return errors
+
+
+def check_snapshot(
+    snapshot: Mapping[str, Any],
+    *,
+    min_pass_ratio: float | None,
+    max_pass_ratio: float | None,
+    min_warn_ratio: float | None,
+    max_warn_ratio: float | None,
+    min_fail_ratio: float | None,
+    max_fail_ratio: float | None,
+    min_unknown_ratio: float | None,
+    max_unknown_ratio: float | None,
+) -> tuple[ScenarioSummary, list[str]]:
+    summary = summarize_snapshot(snapshot)
+    errors: list[str] = []
+    errors.extend(_check_ratio("pass_ratio", summary.pass_ratio, min_value=min_pass_ratio, max_value=max_pass_ratio))
+    errors.extend(_check_ratio("warn_ratio", summary.warn_ratio, min_value=min_warn_ratio, max_value=max_warn_ratio))
+    errors.extend(_check_ratio("fail_ratio", summary.fail_ratio, min_value=min_fail_ratio, max_value=max_fail_ratio))
+    errors.extend(
+        _check_ratio(
+            "unknown_ratio",
+            summary.unknown_ratio,
+            min_value=min_unknown_ratio,
+            max_value=max_unknown_ratio,
+        )
+    )
+    return summary, errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Enforce ratio-based SLO constraints over a policy snapshot.")
+    parser.add_argument("--snapshot", required=True, type=Path, help="Snapshot JSON produced by policy_snapshot.py")
+    parser.add_argument("--output", type=Path, default=None, help="Optional output path for summary JSON")
+    parser.add_argument("--min-pass-ratio", type=float, default=None)
+    parser.add_argument("--max-pass-ratio", type=float, default=None)
+    parser.add_argument("--min-warn-ratio", type=float, default=None)
+    parser.add_argument("--max-warn-ratio", type=float, default=None)
+    parser.add_argument("--min-fail-ratio", type=float, default=None)
+    parser.add_argument("--max-fail-ratio", type=float, default=None)
+    parser.add_argument("--min-unknown-ratio", type=float, default=None)
+    parser.add_argument("--max-unknown-ratio", type=float, default=None)
+    args = parser.parse_args()
+
+    snapshot = _load_json(args.snapshot)
+    summary, errors = check_snapshot(
+        snapshot,
+        min_pass_ratio=args.min_pass_ratio,
+        max_pass_ratio=args.max_pass_ratio,
+        min_warn_ratio=args.min_warn_ratio,
+        max_warn_ratio=args.max_warn_ratio,
+        min_fail_ratio=args.min_fail_ratio,
+        max_fail_ratio=args.max_fail_ratio,
+        min_unknown_ratio=args.min_unknown_ratio,
+        max_unknown_ratio=args.max_unknown_ratio,
+    )
+    payload = summary.to_dict()
+    if args.output is not None:
+        args.output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    if errors:
+        raise SystemExit("Scenario SLO check failed: " + "; ".join(errors))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_policy_scenario_check.py
+++ b/tests/scripts/test_policy_scenario_check.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from scripts import policy_scenario_check
+
+
+def test_policy_scenario_check_summarizes_statuses():
+    snapshot = {
+        "strategies": {
+            "s1": {"status": "pass"},
+            "s2": {"status": "warn"},
+            "s3": {"status": "fail"},
+            "s4": {"status": "weird"},
+        }
+    }
+
+    summary = policy_scenario_check.summarize_snapshot(snapshot)
+    assert summary.total == 4
+    assert summary.passed == 1
+    assert summary.warned == 1
+    assert summary.failed == 1
+    assert summary.unknown == 1
+
+
+def test_policy_scenario_check_enforces_ratio_thresholds():
+    snapshot = {
+        "strategies": {
+            "s1": {"status": "pass"},
+            "s2": {"status": "pass"},
+            "s3": {"status": "fail"},
+            "s4": {"status": "fail"},
+        }
+    }
+
+    summary, errors = policy_scenario_check.check_snapshot(
+        snapshot,
+        min_pass_ratio=0.75,
+        max_pass_ratio=None,
+        min_warn_ratio=None,
+        max_warn_ratio=None,
+        min_fail_ratio=None,
+        max_fail_ratio=0.1,
+        min_unknown_ratio=None,
+        max_unknown_ratio=0.0,
+    )
+
+    assert summary.total == 4
+    assert errors
+    assert any("pass_ratio" in message for message in errors)
+    assert any("fail_ratio" in message for message in errors)


### PR DESCRIPTION
Summary:
- Define Good/Borderline/Bad policy-diff scenario sets
- Add ratio-based scenario SLO checker and gate it in policy-diff-regression CI (artifacts always uploaded)

Fixes #1950
Refs #1941
