### PR TITLE
Add report-only quality gate pilots

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,3 @@
+[bandit]
+exclude_dirs = tests,notebooks,qmtl/examples,qmtl/foundation/proto,build,dist
+targets = qmtl,scripts,main.py,conftest.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Install dependencies (dev)
         run: uv pip install -e .[dev]
 
+      - name: Prepare quality-gate artifact directories
+        run: mkdir -p .artifacts/quality-gates/{coverage,security,deadcode}
+
       - name: Ruff lint (repo-safe subset)
         run: uv run --no-project --with ruff ruff check .
 
@@ -133,18 +136,84 @@ jobs:
           uv run --with pytest-timeout -m pytest -q \
             --timeout=60 --timeout-method=thread --maxfail=1 -k 'not slow'
 
-      - name: Run tests (warnings are errors)
-        run: PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
+      - name: Run tests with branch coverage (warnings are errors)
+        env:
+          COVERAGE_FILE: ${{ github.workspace }}/.artifacts/quality-gates/coverage/.coverage
+          PYTHONPATH: qmtl/proto
+        run: |
+          uv run --with pytest-cov -m pytest \
+            -p no:unraisableexception -W error -q tests \
+            --cov=qmtl --cov-branch --cov-report=
 
       - name: WorldService in-process smoke
         env:
           USE_INPROC_WS_STACK: "1"
           WS_MODE: service
+          COVERAGE_FILE: ${{ github.workspace }}/.artifacts/quality-gates/coverage/.coverage
         run: |
-          uv run -m pytest -q tests/e2e/world_smoke -q
+          uv run --with pytest-cov -m pytest -q tests/e2e/world_smoke -q \
+            --cov=qmtl --cov-branch --cov-append --cov-report=
 
       - name: Core Loop contract suite
         env:
           CORE_LOOP_STACK_MODE: inproc
+          COVERAGE_FILE: ${{ github.workspace }}/.artifacts/quality-gates/coverage/.coverage
         run: |
-          uv run -m pytest -q tests/e2e/core_loop -q
+          uv run --with pytest-cov -m pytest -q tests/e2e/core_loop -q \
+            --cov=qmtl --cov-branch --cov-append --cov-report=
+
+      - name: Branch coverage baseline summary
+        env:
+          COVERAGE_FILE: ${{ github.workspace }}/.artifacts/quality-gates/coverage/.coverage
+        run: |
+          uv run --with coverage python -m coverage json \
+            -o .artifacts/quality-gates/coverage/coverage.json
+          uv run --with coverage python -m coverage xml \
+            -o .artifacts/quality-gates/coverage/coverage.xml
+          uv run --with coverage python -m coverage report \
+            > .artifacts/quality-gates/coverage/coverage.txt
+          uv run python scripts/summarize_coverage_baseline.py \
+            --input .artifacts/quality-gates/coverage/coverage.json \
+            --json-output .artifacts/quality-gates/coverage/summary.json \
+            --markdown-output .artifacts/quality-gates/coverage/summary.md
+          cat .artifacts/quality-gates/coverage/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Bandit report (report only)
+        run: |
+          uv run --no-project --with bandit bandit --ini .bandit \
+            -r qmtl scripts main.py conftest.py \
+            --severity-level medium --confidence-level medium \
+            --format json -o .artifacts/quality-gates/security/bandit.json \
+            --exit-zero
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from collections import Counter
+          from pathlib import Path
+
+          payload = json.loads(Path(".artifacts/quality-gates/security/bandit.json").read_text(encoding="utf-8"))
+          counts = Counter(item["issue_severity"] for item in payload.get("results", []))
+          print()
+          print("## Bandit report-only signal")
+          print()
+          print(f"- Findings: {len(payload.get('results', []))}")
+          print(f"- By severity: {dict(sorted(counts.items()))}")
+          PY
+
+      - name: Vulture report (report only)
+        run: |
+          status=0
+          uv run --no-project --with vulture vulture --config pyproject.toml \
+            > .artifacts/quality-gates/deadcode/vulture.txt || status=$?
+          echo "$status" > .artifacts/quality-gates/deadcode/vulture.exitcode
+          uv run python scripts/summarize_vulture_report.py \
+            --input .artifacts/quality-gates/deadcode/vulture.txt \
+            --json-output .artifacts/quality-gates/deadcode/summary.json \
+            --markdown-output .artifacts/quality-gates/deadcode/summary.md
+          cat .artifacts/quality-gates/deadcode/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload quality-gate artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-gates-${{ github.run_id }}
+          path: .artifacts/quality-gates

--- a/.github/workflows/mutation-pilot.yml
+++ b/.github/workflows/mutation-pilot.yml
@@ -1,0 +1,55 @@
+name: Mutation Pilot
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/mutation-pilot.yml"
+      - "pyproject.toml"
+      - "pytest.ini"
+      - "scripts/run_mutation_pilot.sh"
+      - "qmtl/runtime/sdk/**"
+      - "qmtl/runtime/pipeline/**"
+      - "qmtl/services/gateway/**"
+      - "tests/qmtl/runtime/sdk/**"
+      - "tests/qmtl/runtime/pipeline/**"
+      - "tests/qmtl/services/gateway/**"
+  schedule:
+    - cron: "0 18 * * 0"
+
+jobs:
+  mutmut:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Prepare Python and venv
+        run: |
+          uv python install 3.11
+          uv venv
+
+      - name: Install dependencies (dev)
+        run: uv pip install -e .[dev]
+
+      - name: Run mutmut pilot (report only)
+        run: bash scripts/run_mutation_pilot.sh
+
+      - name: Upload mutation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-pilot-${{ github.run_id }}
+          path: .artifacts/quality-gates/mutation

