### PR TITLE
world: add live promotion candidate listing

### DIFF
--- a/docs/ko/design/core_loop_world_roadmap.md
+++ b/docs/ko/design/core_loop_world_roadmap.md
@@ -327,6 +327,9 @@ Phase 5의 “강한 검증/리스크 컷/스트레스”는 입력 데이터가
 	           운영자가 “왜 아직 승격이 안 되는지(= dryrun/validation/스냅샷/fail‑closed/쿨다운 등)”를 빠르게 판단할 수 있어야 한다.
 	       - `governance.live_promotion.mode=auto_apply`의 초기 구현은 “외부 스케줄러가 호출하는 자동 적용 엔드포인트”로 시작할 수 있다.
 	         - 예: `POST /worlds/{world}/promotions/live/auto-apply`
+	       - 후보군 조회(권장):
+	         - `GET /worlds/{world}/promotions/live/candidates` (최신 paper run 기준 후보군 요약)
+	         - (권장 CLI) `qmtl world live-candidates <world> [--include-plan]`
 	     - RBAC:
 	       - 승인/적용은 operator‑only(또는 별도 role)로 제한하고, 모든 호출은 감사 로그로 남긴다.
 

--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -429,6 +429,13 @@ WORLD_ROUTES: tuple[WorldRoute, ...] = (
         query_params=("strategy_id", "run_id"),
     ),
     WorldRoute(
+        "get",
+        "/worlds/{world_id}/promotions/live/candidates",
+        "get_live_promotion_candidates",
+        path_params=("world_id",),
+        query_params=("limit", "include_plan"),
+    ),
+    WorldRoute(
         "post",
         "/worlds/{world_id}/promotions/live/apply",
         "post_live_promotion_apply",

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -511,6 +511,21 @@ class WorldServiceClient:
             params={"strategy_id": strategy_id, "run_id": run_id},
         )
 
+    async def get_live_promotion_candidates(
+        self,
+        world_id: str,
+        *,
+        limit: int = 20,
+        include_plan: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "GET",
+            f"/worlds/{world_id}/promotions/live/candidates",
+            headers=headers,
+            params={"limit": limit, "include_plan": include_plan},
+        )
+
     async def post_live_promotion_apply(
         self,
         world_id: str,

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -165,6 +165,26 @@ class LivePromotionAutoApplyResponse(BaseModel):
     plan: ApplyPlan | None = None
 
 
+class LivePromotionCandidate(BaseModel):
+    strategy_id: str
+    run_id: str
+    created_at: str | None = None
+    updated_at: str | None = None
+    status: str | None = None
+    override_status: str | None = None
+    pending_manual_approval: bool = False
+    eligible: bool = False
+    blocked_reasons: List[str] = Field(default_factory=list)
+    target_active: List[str] = Field(default_factory=list)
+    plan: ApplyPlan | None = None
+
+
+class LivePromotionCandidatesResponse(BaseModel):
+    world_id: str
+    promotion_mode: str | None = None
+    candidates: List[LivePromotionCandidate] = Field(default_factory=list)
+
+
 class ApplyRequest(EvaluateRequest):
     run_id: str
     plan: ApplyPlan | None = None


### PR DESCRIPTION
Summary:
- Add `GET /worlds/{world}/promotions/live/candidates` to list latest eligible paper runs per strategy with `blocked_reasons`, `pending_manual_approval`, and optional `plan`.
- Proxy the endpoint via Gateway and expose a CLI surface: `qmtl world live-candidates <world> [--include-plan]`.

Testing:
- `uv run -m pytest -q tests/qmtl/services/worldservice/test_worldservice_api.py -k 'live_promotion'`
- `uv run --with mypy -m mypy qmtl/services/worldservice/routers/promotions.py qmtl/services/worldservice/schemas.py qmtl/interfaces/cli/world.py qmtl/services/gateway/world_client.py qmtl/services/gateway/routes/worlds.py`
- `uv run mkdocs build --strict`

Refs #1977
