### PR TITLE
Expose evaluation run status links

### DIFF
--- a/qmtl/services/gateway/routes/worlds.py
+++ b/qmtl/services/gateway/routes/worlds.py
@@ -407,9 +407,22 @@ WORLD_ROUTES: tuple[WorldRoute, ...] = (
         path_params=("world_id", "strategy_id", "run_id"),
     ),
     WorldRoute(
+        "get",
+        "/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}/history",
+        "get_evaluation_run_history",
+        path_params=("world_id", "strategy_id", "run_id"),
+    ),
+    WorldRoute(
         "post",
         "/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}/override",
         "post_evaluation_override",
+        path_params=("world_id", "strategy_id", "run_id"),
+        include_payload=True,
+    ),
+    WorldRoute(
+        "post",
+        "/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}/ex-post-failures",
+        "post_ex_post_failure",
         path_params=("world_id", "strategy_id", "run_id"),
         include_payload=True,
     ),

--- a/qmtl/services/gateway/world_client.py
+++ b/qmtl/services/gateway/world_client.py
@@ -460,6 +460,34 @@ class WorldServiceClient:
             headers=headers,
         )
 
+    async def get_evaluation_run_history(
+        self,
+        world_id: str,
+        strategy_id: str,
+        run_id: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "GET",
+            f"/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}/history",
+            headers=headers,
+        )
+
+    async def post_ex_post_failure(
+        self,
+        world_id: str,
+        strategy_id: str,
+        run_id: str,
+        payload: Any,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        return await self._request_json(
+            "POST",
+            f"/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}/ex-post-failures",
+            headers=headers,
+            json=payload,
+        )
+
     async def post_evaluate(self, world_id: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Any:
         return await self._request_json(
             "POST",

--- a/qmtl/services/worldservice/routers/evaluation_runs.py
+++ b/qmtl/services/worldservice/routers/evaluation_runs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 from fastapi import APIRouter, HTTPException
 
 from ..schemas import (
@@ -12,6 +14,25 @@ from ..schemas import (
 from ..services import WorldService
 
 
+def _metrics_present(metrics: object) -> bool:
+    if metrics is None:
+        return False
+    if isinstance(metrics, Mapping):
+        return bool(metrics)
+    return True
+
+
+def _run_status(metrics: object) -> str:
+    return "evaluated" if _metrics_present(metrics) else "evaluating"
+
+
+def _run_links(*, world_id: str, strategy_id: str, run_id: str) -> dict[str, str]:
+    return {
+        "metrics": f"/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}/metrics",
+        "history": f"/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}/history",
+    }
+
+
 def create_evaluation_runs_router(service: WorldService) -> APIRouter:
     router = APIRouter()
 
@@ -21,7 +42,17 @@ def create_evaluation_runs_router(service: WorldService) -> APIRouter:
     )
     async def list_evaluation_runs(world_id: str, strategy_id: str) -> list[EvaluationRunModel]:
         runs = await service.store.list_evaluation_runs(world_id=world_id, strategy_id=strategy_id)
-        return [EvaluationRunModel(**run) for run in runs]
+        enriched: list[EvaluationRunModel] = []
+        for run in runs:
+            if not isinstance(run, dict):
+                continue
+            payload: dict[str, Any] = dict(run)
+            rid = str(payload.get("run_id") or "")
+            payload["status"] = _run_status(payload.get("metrics"))
+            if rid:
+                payload["links"] = _run_links(world_id=world_id, strategy_id=strategy_id, run_id=rid)
+            enriched.append(EvaluationRunModel(**payload))
+        return enriched
 
     @router.get(
         "/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}",
@@ -31,7 +62,10 @@ def create_evaluation_runs_router(service: WorldService) -> APIRouter:
         record = await service.store.get_evaluation_run(world_id, strategy_id, run_id)
         if record is None:
             raise HTTPException(status_code=404, detail="evaluation run not found")
-        return EvaluationRunModel(**record)
+        payload: dict[str, Any] = dict(record)
+        payload["status"] = _run_status(payload.get("metrics"))
+        payload["links"] = _run_links(world_id=world_id, strategy_id=strategy_id, run_id=run_id)
+        return EvaluationRunModel(**payload)
 
     @router.get(
         "/worlds/{world_id}/strategies/{strategy_id}/runs/{run_id}/metrics",
@@ -43,11 +77,8 @@ def create_evaluation_runs_router(service: WorldService) -> APIRouter:
         record = await service.store.get_evaluation_run(world_id, strategy_id, run_id)
         if record is None:
             raise HTTPException(status_code=404, detail="evaluation run not found")
-        run = EvaluationRunModel(**record)
-        metrics_present = (
-            run.metrics is not None
-            and bool(run.metrics.model_dump(exclude_none=True))
-        )
+        run = EvaluationRunModel(**dict(record))
+        metrics_present = run.metrics is not None and bool(run.metrics.model_dump(exclude_none=True))
         if not metrics_present:
             raise HTTPException(
                 status_code=409,
@@ -60,6 +91,7 @@ def create_evaluation_runs_router(service: WorldService) -> APIRouter:
             world_id=run.world_id,
             strategy_id=run.strategy_id,
             run_id=run.run_id,
+            status=_run_status(record.get("metrics") if isinstance(record, dict) else None),
             stage=run.stage,
             risk_tier=run.risk_tier,
             metrics=run.metrics,
@@ -67,6 +99,7 @@ def create_evaluation_runs_router(service: WorldService) -> APIRouter:
             summary=run.summary,
             created_at=run.created_at,
             updated_at=run.updated_at,
+            links=_run_links(world_id=world_id, strategy_id=strategy_id, run_id=run_id),
         )
 
     @router.get(

--- a/qmtl/services/worldservice/schemas.py
+++ b/qmtl/services/worldservice/schemas.py
@@ -640,10 +640,18 @@ class EvaluationSummary(BaseModel):
     override_timestamp: str | None = None
 
 
+class EvaluationRunLinks(BaseModel):
+    """Hyperlinks for navigating evaluation-run related resources."""
+
+    metrics: str | None = None
+    history: str | None = None
+
+
 class EvaluationRunModel(BaseModel):
     world_id: str
     strategy_id: str
     run_id: str
+    status: Literal["evaluating", "evaluated"] | str | None = None
     stage: Literal["backtest", "paper", "live"] | str
     risk_tier: Literal["high", "medium", "low"] | str
     model_card_version: str | None = None
@@ -652,6 +660,7 @@ class EvaluationRunModel(BaseModel):
     summary: EvaluationSummary | None = None
     created_at: str | None = None
     updated_at: str | None = None
+    links: EvaluationRunLinks | None = None
 
 
 class EvaluationRunMetricsResponse(BaseModel):
@@ -660,6 +669,7 @@ class EvaluationRunMetricsResponse(BaseModel):
     world_id: str
     strategy_id: str
     run_id: str
+    status: Literal["evaluating", "evaluated"] | str | None = None
     stage: Literal["backtest", "paper", "live"] | str
     risk_tier: Literal["high", "medium", "low"] | str
     metrics: EvaluationMetrics
@@ -667,6 +677,7 @@ class EvaluationRunMetricsResponse(BaseModel):
     summary: EvaluationSummary | None = None
     created_at: str | None = None
     updated_at: str | None = None
+    links: EvaluationRunLinks | None = None
 
 
 class EvaluationRunHistoryItem(BaseModel):
@@ -742,6 +753,7 @@ __all__ = [
     'RuleResultModel',
     'EvaluationValidation',
     'EvaluationSummary',
+    'EvaluationRunLinks',
     'EvaluationRunModel',
     'EvaluationRunMetricsResponse',
     'EvaluationRunHistoryItem',

--- a/tests/qmtl/services/worldservice/test_worldservice_api.py
+++ b/tests/qmtl/services/worldservice/test_worldservice_api.py
@@ -453,8 +453,11 @@ async def test_evaluation_run_creation_and_fetch():
             record = run_resp.json()
             assert record["run_id"] == "run-eval-1"
             assert record["strategy_id"] == "s-eval"
+            assert record["status"] == "evaluated"
             assert record["stage"] == "backtest"
             assert record["model_card_version"] == "v1.0"
+            assert record["links"]["metrics"].endswith("/worlds/weval/strategies/s-eval/runs/run-eval-1/metrics")
+            assert record["links"]["history"].endswith("/worlds/weval/strategies/s-eval/runs/run-eval-1/history")
             assert record["metrics"]["returns"]["sharpe"] == 1.5
             assert record["metrics"]["risk"]["adv_utilization_p95"] == 0.2
             assert record["metrics"]["risk"]["participation_rate_p95"] == 0.15


### PR DESCRIPTION
Summary:
- Close Phase 2/3 evaluation-run contract gaps by adding explicit run status + links and proxying history/audit surfaces through Gateway.

Changes:
- WorldService: enrich `GET /worlds/{world}/strategies/{strategy}/runs/{run}` and list endpoints with `status` and `links.{metrics,history}`.
- WorldService: include `status` and `links` in the `/metrics` response.
- Gateway: proxy run `history` and `ex-post-failures` endpoints; add WorldServiceClient methods.
- Docs (ko/en): align `worldservice_evaluation_runs_and_metrics_api.md` examples with implemented schemas and 409 error format.

Validation (CI parity):
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_design_drift.py
- uv run python scripts/lint_dsn_keys.py
- uv run --with grimp python scripts/check_import_cycles.py --baseline scripts/import_cycles_baseline.json
- uv run --with grimp python scripts/check_sdk_layers.py
- uv run python scripts/check_docs_links.py
- uv run -m pytest --collect-only -q
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q
