### PR TITLE
world: gate live promotions on dryrun and fail-closed

### DIFF
--- a/docs/ko/design/core_loop_world_roadmap.md
+++ b/docs/ko/design/core_loop_world_roadmap.md
@@ -323,6 +323,8 @@ Phase 5의 “강한 검증/리스크 컷/스트레스”는 입력 데이터가
 	       - 최종 적용은 `POST /worlds/{id}/apply` (2‑phase apply)로 수렴시키되,
 	         “evaluation run → activation plan” 변환 결과(= promote/demote, activate/deactivate)가
 	         CLI/운영자가 검토 가능한 형태로 제공되어야 한다(예: `GET /worlds/{world}/promotions/live/plan?strategy_id=...&run_id=...`).
+	         - 권장: 위 plan 응답에는 `pending_manual_approval`(수동 승인 대기)과 `blocked_reasons`(차단 사유 코드 목록), `eligible`(현재 정책/가드레일 기준으로 승격 가능 여부) 같은 필드를 포함해,
+	           운영자가 “왜 아직 승격이 안 되는지(= dryrun/validation/스냅샷/fail‑closed/쿨다운 등)”를 빠르게 판단할 수 있어야 한다.
 	       - `governance.live_promotion.mode=auto_apply`의 초기 구현은 “외부 스케줄러가 호출하는 자동 적용 엔드포인트”로 시작할 수 있다.
 	         - 예: `POST /worlds/{world}/promotions/live/auto-apply`
 	     - RBAC:

--- a/qmtl/interfaces/cli/world.py
+++ b/qmtl/interfaces/cli/world.py
@@ -402,7 +402,14 @@ def _world_status(args: argparse.Namespace) -> int:
         print(_t("🚦 Live Promotion"))
         print("=" * 50)
         print(f"Mode:          {plan_resp.get('promotion_mode')}")
+        if plan_resp.get("eligible") is not None:
+            print(f"Eligible:      {bool(plan_resp.get('eligible'))}")
         print(f"Pending:       {bool(plan_resp.get('pending_manual_approval'))}")
+        blocked = plan_resp.get("blocked_reasons")
+        if isinstance(blocked, list) and blocked:
+            rendered = ", ".join(str(v) for v in blocked if str(v).strip())
+            if rendered:
+                print(f"Blocked:       {rendered}")
         if plan_resp.get("cooldown_remaining_sec") is not None:
             print(f"Cooldown sec:  {plan_resp.get('cooldown_remaining_sec')}")
         if plan_resp.get("max_live_slots") is not None:

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -140,6 +140,8 @@ class LivePromotionPlanResponse(BaseModel):
     promotion_mode: str | None = None
     override_status: str | None = None
     pending_manual_approval: bool = False
+    eligible: bool = False
+    blocked_reasons: List[str] = Field(default_factory=list)
     cooldown_remaining_sec: int | None = None
     max_live_slots: int | None = None
     canary_fraction: float | None = None


### PR DESCRIPTION
Summary:
- Enforce live promotion eligibility gates: paper-stage dryrun, passing validation status, and fail-closed risk snapshot presence.
- Enforce `governance.live_promotion.approvers` and make approve/reject idempotent.
- Extend promotion plan response with `eligible` + `blocked_reasons` and surface it in `qmtl world status`.

Testing:
- `uv run -m pytest -q tests/qmtl/services/worldservice/test_worldservice_api.py -k 'live_promotion'`
- `uv run --with mypy -m mypy qmtl/services/worldservice/routers/promotions.py qmtl/services/worldservice/services.py qmtl/services/worldservice/schemas.py qmtl/interfaces/cli/world.py`
- `uv run mkdocs build --strict`

Refs #1977
