### PR TITLE
world: add Phase 4 campaign status

### DIFF
--- a/docs/en/world/world.md
+++ b/docs/en/world/world.md
@@ -107,6 +107,16 @@ selection:
     demote_after: 2
     min_dwell: 3h
 
+# Phase 4: campaign orchestration (observation windows)
+campaign:
+  backtest:
+    window: 180d      # minimum backtest observation window
+  paper:
+    window: 30d       # minimum paper(dryrun) observation window
+  common:
+    min_sample_days: 30
+    min_trades_total: 100
+
 position_policy:
   on_promote: flat_then_enable
   on_demote: disable_then_flat

--- a/docs/ko/design/core_loop_world_roadmap.md
+++ b/docs/ko/design/core_loop_world_roadmap.md
@@ -229,6 +229,10 @@ status: draft
 - CLI:
   - `qmtl world status` 등에서 캠페인 phase와 핵심 지표를 요약해서 보여주는 명령.
 
+권장 최소 API/CLI (예시):
+- `GET /worlds/{world}/campaign/status[?strategy_id=...]` (phase, 진행률, 승격 가능 여부/사유)
+- `qmtl world status <world> --strategy <sid>` (캠페인 phase/승격 가능 여부 요약 포함)
+
 ---
 
 ## Phase 5 — 검증 단계 고도화 & live 승격 거버넌스

--- a/docs/ko/world/world.md
+++ b/docs/ko/world/world.md
@@ -100,6 +100,16 @@ selection:
     demote_after: 2
     min_dwell: 3h        # 최소 체류 시간
 
+# Phase 4: 캠페인 오케스트레이션(관찰 윈도우)
+campaign:
+  backtest:
+    window: 180d      # 최소 backtest 관찰 기간 (예: 180d)
+  paper:
+    window: 30d       # 최소 paper(dryrun) 관찰 기간
+  common:
+    min_sample_days: 30
+    min_trades_total: 100
+
 position_policy:
   on_promote: flat_then_enable   # 기본: 포지션 미이월
   on_demote: disable_then_flat

--- a/qmtl/interfaces/cli/world.py
+++ b/qmtl/interfaces/cli/world.py
@@ -396,6 +396,27 @@ def _world_status(args: argparse.Namespace) -> int:
         except ValueError:
             return 0
 
+        status_code, campaign_resp = http_get(
+            f"/worlds/{world_id}/campaign/status",
+            params={"strategy_id": strategy_id},
+        )
+        if status_code < 400 and status_code != 0 and isinstance(campaign_resp, dict):
+            strategies = campaign_resp.get("strategies")
+            if isinstance(strategies, list) and strategies:
+                first = strategies[0] if isinstance(strategies[0], dict) else None
+                if isinstance(first, dict):
+                    print()
+                    print(_t("🧭 Campaign Status"))
+                    print("=" * 50)
+                    print(f"Phase:         {first.get('phase')}")
+                    print(f"Promote paper: {bool(first.get('promotable_to_paper'))}")
+                    print(f"Promote live:  {bool(first.get('promotable_to_live'))}")
+                    reasons = first.get("reasons")
+                    if isinstance(reasons, list) and reasons:
+                        rendered = ", ".join(str(v) for v in reasons if str(v).strip())
+                        if rendered:
+                            print(f"Reasons:       {rendered}")
+
         run_id = str(args.evaluation_run_id or "latest")
         if run_id == "latest":
             status_code, runs = http_get(f"/worlds/{world_id}/strategies/{strategy_id}/runs")

--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -436,6 +436,13 @@ WORLD_ROUTES: tuple[WorldRoute, ...] = (
         query_params=("limit", "include_plan"),
     ),
     WorldRoute(
+        "get",
+        "/worlds/{world_id}/campaign/status",
+        "get_campaign_status",
+        path_params=("world_id",),
+        query_params=("strategy_id",),
+    ),
+    WorldRoute(
         "post",
         "/worlds/{world_id}/promotions/live/apply",
         "post_live_promotion_apply",

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -526,6 +526,23 @@ class WorldServiceClient:
             params={"limit": limit, "include_plan": include_plan},
         )
 
