### PR TITLE
Risk Signal Hub v1: TTL=900s, stage-required, conflict-safe

### DIFF
--- a/docs/ko/design/core_loop_world_roadmap.md
+++ b/docs/ko/design/core_loop_world_roadmap.md
@@ -27,6 +27,9 @@ status: draft
 
 - 모드는 **사용자가 직접 선택하는 플래그**가 아니라,  
   **월드 정책과 WorldService가 결정하는 상태**에 가깝게 재정의한다.
+- “검증/리스크/exit에 필요한 입력 데이터”는 WorldService가 직접 계산하기보다,  
+  **스냅샷 SSOT(`risk_signal_hub`)를 통해 버전 고정(ref/hash/as_of) 형태로 공유**하는 방향을 지향한다.  
+  (관련: [Risk Signal Hub 설계](risk_signal_hub.md))
 - Core Loop의 표면은 다음 흐름을 기준으로 설계한다.
 
 ```text
@@ -127,6 +130,8 @@ status: draft
      - `SubmitResult`에 적어도 다음 중 하나를 포함한다.
        - `evaluation_run_id`
        - `evaluation_run_url` (상태/메트릭 조회용 링크)
+     - (권장) 평가 런 산출물에 “검증/리스크 입력 스냅샷”을 참조로 남긴다.
+       - 예: `risk_snapshot_version` 또는 `risk_snapshot_ref`(= `risk_signal_hub`의 `(world_id, version)` 혹은 URL)
    - 초기 단계에서는 여전히 “동기 파이프라인”으로 돌아도 괜찮지만,  
      **결과가 어디에 기록되는지**가 Evaluation Run으로 명확히 남아야 한다.
 
@@ -239,6 +244,9 @@ status: draft
        - 리스크 컷(`max_dd_Xd`, `ulcer_index`, tail risk proxy)
        - 시나리오/스트레스 테스트 결과 플래그
    - 이 블록은 “**live 후보군에 오르기 위한 최소 조건**”을 정의하는 곳으로 문서화한다.
+   - (정렬) 검증/스트레스/실현 리턴 등 “입력 스냅샷 SSOT”는 `risk_signal_hub`를 기준으로 읽는다.
+     - WS/Exit Engine/모니터링이 동일한 `version/hash/as_of` 스냅샷을 공유하도록 설계한다.
+     - 관련: [Risk Signal Hub 설계](risk_signal_hub.md)
 
 2. **live 승격 거버넌스 옵션**
 
@@ -286,4 +294,3 @@ status: draft
      제한된 환경에서만 opt‑in 하도록 계획한다.
 
 이 로드맵 하나만으로도 “Core Loop를 월드 중심으로 고도화한다”는 목적과 방향성을 잃지 않고, 각 단계에서 해야 할 일을 판단할 수 있어야 한다. 세부 API·스키마는 관련 설계 문서(`architecture/*.md`, `world/*.md`, `design/worldservice_evaluation_runs_and_metrics_api.md`)를 함께 참고하되, **“지금 이 변경이 전체 그림에서 어느 Phase인지”**는 항상 이 문서를 기준으로 정한다.
-

--- a/docs/ko/design/worldservice_evaluation_runs_and_metrics_api.md
+++ b/docs/ko/design/worldservice_evaluation_runs_and_metrics_api.md
@@ -54,6 +54,10 @@ related_issue: "hyophyop/qmtl#1750"
 - 평가 런이 완료되면:
   - WS가 **표준화된 지표 세트**(returns/PnL 요약, 리스크·성과 지표, 게이팅 사유 등)를 저장하고,
   - 이를 조회하는 **메트릭/스냅샷 API**를 제공한다.
+- (정렬) 평가 런은 “검증/리스크 입력 스냅샷”을 참조로 남긴다.
+  - 포트폴리오 스냅샷(가중치·공분산·실현 리턴·스트레스)은 별도의 SSOT인 `risk_signal_hub`에 저장하고,
+  - Evaluation Run에는 `risk_snapshot_version` 또는 `risk_snapshot_ref` 같은 링크/식별자를 포함해
+    WS/Exit Engine/모니터링이 동일한 `version/hash/as_of`를 공유하도록 한다.
 - Runner/CLI/툴은:
   - `Runner.submit` 결과에서 `evaluation_run_id`(또는 링크)를 받아,
   - WS의 **상태 조회 API**로 “지금 어느 단계인지” 확인하고,

--- a/qmtl/foundation/config.py
+++ b/qmtl/foundation/config.py
@@ -284,7 +284,8 @@ class RiskHubConfig:
     token: str | None = None
     inline_cov_threshold: int | None = 100
     stage: str | None = None  # optional default stage for producers
-    ttl_sec_default: int = 10
+    ttl_sec_default: int = 900
+    ttl_sec_max: int = 86400
     allowed_actors: list[str] | None = None
     allowed_stages: list[str] | None = None
     blob_store: RiskHubBlobStoreConfig = field(default_factory=RiskHubBlobStoreConfig)

--- a/qmtl/services/gateway/api.py
+++ b/qmtl/services/gateway/api.py
@@ -101,8 +101,8 @@ def _build_risk_hub_client(
         return None
     inline_threshold = _resolve_risk_hub_inline(cfg)
     token = cfg.token if cfg else None
-    stage = cfg.stage if cfg else None
-    ttl_sec_default = int(cfg.ttl_sec_default) if cfg else 10
+    stage = (cfg.stage if cfg and cfg.stage else "paper")
+    ttl_sec_default = int(cfg.ttl_sec_default) if cfg else 900
     allowed_actors = list(cfg.allowed_actors) if cfg and cfg.allowed_actors is not None else None
     allowed_stages = list(cfg.allowed_stages) if cfg and cfg.allowed_stages is not None else None
     return RiskHubClient(

--- a/qmtl/services/gateway/routes/rebalancing.py
+++ b/qmtl/services/gateway/routes/rebalancing.py
@@ -328,7 +328,7 @@ def _resolve_venue_policies(request: Request) -> Mapping[str, VenuePolicy]:
 
 
 def _resolve_stage(request: Request) -> str | None:
-    return request.headers.get("X-Stage") or request.headers.get("X-Validation-Stage")
+    return request.headers.get("X-Stage") or request.headers.get("X-Validation-Stage") or "paper"
 
 
 def _resolve_risk_hub_client(

--- a/qmtl/services/risk_hub_contract.py
+++ b/qmtl/services/risk_hub_contract.py
@@ -60,7 +60,8 @@ def normalize_and_validate_snapshot(
     *,
     actor: str | None = None,
     stage: str | None = None,
-    ttl_sec_default: int = 10,
+    ttl_sec_default: int = 900,
+    ttl_sec_max: int = 86400,
     allowed_actors: Sequence[str] | None = None,
     allowed_stages: Sequence[str] | None = None,
 ) -> dict[str, Any]:
@@ -109,6 +110,8 @@ def normalize_and_validate_snapshot(
             raise ValueError("ttl_sec must be an integer") from exc
         if ttl_int <= 0:
             raise ValueError("ttl_sec must be positive")
+        if ttl_sec_max is not None and ttl_int > int(ttl_sec_max):
+            raise ValueError(f"ttl_sec must be <= {int(ttl_sec_max)}")
         data["ttl_sec"] = ttl_int
 
     provenance = data.get("provenance")
@@ -130,10 +133,7 @@ def normalize_and_validate_snapshot(
     _validate_actor(actor_value, allowed_actors=allowed_actors)
 
     stage_value = str(provenance_map.get("stage") or "")
-    if allowed_stages is not None:
-        _validate_stage(stage_value, allowed_stages=allowed_stages)
-    elif stage_value:
-        _validate_stage(stage_value, allowed_stages=None)
+    _validate_stage(stage_value, allowed_stages=allowed_stages)
 
     if provenance_map:
         data["provenance"] = provenance_map

--- a/qmtl/services/worldservice/api.py
+++ b/qmtl/services/worldservice/api.py
@@ -300,7 +300,12 @@ def create_app(
     risk_hub_ttl_default = (
         int(resolved_risk_hub_config.ttl_sec_default)
         if resolved_risk_hub_config is not None
-        else 10
+        else 900
+    )
+    risk_hub_ttl_max = (
+        int(resolved_risk_hub_config.ttl_sec_max)
+        if resolved_risk_hub_config is not None
+        else 86400
     )
     risk_hub_allowed_actors = (
         list(resolved_risk_hub_config.allowed_actors)
@@ -400,6 +405,7 @@ def create_app(
                         ),
                         dedupe_cache=getattr(risk_hub, "_cache", None),
                         ttl_sec_default=risk_hub_ttl_default,
+                        ttl_sec_max=risk_hub_ttl_max,
                         allowed_actors=risk_hub_allowed_actors,
                         allowed_stages=risk_hub_allowed_stages,
                         brokers=brokers,
@@ -486,6 +492,7 @@ def create_app(
             bus=bus_instance,
             expected_token=risk_hub_token,
             ttl_sec_default=risk_hub_ttl_default,
+            ttl_sec_max=risk_hub_ttl_max,
             allowed_actors=risk_hub_allowed_actors,
             allowed_stages=risk_hub_allowed_stages,
             schedule_extended_validation=lambda world_id: service._apply_extended_validation(  # type: ignore[attr-defined]

--- a/qmtl/services/worldservice/blob_store.py
+++ b/qmtl/services/worldservice/blob_store.py
@@ -149,7 +149,7 @@ def build_blob_store(
             client = redis_sync.from_url(redis_dsn, decode_responses=True)
         if client is None:
             raise ValueError("redis blob store requires redis_client or redis_dsn")
-        ttl_final = cache_ttl if cache_ttl is not None else 10
+        ttl_final = cache_ttl if cache_ttl is not None else 900
         return RedisBlobStore(client, prefix=redis_prefix or "risk-blobs:", ttl=ttl_final)
 
     if normalized_type == "s3":

--- a/qmtl/services/worldservice/controlbus_consumer.py
+++ b/qmtl/services/worldservice/controlbus_consumer.py
@@ -71,7 +71,8 @@ class RiskHubControlBusConsumer:
         retry_backoff_sec: float = DEFAULT_RISK_HUB_RETRY_BACKOFF_SEC,
         dlq_topic: str | None = DEFAULT_RISK_HUB_DLQ_TOPIC,
         dlq_producer: KafkaProducerLike | None = None,
-        ttl_sec_default: int = 10,
+        ttl_sec_default: int = 900,
+        ttl_sec_max: int = 86400,
         allowed_actors: Sequence[str] | None = None,
         allowed_stages: Sequence[str] | None = None,
         brokers: Iterable[str] | None = None,
@@ -100,6 +101,7 @@ class RiskHubControlBusConsumer:
         self._dlq_producer: KafkaProducerLike | None = dlq_producer
         self._dlq_started = False
         self._ttl_sec_default = int(ttl_sec_default)
+        self._ttl_sec_max = int(ttl_sec_max)
         self._allowed_actors = list(allowed_actors) if allowed_actors is not None else None
         self._allowed_stages = list(allowed_stages) if allowed_stages is not None else None
 
@@ -311,6 +313,7 @@ class RiskHubControlBusConsumer:
                 world_id,
                 data,
                 ttl_sec_default=self._ttl_sec_default,
+                ttl_sec_max=self._ttl_sec_max,
                 allowed_actors=self._allowed_actors,
                 allowed_stages=self._allowed_stages,
             )

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -455,6 +455,7 @@ class BenchmarkMetrics(BaseModel):
 class ValidationHealth(BaseModel):
     metric_coverage_ratio: float | None = None
     rules_executed_ratio: float | None = None
+    validation_error_count: int | None = None  # v1.5+
 
 
 class DiagnosticsMetrics(BaseModel):

--- a/qmtl/services/worldservice/storage/repositories/risk_snapshots.py
+++ b/qmtl/services/worldservice/storage/repositories/risk_snapshots.py
@@ -14,22 +14,54 @@ class RiskSnapshotRepository:
     def __init__(self, driver: DatabaseDriver) -> None:
         self._driver = driver
 
-    async def upsert(self, world_id: str, payload: Dict[str, Any]) -> None:
-        await self._driver.execute(
+    async def get(self, world_id: str, version: str) -> Optional[Dict[str, Any]]:
+        row = await self._driver.fetchone(
             """
-            INSERT INTO risk_snapshots(world_id, as_of, version, payload, created_at)
-            VALUES(?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))
-            ON CONFLICT(world_id, version) DO UPDATE SET
-                as_of = excluded.as_of,
-                payload = excluded.payload,
-                created_at = excluded.created_at
+            SELECT payload FROM risk_snapshots
+            WHERE world_id = ? AND version = ?
+            LIMIT 1
             """,
             world_id,
-            payload.get("as_of"),
-            payload.get("version"),
-            json.dumps(payload),
-            payload.get("created_at"),
+            version,
         )
+        if not row:
+            return None
+        return json.loads(row[0])
+
+    async def upsert(self, world_id: str, payload: Dict[str, Any]) -> None:
+        """Insert a snapshot with idempotent conflict handling.
+
+        - If (world_id, version) is unused, inserts the record.
+        - If it exists with the same hash, this is treated as an idempotent retry (no-op).
+        - If it exists with a different hash, raise to force a new version.
+        """
+
+        version = str(payload.get("version") or "")
+        if not version:
+            raise ValueError("version is required")
+        incoming_hash = str(payload.get("hash") or "")
+        try:
+            await self._driver.execute(
+                """
+                INSERT INTO risk_snapshots(world_id, as_of, version, payload, created_at)
+                VALUES(?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))
+                """,
+                world_id,
+                payload.get("as_of"),
+                version,
+                json.dumps(payload),
+                payload.get("created_at"),
+            )
+            return
+        except Exception:
+            # Possible uniqueness conflict; compare existing hash for idempotency.
+            existing = await self.get(world_id, version)
+            if existing is None:
+                raise
+            existing_hash = str(existing.get("hash") or "")
+            if existing_hash and incoming_hash and existing_hash == incoming_hash:
+                return
+            raise
 
     async def latest(self, world_id: str) -> Optional[Dict[str, Any]]:
         row = await self._driver.fetchone(

--- a/tests/qmtl/services/gateway/test_risk_hub_client_validation.py
+++ b/tests/qmtl/services/gateway/test_risk_hub_client_validation.py
@@ -22,7 +22,7 @@ def test_risk_hub_client_validates_weights_and_sets_hash():
 
 
 def test_risk_hub_client_rejects_bad_weights():
-    client = RiskHubClient(base_url="http://ws")
+    client = RiskHubClient(base_url="http://ws", actor="gateway", stage="paper")
     payload = {
         "as_of": "2025-01-01T00:00:00Z",
         "version": "v1",
@@ -39,6 +39,8 @@ def test_risk_hub_client_offloads_realized_returns_and_stress(tmp_path):
         base_url="http://ws",
         blob_store=store,
         inline_cov_threshold=1,
+        actor="gateway",
+        stage="paper",
     )
     payload = {
         "as_of": "2025-01-01T00:00:00Z",

--- a/tests/qmtl/services/gateway/test_risk_snapshot_publisher.py
+++ b/tests/qmtl/services/gateway/test_risk_snapshot_publisher.py
@@ -36,6 +36,8 @@ async def test_risk_hub_client_offloads_covariance(tmp_path):
         retries=0,
         blob_store=blob,
         inline_cov_threshold=1,
+        actor="gateway",
+        stage="paper",
     )
     await hub.publish_snapshot(
         "w",

--- a/tests/qmtl/services/worldservice/test_controlbus_consumer.py
+++ b/tests/qmtl/services/worldservice/test_controlbus_consumer.py
@@ -78,7 +78,7 @@ async def test_controlbus_consumer_hydrates_hub_and_triggers_callback():
             "as_of": "2025-01-01T00:00:00Z",
             "version": "v1",
             "weights": {"a": 1.0},
-            "provenance": {"actor": "gateway"},
+            "provenance": {"actor": "gateway", "stage": "paper"},
         },
     }
     msg = SimpleNamespace(value=json.dumps(data))
@@ -163,7 +163,7 @@ async def test_controlbus_consumer_skips_expired_snapshot():
             "weights": {"a": 1.0},
             "ttl_sec": 1,
             "created_at": old_created,
-            "provenance": {"actor": "gateway"},
+            "provenance": {"actor": "gateway", "stage": "paper"},
         },
     }
     msg = SimpleNamespace(value=json.dumps(data))
@@ -182,7 +182,7 @@ async def test_controlbus_consumer_skips_expired_snapshot():
     assert (
         get_metric_value(
             ws_metrics.risk_hub_snapshot_expired_total,
-            {"world_id": "w", "stage": "unknown"},
+            {"world_id": "w", "stage": "paper"},
         )
         == 1
     )

--- a/tests/qmtl/services/worldservice/test_risk_hub_validations.py
+++ b/tests/qmtl/services/worldservice/test_risk_hub_validations.py
@@ -1,6 +1,6 @@
 import pytest
 
-from qmtl.services.worldservice.risk_hub import RiskSignalHub, PortfolioSnapshot
+from qmtl.services.worldservice.risk_hub import RiskSignalHub, PortfolioSnapshot, RiskSnapshotConflictError
 
 
 @pytest.mark.asyncio
@@ -27,9 +27,49 @@ async def test_ttl_filters_expired_snapshot():
         ttl_sec=1,
         created_at="2025-01-01T00:00:00Z",
     )
+    with pytest.raises(ValueError, match="expired"):
+        await hub.upsert_snapshot(snap)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_version_conflict_is_rejected():
+    hub = RiskSignalHub()
+    snap = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"a": 1.0},
+    )
     await hub.upsert_snapshot(snap)
-    latest = await hub.latest_snapshot("w")
-    assert latest is None
+    conflicting = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"a": 0.9, "b": 0.1},
+    )
+    with pytest.raises(RiskSnapshotConflictError):
+        await hub.upsert_snapshot(conflicting)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_version_idempotent_retry_returns_deduped_true():
+    hub = RiskSignalHub()
+    snap = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"a": 1.0},
+    )
+    deduped = await hub.upsert_snapshot(snap)
+    assert deduped is False
+    retry = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"a": 1.0},
+    )
+    deduped_retry = await hub.upsert_snapshot(retry)
+    assert deduped_retry is True
 
 
 def test_snapshot_round_trip_preserves_inline_realized_returns():

--- a/tests/qmtl/services/worldservice/test_validation_invariants.py
+++ b/tests/qmtl/services/worldservice/test_validation_invariants.py
@@ -50,6 +50,21 @@ def test_ensure_validation_health_computes_ratios_without_mutation():
     health = enriched["diagnostics"]["validation_health"]
     assert health["metric_coverage_ratio"] == pytest.approx(1.0)
     assert health["rules_executed_ratio"] == pytest.approx(len(rule_results) / DEFAULT_RULE_COUNT)
+    assert health["validation_error_count"] == 0
+
+
+def test_ensure_validation_health_counts_rule_errors():
+    metrics = _full_metrics()
+    rule_results = {
+        "sample": {"status": "fail", "reason_code": "rule_error"},
+        "performance": {"status": "warn", "reason_code": "missing_metric"},
+        "risk": {"status": "fail", "reason_code": "RULE_ERROR"},
+    }
+
+    enriched = ensure_validation_health(metrics, rule_results)
+
+    health = enriched["diagnostics"]["validation_health"]
+    assert health["validation_error_count"] == 2
 
 
 def test_check_invariants_flags_latest_live_failure():

--- a/tests/qmtl/services/worldservice/test_worldservice_api.py
+++ b/tests/qmtl/services/worldservice/test_worldservice_api.py
@@ -1243,7 +1243,7 @@ async def test_risk_hub_persists_snapshots_with_persistent_storage(tmp_path, fak
                 resp = await client.post(
                     "/risk-hub/worlds/persist-hub/snapshots",
                     json=snap,
-                    headers={"X-Actor": "test-suite"},
+                    headers={"X-Actor": "test-suite", "X-Stage": "paper"},
                 )
                 assert resp.status_code == 200
 


### PR DESCRIPTION
Summary:
- Enforces RiskHub snapshot contract (TTL default/max, stage required, version conflict -> 409).
- Adds lookup API and idempotent persistence semantics.
- Aligns gateway producer defaults and updates docs/tests.

Validation:
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_docs_links.py
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q
- CORE_LOOP_STACK_MODE=inproc uv run -m pytest -q tests/e2e/core_loop -q
