### PR TITLE
Docs: clarify quality gate triage actions

### DIFF
--- a/docs/en/operations/quality_gates.md
+++ b/docs/en/operations/quality_gates.md
@@ -94,6 +94,17 @@ Both paths now perform the following in common:
   - false-positive handling is documented,
   - repeated noise is removed without ad-hoc CLI suppressions,
   - baseline management can distinguish new findings from known noise.
+- Triage rules:
+  - `Bandit / needs fix`: findings in production paths around credential handling, shell injection, unsafe deserialization, or overly broad filesystem permissions are treated as fix-first issues. For example, any shell execution fed by user input should be patched rather than suppressed.
+  - `Bandit / accepted risk`: only narrowly scoped subprocess or tempfile usage with clear intent may remain, and the rationale must live in centralized config plus triage notes. For example, a fixed internal command may be retained only with centralized justification.
+  - `Bandit / tooling noise`: if test, example, or generated paths were scanned by mistake, fix the scan scope before adding any inline ignore.
+  - `Vulture / candidate cleanup`: unreferenced helpers, imports, and locals are first-class cleanup candidates. If there is no runtime reachability evidence, remove them in the next cleanup patch.
+  - `Vulture / keep but document`: externally invoked CLI entrypoints, compatibility shims, and reflection or dynamic-import hooks may stay if they are documented. A plugin hook loaded by string name is the typical example.
+  - `Vulture / false positive`: framework entrypoints, plugin registries, and runtime-only dynamic symbols should repeat across runs before any suppression is added.
+- Follow-up action by classification:
+  - `Bandit / needs fix`, `Vulture / candidate cleanup`: patch or remove in the next code change set.
+  - `Bandit / accepted risk`, `Vulture / keep but document`: keep only with centralized config and written rationale, then re-check on the next baseline refresh.
+  - `Bandit / tooling noise`, `Vulture / false positive`: confirm recurrence before suppression, then adjust scan scope or baseline rules instead of hiding the signal inline.
 
 ### mutmut
 
@@ -103,6 +114,11 @@ Both paths now perform the following in common:
   - equivalent mutant
   - integration gap
   - flaky / tooling noise
+- Survivor examples:
+  - `missing assertion`: a return value or branch condition changes and the test still passes because the observable outcome was not asserted tightly enough. The follow-up action is to add a tighter assertion around that observable behavior.
+  - `equivalent mutant`: the mutation changes syntax but not behavior under current domain constraints. The follow-up action is to tag it as `equivalent` and decide whether it should stay outside future gating denominators.
+  - `integration gap`: unit coverage passes, but the cross-service contract or adapter boundary is not exercised, so the mutant survives. The follow-up action is to add contract or integration coverage at that boundary.
+  - `flaky / tooling noise`: the current pilot example is the `tagquery_manager.stop()/poll_loop` cancellation path, where runner behavior can dominate the result. The follow-up action is to confirm reproducibility and either keep it tagged as tooling noise or move it into runner-stabilization work.
 - Gate proposal criteria:
   - execution time and flake rate are stable,
   - equivalent-mutant volume is manageable,

--- a/docs/ko/operations/quality_gates.md
+++ b/docs/ko/operations/quality_gates.md
@@ -94,6 +94,17 @@ last_modified: 2026-04-08
   - false positive 분류 규칙이 문서화되어 있고
   - 반복적으로 같은 잡음이 suppress/allowlist 없이 정리되며
   - 신규 이슈만 구분 가능한 baseline 운영이 가능할 때
+- triage 기준:
+  - `Bandit / needs fix`: 운영 경로에서의 credential 처리, shell injection, unsafe deserialization, 과도한 파일 권한은 우선 수정 대상으로 분류합니다. 예를 들어 사용자 입력이 들어가는 shell 호출은 suppress 없이 코드 수정이 필요합니다.
+  - `Bandit / accepted risk`: 제한된 subprocess 호출이나 임시 파일 사용처럼 의도가 명확하고 경계가 좁은 경우만 중앙 설정과 triage 메모에 근거를 남기고 유지합니다. 예를 들어 고정된 내부 명령 실행은 근거를 남긴 뒤 중앙 설정으로만 예외 처리합니다.
+  - `Bandit / tooling noise`: 테스트·예제·generated 경로가 잘못 스캔된 경우는 inline ignore 대신 스캔 범위를 먼저 조정합니다.
+  - `Vulture / candidate cleanup`: 참조가 없는 helper, import, local variable은 우선 삭제 후보로 처리합니다. 실제 실행 경로에서 도달 증거가 없으면 cleanup PR에 포함합니다.
+  - `Vulture / keep but document`: 외부 CLI 진입점, 호환성 shim, reflection/dynamic import hook은 문서화한 뒤 유지합니다. 예를 들어 plugin registry에서 문자열 기반으로 로딩되는 hook은 근거 문서를 남기고 유지합니다.
+  - `Vulture / false positive`: framework entrypoint, plugin registry, 런타임 동적 로딩으로만 도달하는 심볼은 suppress 전에 두 번 이상 반복되는지 확인합니다.
+- 분류 후 액션:
+  - `Bandit / needs fix`, `Vulture / candidate cleanup`: 다음 코드 변경 묶음에서 바로 수정하거나 제거합니다.
+  - `Bandit / accepted risk`, `Vulture / keep but document`: 중앙 설정과 문서 근거를 함께 남기고 다음 baseline 갱신 때 재확인합니다.
+  - `Bandit / tooling noise`, `Vulture / false positive`: suppress 전에 같은 finding이 반복되는지 확인하고, 반복되면 스캔 범위 또는 baseline 규칙을 조정합니다.
 
 ### mutmut
 
@@ -103,6 +114,11 @@ last_modified: 2026-04-08
   - equivalent mutant
   - integration gap
   - flaky / tooling noise
+- survivor 예시:
+  - `missing assertion`: 반환값이나 branch 조건이 바뀌어도 테스트가 통과한다면 assertion 강도가 부족한 것으로 분류합니다. 조치는 해당 관찰 결과를 직접 검증하는 assertion을 추가하는 것입니다.
+  - `equivalent mutant`: 도메인 제약상 동치인 비교 연산 변경처럼 관찰 가능한 의미 변화가 없는 경우입니다. 조치는 `equivalent`로 기록하고 gate 분모에서 분리할지 검토하는 것입니다.
+  - `integration gap`: 단위 테스트는 통과하지만 cross-service contract나 adapter 경계가 검증되지 않아 mutant가 살아남는 경우입니다. 조치는 contract 또는 integration test를 추가하는 것입니다.
+  - `flaky / tooling noise`: 현재 pilot에서 관찰된 `tagquery_manager.stop()/poll_loop` cancellation 경로처럼 runner 특성으로 결과가 흔들리는 경우입니다. 조치는 재현성 확인 뒤 tooling noise로 유지하거나 runner/workflow 안정화 작업으로 넘기는 것입니다.
 - gate 제안 조건:
   - 실행 시간과 flake rate가 안정적일 것
   - equivalent mutant 비율이 관리 가능할 것


### PR DESCRIPTION
## Summary\n- add explicit Bandit/Vulture triage examples and action mapping\n- add concrete mutmut survivor examples with required follow-up actions\n- tighten the closeout criteria for the quality-gates rollout issues\n\n## Validation\n- uv run mkdocs build --strict