### PR TITLE
world: add live promotion endpoints

### DIFF
--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -411,6 +411,27 @@ WORLD_ROUTES: tuple[WorldRoute, ...] = (
     ),
     WorldRoute(
         "post",
+        "/worlds/{world_id}/promotions/live/approve",
+        "post_live_promotion_approve",
+        path_params=("world_id",),
+        include_payload=True,
+    ),
+    WorldRoute(
+        "post",
+        "/worlds/{world_id}/promotions/live/reject",
+        "post_live_promotion_reject",
+        path_params=("world_id",),
+        include_payload=True,
+    ),
+    WorldRoute(
+        "get",
+        "/worlds/{world_id}/promotions/live/plan",
+        "get_live_promotion_plan",
+        path_params=("world_id",),
+        query_params=("strategy_id", "run_id"),
+    ),
+    WorldRoute(
+        "post",
         "/worlds/{world_id}/apply",
         "post_apply",
         path_params=("world_id",),

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -470,6 +470,47 @@ class WorldServiceClient:
             json=payload,
         )
 
+    async def post_live_promotion_approve(
+        self,
+        world_id: str,
+        payload: Any,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "POST",
+            f"/worlds/{world_id}/promotions/live/approve",
+            headers=headers,
+            json=payload,
+        )
+
+    async def post_live_promotion_reject(
+        self,
+        world_id: str,
+        payload: Any,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "POST",
+            f"/worlds/{world_id}/promotions/live/reject",
+            headers=headers,
+            json=payload,
+        )
+
+    async def get_live_promotion_plan(
+        self,
+        world_id: str,
+        *,
+        strategy_id: str,
+        run_id: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "GET",
+            f"/worlds/{world_id}/promotions/live/plan",
+            headers=headers,
+            params={"strategy_id": strategy_id, "run_id": run_id},
+        )
+
     async def post_apply(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
         return await self._request_json(
             "POST",

--- a/qmtl/services/worldservice/api.py
+++ b/qmtl/services/worldservice/api.py
@@ -29,6 +29,7 @@ from .routers import (
     create_evaluation_runs_router,
     create_live_monitoring_router,
     create_observability_router,
+    create_promotions_router,
     create_risk_hub_router,
     create_policies_router,
     create_rebalancing_router,
@@ -484,6 +485,7 @@ def create_app(
     app.include_router(create_activation_router(service))
     app.include_router(create_allocations_router(service))
     app.include_router(create_evaluation_runs_router(service))
+    app.include_router(create_promotions_router(service))
     app.include_router(create_live_monitoring_router(service))
     app.include_router(create_observability_router())
     app.include_router(

--- a/qmtl/services/worldservice/routers/__init__.py
+++ b/qmtl/services/worldservice/routers/__init__.py
@@ -2,6 +2,7 @@ from .activation import create_activation_router
 from .allocations import create_allocations_router
 from .bindings import create_bindings_router
 from .evaluation_runs import create_evaluation_runs_router
+from .promotions import create_promotions_router
 from .policies import create_policies_router
 from .rebalancing import create_rebalancing_router
 from .validations import create_validations_router
@@ -15,6 +16,7 @@ __all__ = [
     'create_allocations_router',
     'create_bindings_router',
     'create_evaluation_runs_router',
+    'create_promotions_router',
     'create_policies_router',
     'create_rebalancing_router',
     'create_validations_router',

--- a/qmtl/services/worldservice/routers/promotions.py
+++ b/qmtl/services/worldservice/routers/promotions.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException
+
+from ..schemas import (
+    ApplyPlan,
+    EvaluationOverride,
+    EvaluationRunModel,
+    LivePromotionApproveRequest,
+    LivePromotionPlanResponse,
+    LivePromotionRejectRequest,
+)
+from ..services import WorldService
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def create_promotions_router(service: WorldService) -> APIRouter:
+    router = APIRouter()
+
+    @router.post(
+        "/worlds/{world_id}/promotions/live/approve",
+        response_model=EvaluationRunModel,
+    )
+    async def post_live_promotion_approve(
+        world_id: str,
+        payload: LivePromotionApproveRequest,
+    ) -> EvaluationRunModel:
+        override = EvaluationOverride(
+            status="approved",
+            reason=payload.reason,
+            actor=payload.actor,
+            timestamp=payload.timestamp or _utc_now_iso(),
+        )
+        record = await service.record_evaluation_override(
+            world_id,
+            payload.strategy_id,
+            payload.run_id,
+            override,
+        )
+        return EvaluationRunModel(**record)
+
+    @router.post(
+        "/worlds/{world_id}/promotions/live/reject",
+        response_model=EvaluationRunModel,
+    )
+    async def post_live_promotion_reject(
+        world_id: str,
+        payload: LivePromotionRejectRequest,
+    ) -> EvaluationRunModel:
+        override = EvaluationOverride(
+            status="rejected",
+            reason=payload.reason,
+            actor=payload.actor,
+            timestamp=payload.timestamp or _utc_now_iso(),
+        )
+        record = await service.record_evaluation_override(
+            world_id,
+            payload.strategy_id,
+            payload.run_id,
+            override,
+        )
+        return EvaluationRunModel(**record)
+
+    @router.get(
+        "/worlds/{world_id}/promotions/live/plan",
+        response_model=LivePromotionPlanResponse,
+    )
+    async def get_live_promotion_plan(
+        world_id: str,
+        *,
+        strategy_id: str,
+        run_id: str,
+    ) -> LivePromotionPlanResponse:
+        record = await service.store.get_evaluation_run(world_id, strategy_id, run_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="evaluation run not found")
+
+        summary = record.get("summary") if isinstance(record, dict) else None
+        if not isinstance(summary, dict):
+            raise HTTPException(status_code=422, detail="evaluation run missing summary")
+
+        target_active = summary.get("active_set")
+        if not isinstance(target_active, list) or not all(isinstance(v, str) for v in target_active):
+            raise HTTPException(status_code=422, detail="evaluation run missing summary.active_set")
+
+        current_active = await service.store.get_decisions(world_id)
+        current_set = {str(v) for v in current_active if str(v).strip()}
+        target_set = {str(v) for v in target_active if str(v).strip()}
+
+        plan = ApplyPlan(
+            activate=sorted(target_set - current_set),
+            deactivate=sorted(current_set - target_set),
+        )
+        return LivePromotionPlanResponse(
+            world_id=world_id,
+            strategy_id=strategy_id,
+            run_id=run_id,
+            plan=plan,
+            target_active=sorted(target_set),
+            current_active=sorted(current_set),
+        )
+
+    return router

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -114,6 +114,31 @@ class ApplyPlan(BaseModel):
     deactivate: List[str] = Field(default_factory=list)
 
 
+class LivePromotionApproveRequest(BaseModel):
+    strategy_id: str = Field(min_length=1)
+    run_id: str = Field(min_length=1)
+    reason: str = Field(min_length=1)
+    actor: str = Field(min_length=1)
+    timestamp: str | None = None
+
+
+class LivePromotionRejectRequest(BaseModel):
+    strategy_id: str = Field(min_length=1)
+    run_id: str = Field(min_length=1)
+    reason: str | None = None
+    actor: str | None = None
+    timestamp: str | None = None
+
+
+class LivePromotionPlanResponse(BaseModel):
+    world_id: str
+    strategy_id: str
+    run_id: str
+    plan: ApplyPlan
+    target_active: List[str] = Field(default_factory=list)
+    current_active: List[str] = Field(default_factory=list)
+
+
 class ApplyRequest(EvaluateRequest):
     run_id: str
     plan: ApplyPlan | None = None


### PR DESCRIPTION
Summary:
- Add WorldService live promotion endpoints:
  - POST /worlds/{world}/promotions/live/approve
  - POST /worlds/{world}/promotions/live/reject
  - GET  /worlds/{world}/promotions/live/plan?strategy_id=...&run_id=...
- Proxy them through Gateway.

Tests:
- uv run --with mypy -m mypy
- uv run -m pytest -q tests/qmtl/services/worldservice/test_worldservice_api.py tests/qmtl/interfaces/cli/test_world_cli.py
