### PR TITLE
world: auto-apply live promotion

### DIFF
--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -157,17 +157,15 @@ async def _execute_world_call(
                 },
             )
 
-    args: list[Any] = [path_params[param] for param in config.path_params]
-
+    call_kwargs: dict[str, Any] = {param: path_params[param] for param in config.path_params}
     for query_param in config.query_params:
-        args.append(request.query_params.get(query_param, ""))
-
+        call_kwargs[query_param] = request.query_params.get(query_param, "")
     if config.include_payload:
-        args.append(payload)
+        call_kwargs["payload"] = payload
 
     async def _call(client: WorldServiceClient, headers: dict[str, str]) -> Any:
         method = getattr(client, config.client_method)
-        return await method(*args, headers=headers)
+        return await method(**call_kwargs, headers=headers)
 
     response_builder = config.response_builder
     if response_builder is None and config.stale_response:
@@ -434,6 +432,14 @@ WORLD_ROUTES: tuple[WorldRoute, ...] = (
         "post",
         "/worlds/{world_id}/promotions/live/apply",
         "post_live_promotion_apply",
+        path_params=("world_id",),
+        include_payload=True,
+        enforce_live_guard=True,
+    ),
+    WorldRoute(
+        "post",
+        "/worlds/{world_id}/promotions/live/auto-apply",
+        "post_live_promotion_auto_apply",
         path_params=("world_id",),
         include_payload=True,
         enforce_live_guard=True,

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -524,6 +524,18 @@ class WorldServiceClient:
             json=payload,
         )
 
+    async def post_live_promotion_auto_apply(
+        self,
+        world_id: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "POST",
+            f"/worlds/{world_id}/promotions/live/auto-apply",
+            headers=headers,
+            json={},
+        )
+
     async def post_apply(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
         return await self._request_json(
             "POST",

--- a/qmtl/services/worldservice/activation.py
+++ b/qmtl/services/worldservice/activation.py
@@ -57,7 +57,8 @@ class ActivationEventPublisher:
                 payload=event_payload,
                 version=version,
             )
-        await self._publish_snapshot(world_id, version_hint=str(data.get("ts") or version))
+        ts = str(data.get("ts") or "")
+        await self._publish_snapshot(world_id, version_hint=f"{ts}-{version}" if ts else str(version))
         return data
 
     async def update_activation_state(
@@ -95,7 +96,8 @@ class ActivationEventPublisher:
                 requires_ack=requires_ack,
                 sequence=sequence,
             )
-        await self._publish_snapshot(world_id, version_hint=str(data.get("ts") or version))
+        ts = str(data.get("ts") or "")
+        await self._publish_snapshot(world_id, version_hint=f"{ts}-{version}" if ts else str(version))
         return data
 
     async def freeze_world(

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -146,6 +146,15 @@ class LivePromotionApplyRequest(BaseModel):
     force: bool = False
 
 
+class LivePromotionAutoApplyResponse(BaseModel):
+    world_id: str
+    applied: bool
+    source_strategy_id: str | None = None
+    source_run_id: str | None = None
+    apply_run_id: str | None = None
+    plan: ApplyPlan | None = None
+
+
 class ApplyRequest(EvaluateRequest):
     run_id: str
     plan: ApplyPlan | None = None


### PR DESCRIPTION
Adds a minimal scheduler-friendly auto-apply flow for `governance.live_promotion.mode=auto_apply`.

Summary:
- WorldService: `POST /worlds/{world}/promotions/live/auto-apply` selects the freshest paper evaluation run and applies its `active_set`.
- Gateway: proxy route + client method.
- Fix: make RiskSignalHub snapshot versions unique per activation update to avoid apply rollbacks from version collisions.

Tests:
- uv run --with mypy -m mypy
- uv run -m pytest -q tests/qmtl/services/worldservice/test_apply_coordinator.py tests/qmtl/services/worldservice/test_activation_publisher.py tests/qmtl/services/worldservice/test_worldservice_api.py
- uv run mkdocs build --strict
- uv run python scripts/check_docs_links.py

Refs: #1977
