### PR TITLE
world: enforce live promotion governance mode

### DIFF
--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -432,6 +432,14 @@ WORLD_ROUTES: tuple[WorldRoute, ...] = (
     ),
     WorldRoute(
         "post",
+        "/worlds/{world_id}/promotions/live/apply",
+        "post_live_promotion_apply",
+        path_params=("world_id",),
+        include_payload=True,
+        enforce_live_guard=True,
+    ),
+    WorldRoute(
+        "post",
         "/worlds/{world_id}/apply",
         "post_apply",
         path_params=("world_id",),

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -511,6 +511,19 @@ class WorldServiceClient:
             params={"strategy_id": strategy_id, "run_id": run_id},
         )
 
+    async def post_live_promotion_apply(
+        self,
+        world_id: str,
+        payload: Any,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "POST",
+            f"/worlds/{world_id}/promotions/live/apply",
+            headers=headers,
+            json=payload,
+        )
+
     async def post_apply(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
         return await self._request_json(
             "POST",

--- a/qmtl/services/worldservice/policy_engine.py
+++ b/qmtl/services/worldservice/policy_engine.py
@@ -4,7 +4,7 @@ import json
 import math
 from dataclasses import dataclass, field
 import statistics
-from typing import Any, Dict, Iterable, Iterator, List, Mapping, Protocol, Sequence, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Literal, Mapping, Protocol, Sequence, Tuple
 
 import yaml
 from pydantic import BaseModel, Field
@@ -318,6 +318,20 @@ class ValidationConfig(BaseModel):
     on_missing_metric: str = Field(default="fail", pattern="^(fail|warn|ignore)$")
 
 
+class LivePromotionConfig(BaseModel):
+    """World-level governance configuration for live promotion execution."""
+
+    mode: Literal["disabled", "manual_approval", "auto_apply"] = "manual_approval"
+    cooldown: str | None = None
+    max_live_slots: int | None = None
+    canary_fraction: float | None = None
+    approvers: List[str] | None = None
+
+
+class GovernanceConfig(BaseModel):
+    live_promotion: LivePromotionConfig | None = None
+
+
 class Policy(BaseModel):
     thresholds: dict[str, ThresholdRule] = Field(default_factory=dict)
     top_k: TopKRule | None = None
@@ -333,6 +347,7 @@ class Policy(BaseModel):
     stress: StressRuleConfig | None = None
     paper_shadow_consistency: PaperShadowConsistencyConfig | None = None
     live_monitoring: LiveMonitoringConfig | None = None
+    governance: GovernanceConfig | None = None
 
     def model_post_init(self, __context: Any) -> None:  # type: ignore[override]
         self._normalize_selection()

--- a/qmtl/services/worldservice/routers/promotions.py
+++ b/qmtl/services/worldservice/routers/promotions.py
@@ -4,11 +4,14 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException
 
+from ..policy_engine import Policy
 from ..schemas import (
     ApplyPlan,
+    ApplyRequest,
     EvaluationOverride,
     EvaluationRunModel,
     LivePromotionApproveRequest,
+    LivePromotionApplyRequest,
     LivePromotionPlanResponse,
     LivePromotionRejectRequest,
 )
@@ -17,6 +20,29 @@ from ..services import WorldService
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _extract_live_promotion_mode(policy: object) -> str | None:
+    if isinstance(policy, Policy):
+        governance = policy.governance
+        if governance and governance.live_promotion:
+            return str(governance.live_promotion.mode)
+        return None
+    if isinstance(policy, dict):
+        governance = policy.get("governance")
+        if not isinstance(governance, dict):
+            return None
+        live_promotion = governance.get("live_promotion")
+        if not isinstance(live_promotion, dict):
+            return None
+        mode = live_promotion.get("mode")
+        return str(mode) if mode is not None else None
+    return None
+
+
+async def _get_live_promotion_mode(service: WorldService, world_id: str) -> str | None:
+    policy = await service.store.get_default_policy(world_id)
+    return _extract_live_promotion_mode(policy)
 
 
 def create_promotions_router(service: WorldService) -> APIRouter:
@@ -30,6 +56,9 @@ def create_promotions_router(service: WorldService) -> APIRouter:
         world_id: str,
         payload: LivePromotionApproveRequest,
     ) -> EvaluationRunModel:
+        mode = await _get_live_promotion_mode(service, world_id)
+        if str(mode or "").lower() == "disabled":
+            raise HTTPException(status_code=409, detail="live promotion is disabled by policy")
         override = EvaluationOverride(
             status="approved",
             reason=payload.reason,
@@ -52,6 +81,9 @@ def create_promotions_router(service: WorldService) -> APIRouter:
         world_id: str,
         payload: LivePromotionRejectRequest,
     ) -> EvaluationRunModel:
+        mode = await _get_live_promotion_mode(service, world_id)
+        if str(mode or "").lower() == "disabled":
+            raise HTTPException(status_code=409, detail="live promotion is disabled by policy")
         override = EvaluationOverride(
             status="rejected",
             reason=payload.reason,
@@ -104,5 +136,45 @@ def create_promotions_router(service: WorldService) -> APIRouter:
             target_active=sorted(target_set),
             current_active=sorted(current_set),
         )
+
+    @router.post(
+        "/worlds/{world_id}/promotions/live/apply",
+        response_model=EvaluationRunModel,
+    )
+    async def post_live_promotion_apply(
+        world_id: str,
+        payload: LivePromotionApplyRequest,
+    ) -> EvaluationRunModel:
+        mode = await _get_live_promotion_mode(service, world_id)
+        mode_normalized = str(mode or "").lower()
+        if mode_normalized == "disabled":
+            raise HTTPException(status_code=409, detail="live promotion is disabled by policy")
+
+        record = await service.store.get_evaluation_run(world_id, payload.strategy_id, payload.run_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="evaluation run not found")
+
+        summary = record.get("summary") if isinstance(record, dict) else None
+        if not isinstance(summary, dict):
+            raise HTTPException(status_code=422, detail="evaluation run missing summary")
+
+        override_status = str(summary.get("override_status") or "none").lower()
+        if mode_normalized == "manual_approval" and override_status != "approved" and not payload.force:
+            raise HTTPException(status_code=409, detail="manual approval required before applying live promotion")
+
+        plan_resp = await get_live_promotion_plan(
+            world_id,
+            strategy_id=payload.strategy_id,
+            run_id=payload.run_id,
+        )
+        apply_payload = ApplyRequest(
+            run_id=payload.apply_run_id,
+            plan=plan_resp.plan,
+        )
+        await service.apply(world_id, apply_payload, gating=None)
+        updated = await service.store.get_evaluation_run(world_id, payload.strategy_id, payload.run_id)
+        if updated is None:
+            raise HTTPException(status_code=404, detail="evaluation run not found")
+        return EvaluationRunModel(**updated)
 
     return router

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -139,6 +139,13 @@ class LivePromotionPlanResponse(BaseModel):
     current_active: List[str] = Field(default_factory=list)
 
 
+class LivePromotionApplyRequest(BaseModel):
+    strategy_id: str = Field(min_length=1)
+    run_id: str = Field(min_length=1)
+    apply_run_id: str = Field(min_length=1)
+    force: bool = False
+
+
 class ApplyRequest(EvaluateRequest):
     run_id: str
     plan: ApplyPlan | None = None

--- a/tests/qmtl/interfaces/cli/test_world_cli.py
+++ b/tests/qmtl/interfaces/cli/test_world_cli.py
@@ -399,8 +399,10 @@ def test_world_live_approve_posts_override(monkeypatch, capsys):
     )
 
     assert exit_code == 0