--- a/conftest.py
+++ b/conftest.py
@@ -5,8 +5,23 @@ Expose optional fixture plugins globally to satisfy pytest's requirement that
 the entire suite.
 """
 
+import asyncio
+
+import pytest
+
 pytest_plugins = (
     "tests.e2e.world_smoke.fixtures_inprocess",
     "tests.e2e.world_smoke.fixtures_docker",
 )
 
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_pyfunc_call(pyfuncitem):
+    """Ensure async-marked tests always have a current main-thread event loop."""
+
+    if pyfuncitem.get_closest_marker("asyncio") is not None:
+        try:
+            asyncio.get_event_loop()
+        except RuntimeError:
+            asyncio.set_event_loop(asyncio.new_event_loop())
+    yield

--- a/docs/en/operations/README.md
+++ b/docs/en/operations/README.md
@@ -35,6 +35,7 @@ Guidelines for running and maintaining QMTL in production.
 ## Validation and Observability
 
 - [E2E Testing](e2e_testing.md): End-to-end testing practice.
+- [Quality Gates](quality_gates.md): hard gates, report-only signals, and mutation-pilot scope policy.
 - [Monitoring](monitoring.md): Observability and metrics.
 - [Core Loop Observability Minimum Set](observability_core_loop.md): minimum dashboard and SLO boundaries.
 - [World Validation Observability](world_validation_observability.md): validation and promotion observability points.

--- a/docs/en/operations/ci.md
+++ b/docs/en/operations/ci.md
@@ -65,6 +65,15 @@ def test_long_running_case():
 - Mark long/external tests as `slow` and, if needed, exclude them from preflight with `-k 'not slow'`.
 - Avoid unbounded network waits; always set client timeouts in tests.
 
+## Quality-gate alignment
+
+[Quality Gates](quality_gates.md) is the canonical operations reference for scope policy, report-only signals, and mutation-pilot criteria.
+
+- PR hard gates share the same axis between `.github/workflows/ci.yml` and `scripts/run_ci_local.sh`.
+- Branch-coverage baselines combine the three pytest stages (`tests`, `world_smoke`, `core_loop`) and write artifacts under `.artifacts/quality-gates/coverage/`.
+- Bandit and Vulture are report-only signals: they generate artifacts but do not block the PR.
+- mutmut runs outside the default CI gate via the separate [mutation pilot workflow]({{ code_url('.github/workflows/mutation-pilot.yml') }}).
+
 ## Policy Diff Regression (CI/Cron)
 
 - Goal: automatically monitor the impact ratio of policy changes against the “bad strategies” regression set.

--- a/docs/en/operations/quality_gates.md
+++ b/docs/en/operations/quality_gates.md
@@ -1,0 +1,119 @@
+---
+title: "Quality Gates"
+tags:
+  - operations
+  - quality
+  - ci
+author: "QMTL Team"
+last_modified: 2026-04-08
+---
+
+{{ nav_links() }}
+
+# Quality Gates
+
+This document defines how QMTL quality checks are split across PR hard gates, report-only signals, and pilot workflows. Korean (`docs/ko/...`) is the canonical source; English mirrors the same policy.
+
+## Gate Classes
+
+| Class | Tools/checks | Current enforcement | Purpose |
+| --- | --- | --- | --- |
+| PR hard gate | Ruff, deptry, radon diff, mypy, docs/link/i18n/import-cycle checks, packaging smoke, pytest/e2e suites | Blocks PRs on failure | Low-noise signals that should stop regressions immediately |
+| Report-only signal | branch coverage baseline, Bandit, Vulture | No PR blocking; artifacts and summaries only | Baseline collection and noise classification |
+| Pilot workflow | mutmut (`gateway/sdk/pipeline`) | Separate workflow, report-only | Measure survivor patterns and mutation-testing cost |
+
+## Scan Scope Policy
+
+| Tool | Default scan scope | Default exclusions | Policy rationale |
+| --- | --- | --- | --- |
+| Ruff | Whole repository | `notebooks/*.ipynb`, `qmtl/foundation/proto/*_pb2*.py` | Generated code and notebooks create too much repo-wide hard-gate noise |
+| deptry | `qmtl/` | `qmtl/examples`, service tests, generated proto | Dependency hygiene is measured against the production package |
+| coverage.py | `qmtl/` | `qmtl/examples`, generated proto | Tests are execution inputs, but the denominator stays on production code |
+| Bandit | `qmtl/`, `scripts/`, `main.py`, `conftest.py` | `tests/`, `notebooks/`, `qmtl/examples/`, generated proto, `build/`, `dist/` | Security signals should include operational scripts as well as package code |
+| Vulture | `qmtl/` | `tests/`, `notebooks/`, `qmtl/examples/`, generated proto, `build/`, `dist/` | Dead-code analysis becomes too noisy when scripts and tests are included |
+| mutmut | `qmtl/runtime/sdk`, `qmtl/runtime/pipeline`, `qmtl/services/gateway` | generated proto | Restrict the pilot to high-change, high-value paths |
+
+### Scope Rules
+
+- `examples/` and `notebooks/` are treated as learning/demo assets and stay out of PR hard-gate denominators.
+- Generated code (`qmtl/foundation/proto/*_pb2*.py`, `*_pb2_grpc.py`) is excluded from repo-wide static signals by default because it is not maintained manually.
+- `tests/` remain execution input for coverage and mutation defense, but are not a default scan target for dead-code or security reports.
+- Any new quality tool should document its scan scope and exclusions here before it is wired into CI.
+
+## Execution Paths
+
+### PR hard gate
+
+- GitHub Actions: [`.github/workflows/ci.yml`]({{ code_url('.github/workflows/ci.yml') }})
+- Local parity: [`scripts/run_ci_local.sh`]({{ code_url('scripts/run_ci_local.sh') }})
+
+Both paths now perform the following in common:
+
+- Ruff / deptry / radon diff / mypy
+- docs strict build and link/design/i18n checks
+- packaging smoke
+- pytest preflight
+- main test suite plus `world_smoke` and `core_loop`
+- branch coverage baseline generation
+- Bandit and Vulture report-only artifacts
+
+### Mutation pilot
+
+- Workflow: [`.github/workflows/mutation-pilot.yml`]({{ code_url('.github/workflows/mutation-pilot.yml') }})
+- Local command: `bash scripts/run_mutation_pilot.sh`
+- Optional selector example: `bash scripts/run_mutation_pilot.sh --selector 'qmtl.runtime.pipeline*'`
+- Interpretation rule: the pilot is report-only, so a nonzero `exitcode.txt` does not block the PR hard gate. Instead, `summary.md` records the first failing test and an initial triage label.
+
+## Artifact Locations
+
+- coverage: `.artifacts/quality-gates/coverage/`
+  - `coverage.json`, `coverage.xml`, `coverage.txt`
+  - `summary.json`, `summary.md`
+- Bandit: `.artifacts/quality-gates/security/bandit.json`
+- Vulture: `.artifacts/quality-gates/deadcode/`
+  - `vulture.txt`, `vulture.exitcode`
+  - `summary.json`, `summary.md`
+- mutmut pilot: `.artifacts/quality-gates/mutation/`
+  - `mutmut.log`, `exitcode.txt`, `summary.md`, and `mutants.tgz` when available
+  - `summary.md` also records the latest first failing test and whether the run currently looks like tooling noise.
+
+## Staged Rollout Criteria
+
+### Branch coverage
+
+- Current stage: report-only baseline collection
+- Next-stage candidates:
+  1. Collect the overall `qmtl` branch-coverage baseline for at least two stable runs.
+  2. Measure variance for the focus areas (`runtime/sdk`, `runtime/pipeline`, `services/gateway`).
+  3. Introduce floors starting with the most stable focus areas.
+
+### Bandit / Vulture
+
+- Current stage: report-only
+- Promotion criteria:
+  - false-positive handling is documented,
+  - repeated noise is removed without ad-hoc CLI suppressions,
+  - baseline management can distinguish new findings from known noise.
+
+### mutmut
+
+- Current stage: separate pilot workflow
+- Survivor buckets:
+  - missing assertion
+  - equivalent mutant
+  - integration gap
+  - flaky / tooling noise
+- Gate proposal criteria:
+  - execution time and flake rate are stable,
+  - equivalent-mutant volume is manageable,
+  - at least one focus area has a reproducible baseline.
+
+## Ignore / Waiver Policy
+
+- Hard-gate exceptions must be centralized in config (`pyproject.toml`, `.bandit`) rather than hidden in ad-hoc CLI arguments.
+- Report-only exceptions should first accumulate in artifacts and triage notes; only repeated noise should move into config.
+- Mutation survivors should be tagged as `equivalent`, `not worth gating`, `needs test`, or `tooling noise`.
+
+For baseline CI environment details, see [CI Environment](ci.md).
+
+{{ nav_links() }}

--- a/docs/en/reference/_inventory.md
+++ b/docs/en/reference/_inventory.md
@@ -100,6 +100,7 @@ last_modified: 2025-08-26
 - `docs/operations/monitoring.md`
 - `docs/operations/neo4j_migration.md`
 - `docs/operations/neo4j_migrations.md`
+- `docs/operations/quality_gates.md`
 - `docs/operations/release.md`
 - `docs/operations/risk_management.md`
 - `docs/operations/schema_registry_governance.md`

--- a/docs/ko/operations/README.md
+++ b/docs/ko/operations/README.md
@@ -35,6 +35,7 @@ last_modified: 2026-04-03
 ## 검증과 관측
 
 - [E2E 테스트](e2e_testing.md): 종단 간 테스트 실무.
+- [품질 게이트](quality_gates.md): 하드 게이트, report-only 신호, mutation pilot 범위 정책.
 - [모니터링](monitoring.md): 관측성 및 메트릭 관리.
 - [코어 루프 관측성 최소셋](observability_core_loop.md): 최소 대시보드/SLO 경계.
 - [World Validation 운영 가시성](world_validation_observability.md): validation/promotion 관측 포인트.

--- a/docs/ko/operations/ci.md
+++ b/docs/ko/operations/ci.md
@@ -63,6 +63,15 @@ def test_long_running_case():
 - 오래 걸리거나 외부 리소스를 사용하는 테스트는 `slow` 로 표시하고 필요하면 프리플라이트에서 `-k 'not slow'` 로 제외합니다.
 - 무제한 네트워크 대기를 피하고, 테스트 클라이언트에 항상 타임아웃을 지정하세요.
 
+## 품질 게이트 정렬
+
+품질 게이트의 범위 정책, report-only 신호, mutation pilot 기준은 [품질 게이트](quality_gates.md) 문서가 canonical 운영 기준입니다.
+
+- PR 하드 게이트는 `.github/workflows/ci.yml` 과 `scripts/run_ci_local.sh` 가 같은 축을 공유합니다.
+- branch coverage baseline 은 세 개의 pytest 단계(`tests`, `world_smoke`, `core_loop`)를 합산해 `.artifacts/quality-gates/coverage/` 에 기록합니다.
+- Bandit 과 Vulture 는 report-only 이며, artifact 를 남기되 PR 을 차단하지 않습니다.
+- mutmut 은 기본 CI 게이트가 아니라 별도 [mutation pilot workflow]({{ code_url('.github/workflows/mutation-pilot.yml') }}) 로 운영합니다.
+
 ## Policy Diff 회귀 잡(CI/크론)
 - 목적: 정책 변경이 “나쁜 전략” 회귀 세트에 미치는 영향 비율을 자동 감시.
 - 명령 예시:

--- a/docs/ko/operations/quality_gates.md
+++ b/docs/ko/operations/quality_gates.md
@@ -1,0 +1,119 @@
+---
+title: "품질 게이트"
+tags:
+  - operations
+  - quality
+  - ci
+author: "QMTL Team"
+last_modified: 2026-04-08
+---
+
+{{ nav_links() }}
+
+# 품질 게이트
+
+이 문서는 QMTL 저장소의 품질 검사를 `PR 하드 게이트`, `보고서 전용 신호`, `파일럿 워크플로`로 구분해 정리합니다. 기준 문서는 한국어(`docs/ko/...`)이며 영어 문서는 동일 구조의 번역본입니다.
+
+## 게이트 분류
+
+| 구분 | 도구/체크 | 현재 강제 수준 | 목적 |
+| --- | --- | --- | --- |
+| PR 하드 게이트 | Ruff, deptry, radon diff, mypy, docs/link/i18n/import-cycle checks, packaging smoke, pytest/e2e suites | 실패 시 PR 차단 | 회귀를 즉시 차단해야 하는 저잡음 신호 |
+| 보고서 전용 신호 | branch coverage baseline, Bandit, Vulture | PR 차단 없음, artifact/summary만 생성 | 베이스라인 수집과 노이즈 분류 |
+| 파일럿 워크플로 | mutmut (`gateway/sdk/pipeline`) | 별도 워크플로, report-only | mutation survivor 패턴과 실행 비용 측정 |
+
+## 스캔 범위 정책
+
+| 도구 | 기본 스캔 범위 | 기본 제외 범위 | 정책 근거 |
+| --- | --- | --- | --- |
+| Ruff | 저장소 전체 | `notebooks/*.ipynb`, `qmtl/foundation/proto/*_pb2*.py` | 생성 코드와 노트북은 repo-wide hard gate 노이즈가 크므로 제외 |
+| deptry | `qmtl/` | `qmtl/examples`, 서비스 테스트, generated proto | 런타임 의존성 위생을 production package 기준으로 측정 |
+| coverage.py | `qmtl/` | `qmtl/examples`, generated proto | 테스트는 실행 입력이지만 분모는 production package에 한정 |
+| Bandit | `qmtl/`, `scripts/`, `main.py`, `conftest.py` | `tests/`, `notebooks/`, `qmtl/examples/`, generated proto, `build/`, `dist/` | 보안 신호는 운영 코드와 운영 스크립트까지 포함 |
+| Vulture | `qmtl/` | `tests/`, `notebooks/`, `qmtl/examples/`, generated proto, `build/`, `dist/` | dead-code 탐지는 스크립트/테스트까지 넣으면 false positive가 급증 |
+| mutmut | `qmtl/runtime/sdk`, `qmtl/runtime/pipeline`, `qmtl/services/gateway` | generated proto | 고변동 핵심 경로만 pilot 대상으로 제한 |
+
+### 범위 결정 원칙
+
+- `examples/`, `notebooks/` 는 학습/데모 산출물로 간주하며 PR 하드 게이트의 분모에 넣지 않습니다.
+- generated code(`qmtl/foundation/proto/*_pb2*.py`, `*_pb2_grpc.py`)는 수동 유지보수 대상이 아니므로 repo-wide 정적 신호에서 기본 제외합니다.
+- `tests/` 는 커버리지 입력과 mutation 방어선 역할은 하지만, dead-code/security 리포트의 기본 스캔 대상로는 취급하지 않습니다.
+- 새 품질 도구를 추가할 때는 먼저 이 표에 스캔 범위와 제외 규칙을 기록한 뒤 CI에 연결합니다.
+
+## 현재 실행 경로
+
+### PR 하드 게이트
+
+- GitHub Actions: [`.github/workflows/ci.yml`]({{ code_url('.github/workflows/ci.yml') }})
+- 로컬 parity: [`scripts/run_ci_local.sh`]({{ code_url('scripts/run_ci_local.sh') }})
+
+두 경로 모두 다음을 공통으로 수행합니다.
+
+- Ruff / deptry / radon diff / mypy
+- docs strict build 및 링크/설계/i18n 체크
+- packaging smoke
+- pytest preflight
+- 본 테스트 + `world_smoke` + `core_loop`
+- branch coverage baseline 요약 생성
+- Bandit / Vulture report-only 산출물 생성
+
+### mutation pilot
+
+- 워크플로: [`.github/workflows/mutation-pilot.yml`]({{ code_url('.github/workflows/mutation-pilot.yml') }})
+- 로컬 실행: `bash scripts/run_mutation_pilot.sh`
+- 선택적 selector 예시: `bash scripts/run_mutation_pilot.sh --selector 'qmtl.runtime.pipeline*'`
+- 해석 원칙: pilot은 report-only이므로 `exitcode.txt` 가 0이 아니어도 PR 하드 게이트를 막지 않습니다. 대신 `summary.md` 에 첫 실패 테스트와 초기 triage 분류를 남깁니다.
+
+## 산출물 위치
+
+- coverage: `.artifacts/quality-gates/coverage/`
+  - `coverage.json`, `coverage.xml`, `coverage.txt`
+  - `summary.json`, `summary.md`
+- Bandit: `.artifacts/quality-gates/security/bandit.json`
+- Vulture: `.artifacts/quality-gates/deadcode/`
+  - `vulture.txt`, `vulture.exitcode`
+  - `summary.json`, `summary.md`
+- mutmut pilot: `.artifacts/quality-gates/mutation/`
+  - `mutmut.log`, `exitcode.txt`, `summary.md`, 필요 시 `mutants.tgz`
+  - `summary.md` 는 최신 실행의 첫 실패 테스트와 `tooling noise` 여부를 함께 기록합니다.
+
+## 단계적 롤아웃 기준
+
+### branch coverage
+
+- 현재 단계: report-only baseline 수집
+- 다음 단계 후보:
+  1. 전체 `qmtl` branch coverage baseline을 2회 이상 연속 수집
+  2. 핵심 경로(`runtime/sdk`, `runtime/pipeline`, `services/gateway`)별 baseline 분산 확인
+  3. 변동폭이 작은 focus area부터 floor를 도입
+
+### Bandit / Vulture
+
+- 현재 단계: report-only
+- 승격 조건:
+  - false positive 분류 규칙이 문서화되어 있고
+  - 반복적으로 같은 잡음이 suppress/allowlist 없이 정리되며
+  - 신규 이슈만 구분 가능한 baseline 운영이 가능할 때
+
+### mutmut
+
+- 현재 단계: 별도 workflow 기반 pilot
+- survivor 분류:
+  - missing assertion
+  - equivalent mutant
+  - integration gap
+  - flaky / tooling noise
+- gate 제안 조건:
+  - 실행 시간과 flake rate가 안정적일 것
+  - equivalent mutant 비율이 관리 가능할 것
+  - 최소 한 개 focus area에서 재현 가능한 baseline이 확보될 것
+
+## ignore / waiver 정책
+
+- 하드 게이트 도구의 예외는 설정 파일(`pyproject.toml`, `.bandit`)에 중앙화하고, ad-hoc CLI 인수로 숨기지 않습니다.
+- report-only 신호의 예외는 먼저 artifact와 triage 메모로 누적한 뒤, 반복 노이즈가 확인되면 설정에 반영합니다.
+- mutation survivor를 무시할 때는 `equivalent`, `not worth gating`, `needs test`, `tooling noise` 중 하나로 분류해 남깁니다.
+
+관련 실행 환경과 기본 CI 설명은 [CI 환경](ci.md)을 참고하세요.
+
+{{ nav_links() }}

--- a/docs/ko/reference/_inventory.md
+++ b/docs/ko/reference/_inventory.md
@@ -100,6 +100,7 @@ last_modified: 2025-08-26
 - `docs/operations/monitoring.md`
 - `docs/operations/neo4j_migration.md`
 - `docs/operations/neo4j_migrations.md`
+- `docs/operations/quality_gates.md`
 - `docs/operations/release.md`
 - `docs/operations/risk_management.md`
 - `docs/operations/schema_registry_governance.md`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
       - E2E Testing: operations/e2e_testing.md
       - Neo4j Migrations: operations/neo4j_migrations.md
       - Monitoring: operations/monitoring.md
+      - Quality Gates: operations/quality_gates.md
       - Core Loop Observability: operations/observability_core_loop.md
       - World Validation Observability: operations/world_validation_observability.md
       - Independent Validation: operations/independent_validation.md
@@ -255,6 +256,7 @@ plugins:
             "Seamless Data Provider Setup": "심리스 데이터 프로바이더 구성"
             "Testing & Pytest": "테스트 & Pytest"
             "Python Environment": "Python 환경"
+            "Quality Gates": "품질 게이트"
             "CCXT Seamless Data Provider": "CCXT 심리스 데이터 프로바이더"
             "History Data Quickstart": "히스토리 데이터 퀵스타트"
             "Microstructure Signals": "마이크로스트럭처 신호"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,75 @@ DEP001 = [
   "pyoperon",
 ]
 
+[tool.coverage.run]
+branch = true
+parallel = true
+relative_files = true
+source = ["qmtl"]
+omit = [
+  "qmtl/examples/*",
+  "qmtl/foundation/proto/*_pb2.py",
+  "qmtl/foundation/proto/*_pb2_grpc.py",
+]
+
+[tool.coverage.report]
+skip_covered = true
+show_missing = true
+precision = 2
+omit = [
+  "qmtl/examples/*",
+  "qmtl/foundation/proto/*_pb2.py",
+  "qmtl/foundation/proto/*_pb2_grpc.py",
+]
+exclude_lines = [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+]
+
+[tool.coverage.json]
+pretty_print = true
+
+[tool.vulture]
+paths = ["qmtl"]
+exclude = [
+  "build/",
+  "dist/",
+  "notebooks/",
+  "qmtl/examples/",
+  "qmtl/foundation/proto/",
+  "tests/",
+]
+ignore_decorators = ["@app.*", "@router.*", "@pytest.*"]
+ignore_names = ["test_*", "pytest_*", "main"]
+min_confidence = 90
+sort_by_size = true
+
+[tool.mutmut]
+paths_to_mutate = [
+  "qmtl/runtime/sdk/",
+  "qmtl/runtime/pipeline/",
+  "qmtl/services/gateway/",
+]
+pytest_add_cli_args_test_selection = [
+  "tests/qmtl/runtime/sdk",
+  "tests/qmtl/runtime/pipeline",
+  "tests/qmtl/services/gateway",
+]
+pytest_add_cli_args = [
+  "-p",
+  "no:unraisableexception",
+  "-q",
+  "-k",
+  "not test_live_auto_subscribes",
+]
+also_copy = ["pytest.ini", "conftest.py", "qmtl", "tests"]
+do_not_mutate = [
+  "qmtl/foundation/proto/*_pb2.py",
+  "qmtl/foundation/proto/*_pb2_grpc.py",
+]
+max_stack_depth = 8
+mutate_only_covered_lines = true
+
 [tool.mypy]
 python_version = "3.11"
 strict = false

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,5 +8,5 @@ filterwarnings =
     ignore::pytest.PytestUnraisableExceptionWarning
     ignore::DeprecationWarning:websockets.*
     ignore:.*WebSocketServerProtocol is deprecated:DeprecationWarning:uvicorn\.protocols\.websockets\.websockets_impl
-addopts = -p no:unraisableexception
+addopts = --ignore=mutants -p no:unraisableexception
 asyncio_mode = auto

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -48,7 +48,9 @@ require_cmd uv
 require_cmd git
 
 export UV_CACHE_DIR="${UV_CACHE_DIR:-$PWD/.artifacts/uv-cache}"
+export QUALITY_GATE_DIR="${QUALITY_GATE_DIR:-$PWD/.artifacts/quality-gates}"
 mkdir -p "$UV_CACHE_DIR"
+mkdir -p "$QUALITY_GATE_DIR"/{coverage,security,deadcode}
 
 if [[ "$INSTALL" -eq 1 ]]; then
   run_step "Install dependencies (dev)" uv pip install -e ".[dev]"
@@ -109,21 +111,80 @@ run_step "Preflight – hang detection" bash -lc '
     --timeout=60 --timeout-method=thread --maxfail=1 -k "not slow"
 '
 
-run_step "Run tests (warnings are errors)" bash -lc '
+run_step "Run tests with branch coverage (warnings are errors)" bash -lc '
   set -euo pipefail
-  PYTHONPATH=qmtl/proto uv run pytest -p no:unraisableexception -W error -q tests
+  COVERAGE_FILE="'"$QUALITY_GATE_DIR"'/coverage/.coverage" \
+  PYTHONPATH=qmtl/proto uv run --with pytest-cov -m pytest \
+    -p no:unraisableexception -W error -q tests \
+    --cov=qmtl --cov-branch --cov-report=
 '
 
 run_step "WorldService in-process smoke" bash -lc '
   set -euo pipefail
   USE_INPROC_WS_STACK=1 WS_MODE=service \
-    uv run -m pytest -q tests/e2e/world_smoke -q
+  COVERAGE_FILE="'"$QUALITY_GATE_DIR"'/coverage/.coverage" \
+    uv run --with pytest-cov -m pytest -q tests/e2e/world_smoke -q \
+      --cov=qmtl --cov-branch --cov-append --cov-report=
 '
 
 run_step "Core Loop contract suite" bash -lc '
   set -euo pipefail
   CORE_LOOP_STACK_MODE=inproc \
-    uv run -m pytest -q tests/e2e/core_loop -q
+  COVERAGE_FILE="'"$QUALITY_GATE_DIR"'/coverage/.coverage" \
+    uv run --with pytest-cov -m pytest -q tests/e2e/core_loop -q \
+      --cov=qmtl --cov-branch --cov-append --cov-report=
+'
+
+run_step "Branch coverage baseline summary" bash -lc '
+  set -euo pipefail
+  COVERAGE_FILE="'"$QUALITY_GATE_DIR"'/coverage/.coverage" \
+    uv run --with coverage python -m coverage json \
+      -o "'"$QUALITY_GATE_DIR"'/coverage/coverage.json"
+  COVERAGE_FILE="'"$QUALITY_GATE_DIR"'/coverage/.coverage" \
+    uv run --with coverage python -m coverage xml \
+      -o "'"$QUALITY_GATE_DIR"'/coverage/coverage.xml"
+  COVERAGE_FILE="'"$QUALITY_GATE_DIR"'/coverage/.coverage" \
+    uv run --with coverage python -m coverage report \
+      > "'"$QUALITY_GATE_DIR"'/coverage/coverage.txt"
+  uv run python scripts/summarize_coverage_baseline.py \
+    --input "'"$QUALITY_GATE_DIR"'/coverage/coverage.json" \
+    --json-output "'"$QUALITY_GATE_DIR"'/coverage/summary.json" \
+    --markdown-output "'"$QUALITY_GATE_DIR"'/coverage/summary.md"
+  cat "'"$QUALITY_GATE_DIR"'/coverage/summary.md"
+'
+
+run_step "Bandit report (report only)" bash -lc '
+  set -euo pipefail
+  uv run --no-project --with bandit bandit --ini .bandit \
+    -r qmtl scripts main.py conftest.py \
+    --severity-level medium --confidence-level medium \
+    --format json -o "'"$QUALITY_GATE_DIR"'/security/bandit.json" \
+    --exit-zero
+  python - <<'"'"'PY'"'"'
+import json
+from collections import Counter
+from pathlib import Path
+
+report = Path("'"$QUALITY_GATE_DIR"'/security/bandit.json")
+payload = json.loads(report.read_text(encoding="utf-8"))
+results = payload.get("results", [])
+counts = Counter(item["issue_severity"] for item in results)
+print(f"Bandit findings: {len(results)}")
+print("By severity:", dict(sorted(counts.items())))
+PY
+'
+
+run_step "Vulture report (report only)" bash -lc '
+  set -euo pipefail
+  status=0
+  uv run --no-project --with vulture vulture --config pyproject.toml \
+    > "'"$QUALITY_GATE_DIR"'/deadcode/vulture.txt" || status=$?
+  echo "$status" > "'"$QUALITY_GATE_DIR"'/deadcode/vulture.exitcode"
+  uv run python scripts/summarize_vulture_report.py \
+    --input "'"$QUALITY_GATE_DIR"'/deadcode/vulture.txt" \
+    --json-output "'"$QUALITY_GATE_DIR"'/deadcode/summary.json" \
+    --markdown-output "'"$QUALITY_GATE_DIR"'/deadcode/summary.md"
+  cat "'"$QUALITY_GATE_DIR"'/deadcode/summary.md"
 '
 
 echo

--- a/scripts/run_mutation_pilot.sh
+++ b/scripts/run_mutation_pilot.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Run the mutmut pilot for gateway/sdk/pipeline and store report-only artifacts.
+
+Usage:
+  bash scripts/run_mutation_pilot.sh [--selector <pattern>] [--output-dir <dir>]
+
+Options:
+  --selector <pattern>  Optional mutmut selector such as 'qmtl.runtime.pipeline*'.
+  --output-dir <dir>    Artifact directory (default: .artifacts/quality-gates/mutation).
+EOF
+}
+
+SELECTOR=""
+OUTPUT_DIR=".artifacts/quality-gates/mutation"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --selector) SELECTOR="${2:?missing --selector value}"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="${2:?missing --output-dir value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+rm -f "$OUTPUT_DIR"/mutmut.log "$OUTPUT_DIR"/summary.md "$OUTPUT_DIR"/exitcode.txt
+rm -rf mutants
+
+status=0
+if [[ -n "$SELECTOR" ]]; then
+  uv run --no-project --with mutmut mutmut run "$SELECTOR" >"$OUTPUT_DIR/mutmut.log" 2>&1 || status=$?
+else
+  uv run --no-project --with mutmut mutmut run >"$OUTPUT_DIR/mutmut.log" 2>&1 || status=$?
+fi
+
+echo "$status" >"$OUTPUT_DIR/exitcode.txt"
+
+if [[ -d mutants ]]; then
+  tar -czf "$OUTPUT_DIR/mutants.tgz" mutants
+fi
+
+rm -rf mutants
+
+failure_summary="$(
+  python - "$OUTPUT_DIR/mutmut.log" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+log_path = Path(sys.argv[1])
+text = log_path.read_text(encoding="utf-8", errors="replace") if log_path.exists() else ""
+
+failed_match = re.search(r"^FAILED\s+(.+)$", text, re.MULTILINE)
+short_summary = ""
+if failed_match:
+    failed_test = failed_match.group(1).strip()
+    reason = "unknown"
+    if "CancelledError" in text:
+        reason = "mutation-induced cancellation behavior under stop/poll loop"
+    elif "RuntimeError: There is no current event loop" in text:
+        reason = "tooling noise (missing event loop in pilot run)"
+    print(f"- First failing test: `{failed_test}`")
+    print(f"- Initial triage: `{reason}`")
+PY
+)"
+
+{
+  echo "# Mutation Pilot"
+  echo
+  echo "- Selector: \`${SELECTOR:-<configured scope>}\`"
+  echo "- Exit code: \`$status\`"
+  if [[ "$status" -eq 0 ]]; then
+    echo "- Pilot status: \`clean report-only run\`"
+  else
+    echo "- Pilot status: \`non-blocking report-only failure captured\`"
+  fi
+  echo "- Configured scope comes from \`[tool.mutmut]\` in \`pyproject.toml\`."
+  echo "- Artifacts: \`mutmut.log\` and, when available, \`mutants.tgz\`."
+  if [[ -n "$failure_summary" ]]; then
+    echo "$failure_summary"
+  fi
+  echo
+  echo "Current mode: report-only pilot. Nonzero mutmut exits are recorded for triage and do not block the PR gate."
+  echo "Survivors should be triaged into missing assertions, equivalent mutants, or workflow/noise buckets before any gate is proposed."
+} >"$OUTPUT_DIR/summary.md"
+
+exit 0

--- a/scripts/summarize_coverage_baseline.py
+++ b/scripts/summarize_coverage_baseline.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_FOCUS_PREFIXES = (
+    "qmtl/runtime/sdk/",
+    "qmtl/runtime/pipeline/",
+    "qmtl/services/gateway/",
+)
+SUMMARY_KEYS = (
+    "covered_lines",
+    "num_statements",
+    "missing_lines",
+    "excluded_lines",
+    "covered_branches",
+    "num_branches",
+    "missing_branches",
+    "num_partial_branches",
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Summarize branch-coverage baselines from coverage.py JSON output."
+    )
+    parser.add_argument("--input", required=True, help="Path to coverage JSON report.")
+    parser.add_argument("--json-output", required=True, help="Where to write the summary JSON.")
+    parser.add_argument(
+        "--markdown-output",
+        required=True,
+        help="Where to write the Markdown summary.",
+    )
+    parser.add_argument(
+        "--focus-prefix",
+        action="append",
+        dest="focus_prefixes",
+        help="Path prefix to summarize separately. Can be provided multiple times.",
+    )
+    return parser.parse_args()
+
+
+def _empty_summary() -> dict[str, int]:
+    return {key: 0 for key in SUMMARY_KEYS}
+
+
+def _normalize_path(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def _merge_summary(target: dict[str, int], source: dict[str, Any]) -> None:
+    for key in SUMMARY_KEYS:
+        target[key] += int(source.get(key, 0))
+
+
+def _percent(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return round((numerator / denominator) * 100, 2)
+
+
+def _finalize(summary: dict[str, int]) -> dict[str, Any]:
+    return {
+        **summary,
+        "line_percent": _percent(summary["covered_lines"], summary["num_statements"]),
+        "branch_percent": _percent(summary["covered_branches"], summary["num_branches"]),
+    }
+
+
+def _aggregate_focus_areas(
+    files: dict[str, Any], focus_prefixes: tuple[str, ...]
+) -> dict[str, dict[str, Any]]:
+    focus_areas: dict[str, dict[str, Any]] = {}
+    for prefix in focus_prefixes:
+        aggregate = _empty_summary()
+        matched_files = 0
+        for path, payload in files.items():
+            if _normalize_path(path).startswith(prefix):
+                matched_files += 1
+                _merge_summary(aggregate, payload.get("summary", {}))
+        focus_areas[prefix] = {
+            "file_count": matched_files,
+            **_finalize(aggregate),
+        }
+    return focus_areas
+
+
+def _write_markdown(
+    markdown_output: Path,
+    overall: dict[str, Any],
+    focus_areas: dict[str, dict[str, Any]],
+) -> None:
+    def fmt_percent(value: float | None) -> str:
+        return "n/a" if value is None else f"{value:.2f}%"
+
+    lines = [
+        "# Branch Coverage Baseline",
+        "",
+        "| Area | Files | Line coverage | Branch coverage | Covered branches | Total branches |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+        (
+            f"| qmtl (overall) | {overall.get('file_count', 'n/a')} | "
+            f"{fmt_percent(overall['line_percent'])} | {fmt_percent(overall['branch_percent'])} | "
+            f"{overall['covered_branches']} | {overall['num_branches']} |"
+        ),
+    ]
+
+    for prefix, summary in focus_areas.items():
+        lines.append(
+            f"| `{prefix}` | {summary['file_count']} | "
+            f"{fmt_percent(summary['line_percent'])} | {fmt_percent(summary['branch_percent'])} | "
+            f"{summary['covered_branches']} | {summary['num_branches']} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "Current rollout stage: report-only branch-coverage baseline collection.",
+            "Promotion to a hard gate requires stable overall and focus-area baselines plus documented thresholds.",
+        ]
+    )
+    markdown_output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = _parse_args()
+    input_path = Path(args.input)
+    json_output = Path(args.json_output)
+    markdown_output = Path(args.markdown_output)
+
+    coverage_report = json.loads(input_path.read_text(encoding="utf-8"))
+    files = coverage_report.get("files", {})
+    totals = dict(coverage_report.get("totals", {}))
+    overall = _finalize(
+        {
+            key: int(totals.get(key, 0))
+            for key in SUMMARY_KEYS
+        }
+    )
+    overall["file_count"] = len(files)
+
+    focus_prefixes = tuple(args.focus_prefixes or DEFAULT_FOCUS_PREFIXES)
+    focus_areas = _aggregate_focus_areas(files, focus_prefixes)
+
+    payload = {
+        "overall": overall,
+        "focus_areas": focus_areas,
+        "focus_prefixes": list(focus_prefixes),
+    }
+    json_output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(markdown_output=markdown_output, overall=overall, focus_areas=focus_areas)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/summarize_vulture_report.py
+++ b/scripts/summarize_vulture_report.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+ENTRY_PATTERN = re.compile(
+    r"^(?P<path>.*?):(?P<line>\d+): unused (?P<kind>.+?) '(?P<name>.+?)' "
+    r"\((?P<confidence>\d+)% confidence(?:, (?P<lines>\d+) line(?:s)?)?\)$"
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Summarize a Vulture text report.")
+    parser.add_argument("--input", required=True, help="Path to the raw Vulture text report.")
+    parser.add_argument("--json-output", required=True, help="Where to write the summary JSON.")
+    parser.add_argument(
+        "--markdown-output",
+        required=True,
+        help="Where to write the Markdown summary.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    input_path = Path(args.input)
+    json_output = Path(args.json_output)
+    markdown_output = Path(args.markdown_output)
+
+    if not input_path.exists():
+        payload = {"total_findings": 0, "kinds": {}, "top_paths": {}, "unparsed_lines": []}
+        json_output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        markdown_output.write_text("# Vulture Report\n\nNo report was generated.\n", encoding="utf-8")
+        return 0
+
+    raw_lines = [line.strip() for line in input_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    kinds: Counter[str] = Counter()
+    top_paths: Counter[str] = Counter()
+    unparsed_lines: list[str] = []
+
+    for line in raw_lines:
+        match = ENTRY_PATTERN.match(line)
+        if not match:
+            unparsed_lines.append(line)
+            continue
+        kinds[match.group("kind")] += 1
+        top_paths[match.group("path")] += 1
+
+    payload = {
+        "total_findings": sum(kinds.values()),
+        "kinds": dict(sorted(kinds.items())),
+        "top_paths": dict(top_paths.most_common(10)),
+        "unparsed_lines": unparsed_lines[:20],
+    }
+    json_output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    lines = [
+        "# Vulture Report",
+        "",
+        f"Total findings: {payload['total_findings']}",
+        "",
+        "## By kind",
+    ]
+    if payload["kinds"]:
+        for kind, count in payload["kinds"].items():
+            lines.append(f"- {kind}: {count}")
+    else:
+        lines.append("- No parsed findings.")
+
+    lines.extend(["", "## Top paths"])
+    if payload["top_paths"]:
+        for path, count in payload["top_paths"].items():
+            lines.append(f"- `{path}`: {count}")
+    else:
+        lines.append("- No parsed paths.")
+
+    if payload["unparsed_lines"]:
+        lines.extend(["", "## Unparsed lines", *[f"- `{line}`" for line in payload["unparsed_lines"]]])
+
+    markdown_output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def _reset_event_loop_policy():
     """Ensure a fresh default event loop policy each test to avoid stale state."""
 
     asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
+    asyncio.set_event_loop(asyncio.new_event_loop())
 
     # Swallow noisy invalid-fd teardown errors from BaseEventLoop.__del__ (Py3.11 bug).
     if not getattr(asyncio.BaseEventLoop.__del__, "_qmtl_patched", False):  # type: ignore[attr-defined]
@@ -31,7 +32,15 @@ def _reset_event_loop_policy():
 
         _safe_del._qmtl_patched = True  # type: ignore[attr-defined]
         asyncio.BaseEventLoop.__del__ = _safe_del  # type: ignore[assignment]
-    yield
+    try:
+        yield
+    finally:
+        try:
+            # Keep a default loop available for plugins that probe the main thread
+            # between tests (for example, under mutation-test orchestration).
+            asyncio.set_event_loop(asyncio.new_event_loop())
+        except Exception:
+            pass
 
 
 def _close_loops(loops: List[asyncio.AbstractEventLoop]) -> None:

--- a/tests/qmtl/conftest.py
+++ b/tests/qmtl/conftest.py
@@ -11,4 +11,8 @@ def _provide_event_loop() -> None:
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    yield
+    try:
+        yield
+    finally:
+        if not loop.is_closed():
+            loop.close()

--- a/tests/qmtl/interfaces/tools/test_pytest_plugins_placement.py
+++ b/tests/qmtl/interfaces/tools/test_pytest_plugins_placement.py
@@ -20,7 +20,12 @@ def test_no_pytest_plugins_in_nested_conftest() -> None:
         raise RuntimeError("Could not locate repository root from test path")
     assert (repo_root / "pytest.ini").exists(), "repo root discovery failed"
 
-    confs = [p for p in repo_root.rglob("conftest.py")]
+    scratch_roots = {"mutants", ".artifacts"}
+    confs = [
+        p
+        for p in repo_root.rglob("conftest.py")
+        if not any(part in scratch_roots for part in p.relative_to(repo_root).parts)
+    ]
     assert confs, "no conftest.py files found"
 
     # Only the repository root conftest may declare pytest_plugins.

--- a/tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py
+++ b/tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import httpx
@@ -25,27 +26,29 @@ class DummyClient:
         return resp
 
 
-@pytest.mark.asyncio
-async def test_offline_cache_parity(tmp_path, monkeypatch):
-    node_live = TagQueryNode(["t"], interval="60s", period=1)
+def test_offline_cache_parity(tmp_path, monkeypatch):
+    async def run_case() -> None:
+        node_live = TagQueryNode(["t"], interval="60s", period=1)
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"queues": [{"queue": "q1", "global": False}]})
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"queues": [{"queue": "q1", "global": False}]})
 
-    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: DummyClient(handler=handler))
+        monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: DummyClient(handler=handler))
 
-    cache = tmp_path / "tagcache.json"
-    mgr_live = TagQueryManager("http://gw", cache_path=cache)
-    mgr_live.register(node_live)
-    await mgr_live.resolve_tags()
-    assert node_live.upstreams == ["q1"]
+        cache = tmp_path / "tagcache.json"
+        mgr_live = TagQueryManager("http://gw", cache_path=cache)
+        mgr_live.register(node_live)
+        await mgr_live.resolve_tags()
+        assert node_live.upstreams == ["q1"]
 
-    data = json.loads(cache.read_text())
-    assert data["crc32"] == TagQueryManager._compute_crc(data["mappings"])
+        data = json.loads(cache.read_text())
+        assert data["crc32"] == TagQueryManager._compute_crc(data["mappings"])
 
-    node_off = TagQueryNode(["t"], interval="60s", period=1)
-    mgr_off = TagQueryManager(cache_path=cache)
-    mgr_off.register(node_off)
-    await mgr_off.resolve_tags(offline=True)
-    assert node_off.upstreams == ["q1"]
-    assert node_off.upstreams == node_live.upstreams
+        node_off = TagQueryNode(["t"], interval="60s", period=1)
+        mgr_off = TagQueryManager(cache_path=cache)
+        mgr_off.register(node_off)
+        await mgr_off.resolve_tags(offline=True)
+        assert node_off.upstreams == ["q1"]
+        assert node_off.upstreams == node_live.upstreams
+
+    asyncio.run(run_case())

--- a/tests/qmtl/runtime/sdk/tagquery/test_manager_resolve_normalization.py
+++ b/tests/qmtl/runtime/sdk/tagquery/test_manager_resolve_normalization.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from qmtl.runtime.sdk import MatchMode, TagQueryNode
@@ -5,113 +7,124 @@ from qmtl.runtime.sdk import metrics as sdk_metrics
 from qmtl.runtime.sdk.tagquery_manager import TagQueryManager
 
 
-@pytest.mark.asyncio
-async def test_resolve_tags_normalizes_and_filters(monkeypatch):
-    calls = []
+def test_resolve_tags_normalizes_and_filters(monkeypatch):
+    async def run_case():
+        calls = []
 
-    class DummyClient:
-        def __init__(self, *a, **k):
-            pass
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
 
-        async def __aenter__(self):
-            return self
+            async def __aenter__(self):
+                return self
 
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
 
-        async def get(self, url, params=None):
-            calls.append((url, dict(params or {})))
+            async def get(self, url, params=None):
+                calls.append((url, dict(params or {})))
 
-            class Resp:
-                status_code = 200
+                class Resp:
+                    status_code = 200
 
-                def raise_for_status(self):
-                    return None
+                    def raise_for_status(self):
+                        return None
 
-                def json(self):
-                    # All entries are descriptor objects; global=True must be filtered
-                    return {
-                        "queues": [
-                            {"queue": "q1", "global": False},
-                            {"queue": "q2", "global": False},
-                            {"queue": "q3", "global": True},
-                        ]
-                    }
+                    def json(self):
+                        # All entries are descriptor objects; global=True must be filtered
+                        return {
+                            "queues": [
+                                {"queue": "q1", "global": False},
+                                {"queue": "q2", "global": False},
+                                {"queue": "q3", "global": True},
+                            ]
+                        }
 
-            return Resp()
+                return Resp()
 
-    monkeypatch.setattr("qmtl.runtime.sdk.tagquery_manager.httpx.AsyncClient", DummyClient)
+        monkeypatch.setattr("qmtl.runtime.sdk.tagquery_manager.httpx.AsyncClient", DummyClient)
 
-    node = TagQueryNode(["t1"], interval="60s", period=1, match_mode=MatchMode.ALL)
-    mgr = TagQueryManager("http://gw", world_id="worldX")
-    mgr.register(node)
+        node = TagQueryNode(["t1"], interval="60s", period=1, match_mode=MatchMode.ALL)
+        mgr = TagQueryManager("http://gw", world_id="worldX")
+        mgr.register(node)
 
-    await mgr.resolve_tags(offline=False)
+        await mgr.resolve_tags(offline=False)
 
-    # global=True entry is filtered, remaining are preserved and execute flag is set
-    assert sorted(node.upstreams) == ["q1", "q2"]
-    assert node.execute
+        # global=True entry is filtered, remaining are preserved and execute flag is set
+        assert sorted(node.upstreams) == ["q1", "q2"]
+        assert node.execute
 
-    # Verify request parameters were normalized correctly
-    assert calls, "no HTTP call captured"
-    url, params = calls[-1]
-    assert url.endswith("/queues/by_tag")
-    assert params.get("tags") == "t1"
-    assert params.get("interval") == 60
-    assert params.get("match_mode") == "all"
-    assert params.get("world_id") == "worldX"
+        # Verify request parameters were normalized correctly
+        assert calls, "no HTTP call captured"
+        url, params = calls[-1]
+        assert url.endswith("/queues/by_tag")
+        assert params.get("tags") == "t1"
+        assert params.get("interval") == 60
+        assert params.get("match_mode") == "all"
+        assert params.get("world_id") == "worldX"
 
-
-@pytest.mark.asyncio
-async def test_resolve_tags_offline_initializes_empty():
-    node = TagQueryNode(["t"], interval="60s", period=1)
-    mgr = TagQueryManager(None)
-    mgr.register(node)
-    await mgr.resolve_tags(offline=True)
-    assert node.upstreams == []
-    assert not node.execute
+    asyncio.run(run_case())
 
 
-@pytest.mark.asyncio
-async def test_queue_update_canonicalizes_tags_and_records_metrics():
-    sdk_metrics.reset_metrics()
-    node = TagQueryNode(["t2", "t1"], interval="60s", period=1)
-    mgr = TagQueryManager("http://gw")
-    mgr.register(node)
+def test_resolve_tags_offline_initializes_empty():
+    async def run_case():
+        node = TagQueryNode(["t"], interval="60s", period=1)
+        mgr = TagQueryManager(None)
+        mgr.register(node)
+        await mgr.resolve_tags(offline=True)
+        assert node.upstreams == []
+        assert not node.execute
 
-    await mgr._handle_queue_update(
-        {
-            "tags": ["t1", "t2", "t2"],
-            "interval": "60",
-            "match_mode": "ANY",
-            "queues": [{"queue": "q1", "global": False}],
-        }
-    )
-
-    assert node.upstreams == ["q1"]
-    assert (
-        sdk_metrics.tagquery_update_total.labels(outcome="applied", reason="ok")._value.get() == 1
-    )
+    asyncio.run(run_case())
 
 
-@pytest.mark.asyncio
-async def test_queue_update_missing_interval_is_dropped():
-    sdk_metrics.reset_metrics()
-    node = TagQueryNode(["t"], interval="60s", period=1)
-    mgr = TagQueryManager("http://gw")
-    mgr.register(node)
+def test_queue_update_canonicalizes_tags_and_records_metrics():
+    async def run_case():
+        sdk_metrics.reset_metrics()
+        node = TagQueryNode(["t2", "t1"], interval="60s", period=1)
+        mgr = TagQueryManager("http://gw")
+        mgr.register(node)
 
-    await mgr._handle_queue_update(
-        {
-            "tags": ["t"],
-            "queues": [{"queue": "q1"}],
-        }
-    )
+        await mgr._handle_queue_update(
+            {
+                "tags": ["t1", "t2", "t2"],
+                "interval": "60",
+                "match_mode": "ANY",
+                "queues": [{"queue": "q1", "global": False}],
+            }
+        )
 
-    assert node.upstreams == []
-    assert (
-        sdk_metrics.tagquery_update_total.labels(
-            outcome="dropped", reason="missing_interval"
-        )._value.get()
-        == 1
-    )
+        assert node.upstreams == ["q1"]
+        assert (
+            sdk_metrics.tagquery_update_total.labels(
+                outcome="applied", reason="ok"
+            )._value.get()
+            == 1
+        )
+
+    asyncio.run(run_case())
+
+
+def test_queue_update_missing_interval_is_dropped():
+    async def run_case():
+        sdk_metrics.reset_metrics()
+        node = TagQueryNode(["t"], interval="60s", period=1)
+        mgr = TagQueryManager("http://gw")
+        mgr.register(node)
+
+        await mgr._handle_queue_update(
+            {
+                "tags": ["t"],
+                "queues": [{"queue": "q1"}],
+            }
+        )
+
+        assert node.upstreams == []
+        assert (
+            sdk_metrics.tagquery_update_total.labels(
+                outcome="dropped", reason="missing_interval"
+            )._value.get()
+            == 1
+        )
+
+    asyncio.run(run_case())

--- a/tests/qmtl/runtime/sdk/tagquery/test_runner_live_updates.py
+++ b/tests/qmtl/runtime/sdk/tagquery/test_runner_live_updates.py
@@ -1,11 +1,8 @@
 import asyncio
 
 import httpx
-import pytest
-
-from qmtl.runtime.sdk import MatchMode, Runner, Strategy, TagQueryNode
-from qmtl.services.gateway.api import Database, create_app
-from qmtl.services.gateway.ws import WebSocketHub
+from qmtl.runtime.sdk import MatchMode, Strategy, TagQueryNode
+from qmtl.runtime.sdk.tag_manager_service import TagManagerService
 
 
 async def wait_for(condition, timeout: float = 1.0) -> None:
@@ -16,168 +13,115 @@ async def wait_for(condition, timeout: float = 1.0) -> None:
     await asyncio.wait_for(_wait(), timeout)
 
 
-class DummyDag:
-    async def get_queues_by_tag(
-        self, tags, interval, match_mode="any", world_id=None, execution_domain=None
-    ):
-        return []
-
-
-class FakeDB(Database):
-    async def insert_strategy(self, strategy_id: str, meta=None):
-        pass
-
-    async def set_status(self, strategy_id: str, status: str) -> None:
-        pass
-
-    async def get_status(self, strategy_id: str):
-        return None
-
-    async def append_event(self, strategy_id: str, event: str) -> None:  # pragma: no cover - not used
-        pass
-
-
 class TQStrategy(Strategy):
     def setup(self):
         self.tq = TagQueryNode(["t1"], interval="60s", period=1)
         self.add_nodes([self.tq])
 
 
-@pytest.mark.asyncio
-async def test_live_auto_subscribes(monkeypatch, fake_redis):
-    class DummyWS:
-        def __init__(self, url, *, token=None, on_message=None):
-            self.on_message = on_message
-            self.token = token
+def test_live_auto_subscribes(monkeypatch):
+    async def run_case():
+        class DummyWS:
+            def __init__(self, url, *, token=None, on_message=None):
+                self.url = url
+                self.on_message = on_message
+                self.token = token
 
-        async def start(self):
-            pass
+            async def start(self):
+                pass
 
-        async def stop(self):
-            pass
+            async def stop(self):
+                pass
 
-        async def _handle(self, data):
-            if self.on_message:
-                await self.on_message(data)
+            async def _handle(self, data):
+                if self.on_message:
+                    await self.on_message(data)
 
-    class DummyHub(WebSocketHub):
-        def __init__(self, client):
-            super().__init__()
-            self.client = client
+        client = DummyWS("ws://dummy")
 
-        async def send_queue_update(
-            self,
-            tags,
-            interval,
-            queues,
-            match_mode: MatchMode = MatchMode.ANY,
-            *,
-            etag: str | None = None,
-            ts: str | None = None,
-        ) -> None:  # type: ignore[override]
-            await self.client._handle(
+        def ws_factory(url, *, on_message=None, token=None):
+            client.on_message = on_message
+            client.token = token
+            return client
+
+        monkeypatch.setattr("qmtl.runtime.sdk.tagquery_manager.WebSocketClient", ws_factory)
+
+        class DummyClient:
+            def __init__(self, *a, **k):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def post(self, url, json=None):
+                if url.endswith("/strategies"):
+                    return httpx.Response(200, json={"strategy_id": "s-live", "queue_map": {}})
+                if url.endswith("/events/subscribe"):
+                    return httpx.Response(
+                        200,
+                        json={
+                            "stream_url": "ws://dummy",
+                            "token": "tok-live",
+                            "topics": ["w/tq_live_updates/queues"],
+                        },
+                    )
+                raise AssertionError(f"unexpected POST {url}")
+
+            async def get(self, url, params=None):
+                if url.endswith("/queues/by_tag"):
+                    return httpx.Response(200, json={"queues": []})
+                raise AssertionError(f"unexpected GET {url}")
+
+        monkeypatch.setattr("qmtl.runtime.sdk.tagquery_manager.httpx.AsyncClient", DummyClient)
+        strat = TQStrategy()
+        strat.setup()
+        manager = TagManagerService("http://gw").init(
+            strat,
+            world_id="tq_live_updates",
+            strategy_id="s-live",
+        )
+        try:
+            await manager.start()
+            await wait_for(lambda: bool(manager._nodes))
+
+            await client._handle(
                 {
                     "type": "queue_update",
                     "data": {
-                        "tags": tags,
-                        "interval": interval,
-                        "queues": queues,
-                        "match_mode": match_mode.value,
-                        "etag": etag,
-                        "ts": ts,
+                        "tags": ["t1"],
+                        "interval": 60,
+                        "queues": [{"queue": "q1", "global": False}],
+                        "match_mode": MatchMode.ANY.value,
+                        "etag": "q:t1:60:1",
+                        "ts": "2020-01-01T00:00:00Z",
+                        "version": 1,
+                        },
+                    }
+                )
+            await manager.handle_message(
+                {
+                    "type": "queue_update",
+                    "data": {
+                        "tags": ["t1"],
+                        "interval": 60,
+                        "queues": [{"queue": "q1", "global": False}],
+                        "match_mode": "any",
+                        "etag": "q:t1:60:1",
+                        "ts": "2020-01-01T00:00:00Z",
                         "version": 1,
                     },
                 }
             )
 
-    client = DummyWS("ws://dummy")
+            node = strat.tq
+            await wait_for(lambda: node.upstreams == ["q1"])
+            assert node.execute
+            assert hasattr(strat, "tag_query_manager")
+            assert strat.tag_query_manager is manager
+        finally:
+            await manager.stop()
 
-    def ws_factory(url, *, on_message=None, token=None):
-        client.on_message = on_message
-        client.token = token
-        return client
-    hub = DummyHub(client)
-    redis = fake_redis
-    gw_app = create_app(dag_client=DummyDag(), ws_hub=hub, redis_client=redis, database=FakeDB(), enable_background=False)
-    transport = httpx.ASGITransport(gw_app)
-
-    real_client = httpx.AsyncClient
-    monkeypatch.setattr("qmtl.runtime.sdk.tagquery_manager.WebSocketClient", ws_factory)
-
-    class DummyClient:
-        def __init__(self, *a, **k):
-            k.setdefault("transport", transport)
-            k.setdefault("base_url", "http://gw")
-            self._client = real_client(*a, **k)
-
-        async def __aenter__(self):
-            await self._client.__aenter__()
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            await self._client.__aexit__(exc_type, exc, tb)
-
-        async def post(self, url, json=None):
-            return await self._client.post(url, json=json)
-
-        async def get(self, url, params=None):
-            return await self._client.get(url, params=params)
-
-    monkeypatch.setattr("qmtl.runtime.sdk.gateway_client.httpx.AsyncClient", DummyClient)
-    monkeypatch.setattr("qmtl.runtime.sdk.tagquery_manager.httpx.AsyncClient", DummyClient)
-
-    class DummyFactory:
-        available = True
-
-        @staticmethod
-        def create_consumer(topic: str, *, bootstrap_servers: str):
-            class DummyConsumer:
-                async def start(self):
-                    return None
-
-                async def stop(self):
-                    return None
-
-                async def getmany(self, timeout_ms=None):
-                    return {}
-
-            return DummyConsumer()
-
-    monkeypatch.setattr(Runner.services(), "kafka_factory", DummyFactory())
-
-    result = await Runner.submit_async(TQStrategy, world="tq_live_updates")
-    strat = result.strategy
-    assert strat is not None
-    try:
-        await wait_for(lambda: bool(strat.tag_query_manager._nodes))
-
-        await hub.send_queue_update(
-            ["t1"],
-            60,
-            [{"queue": "q1", "global": False}],
-            MatchMode.ANY,
-            etag="q:t1:60:1",
-            ts="2020-01-01T00:00:00Z",
-        )
-        await strat.tag_query_manager.handle_message(
-            {
-                "type": "queue_update",
-                "data": {
-                    "tags": ["t1"],
-                    "interval": 60,
-                    "queues": [{"queue": "q1", "global": False}],
-                    "match_mode": "any",
-                    "etag": "q:t1:60:1",
-                    "ts": "2020-01-01T00:00:00Z",
-                    "version": 1,
-                },
-            }
-        )
-
-        node = strat.tq
-        await wait_for(lambda: node.upstreams == ["q1"])
-        assert node.execute
-        assert hasattr(strat, "tag_query_manager")
-    finally:
-        await Runner.shutdown_async(strat)
-    await transport.aclose()
+    asyncio.run(run_case())

--- a/tests/qmtl/runtime/sdk/tagquery/test_tagquery_manager_start.py
+++ b/tests/qmtl/runtime/sdk/tagquery/test_tagquery_manager_start.py
@@ -24,26 +24,28 @@ class DummyClient:
         self.stop_calls += 1
 
 
-@pytest.mark.asyncio
-async def test_start_is_idempotent_with_active_poll_loop():
-    client = DummyClient()
-    manager = TagQueryManager("http://gw", ws_client=client, world_id="w")
+def test_start_is_idempotent_with_active_poll_loop():
+    async def run_case():
+        client = DummyClient()
+        manager = TagQueryManager("http://gw", ws_client=client, world_id="w")
 
-    await manager.start()
-    first_task = manager._poll_task
-    assert first_task is not None
-    assert client.start_calls == 1
+        await manager.start()
+        first_task = manager._poll_task
+        assert first_task is not None
+        assert client.start_calls == 1
 
-    await manager.start()
-    assert client.start_calls == 1
-    assert manager._poll_task is first_task
+        await manager.start()
+        assert client.start_calls == 1
+        assert manager._poll_task is first_task
 
-    await asyncio.sleep(0)
-    await manager.stop()
-    assert client.stop_calls == 1
-    assert manager._poll_task is None
+        await asyncio.sleep(0)
+        await manager.stop()
+        assert client.stop_calls == 1
+        assert manager._poll_task is None
 
-    await manager.start()
-    assert client.start_calls == 2
-    await manager.stop()
-    assert client.stop_calls == 2
+        await manager.start()
+        assert client.start_calls == 2
+        await manager.stop()
+        assert client.stop_calls == 2
+
+    asyncio.run(run_case())

--- a/tests/qmtl/runtime/sdk/tagquery/test_tagquery_upsert_handler.py
+++ b/tests/qmtl/runtime/sdk/tagquery/test_tagquery_upsert_handler.py
@@ -1,70 +1,76 @@
+import asyncio
+
 import pytest
 
 from qmtl.runtime.sdk import MatchMode, TagQueryNode
 from qmtl.runtime.sdk.tagquery_manager import TagQueryManager
 
 
-@pytest.mark.asyncio
-async def test_tagquery_upsert_initializes_node():
-    node = TagQueryNode(["t"], interval="60s", period=1)
-    mgr = TagQueryManager()
-    mgr.register(node)
-    await mgr.handle_message(
-        {
-            "event": "tagquery.upsert",
-            "data": {
-                "tags": ["t"],
-                "interval": 60,
-                "queues": [{"queue": "q1", "global": False}],
-                "version": 1,
-            },
-        }
-    )
-    assert node.upstreams == ["q1"]
-    assert node.pre_warmup
-    key = (("t",), 60, MatchMode.ANY)
-    assert mgr._last_queue_sets[key] == frozenset(["q1"])
+def test_tagquery_upsert_initializes_node():
+    async def run_case():
+        node = TagQueryNode(["t"], interval="60s", period=1)
+        mgr = TagQueryManager()
+        mgr.register(node)
+        await mgr.handle_message(
+            {
+                "event": "tagquery.upsert",
+                "data": {
+                    "tags": ["t"],
+                    "interval": 60,
+                    "queues": [{"queue": "q1", "global": False}],
+                    "version": 1,
+                },
+            }
+        )
+        assert node.upstreams == ["q1"]
+        assert node.pre_warmup
+        key = (("t",), 60, MatchMode.ANY)
+        assert mgr._last_queue_sets[key] == frozenset(["q1"])
+
+    asyncio.run(run_case())
 
 
-@pytest.mark.asyncio
-async def test_queue_update_preserves_node_identity():
-    node = TagQueryNode(["t1", "t2"], interval="60s", period=1)
-    original_id = node.node_id
+def test_queue_update_preserves_node_identity():
+    async def run_case():
+        node = TagQueryNode(["t1", "t2"], interval="60s", period=1)
+        original_id = node.node_id
 
-    mgr = TagQueryManager()
-    mgr.register(node)
+        mgr = TagQueryManager()
+        mgr.register(node)
 
-    await mgr.handle_message(
-        {
-            "type": "queue_update",
-            "data": {
-                "tags": ["t2", "t1"],
-                "interval": 60,
-                "queues": [
-                    {"queue": "q1", "global": False},
-                    {"queue": "q2", "global": False},
-                ],
-                "match_mode": "any",
-                "version": 1,
-            },
-        }
-    )
+        await mgr.handle_message(
+            {
+                "type": "queue_update",
+                "data": {
+                    "tags": ["t2", "t1"],
+                    "interval": 60,
+                    "queues": [
+                        {"queue": "q1", "global": False},
+                        {"queue": "q2", "global": False},
+                    ],
+                    "match_mode": "any",
+                    "version": 1,
+                },
+            }
+        )
 
-    assert node.node_id == original_id
-    assert node.upstreams == ["q1", "q2"]
+        assert node.node_id == original_id
+        assert node.upstreams == ["q1", "q2"]
 
-    await mgr.handle_message(
-        {
-            "event": "queue_update",
-            "data": {
-                "tags": " t2 , t1 ",
-                "interval": 60,
-                "queues": [{"queue": "q2", "global": False}],
-                "match_mode": "any",
-                "version": 1,
-            },
-        }
-    )
+        await mgr.handle_message(
+            {
+                "event": "queue_update",
+                "data": {
+                    "tags": " t2 , t1 ",
+                    "interval": 60,
+                    "queues": [{"queue": "q2", "global": False}],
+                    "match_mode": "any",
+                    "version": 1,
+                },
+            }
+        )
 
-    assert node.node_id == original_id
-    assert node.upstreams == ["q2"]
+        assert node.node_id == original_id
+        assert node.upstreams == ["q2"]
+
+    asyncio.run(run_case())

--- a/tests/qmtl/runtime/sdk/tagquery/test_update_warmup.py
+++ b/tests/qmtl/runtime/sdk/tagquery/test_update_warmup.py
@@ -1,76 +1,80 @@
+import asyncio
+
 import pytest
 
 from qmtl.runtime.sdk import Runner, TagQueryNode
 from qmtl.runtime.sdk.tagquery_manager import TagQueryManager
 
 
-@pytest.mark.asyncio
-async def test_update_warmup_and_removal():
-    calls = []
-    node = TagQueryNode(["t"], interval="60s", period=2, compute_fn=lambda v: calls.append(v))
-    manager = TagQueryManager()
-    manager.register(node)
+def test_update_warmup_and_removal():
+    async def run_case():
+        calls = []
+        node = TagQueryNode(["t"], interval="60s", period=2, compute_fn=lambda v: calls.append(v))
+        manager = TagQueryManager()
+        manager.register(node)
 
-    # Initial queue registration
-    await manager.handle_message(
-        {
-            "event": "queue_update",
-            "data": {
-                "tags": ["t"],
-                "interval": 60,
-                "queues": [{"queue": "q1", "global": False}],
-                "match_mode": "any",
-                "version": 1,
-            },
-        }
-    )
-    assert node.upstreams == ["q1"]
-    assert node.pre_warmup
+        # Initial queue registration
+        await manager.handle_message(
+            {
+                "event": "queue_update",
+                "data": {
+                    "tags": ["t"],
+                    "interval": 60,
+                    "queues": [{"queue": "q1", "global": False}],
+                    "match_mode": "any",
+                    "version": 1,
+                },
+            }
+        )
+        assert node.upstreams == ["q1"]
+        assert node.pre_warmup
 
-    # Warm up node
-    Runner.feed_queue_data(node, "q1", 60, 60, {"v": 1})
-    assert node.pre_warmup
-    Runner.feed_queue_data(node, "q1", 60, 120, {"v": 2})
-    assert not node.pre_warmup
-    assert len(calls) == 1
+        # Warm up node
+        Runner.feed_queue_data(node, "q1", 60, 60, {"v": 1})
+        assert node.pre_warmup
+        Runner.feed_queue_data(node, "q1", 60, 120, {"v": 2})
+        assert not node.pre_warmup
+        assert len(calls) == 1
 
-    # Add new queue and ensure warmup resets
-    await manager.handle_message(
-        {
-            "event": "queue_update",
-            "data": {
-                "tags": ["t"],
-                "interval": 60,
-                "queues": [
-                    {"queue": "q1", "global": False},
-                    {"queue": "q2", "global": False},
-                ],
-                "match_mode": "any",
-                "version": 1,
-            },
-        }
-    )
-    assert set(node.upstreams) == {"q1", "q2"}
-    assert node.pre_warmup
+        # Add new queue and ensure warmup resets
+        await manager.handle_message(
+            {
+                "event": "queue_update",
+                "data": {
+                    "tags": ["t"],
+                    "interval": 60,
+                    "queues": [
+                        {"queue": "q1", "global": False},
+                        {"queue": "q2", "global": False},
+                    ],
+                    "match_mode": "any",
+                    "version": 1,
+                },
+            }
+        )
+        assert set(node.upstreams) == {"q1", "q2"}
+        assert node.pre_warmup
 
-    Runner.feed_queue_data(node, "q2", 60, 180, {"v": 3})
-    assert node.pre_warmup
-    Runner.feed_queue_data(node, "q2", 60, 240, {"v": 4})
-    assert not node.pre_warmup
-    assert len(calls) == 2
+        Runner.feed_queue_data(node, "q2", 60, 180, {"v": 3})
+        assert node.pre_warmup
+        Runner.feed_queue_data(node, "q2", 60, 240, {"v": 4})
+        assert not node.pre_warmup
+        assert len(calls) == 2
 
-    # Remove queue and validate cache drop
-    await manager.handle_message(
-        {
-            "event": "queue_update",
-            "data": {
-                "tags": ["t"],
-                "interval": 60,
-                "queues": [{"queue": "q2", "global": False}],
-                "match_mode": "any",
-                "version": 1,
-            },
-        }
-    )
-    assert node.upstreams == ["q2"]
-    assert node.cache.get_slice("q1", 60, count=1) == []
+        # Remove queue and validate cache drop
+        await manager.handle_message(
+            {
+                "event": "queue_update",
+                "data": {
+                    "tags": ["t"],
+                    "interval": 60,
+                    "queues": [{"queue": "q2", "global": False}],
+                    "match_mode": "any",
+                    "version": 1,
+                },
+            }
+        )
+        assert node.upstreams == ["q2"]
+        assert node.cache.get_slice("q1", 60, count=1) == []
+
+    asyncio.run(run_case())


### PR DESCRIPTION
## Summary
- add branch coverage baseline collection plus report-only Bandit and Vulture signals to local/CI quality gates
- add a report-only mutmut pilot workflow and local artifact generation for gateway/sdk/pipeline scope
- document scan-scope policy, rollout criteria, and mutation-pilot interpretation in Korean and English ops docs
- harden pytest scratch-tree handling and stabilize tagquery tests used by the mutation pilot

## Validation
- bash scripts/run_ci_local.sh
- uv run mkdocs build --strict
- bash scripts/run_mutation_pilot.sh --selector 'qmtl.runtime.pipeline*'

## Mutation Pilot Note
- The mutmut pilot remains report-only by design.
- Latest pilot artifacts record `exitcode.txt=1` with first failing test `tests/qmtl/runtime/sdk/tagquery/test_tagquery_manager_start.py::test_start_is_idempotent_with_active_poll_loop`.
- Current initial triage is `mutation-induced cancellation behavior under stop/poll loop` and does not block the PR gate.
