### PR TITLE
Risk hub 기반 evaluate 입력 보강 (campaign executor)

### DIFF
--- a/docs/en/architecture/risk_signal_hub.md
+++ b/docs/en/architecture/risk_signal_hub.md
@@ -57,8 +57,10 @@ flowchart LR
   - Idempotent retries (same `hash`) are treated as success and counted in `risk_hub_snapshot_dedupe_total`.
 - API:
   - `POST /risk-hub/worlds/{world_id}/snapshots` (write; token/headers required)
-  - `GET /risk-hub/worlds/{world_id}/snapshots/latest`
-  - `GET /risk-hub/worlds/{world_id}/snapshots` (list)
+  - `GET /risk-hub/worlds/{world_id}/snapshots/latest[?stage=...&actor=...&expand=true]`
+    - `stage`/`actor`: filter by `provenance.stage` / `provenance.actor`.
+    - `expand=true`: resolves `covariance_ref` / `realized_returns_ref` / `stress_ref` when possible and returns inline fields (`covariance`, `realized_returns`, `stress`).
+  - `GET /risk-hub/worlds/{world_id}/snapshots[?limit=...&stage=...&actor=...&expand=true]` (list)
   - `GET /risk-hub/worlds/{world_id}/snapshots/lookup?version=...|as_of=...`
 
 ---

--- a/docs/ko/architecture/risk_signal_hub.md
+++ b/docs/ko/architecture/risk_signal_hub.md
@@ -58,8 +58,10 @@ flowchart LR
   - 동일 페이로드(동일 `hash`)의 재전송은 멱등 성공으로 처리하고 `risk_hub_snapshot_dedupe_total`로 계수한다.
 - API:
   - `POST /risk-hub/worlds/{world_id}/snapshots` (write, token/헤더 필요)
-  - `GET /risk-hub/worlds/{world_id}/snapshots/latest`
-  - `GET /risk-hub/worlds/{world_id}/snapshots` (list)
+  - `GET /risk-hub/worlds/{world_id}/snapshots/latest[?stage=...&actor=...&expand=true]`
+    - `stage`/`actor`: `provenance.stage`/`provenance.actor`로 필터링한 최신 스냅샷을 반환한다.
+    - `expand=true`: `covariance_ref`/`realized_returns_ref`/`stress_ref`를 가능한 경우 해석해 inline 필드(`covariance`, `realized_returns`, `stress`)를 함께 반환한다.
+  - `GET /risk-hub/worlds/{world_id}/snapshots[?limit=...&stage=...&actor=...&expand=true]` (list)
   - `GET /risk-hub/worlds/{world_id}/snapshots/lookup?version=...|as_of=...`
 
 ---

--- a/qmtl/automation/campaign_executor.py
+++ b/qmtl/automation/campaign_executor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
+import math
 import os
 from pathlib import Path
 import tempfile
@@ -47,6 +48,9 @@ class CampaignExecutor:
     implementations, we source metrics by reusing the latest available evaluated
     metrics for the strategy (prefer matching stage; fallback to any stage).
     This keeps the executor lightweight and swappable for future producers.