-    assert posts[0][0] == "/worlds/w1/strategies/s1/runs/run-1/override"
+    assert posts[0][0] == "/worlds/w1/promotions/live/approve"
     assert posts[0][1]["status"] == "approved"
+    assert posts[0][1]["strategy_id"] == "s1"
+    assert posts[0][1]["run_id"] == "run-1"
     assert posts[0][1]["reason"] == "approved for live"
     assert posts[0][1]["actor"] == "risk"
     assert posts[0][1]["timestamp"] == "2025-01-02T03:04:05Z"
@@ -414,10 +416,8 @@ def test_world_live_apply_plan_only(monkeypatch, capsys):
 
     def fake_get(path, params=None):
         gets.append((path, params))
-        if path == "/worlds/w1/strategies/s1/runs/run-1":
-            return 200, {"summary": {"active_set": ["s1", "s2"], "override_status": "approved"}}
-        if path == "/worlds/w1/decisions":
-            return 200, {"strategies": ["s2", "s3"]}
+        if path == "/worlds/w1/promotions/live/plan":
+            return 200, {"plan": {"activate": ["s1"], "deactivate": ["s3"]}}
         return 404, {"detail": "not found"}
 
     def fake_post(path, payload):
@@ -443,10 +443,8 @@ def test_world_live_apply_posts_apply(monkeypatch, capsys):
 
     def fake_get(path, params=None):
         gets.append((path, params))
-        if path == "/worlds/w1/strategies/s1/runs/run-1":
-            return 200, {"summary": {"active_set": ["s1", "s2"], "override_status": "approved"}}
-        if path == "/worlds/w1/decisions":
-            return 200, {"strategies": ["s2", "s3"]}
+        if path == "/worlds/w1/promotions/live/plan":
+            return 200, {"plan": {"activate": ["s1"], "deactivate": ["s3"]}}
         return 404, {"detail": "not found"}
 
     def fake_post(path, payload):
@@ -461,9 +459,9 @@ def test_world_live_apply_posts_apply(monkeypatch, capsys):
     )
 
     assert exit_code == 0
-    assert posts[0][0] == "/worlds/w1/apply"
-    assert posts[0][1]["run_id"] == "apply-1"
-    assert posts[0][1]["plan"]["activate"] == ["s1"]
-    assert posts[0][1]["plan"]["deactivate"] == ["s3"]
+    assert posts[0][0] == "/worlds/w1/promotions/live/apply"
+    assert posts[0][1]["apply_run_id"] == "apply-1"
+    assert posts[0][1]["strategy_id"] == "s1"
+    assert posts[0][1]["run_id"] == "run-1"
     out = capsys.readouterr().out
     assert "Apply request sent" in out


### PR DESCRIPTION
Implements Phase 5 live promotion governance wiring.

Summary:
- Add `governance.live_promotion` to World policy DSL (`Policy` model).
- Enforce `disabled`/`manual_approval` on live promotion endpoints.
- Add `POST /worlds/{world}/promotions/live/apply` (computes plan from evaluation run and executes apply).
- Switch CLI to use promotions endpoints (`live-approve`, `live-reject`, `live-apply`).

Tests:
- uv run --with mypy -m mypy
- uv run -m pytest -q tests/qmtl/interfaces/cli/test_world_cli.py tests/qmtl/services/worldservice/test_worldservice_api.py
- uv run mkdocs build --strict
- uv run python scripts/check_docs_links.py

Refs: #1977
