### PR TITLE
world: add Phase 4 campaign tick

### DIFF
--- a/docs/ko/design/core_loop_world_roadmap.md
+++ b/docs/ko/design/core_loop_world_roadmap.md
@@ -213,6 +213,8 @@ status: draft
 
    - 초기 단계에서는 **외부 스케줄러/워크플로**를 전제로 단순하게 시작한다.
      - 예: “매일 1회 `/worlds/{id}/evaluate` 호출 → 정책 기반 승격 후보 계산 → `/apply`로 반영 또는 큐에 보관”.
+     - 권장: 외부 스케줄러가 “다음에 무엇을 호출해야 하는지”를 얻기 위해, WorldService가 상태를 읽고 **추천 액션을 반환하는 tick 엔드포인트**를 제공한다(사이드이펙트 없음).
+       - 예: `POST /worlds/{id}/campaign/tick` → `evaluate(backtest/paper)` 또는 `promotions/live/auto-apply` 호출 권장 목록 반환
    - 이후 필요 시 WorldService 내부에 간단한 주기 평가 루프를 추가할 수 있다.
 
 4. **Runner/CLI와의 연결**

--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -444,6 +444,14 @@ WORLD_ROUTES: tuple[WorldRoute, ...] = (
     ),
     WorldRoute(
         "post",
+        "/worlds/{world_id}/campaign/tick",
+        "post_campaign_tick",
+        path_params=("world_id",),
+        query_params=("strategy_id",),
+        include_payload=True,
+    ),
+    WorldRoute(
+        "post",
         "/worlds/{world_id}/promotions/live/apply",
         "post_live_promotion_apply",
         path_params=("world_id",),

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -543,6 +543,24 @@ class WorldServiceClient:
             params=params or None,
         )
 
+    async def post_campaign_tick(
+        self,
+        world_id: str,
+        *,
+        strategy_id: str | None = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        params: Dict[str, Any] = {}
+        if strategy_id is not None:
+            params["strategy_id"] = strategy_id
+        return await self._request_json(
+            "POST",
+            f"/worlds/{world_id}/campaign/tick",
+            headers=headers,
+            params=params or None,
+            json={},
+        )
+
     async def post_live_promotion_apply(
         self,
         world_id: str,

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -198,6 +198,9 @@ class CampaignWindowStatus(BaseModel):
 class CampaignStrategyStatus(BaseModel):
     strategy_id: str
     phase: Literal["backtest_campaign", "paper_campaign", "live_campaign"] | str
+    latest_backtest_run_id: str | None = None
+    latest_paper_run_id: str | None = None
+    latest_live_run_id: str | None = None
     backtest: CampaignWindowStatus | None = None
     paper: CampaignWindowStatus | None = None
     sample_days: int | None = None
@@ -214,6 +217,23 @@ class CampaignStatusResponse(BaseModel):
     generated_at: str
     config: Dict[str, Any] | None = None
     strategies: List[CampaignStrategyStatus] = Field(default_factory=list)
+
+
+class CampaignTickAction(BaseModel):
+    action: str
+    strategy_id: str | None = None
+    stage: str | None = None
+    reason: str | None = None
+    suggested_endpoint: str | None = None
+    suggested_method: str | None = None
+    suggested_params: Dict[str, Any] | None = None
+    suggested_body: Dict[str, Any] | None = None
+
+
+class CampaignTickResponse(BaseModel):
+    world_id: str
+    generated_at: str
+    actions: List[CampaignTickAction] = Field(default_factory=list)
 
 
 class ApplyRequest(EvaluateRequest):


### PR DESCRIPTION
Summary:
- Add `POST /worlds/{world}/campaign/tick` (side-effect free) to emit recommended external-scheduler actions for Phase 4.
- Proxy via Gateway and add CLI: `qmtl world campaign-tick <world> [--strategy <sid>]`.

Testing:
- `uv run -m pytest -q tests/qmtl/services/worldservice/test_worldservice_api.py -k 'campaign_tick or campaign_status'`
- `uv run --with mypy -m mypy qmtl/services/worldservice/routers/campaigns.py qmtl/services/worldservice/schemas.py qmtl/services/gateway/world_client.py qmtl/services/gateway/routes/worlds.py qmtl/interfaces/cli/world.py`
- `uv run mkdocs build --strict`

Refs #1977
