### PR TITLE
Harden campaign tick contract

### DIFF
--- a/qmtl/automation/campaign_executor.py
+++ b/qmtl/automation/campaign_executor.py
@@ -181,6 +181,20 @@ class CampaignExecutor:
                                 )
                             )
                             continue
+                        metrics = suggested_body.get("metrics")
+                        if not isinstance(metrics, Mapping) or not metrics:
+                            results.append(
+                                ExecutionResult(
+                                    action=action,
+                                    method=method,
+                                    path=path,
+                                    status_code=None,
+                                    ok=True,
+                                    skipped=True,
+                                    reason="missing_metrics",
+                                )
+                            )
+                            continue
                         body = self._materialize_evaluate_payload(suggested_body, strategy_id=sid)
                     else:
                         body = {str(k): v for k, v in suggested_body.items() if v is not None}

--- a/qmtl/interfaces/cli/world.py
+++ b/qmtl/interfaces/cli/world.py
@@ -731,6 +731,9 @@ def _world_campaign_tick(args: argparse.Namespace) -> int:
     print(_t("🧭 Campaign Tick"))
     print("=" * 60)
     print(f"World: {world_id}")
+    schema_version = payload.get("schema_version")
+    if schema_version is not None:
+        print(f"Schema: {schema_version}")
     print(f"Count: {len(actions)}")
     if not actions:
         return 0
@@ -741,6 +744,9 @@ def _world_campaign_tick(args: argparse.Namespace) -> int:
         sid = item.get("strategy_id")
         stage = item.get("stage")
         reason = item.get("reason")
+        idem = item.get("idempotency_key")
+        suggested_run_id = item.get("suggested_run_id")
+        requires = item.get("requires")
         method = item.get("suggested_method")
         endpoint = item.get("suggested_endpoint")
         line = f"- {action}"
@@ -748,8 +754,16 @@ def _world_campaign_tick(args: argparse.Namespace) -> int:
             line += f" strategy={sid}"
         if stage:
             line += f" stage={stage}"
+        if suggested_run_id:
+            line += f" run={suggested_run_id}"
         if reason:
             line += f" reason={reason}"
+        if isinstance(requires, list) and requires:
+            rendered = ",".join(str(v) for v in requires if str(v).strip())
+            if rendered:
+                line += f" requires={rendered}"
+        if idem:
+            line += f" key={idem}"
         if method and endpoint:
             line += f" -> {method} {endpoint}"
         print(line)

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -221,9 +221,12 @@ class CampaignStatusResponse(BaseModel):
 
 class CampaignTickAction(BaseModel):
     action: str
+    idempotency_key: str | None = None
     strategy_id: str | None = None
     stage: str | None = None
     reason: str | None = None
+    requires: List[str] = Field(default_factory=list)
+    suggested_run_id: str | None = None
     suggested_endpoint: str | None = None
     suggested_method: str | None = None
     suggested_params: Dict[str, Any] | None = None
@@ -231,6 +234,7 @@ class CampaignTickAction(BaseModel):
 
 
 class CampaignTickResponse(BaseModel):
+    schema_version: int = 1
     world_id: str
     generated_at: str
     actions: List[CampaignTickAction] = Field(default_factory=list)


### PR DESCRIPTION
Summary:
- Harden the Phase 4 /campaign/tick contract so external schedulers can dedupe safely and so we don't suggest dummy metrics.

Changes:
- Add schema_version, idempotency_key, suggested_run_id and requires[] to campaign tick responses.
- Remove placeholder/dummy metrics from evaluate suggested_body; evaluate actions are now templates (requires=["metrics"]).
- CampaignExecutor skips executing evaluate when metrics are missing (even with --execute-evaluate), to avoid writing meaningless runs.
- Update CLI output for campaign-tick to display schema and action keys.

Validation:
- uv run --with mypy -m mypy (touched files)
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q
