### PR TITLE
Docs: move Risk Signal Hub design into architecture

### DIFF
--- a/docs/en/archive/risk_signal_hub.md
+++ b/docs/en/archive/risk_signal_hub.md
@@ -1,0 +1,6 @@
+# Risk Signal Hub (Archived Design)
+
+The working design draft has been archived. Refer to the canonical architecture page:
+
+- `docs/en/architecture/risk_signal_hub.md`
+

--- a/docs/ko/archive/risk_signal_hub.md
+++ b/docs/ko/archive/risk_signal_hub.md
@@ -14,11 +14,11 @@ status: draft
     WorldService/Exit Engine/모니터링이 동일한 스냅샷을 읽어 **일관된 검증·exit·모니터링**을 수행하도록 한다.
 
 연관 문서:
-- Core Loop × WorldService 로드맵: [core_loop_world_roadmap.md](core_loop_world_roadmap.md)
-- WorldService 평가 런 & 메트릭 API: [worldservice_evaluation_runs_and_metrics_api.md](worldservice_evaluation_runs_and_metrics_api.md)
-- World 검증 v1 구현 계획: [world_validation_v1_implementation_plan.md](world_validation_v1_implementation_plan.md) §6
-- Exit Engine 개요: [exit_engine_overview.md](exit_engine_overview.md)
-- World Validation 아키텍처: [world_validation_architecture.md](world_validation_architecture.md)
+- Core Loop × WorldService 로드맵: [design/core_loop_world_roadmap.md](../design/core_loop_world_roadmap.md)
+- WorldService 평가 런 & 메트릭 API: [design/worldservice_evaluation_runs_and_metrics_api.md](../design/worldservice_evaluation_runs_and_metrics_api.md)
+- World 검증 v1 구현 계획: [design/world_validation_v1_implementation_plan.md](../design/world_validation_v1_implementation_plan.md) §6
+- Exit Engine 개요: [design/exit_engine_overview.md](../design/exit_engine_overview.md)
+- World Validation 아키텍처: [design/world_validation_architecture.md](../design/world_validation_architecture.md)
 
 ---
 

--- a/docs/ko/design/core_loop_world_roadmap.md
+++ b/docs/ko/design/core_loop_world_roadmap.md
@@ -29,7 +29,7 @@ status: draft
   **월드 정책과 WorldService가 결정하는 상태**에 가깝게 재정의한다.
 - “검증/리스크/exit에 필요한 입력 데이터”는 WorldService가 직접 계산하기보다,  
   **스냅샷 SSOT(`risk_signal_hub`)를 통해 버전 고정(ref/hash/as_of) 형태로 공유**하는 방향을 지향한다.  
-  (관련: [Risk Signal Hub 설계](risk_signal_hub.md))
+  (관련: [Risk Signal Hub 아키텍처](../architecture/risk_signal_hub.md))
 - Core Loop의 표면은 다음 흐름을 기준으로 설계한다.
 
 ```text
@@ -246,7 +246,7 @@ status: draft
    - 이 블록은 “**live 후보군에 오르기 위한 최소 조건**”을 정의하는 곳으로 문서화한다.
    - (정렬) 검증/스트레스/실현 리턴 등 “입력 스냅샷 SSOT”는 `risk_signal_hub`를 기준으로 읽는다.
      - WS/Exit Engine/모니터링이 동일한 `version/hash/as_of` 스냅샷을 공유하도록 설계한다.
-     - 관련: [Risk Signal Hub 설계](risk_signal_hub.md)
+     - 관련: [Risk Signal Hub 아키텍처](../architecture/risk_signal_hub.md)
 
 2. **live 승격 거버넌스 옵션**
 

--- a/docs/ko/design/world_validation_v1.5_implementation.md
+++ b/docs/ko/design/world_validation_v1.5_implementation.md
@@ -111,5 +111,5 @@
 ## 참고 링크
 - 설계: [world_validation_architecture.md](world_validation_architecture.md)
 - v1 계획: [world_validation_v1_implementation_plan.md](world_validation_v1_implementation_plan.md)
-- Risk Hub 설계: [risk_signal_hub.md](risk_signal_hub.md)
+- Risk Hub 아키텍처: [architecture/risk_signal_hub.md](../architecture/risk_signal_hub.md)
 - 운영 런북: [../operations/risk_signal_hub_runbook.md](../operations/risk_signal_hub_runbook.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,7 +104,6 @@ nav:
       - World Validation v1 Implementation Plan: design/world_validation_v1_implementation_plan.md
       - World Validation v1.5 Implementation: design/world_validation_v1.5_implementation.md
       - World Strategy Weighting v1.5 Design: design/world_strategy_weighting_v1.5_design.md
-      - Risk Signal Hub Design: design/risk_signal_hub.md
       - Exit Engine Overview: design/exit_engine_overview.md
       - Model Risk Management Framework: design/model_risk_management_framework.md
       - WorldService Evaluation Runs & Metrics API: design/worldservice_evaluation_runs_and_metrics_api.md


### PR DESCRIPTION
Summary:
- Moves `docs/ko/design/risk_signal_hub.md` to `docs/ko/archive/risk_signal_hub.md`.
- Updates ko/en architecture pages with v1 contract defaults and removes dependency on design doc.
- Adjusts design references and removes the design doc from mkdocs navigation.

Validation:
- uv run mkdocs build --strict
- uv run python scripts/check_docs_links.py
