### PR TITLE
Make live monitoring CI manual-only

### DIFF
--- a/.github/workflows/live-monitoring-schedule.yml
+++ b/.github/workflows/live-monitoring-schedule.yml
@@ -23,8 +23,6 @@ on:
         description: "Base dir for file blob store (when blob_store_type=file)"
         required: false
         default: ".risk_blobs"
-  schedule:
-    - cron: "13 */2 * * *" # Every 2 hours at :13 UTC
 
 permissions:
   contents: read
@@ -105,4 +103,3 @@ jobs:
           path: |
             live_monitoring_report.md
             live_monitoring_report.json
-

--- a/docs/en/operations/world_validation_observability.md
+++ b/docs/en/operations/world_validation_observability.md
@@ -51,7 +51,9 @@ This document defines core SLIs/SLOs and dashboard/alert criteria so the WorldSe
 - Operational entrypoints (examples):
   - Live run generator (cron/daemon): `uv run python scripts/live_monitoring_worker.py --interval-seconds 3600`
   - Report generator (Markdown/JSON): `uv run python scripts/generate_live_monitoring_report.py --world <world_id> --output live_report.md`
-  - GitHub Actions schedule (recommended): `.github/workflows/live-monitoring-schedule.yml` (auto-skips if secrets are missing + uploads report artifacts)
+  - GitHub Actions schedule (recommended): `.github/workflows/live-monitoring-schedule.yml`
+    - Current: manual-only (`workflow_dispatch`) during pre-deployment development (scheduled runs can be reintroduced after deployment)
+    - Auto-skips if secrets are missing + uploads report artifacts
 
 ### 6) Validation Health / Invariants
 

--- a/docs/ko/operations/world_validation_observability.md
+++ b/docs/ko/operations/world_validation_observability.md
@@ -51,7 +51,9 @@
 - 운영 엔트리포인트(예시):
   - Live run 생성(크론/데몬): `uv run python scripts/live_monitoring_worker.py --interval-seconds 3600`
   - 리포트 생성(Markdown/JSON): `uv run python scripts/generate_live_monitoring_report.py --world <world_id> --output live_report.md`
-  - GitHub Actions 스케줄(권장): `.github/workflows/live-monitoring-schedule.yml` (secrets 미설정 시 자동 skip + 리포트 아티팩트 업로드)
+  - GitHub Actions 스케줄(권장): `.github/workflows/live-monitoring-schedule.yml`
+    - 현재: 배포 전 개발 단계에서는 **수동(workflow_dispatch) 전용**으로 운영(주기 실행은 배포 이후 재도입)
+    - secrets 미설정 시 자동 skip + 리포트 아티팩트 업로드
 
 ### 6) Validation Health / Invariants
 


### PR DESCRIPTION
Summary: Remove the scheduled trigger for live monitoring CI to avoid noisy failures before deployment.\n\nNotes: Workflow remains available via workflow_dispatch.\n