### PR TITLE
feat: allow campaign executor to execute evaluate actions

### DIFF
--- a/docs/ko/design/core_loop_world_roadmap.md
+++ b/docs/ko/design/core_loop_world_roadmap.md
@@ -203,10 +203,13 @@ status: draft
          - `schema_version`: 스키마 진화용 버전 필드(하위 호환 유지 전제)
          - `idempotency_key`: 외부 스케줄러가 중복 실행을 회피/디듀프하는 키
          - `suggested_run_id`: (특히 `evaluate`) 재실행 시 동일 런으로 업데이트되도록 유도하는 권장 `run_id`
-       - `evaluate` 액션의 `suggested_body`는 **실제 metrics를 포함하지 않는 템플릿**으로 취급한다. (`requires=["metrics"]`)  
-         즉, 평가 엔진/프로듀서가 metrics를 생성해 채운 뒤 `/evaluate`에 전달해야 하며, 더미 metrics로 승격 판단을 왜곡하지 않는다.
-     - (옵션) 외부 엔진 없이도 qmtl 내부 실행기로 운영할 수 있다.
-       - 예: `qmtl world campaign-execute <world> [--execute]`, `qmtl world campaign-loop <world> --interval-sec 3600 [--execute]`
+      - `evaluate` 액션의 `suggested_body`는 **실제 metrics를 포함하지 않는 템플릿**으로 취급한다. (`requires=["metrics"]`)
+        - 초기(경량) 구현: qmtl 내부 실행기(`CampaignExecutor`)가 **최근 평가 런의 metrics를 재사용**해 `/evaluate`를 호출할 수 있다.
+          - stage 일치(예: paper 추천이면 paper-stage run) 우선, 없으면 최근 evaluated run을 fallback.
+          - 목적: 외부 엔진 없이도 “캠페인 윈도우 관찰/상태 전이/승격 후보 산출”을 end-to-end로 돌릴 수 있게 한다.
+          - 한계: 실제 신규 backtest/paper 실행을 대체하지는 않으며, 진짜 지표 생산은 추후(리스크 허브/데이터 플레인/전용 프로듀서)로 확장한다.
+    - (옵션) 외부 엔진 없이도 qmtl 내부 실행기로 운영할 수 있다.
+      - 예: `qmtl world campaign-execute <world> [--execute] [--execute-evaluate]`, `qmtl world campaign-loop <world> --interval-sec 3600 [--execute] [--execute-evaluate]`
    - 이후 필요 시 WorldService 내부에 간단한 주기 평가 루프를 추가할 수 있다.
 
 4. **Runner/CLI와의 연결**

--- a/tests/qmtl/automation/test_campaign_executor.py
+++ b/tests/qmtl/automation/test_campaign_executor.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any
+
+from qmtl.automation.campaign_executor import CampaignExecutor, CampaignRunConfig
+
+
+class FakeCampaignExecutor(CampaignExecutor):
+    def __init__(self) -> None:
+        super().__init__(base_url="http://example.invalid")
+        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]] = []
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str | int | float | bool] | None = None,
+        json_body: dict[str, object] | None = None,
+    ) -> tuple[int, Any]:
+        self.calls.append((method, path, params, dict(json_body) if json_body is not None else None))
+
+        if path == "/worlds/w/campaign/tick":
+            return (
+                200,
+                {
+                    "actions": [
+                        {
+                            "action": "evaluate",
+                            "strategy_id": "s1",
+                            "stage": "backtest",
+                            "suggested_method": "POST",
+                            "suggested_endpoint": "/worlds/w/evaluate",
+                            "suggested_body": {
+                                "strategy_id": "s1",
+                                "stage": "backtest",
+                                "risk_tier": "low",
+                                "run_id": "camp-w-s1-backtest-20250101",
+                            },
+                        }
+                    ]
+                },
+            )
+
+        if path == "/worlds/w/strategies/s1/runs":
+            return (
+                200,
+                [
+                    {
+                        "world_id": "w",
+                        "strategy_id": "s1",
+                        "run_id": "eval-prev",
+                        "stage": "backtest",
+                        "status": "evaluated",
+                        "created_at": "2025-01-01T00:00:00Z",
+                        "updated_at": "2025-01-01T00:00:10Z",
+                    }
+                ],
+            )
+
+        if path == "/worlds/w/strategies/s1/runs/eval-prev/metrics":
+            return (
+                200,
+                {
+                    "metrics": {
+                        "returns": {"sharpe": 1.2, "max_drawdown": 0.1},
+                        "sample": {"effective_history_years": 0.5},
+                    }
+                },
+            )
+
+        if path == "/worlds/w/evaluate":
+            return 200, {"active": ["s1"], "evaluation_run_id": "camp-w-s1-backtest-20250101"}
+
+        raise AssertionError(f"unexpected request: {method} {path} params={params} json={json_body}")
+
+
+def test_campaign_executor_executes_evaluate_with_sourced_metrics() -> None:
+    exe = FakeCampaignExecutor()
+    cfg = CampaignRunConfig(world_id="w", strategy_id="s1", execute=True, execute_evaluate=True)
+
+    tick, results = exe.execute_tick(cfg)
+
+    assert tick["actions"][0]["action"] == "evaluate"
+    assert results and results[0].ok is True
+    assert results[0].skipped is False
+
+    # Ensure the evaluate call includes metrics keyed by strategy_id.
+    evaluate_calls = [c for c in exe.calls if c[0] == "POST" and c[1] == "/worlds/w/evaluate"]
+    assert len(evaluate_calls) == 1
+    _, _, _, body = evaluate_calls[0]
+    assert body is not None
+    metrics = body.get("metrics")
+    assert isinstance(metrics, dict)
+    assert metrics.get("s1", {}).get("returns", {}).get("sharpe") == 1.2
+
+
+def test_campaign_executor_skips_evaluate_when_no_metrics_source() -> None:
+    class NoMetricsExecutor(FakeCampaignExecutor):
+        def _request(self, method: str, path: str, *, params=None, json_body=None):
+            if path == "/worlds/w/strategies/s1/runs":
+                return 200, []
+            return super()._request(method, path, params=params, json_body=json_body)
+
+    exe = NoMetricsExecutor()
+    cfg = CampaignRunConfig(world_id="w", strategy_id="s1", execute=True, execute_evaluate=True)
+
+    _, results = exe.execute_tick(cfg)
+
+    assert results and results[0].skipped is True
+    assert results[0].reason == "missing_metrics_source"


### PR DESCRIPTION
Summary:
- `CampaignExecutor` can now execute tick `evaluate` actions by sourcing the latest evaluated metrics for the strategy (prefer matching stage, fallback to any).
- Adds unit tests for the new behavior.
- Updates Phase 4 roadmap to document the initial lightweight metrics reuse approach and its limits.

Validation:
- `uv run --with mypy -m mypy`
- `uv run mkdocs build --strict`
- `uv run python scripts/check_docs_links.py`
- `PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'`