### PR TITLE
world: add CLI run status and live approval/apply

### DIFF
--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -344,6 +344,12 @@ WORLD_ROUTES: tuple[WorldRoute, ...] = (
         include_payload=True,
     ),
     WorldRoute(
+        "get",
+        "/worlds/{world_id}/decisions",
+        "get_decisions",
+        path_params=("world_id",),
+    ),
+    WorldRoute(
         "put",
         "/worlds/{world_id}/activation",
         "put_activation",

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -359,6 +359,13 @@ class WorldServiceClient:
             json=payload,
         )
 
+    async def get_decisions(self, world_id: str, headers: Optional[Dict[str, str]] = None) -> Any:
+        return await self._request_json(
+            "GET",
+            f"/worlds/{world_id}/decisions",
+            headers=headers,
+        )
+
     async def post_history_metadata(
         self,
         world_id: str,

--- a/qmtl/services/worldservice/routers/bindings.py
+++ b/qmtl/services/worldservice/routers/bindings.py
@@ -44,4 +44,10 @@ def create_bindings_router(service: WorldService) -> APIRouter:
         strategies = await store.get_decisions(world_id)
         return BindingsResponse(strategies=strategies)
 
+    @router.get('/worlds/{world_id}/decisions', response_model=BindingsResponse)
+    async def get_decisions(world_id: str) -> BindingsResponse:
+        store = service.store
+        strategies = await store.get_decisions(world_id)
+        return BindingsResponse(strategies=strategies)
+
     return router

--- a/tests/qmtl/services/worldservice/test_worldservice_api.py
+++ b/tests/qmtl/services/worldservice/test_worldservice_api.py
@@ -512,6 +512,20 @@ async def test_evaluation_run_override_flow():
 
 
 @pytest.mark.asyncio
+async def test_world_decisions_get_endpoint_returns_active_strategies():
+    app = create_app(storage=Storage())
+    async with httpx.ASGITransport(app=app) as asgi:
+        async with httpx.AsyncClient(transport=asgi, base_url="http://test") as client:
+            await client.post("/worlds", json={"id": "wdec", "name": "Decision World"})
+            set_resp = await client.post("/worlds/wdec/decisions", json={"strategies": ["s1", "s2"]})
+            assert set_resp.status_code == 200
+
+            get_resp = await client.get("/worlds/wdec/decisions")
+            assert get_resp.status_code == 200
+            assert get_resp.json()["strategies"] == ["s1", "s2"]
+
+
+@pytest.mark.asyncio
 async def test_ex_post_failure_record_flow_appends_history():
     app = create_app(storage=Storage())
     async with httpx.ASGITransport(app=app) as asgi:


### PR DESCRIPTION
Summary:
- Add GET /worlds/{id}/decisions for current active strategies.
- Add qmtl world status, run-status, live-approve, live-reject, live-apply commands.
- Update Phase 5 roadmap doc with CLI/API linkage.

Tests:
- uv run --with mypy -m mypy
- uv run -m pytest -q tests/qmtl/interfaces/cli/test_world_cli.py tests/qmtl/services/worldservice/test_worldservice_api.py
- uv run mkdocs build --strict
- uv run python scripts/check_docs_links.py