+
+    When available, we also enrich (or fallback to) Risk Signal Hub snapshots to
+    provide portfolio-level risk/stress inputs at evaluation time.
     """
 
     def __init__(self, *, base_url: str, timeout_sec: float = 10.0) -> None:
@@ -179,6 +183,278 @@ class CampaignExecutor:
             return {str(k): v for k, v in metrics.items()}
         return None
 
+    def _fetch_risk_hub_snapshot(
+        self,
+        *,
+        world_id: str,
+        stage: str | None,
+        actor: str | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any] | None:
+        params: dict[str, str | int | float | bool] = {"expand": True, "limit": int(limit)}
+        if stage:
+            params["stage"] = str(stage)
+        if actor:
+            params["actor"] = str(actor)
+        status, payload = self._request(
+            "GET",
+            f"/risk-hub/worlds/{world_id}/snapshots/latest",
+            params=params,
+        )
+        if status >= 400 or status == 0 or not isinstance(payload, Mapping):
+            return None
+        return dict(payload)
+
+    @staticmethod
+    def _coerce_float_series(source: Any) -> list[float] | None:
+        if isinstance(source, (list, tuple)):
+            try:
+                series = [float(v) for v in source]
+            except Exception:
+                return None
+            clean = [v for v in series if math.isfinite(v)]
+            return clean or None
+        return None
+
+    @classmethod
+    def _extract_returns_from_realized(
+        cls,
+        realized: Any,
+        *,
+        strategy_id: str,
+    ) -> list[float] | None:
+        if realized is None:
+            return None
+        if isinstance(realized, Mapping):
+            for key in (strategy_id, str(strategy_id), "live_returns", "returns"):
+                if key in realized:
+                    series = cls._coerce_float_series(realized.get(key))
+                    if series is not None:
+                        return series
+            nested = realized.get("strategies")
+            if isinstance(nested, Mapping) and strategy_id in nested:
+                series = cls._coerce_float_series(nested.get(strategy_id))
+                if series is not None:
+                    return series
+        return cls._coerce_float_series(realized)
+
+    @staticmethod
+    def _extract_stress_for_strategy(stress_payload: Any, *, strategy_id: str) -> dict[str, Any] | None:
+        if stress_payload is None:
+            return None
+        if isinstance(stress_payload, Mapping):
+            direct = stress_payload.get(strategy_id)
+            if isinstance(direct, Mapping):
+                return dict(direct)
+            nested = stress_payload.get("strategies")
+            if isinstance(nested, Mapping):
+                bucket = nested.get(strategy_id)
+                if isinstance(bucket, Mapping):
+                    return dict(bucket)
+            if any(isinstance(v, Mapping) for v in stress_payload.values()):
+                return dict(stress_payload)
+        return None
+
+    @staticmethod
+    def _lookup_covariance(covariance: Mapping[str, Any], a: str, b: str) -> float | None:
+        for sep in (",", ":"):
+            key = f"{a}{sep}{b}"
+            if key in covariance:
+                try:
+                    value = float(covariance[key])
+                except Exception:
+                    value = None
+                if value is not None and math.isfinite(value):
+                    return value
+                return None
+            rev = f"{b}{sep}{a}"
+            if rev in covariance:
+                try:
+                    value = float(covariance[rev])
+                except Exception:
+                    value = None
+                if value is not None and math.isfinite(value):
+                    return value
+                return None
+        return None
+
+    @staticmethod
+    def _candidate_weight_from_snapshot(snapshot: Mapping[str, Any]) -> float | None:
+        constraints = snapshot.get("constraints")
+        if isinstance(constraints, Mapping):
+            raw = None
+            for key in ("candidate_weight", "candidate_weight_default", "candidate_weight_pct"):
+                if key in constraints:
+                    raw = constraints.get(key)
+                    if key == "candidate_weight_pct":
+                        if isinstance(raw, bool):
+                            raw = None
+                        elif isinstance(raw, (int, float, str)):
+                            try:
+                                raw = float(raw) / 100.0
+                            except (TypeError, ValueError):
+                                raw = None
+                        else:
+                            raw = None
+                    break
+            if raw is not None:
+                try:
+                    value = float(raw)
+                except Exception:
+                    value = None
+                if value is not None and math.isfinite(value) and 0.0 < value <= 1.0:
+                    return float(value)
+        return None
+
+    def _baseline_from_covariance(
+        self,
+        *,
+        weights: Mapping[str, Any],
+        covariance: Mapping[str, Any],
+    ) -> dict[str, float] | None:
+        if not weights or not covariance:
+            return None
+        w_sum = 0.0
+        for value in weights.values():
+            try:
+                w_sum += float(value)
+            except Exception:
+                return None
+        if w_sum <= 0:
+            return None
+        norm_weights = {str(k): float(v) / w_sum for k, v in weights.items() if isinstance(v, (int, float))}
+        variance = 0.0
+        sids = list(norm_weights.keys())
+        for a in sids:
+            for b in sids:
+                cov_val = self._lookup_covariance(covariance, a, b)
+                if cov_val is None:
+                    continue
+                variance += norm_weights.get(a, 0.0) * norm_weights.get(b, 0.0) * float(cov_val)
+        if not (variance >= 0.0 and math.isfinite(variance)):
+            return None
+        z_var_99 = 2.33
+        var_99 = math.sqrt(variance) * z_var_99
+        if not math.isfinite(var_99):
+            return None
+        return {"var_99": float(var_99), "es_99": float(var_99) * 1.2}
+
+    def _incremental_var_es_from_covariance(
+        self,
+        *,
+        weights: Mapping[str, Any],
+        covariance: Mapping[str, Any],
+        candidate_id: str,
+        candidate_weight: float,
+        baseline: Mapping[str, Any],
+    ) -> dict[str, float] | None:
+        if candidate_id in weights:
+            return None
+        base_var = baseline.get("var_99")
+        base_es = baseline.get("es_99")
+        if not isinstance(base_var, (int, float)) or not isinstance(base_es, (int, float)):
+            return None
+        alpha = float(candidate_weight)
+        if not math.isfinite(alpha) or alpha <= 0.0:
+            return None
+        if alpha > 1.0:
+            alpha = 1.0
+        if self._lookup_covariance(covariance, candidate_id, candidate_id) is None:
+            return None
+
+        scaled_existing: dict[str, float] = {}
+        if alpha < 1.0:
+            for sid, weight in weights.items():
+                if not isinstance(weight, (int, float)):
+                    continue
+                if weight == 0:
+                    continue
+                scaled = float(weight) * (1.0 - alpha)
+                if scaled != 0:
+                    scaled_existing[str(sid)] = scaled
+
+        new_weights = dict(scaled_existing)
+        new_weights[candidate_id] = alpha
+        with_candidate = self._baseline_from_covariance(weights=new_weights, covariance=covariance)
+        if with_candidate is None:
+            return None
+        with_var = with_candidate.get("var_99")
+        with_es = with_candidate.get("es_99")
+        if not isinstance(with_var, (int, float)) or not isinstance(with_es, (int, float)):
+            return None
+        return {
+            "candidate_weight": float(alpha),
+            "incremental_var_99": float(with_var) - float(base_var),
+            "incremental_es_99": float(with_es) - float(base_es),
+        }
+
+    @staticmethod
+    def _deep_merge(base: Mapping[str, Any], overlay: Mapping[str, Any]) -> dict[str, Any]:
+        out: dict[str, Any] = dict(base)
+        for key, value in overlay.items():
+            if key in out and isinstance(out.get(key), Mapping) and isinstance(value, Mapping):
+                out[key] = CampaignExecutor._deep_merge(out[key], value)
+            else:
+                out[key] = value
+        return out
+
+    def _metrics_from_risk_hub(
+        self,
+        *,
+        world_id: str,
+        strategy_id: str,
+        stage: str | None,
+    ) -> dict[str, Any] | None:
+        snapshot = self._fetch_risk_hub_snapshot(world_id=world_id, stage=stage)
+        if not snapshot:
+            return None
+        derived: dict[str, Any] = {}
+
+        realized = snapshot.get("realized_returns")
+        live_returns = self._extract_returns_from_realized(realized, strategy_id=strategy_id)
+        if live_returns is not None:
+            diagnostics = dict(derived.get("diagnostics") or {})
+            diagnostics["live_returns"] = live_returns
+            diagnostics.setdefault("live_returns_source", "risk_hub")
+            derived["diagnostics"] = diagnostics
+
+        stress_payload = snapshot.get("stress")
+        stress = self._extract_stress_for_strategy(stress_payload, strategy_id=strategy_id)
+        if stress is not None:
+            derived["stress"] = stress
+
+        weights = snapshot.get("weights")
+        covariance = snapshot.get("covariance")
+        if isinstance(weights, Mapping) and isinstance(covariance, Mapping) and covariance:
+            baseline = self._baseline_from_covariance(weights=weights, covariance=covariance)
+            if baseline:
+                candidate_weight = self._candidate_weight_from_snapshot(snapshot)
+                if candidate_weight is None:
+                    candidate_weight = 1.0 / float(max(1, len(weights)) + 1)
+                risk_metrics = self._incremental_var_es_from_covariance(
+                    weights=weights,
+                    covariance=covariance,
+                    candidate_id=strategy_id,
+                    candidate_weight=candidate_weight,
+                    baseline=baseline,
+                )
+                if risk_metrics:
+                    risk = dict(derived.get("risk") or {})
+                    risk["incremental_var_99"] = risk_metrics.get("incremental_var_99")
+                    risk["incremental_es_99"] = risk_metrics.get("incremental_es_99")
+                    risk["candidate_weight"] = risk_metrics.get("candidate_weight")
+                    derived["risk"] = risk
+
+                    diagnostics = dict(derived.get("diagnostics") or {})
+                    extra = dict(diagnostics.get("extra_metrics") or {})
+                    extra.setdefault("portfolio_baseline_var_99", baseline.get("var_99"))
+                    extra.setdefault("portfolio_baseline_es_99", baseline.get("es_99"))
+                    extra.setdefault("risk_hub_snapshot_version", snapshot.get("version"))
+                    diagnostics["extra_metrics"] = extra
+                    derived["diagnostics"] = diagnostics
+
+        return derived or None
+
     @staticmethod
     def _materialize_evaluate_payload(template: Mapping[str, Any], *, strategy_id: str) -> dict[str, object]:
         payload: dict[str, object] = json.loads(json.dumps(dict(template)))
@@ -276,11 +552,26 @@ class CampaignExecutor:
                             )
                             continue
                         stage = str(suggested_body.get("stage") or raw.get("stage") or "").strip() or None
-                        derived_metrics = self._fetch_latest_metrics(
+                        base_metrics = self._fetch_latest_metrics(
                             world_id=cfg.world_id,
                             strategy_id=sid,
                             stage=stage,
                         )
+                        hub_metrics = self._metrics_from_risk_hub(
+                            world_id=cfg.world_id,
+                            strategy_id=sid,
+                            stage=stage,
+                        )
+                        derived_metrics: dict[str, Any] | None
+                        if base_metrics and hub_metrics:
+                            derived_metrics = self._deep_merge(base_metrics, hub_metrics)
+                        elif base_metrics:
+                            derived_metrics = base_metrics
+                        elif hub_metrics:
+                            derived_metrics = hub_metrics
+                        else:
+                            derived_metrics = None
+
                         if not derived_metrics:
                             results.append(
                                 ExecutionResult(

--- a/qmtl/services/worldservice/routers/risk_hub.py
+++ b/qmtl/services/worldservice/routers/risk_hub.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from datetime import datetime
 from typing import Any, Dict, Callable, Awaitable
 
 import inspect
@@ -16,6 +17,43 @@ from ..risk_hub import PortfolioSnapshot, RiskSignalHub, RiskSnapshotConflictErr
 from ..controlbus_producer import ControlBusProducer
 
 logger = logging.getLogger(__name__)
+
+def _parse_iso_ts(value: Any) -> float:
+    text = str(value or "").strip()
+    if not text:
+        return 0.0
+    candidate = text
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        return float(datetime.fromisoformat(candidate).timestamp())
+    except Exception:
+        return 0.0
+
+
+async def _expand_snapshot_payload(
+    hub: RiskSignalHub,
+    payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    covariance_ref = payload.get("covariance_ref")
+    if payload.get("covariance") is None and isinstance(covariance_ref, str) and covariance_ref:
+        cov = await hub.resolve_blob_ref(covariance_ref)
+        if isinstance(cov, Mapping):
+            payload["covariance"] = dict(cov)
+
+    realized_ref = payload.get("realized_returns_ref")
+    if payload.get("realized_returns") is None and isinstance(realized_ref, str) and realized_ref:
+        realized = await hub.resolve_blob_ref(realized_ref)
+        if realized is not None:
+            payload["realized_returns"] = realized
+
+    stress_ref = payload.get("stress_ref")
+    if payload.get("stress") is None and isinstance(stress_ref, str) and stress_ref:
+        stress = await hub.resolve_blob_ref(stress_ref)
+        if isinstance(stress, Mapping):
+            payload["stress"] = dict(stress)
+
+    return payload
 
 
 def create_risk_hub_router(
@@ -97,22 +135,89 @@ def create_risk_hub_router(
         world_id: str,
         version: str | None = None,
         as_of: str | None = None,
+        expand: bool = False,
     ) -> Dict[str, Any]:
         snap = await hub.get_snapshot(world_id, version=version, as_of=as_of)
         if snap is None:
             raise HTTPException(status_code=404, detail="snapshot not found")
-        return snap.to_dict()
+        payload = snap.to_dict()
+        if expand:
+            payload = await _expand_snapshot_payload(hub, payload)
+        return payload
 
     @router.get("/worlds/{world_id}/snapshots/latest")
-    async def get_latest_snapshot(world_id: str) -> Dict[str, Any]:
-        snap = await hub.latest_snapshot(world_id)
-        if snap is None:
-            raise HTTPException(status_code=404, detail="snapshot not found")
-        return snap.to_dict()
+    async def get_latest_snapshot(
+        world_id: str,
+        stage: str | None = None,
+        actor: str | None = None,
+        *,
+        limit: int = 50,
+        expand: bool = False,
+    ) -> Dict[str, Any]:
+        normalized_stage = str(stage or "").strip().lower() or None
+        normalized_actor = str(actor or "").strip() or None
+
+        payload: Dict[str, Any] | None = None
+        if normalized_stage is None and normalized_actor is None:
+            snap = await hub.latest_snapshot(world_id)
+            if snap is None:
+                raise HTTPException(status_code=404, detail="snapshot not found")
+            payload = snap.to_dict()
+        else:
+            status = await hub.list_snapshots(world_id, limit=max(1, int(limit or 0)))
+            candidates: list[dict[str, Any]] = []
+            for item in status:
+                if not isinstance(item, dict):
+                    continue
+                prov = item.get("provenance")
+                prov_map = prov if isinstance(prov, Mapping) else {}
+                item_stage = str(prov_map.get("stage") or "").strip().lower()
+                item_actor = str(prov_map.get("actor") or "").strip()
+                if normalized_stage is not None and item_stage != normalized_stage:
+                    continue
+                if normalized_actor is not None and item_actor != normalized_actor:
+                    continue
+                candidates.append(item)
+            if not candidates:
+                raise HTTPException(status_code=404, detail="snapshot not found")
+
+            def _rank(item: dict[str, Any]) -> tuple[float, float]:
+                return (_parse_iso_ts(item.get("as_of")), _parse_iso_ts(item.get("created_at")))
+
+            payload = max(candidates, key=_rank)
+
+        if expand and payload is not None:
+            payload = await _expand_snapshot_payload(hub, payload)
+        return payload or {}
 
     @router.get("/worlds/{world_id}/snapshots")
-    async def list_snapshots(world_id: str, limit: int = 10) -> Dict[str, Any]:
+    async def list_snapshots(
+        world_id: str,
+        limit: int = 10,
+        stage: str | None = None,
+        actor: str | None = None,
+        expand: bool = False,
+    ) -> Dict[str, Any]:
         snapshots = await hub.list_snapshots(world_id, limit=limit)
+        normalized_stage = str(stage or "").strip().lower() or None
+        normalized_actor = str(actor or "").strip() or None
+        if normalized_stage is not None or normalized_actor is not None:
+            filtered: list[dict[str, Any]] = []
+            for item in snapshots:
+                if not isinstance(item, dict):
+                    continue
+                prov = item.get("provenance")
+                prov_map = prov if isinstance(prov, Mapping) else {}
+                item_stage = str(prov_map.get("stage") or "").strip().lower()
+                item_actor = str(prov_map.get("actor") or "").strip()
+                if normalized_stage is not None and item_stage != normalized_stage:
+                    continue
+                if normalized_actor is not None and item_actor != normalized_actor:
+                    continue
+                filtered.append(item)
+            snapshots = filtered
+        if expand:
+            snapshots = [await _expand_snapshot_payload(hub, dict(item)) for item in snapshots]
         return {"snapshots": snapshots}
 
     return router


### PR DESCRIPTION
Summary:
- Campaign tick의 evaluate 실행 시, CampaignExecutor가 Risk Signal Hub 스냅샷(공분산/스트레스/리턴 ref)을 조회해 포트폴리오 룰 입력(incremental_var_99/es_99 등)을 보강하고, 기존 평가 런 metrics가 없으면 risk hub 기반 입력으로 fallback 합니다.
- Risk hub read API에 stage/actor 필터와 expand=true(ref 해석) 옵션을 추가했습니다.
- 관련 문서(ko/en) 업데이트 및 테스트 추가.

Validation:
- uv run --with mypy -m mypy
- uv run mkdocs build --strict
- uv run python scripts/check_docs_links.py
- PYTHONFAULTHANDLER=1 uv run --with pytest-timeout -m pytest -q --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
- PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
- USE_INPROC_WS_STACK=1 WS_MODE=service uv run -m pytest -q tests/e2e/world_smoke -q