+    async def get_campaign_status(
+        self,
+        world_id: str,
+        *,
+        strategy_id: str | None = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        params: Dict[str, Any] = {}
+        if strategy_id is not None:
+            params["strategy_id"] = strategy_id
+        return await self._request_json(
+            "GET",
+            f"/worlds/{world_id}/campaign/status",
+            headers=headers,
+            params=params or None,
+        )
+
     async def post_live_promotion_apply(
         self,
         world_id: str,

--- a/qmtl/services/worldservice/api.py
+++ b/qmtl/services/worldservice/api.py
@@ -26,6 +26,7 @@ from .routers import (
     create_activation_router,
     create_allocations_router,
     create_bindings_router,
+    create_campaigns_router,
     create_evaluation_runs_router,
     create_live_monitoring_router,
     create_observability_router,
@@ -485,6 +486,7 @@ def create_app(
     app.include_router(create_activation_router(service))
     app.include_router(create_allocations_router(service))
     app.include_router(create_evaluation_runs_router(service))
+    app.include_router(create_campaigns_router(service))
     app.include_router(create_promotions_router(service))
     app.include_router(create_live_monitoring_router(service))
     app.include_router(create_observability_router())

--- a/qmtl/services/worldservice/policy_engine.py
+++ b/qmtl/services/worldservice/policy_engine.py
@@ -332,6 +332,23 @@ class GovernanceConfig(BaseModel):
     live_promotion: LivePromotionConfig | None = None
 
 
+class CampaignStageConfig(BaseModel):
+    window: str | None = None
+
+
+class CampaignCommonConfig(BaseModel):
+    min_sample_days: int | None = None
+    min_trades_total: int | None = None
+
+
+class CampaignConfig(BaseModel):
+    """World-level campaign observation configuration (Phase 4)."""
+
+    backtest: CampaignStageConfig | None = None
+    paper: CampaignStageConfig | None = None
+    common: CampaignCommonConfig | None = None
+
+
 class Policy(BaseModel):
     thresholds: dict[str, ThresholdRule] = Field(default_factory=dict)
     top_k: TopKRule | None = None
@@ -348,6 +365,7 @@ class Policy(BaseModel):
     paper_shadow_consistency: PaperShadowConsistencyConfig | None = None
     live_monitoring: LiveMonitoringConfig | None = None
     governance: GovernanceConfig | None = None
+    campaign: CampaignConfig | None = None
 
     def model_post_init(self, __context: Any) -> None:  # type: ignore[override]
         self._normalize_selection()

--- a/qmtl/services/worldservice/routers/__init__.py
+++ b/qmtl/services/worldservice/routers/__init__.py
@@ -2,6 +2,7 @@ from .activation import create_activation_router
 from .allocations import create_allocations_router
 from .bindings import create_bindings_router
 from .evaluation_runs import create_evaluation_runs_router
+from .campaigns import create_campaigns_router
 from .promotions import create_promotions_router
 from .policies import create_policies_router
 from .rebalancing import create_rebalancing_router
@@ -15,6 +16,7 @@ __all__ = [
     'create_activation_router',
     'create_allocations_router',
     'create_bindings_router',
+    'create_campaigns_router',
     'create_evaluation_runs_router',
     'create_promotions_router',
     'create_policies_router',

--- a/qmtl/services/worldservice/routers/campaigns.py
+++ b/qmtl/services/worldservice/routers/campaigns.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import re
+from typing import Any, Mapping
+
+from fastapi import APIRouter, HTTPException
+
+from ..policy_engine import Policy
+from ..schemas import CampaignStatusResponse, CampaignStrategyStatus, CampaignWindowStatus
+from ..services import WorldService
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(ts: str | None) -> datetime:
+    candidate = str(ts or "").strip()
+    if not candidate:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except Exception:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+_DURATION_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smhd])\s*$", re.IGNORECASE)
+
+
+def _parse_duration_seconds(value: str | None) -> int | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    match = _DURATION_RE.match(text)
+    if not match:
+        raise ValueError(f"invalid duration: {text!r}")
+    amount = float(match.group(1))
+    unit = match.group(2).lower()
+    multiplier = {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+    seconds = int(amount * multiplier)
+    return max(0, seconds)
+
+
+@dataclass(frozen=True, slots=True)
+class CampaignPolicy:
+    backtest_window: str | None
+    paper_window: str | None
+    min_sample_days: int | None
+    min_trades_total: int | None
+
+
+def _extract_campaign_policy(policy: object) -> CampaignPolicy:
+    if isinstance(policy, Policy):
+        campaign = policy.campaign
+        backtest_window = campaign.backtest.window if campaign and campaign.backtest else None
+        paper_window = campaign.paper.window if campaign and campaign.paper else None
+        common = campaign.common if campaign else None
+        min_sample_days = common.min_sample_days if common else None
+        min_trades_total = common.min_trades_total if common else None
+        return CampaignPolicy(
+            backtest_window=backtest_window,
+            paper_window=paper_window,
+            min_sample_days=min_sample_days,
+            min_trades_total=min_trades_total,
+        )
+    if isinstance(policy, dict):
+        campaign = policy.get("campaign")
+        if not isinstance(campaign, dict):
+            return CampaignPolicy(None, None, None, None)
+        backtest = campaign.get("backtest") if isinstance(campaign.get("backtest"), dict) else {}
+        paper = campaign.get("paper") if isinstance(campaign.get("paper"), dict) else {}
+        common = campaign.get("common") if isinstance(campaign.get("common"), dict) else {}
+        backtest_window = backtest.get("window")
+        paper_window = paper.get("window")
+        min_sample_days = common.get("min_sample_days")
+        min_trades_total = common.get("min_trades_total")
+        try:
+            min_sample_days = int(min_sample_days) if min_sample_days is not None else None
+        except Exception:
+            min_sample_days = None
+        try:
+            min_trades_total = int(min_trades_total) if min_trades_total is not None else None
+        except Exception:
+            min_trades_total = None
+        return CampaignPolicy(
+            backtest_window=str(backtest_window) if backtest_window is not None else None,
+            paper_window=str(paper_window) if paper_window is not None else None,
+            min_sample_days=min_sample_days,
+            min_trades_total=min_trades_total,
+        )
+    return CampaignPolicy(None, None, None, None)
+
+
+def _metric_float(metrics: Mapping[str, Any] | None, section: str, key: str) -> float | None:
+    if not metrics:
+        return None
+    direct = metrics.get(key)
+    if isinstance(direct, (int, float)) and not isinstance(direct, bool):
+        return float(direct)
+    block = metrics.get(section)
+    if isinstance(block, Mapping):
+        value = block.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return None
+
+
+def _metric_int(metrics: Mapping[str, Any] | None, section: str, key: str) -> int | None:
+    if not metrics:
+        return None
+    direct = metrics.get(key)
+    if isinstance(direct, int) and not isinstance(direct, bool):
+        return int(direct)
+    block = metrics.get(section)
+    if isinstance(block, Mapping):
+        value = block.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return int(value)
+    return None
+
+
+def _estimate_sample_days(metrics: Mapping[str, Any] | None) -> int | None:
+    years = _metric_float(metrics, "sample", "effective_history_years")
+    if years is None:
+        return None
+    return max(0, int(years * 365))
+
+
+def _latest_run_by_stage(runs: list[dict], stage: str) -> dict | None:
+    stage_runs = [r for r in runs if str(r.get("stage") or "").lower() == stage]
+    if not stage_runs:
+        return None
+    return max(stage_runs, key=lambda r: (_parse_iso(str(r.get("updated_at") or "")), _parse_iso(str(r.get("created_at") or ""))))
+
+
+def _window_observation(runs: list[dict], stage: str) -> tuple[datetime | None, datetime | None, int | None]:
+    stage_runs = [r for r in runs if str(r.get("stage") or "").lower() == stage]
+    if not stage_runs:
+        return None, None, None
+    starts = [_parse_iso(str(r.get("created_at") or "")) for r in stage_runs]
+    ends = [_parse_iso(str(r.get("updated_at") or "")) for r in stage_runs]
+    start = min(starts) if starts else None
+    end = max(ends) if ends else None
+    if start is None or end is None or start == datetime.min.replace(tzinfo=timezone.utc) or end == datetime.min.replace(tzinfo=timezone.utc):
+        return None, None, None
+    observed_sec = max(0, int((end - start).total_seconds()))
+    return start, end, observed_sec
+
+
+def _window_status(window: str | None, *, start: datetime | None, end: datetime | None, observed_sec: int | None) -> CampaignWindowStatus:
+    required_sec = _parse_duration_seconds(window)
+    progress = None
+    satisfied = False
+    if required_sec is not None:
+        if observed_sec is None:
+            progress = 0.0
+        elif required_sec <= 0:
+            progress = 1.0
+            satisfied = True
+        else:
+            progress = min(1.0, max(0.0, observed_sec / required_sec))
+            satisfied = progress >= 1.0
+    return CampaignWindowStatus(
+        window=window,
+        required_sec=required_sec,
+        observed_sec=observed_sec,
+        progress=progress,
+        started_at=start.isoformat().replace("+00:00", "Z") if start else None,
+        ended_at=end.isoformat().replace("+00:00", "Z") if end else None,
+        satisfied=satisfied,
+    )
+
+
+def create_campaigns_router(service: WorldService) -> APIRouter:
+    router = APIRouter()
+
+    @router.get(
+        "/worlds/{world_id}/campaign/status",
+        response_model=CampaignStatusResponse,
+    )
+    async def get_campaign_status(
+        world_id: str,
+        *,
+        strategy_id: str | None = None,
+    ) -> CampaignStatusResponse:
+        policy_obj = await service.store.get_default_policy(world_id)
+        campaign_policy = _extract_campaign_policy(policy_obj)
+        try:
+            _ = _parse_duration_seconds(campaign_policy.backtest_window)
+            _ = _parse_duration_seconds(campaign_policy.paper_window)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        runs = await service.store.list_evaluation_runs(world_id=world_id, strategy_id=strategy_id)
+        grouped: dict[str, list[dict]] = {}
+        for run in runs:
+            if not isinstance(run, dict):
+                continue
+            sid = str(run.get("strategy_id") or "")
+            if not sid:
+                continue
+            grouped.setdefault(sid, []).append(run)
+
+        statuses: list[CampaignStrategyStatus] = []
+        for sid, sruns in grouped.items():
+            backtest_latest = _latest_run_by_stage(sruns, "backtest")
+            paper_latest = _latest_run_by_stage(sruns, "paper")
+            live_latest = _latest_run_by_stage(sruns, "live")
+
+            if live_latest is not None:
+                phase = "live_campaign"
+            elif paper_latest is not None:
+                phase = "paper_campaign"
+            else:
+                phase = "backtest_campaign"
+
+            reasons: list[str] = []
+
+            backtest_start, backtest_end, backtest_observed = _window_observation(sruns, "backtest")
+            paper_start, paper_end, paper_observed = _window_observation(sruns, "paper")
+
+            backtest_window = _window_status(
+                campaign_policy.backtest_window,
+                start=backtest_start,
+                end=backtest_end,
+                observed_sec=backtest_observed,
+            )
+            paper_window = _window_status(
+                campaign_policy.paper_window,
+                start=paper_start,
+                end=paper_end,
+                observed_sec=paper_observed,
+            )
+
+            latest_metrics: Mapping[str, Any] | None = None
+            latest_summary: Mapping[str, Any] | None = None
+            if paper_latest is not None:
+                latest_metrics = paper_latest.get("metrics") if isinstance(paper_latest.get("metrics"), Mapping) else None
+                latest_summary = paper_latest.get("summary") if isinstance(paper_latest.get("summary"), Mapping) else None
+            elif backtest_latest is not None:
+                latest_metrics = backtest_latest.get("metrics") if isinstance(backtest_latest.get("metrics"), Mapping) else None
+                latest_summary = backtest_latest.get("summary") if isinstance(backtest_latest.get("summary"), Mapping) else None
+
+            sample_days = _estimate_sample_days(latest_metrics)
+            trades_total = _metric_int(latest_metrics, "sample", "n_trades_total")
+            sharpe = _metric_float(latest_metrics, "returns", "sharpe")
+            max_drawdown = _metric_float(latest_metrics, "returns", "max_drawdown")
+
+            if campaign_policy.min_sample_days is not None:
+                if sample_days is None:
+                    reasons.append("missing_sample_days_metric")
+                elif sample_days < campaign_policy.min_sample_days:
+                    reasons.append("insufficient_sample_days")
+
+            if campaign_policy.min_trades_total is not None:
+                if trades_total is None:
+                    reasons.append("missing_trades_metric")
+                elif trades_total < campaign_policy.min_trades_total:
+                    reasons.append("insufficient_trades")
+
+            backtest_ok = backtest_window.satisfied or campaign_policy.backtest_window is None
+            paper_ok = paper_window.satisfied or campaign_policy.paper_window is None
+
+            backtest_status = (
+                str((backtest_latest or {}).get("summary", {}).get("status") or "").lower()
+                if backtest_latest
+                else ""
+            )
+            paper_status = (
+                str((paper_latest or {}).get("summary", {}).get("status") or "").lower()
+                if paper_latest
+                else ""
+            )
+            if backtest_latest is None:
+                reasons.append("missing_backtest_run")
+            if paper_latest is None:
+                reasons.append("missing_paper_run")
+            if not backtest_ok:
+                reasons.append("backtest_window_incomplete")
+            if not paper_ok:
+                reasons.append("paper_window_incomplete")
+
+            promotable_to_paper = (
+                backtest_latest is not None
+                and backtest_ok
+                and backtest_status in {"pass", "warn"}
+                and "insufficient_sample_days" not in reasons
+                and "insufficient_trades" not in reasons
+                and "missing_sample_days_metric" not in reasons
+                and "missing_trades_metric" not in reasons
+            )
+            promotable_to_live = (
+                paper_latest is not None
+                and paper_ok
+                and paper_status in {"pass", "warn"}
+                and "insufficient_sample_days" not in reasons
+                and "insufficient_trades" not in reasons
+                and "missing_sample_days_metric" not in reasons
+                and "missing_trades_metric" not in reasons
+            )
+
+            statuses.append(
+                CampaignStrategyStatus(
+                    strategy_id=sid,
+                    phase=phase,
+                    backtest=backtest_window,
+                    paper=paper_window,
+                    sample_days=sample_days,
+                    trades_total=trades_total,
+                    sharpe=sharpe,
+                    max_drawdown=max_drawdown,
+                    promotable_to_paper=promotable_to_paper,
+                    promotable_to_live=promotable_to_live,
+                    reasons=reasons,
+                )
+            )
+
+        statuses.sort(key=lambda s: s.strategy_id)
+        config = {
+            "backtest_window": campaign_policy.backtest_window,
+            "paper_window": campaign_policy.paper_window,
+            "min_sample_days": campaign_policy.min_sample_days,
+            "min_trades_total": campaign_policy.min_trades_total,
+        }
+        return CampaignStatusResponse(
+            world_id=world_id,
+            generated_at=_utc_now_iso(),
+            config=config,
+            strategies=statuses,
+        )
+
+    return router
+
+
+__all__ = ["create_campaigns_router"]

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -185,6 +185,37 @@ class LivePromotionCandidatesResponse(BaseModel):
     candidates: List[LivePromotionCandidate] = Field(default_factory=list)
 
 
+class CampaignWindowStatus(BaseModel):
+    window: str | None = None
+    required_sec: int | None = None
+    observed_sec: int | None = None
+    progress: float | None = None
+    started_at: str | None = None
+    ended_at: str | None = None
+    satisfied: bool = False
+
+
+class CampaignStrategyStatus(BaseModel):
+    strategy_id: str
+    phase: Literal["backtest_campaign", "paper_campaign", "live_campaign"] | str
+    backtest: CampaignWindowStatus | None = None
+    paper: CampaignWindowStatus | None = None
+    sample_days: int | None = None
+    trades_total: int | None = None
+    sharpe: float | None = None
+    max_drawdown: float | None = None
+    promotable_to_paper: bool = False
+    promotable_to_live: bool = False
+    reasons: List[str] = Field(default_factory=list)
+
+
+class CampaignStatusResponse(BaseModel):
+    world_id: str
+    generated_at: str
+    config: Dict[str, Any] | None = None
+    strategies: List[CampaignStrategyStatus] = Field(default_factory=list)
+
+
 class ApplyRequest(EvaluateRequest):
     run_id: str
     plan: ApplyPlan | None = None


### PR DESCRIPTION
Summary:
- Add Phase 4 campaign config to policy DSL: `campaign.backtest.window`, `campaign.paper.window`, `campaign.common.*`.
- Add `GET /worlds/{world}/campaign/status[?strategy_id=...]` to aggregate campaign phase/progress/promotability from evaluation runs.
- Proxy via Gateway and show campaign summary in `qmtl world status --strategy`.
- Update world policy docs (ko/en) to include campaign fields.

Testing:
- `uv run -m pytest -q tests/qmtl/services/worldservice/test_worldservice_api.py -k 'campaign_status or live_promotion'`
- `uv run --with mypy -m mypy qmtl/services/worldservice/policy_engine.py qmtl/services/worldservice/routers/campaigns.py qmtl/services/worldservice/api.py qmtl/services/gateway/world_client.py qmtl/services/gateway/routes/worlds.py qmtl/interfaces/cli/world.py`
- `uv run mkdocs build --strict`

Refs #1977
