### PR TITLE
Fix workflow edge-case regressions

### DIFF
--- a/.github/workflows/evaluation-store-retention.yml
+++ b/.github/workflows/evaluation-store-retention.yml
@@ -24,19 +24,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Skip if secrets missing
-        if: ${{ env.WORLDS_DB_DSN == '' || env.WORLDS_REDIS_DSN == '' }}
+      - name: Check secrets gate
+        id: secrets_gate
         run: |
-          echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping retention job."
-          exit 0
+          if [[ -z "${WORLDS_DB_DSN}" || -z "${WORLDS_REDIS_DSN}" ]]; then
+            echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping retention job."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         run: uv pip install -e ".[dev]"
 
       - name: Run purge (dry-run by default)
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         run: |
           retention_days="${{ inputs.retention_days || '180' }}"
           dry_run="${{ inputs.dry_run || 'true' }}"
@@ -49,6 +56,7 @@ jobs:
           uv run python scripts/purge_evaluation_run_history.py "${args[@]}"
 
       - name: Upload report
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: purge_report

--- a/.github/workflows/ex-post-failure-report.yml
+++ b/.github/workflows/ex-post-failure-report.yml
@@ -30,19 +30,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Skip if secrets missing
-        if: ${{ env.WORLDS_DB_DSN == '' || env.WORLDS_REDIS_DSN == '' }}
+      - name: Check secrets gate
+        id: secrets_gate
         run: |
-          echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping ex-post failure report."
-          exit 0
+          if [[ -z "${WORLDS_DB_DSN}" || -z "${WORLDS_REDIS_DSN}" ]]; then
+            echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping ex-post failure report."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         run: uv pip install -e ".[dev]"
 
       - name: Generate ex-post failure report
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -63,10 +70,10 @@ jobs:
           uv run python scripts/generate_ex_post_failure_report.py "${args[@]}" --format json --output ex_post_failure_report.json
 
       - name: Upload report
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ex-post-failure-report
           path: |
             ex_post_failure_report.md
             ex_post_failure_report.json
-

--- a/.github/workflows/live-monitoring-schedule.yml
+++ b/.github/workflows/live-monitoring-schedule.yml
@@ -36,19 +36,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Skip if secrets missing
-        if: ${{ env.WORLDS_DB_DSN == '' || env.WORLDS_REDIS_DSN == '' }}
+      - name: Check secrets gate
+        id: secrets_gate
         run: |
-          echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping live monitoring job."
-          exit 0
+          if [[ -z "${WORLDS_DB_DSN}" || -z "${WORLDS_REDIS_DSN}" ]]; then
+            echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping live monitoring job."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         run: uv pip install -e ".[dev]"
 
       - name: Run live monitoring worker (once)
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -79,6 +86,7 @@ jobs:
           uv run python scripts/live_monitoring_worker.py "${args[@]}"
 
       - name: Generate live monitoring report
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -97,6 +105,7 @@ jobs:
           uv run python scripts/generate_live_monitoring_report.py "${args[@]}" --format json --output live_monitoring_report.json
 
       - name: Upload report
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: live-monitoring-report

--- a/.github/workflows/override-rereview-queue.yml
+++ b/.github/workflows/override-rereview-queue.yml
@@ -20,19 +20,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Skip if secrets missing
-        if: ${{ env.WORLDS_DB_DSN == '' || env.WORLDS_REDIS_DSN == '' }}
+      - name: Check secrets gate
+        id: secrets_gate
         run: |
-          echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping override re-review job."
-          exit 0
+          if [[ -z "${WORLDS_DB_DSN}" || -z "${WORLDS_REDIS_DSN}" ]]; then
+            echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping override re-review job."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         run: uv pip install -e ".[dev]"
 
       - name: Generate override re-review queue
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -51,6 +58,7 @@ jobs:
           uv run python scripts/generate_override_rereview_report.py "${args[@]}" --format json --output override_queue.json
 
       - name: Upload report
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: override-rereview-queue

--- a/.github/workflows/policy-diff-history-report.yml
+++ b/.github/workflows/policy-diff-history-report.yml
@@ -50,22 +50,30 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Skip if secrets missing
-        if: ${{ env.WORLDS_DB_DSN == '' || env.WORLDS_REDIS_DSN == '' }}
+      - name: Check secrets gate
+        id: secrets_gate
         run: |
-          echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping policy diff history report."
-          exit 0
+          if [[ -z "${WORLDS_DB_DSN}" || -z "${WORLDS_REDIS_DSN}" ]]; then
+            echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping policy diff history report."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: astral-sh/setup-uv@v3
 
       - name: Prepare venv
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         run: uv venv
 
       - name: Install dependencies
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         run: uv pip install -e ".[dev]"
 
       - name: Resolve baseline revision
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         id: baseline
         shell: bash
         run: |
@@ -78,14 +86,14 @@ jobs:
           echo "skip=true" >> "$GITHUB_OUTPUT"
 
       - name: Create baseline worktree
-        if: ${{ steps.baseline.outputs.skip != 'true' }}
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' && steps.baseline.outputs.skip != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           git worktree add --detach baseline "${{ steps.baseline.outputs.baseline_rev }}"
 
       - name: Generate report
-        if: ${{ steps.baseline.outputs.skip != 'true' }}
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' && steps.baseline.outputs.skip != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -129,7 +137,7 @@ jobs:
           uv run python scripts/policy_diff_store_history.py "${args[@]}"
 
       - name: Write skip report
-        if: ${{ steps.baseline.outputs.skip == 'true' }}
+        if: ${{ steps.secrets_gate.outputs.skip == 'true' || steps.baseline.outputs.skip == 'true' }}
         run: |
           cat > policy_diff_history_report.json <<'JSON'
           {"skipped": true}

--- a/.github/workflows/policy-diff-regression.yml
+++ b/.github/workflows/policy-diff-regression.yml
@@ -114,7 +114,7 @@ jobs:
               baseline_runs_dir="$runs_dir"
             fi
 
-            PYTHONPATH="$PWD/baseline" uv run python scripts/policy_snapshot.py \
+            PYTHONPATH="$PWD/baseline" uv run python baseline/scripts/policy_snapshot.py \
               --policy "baseline/$policy_path" \
               --runs-dir "$baseline_runs_dir" \
               --runs-pattern '*.json' \

--- a/.github/workflows/validation-slo-report.yml
+++ b/.github/workflows/validation-slo-report.yml
@@ -44,19 +44,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Skip if secrets missing
-        if: ${{ env.WORLDS_DB_DSN == '' || env.WORLDS_REDIS_DSN == '' }}
+      - name: Check secrets gate
+        id: secrets_gate
         run: |
-          echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping validation SLO report."
-          exit 0
+          if [[ -z "${WORLDS_DB_DSN}" || -z "${WORLDS_REDIS_DSN}" ]]; then
+            echo "Missing WORLDS_DB_DSN/WORLDS_REDIS_DSN secrets; skipping validation SLO report."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         run: uv pip install -e ".[dev]"
 
       - name: Generate report (md/json)
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -92,6 +99,7 @@ jobs:
           uv run python scripts/report_validation_slo.py "${args[@]}" --format md --output validation_slo_report.md
 
       - name: Gate (fail on breach)
+        if: ${{ steps.secrets_gate.outputs.skip != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -126,7 +134,7 @@ jobs:
           uv run python scripts/report_validation_slo.py "${args[@]}" --format json --output validation_slo_report.json --fail
 
       - name: Upload report
-        if: ${{ always() }}
+        if: ${{ always() && steps.secrets_gate.outputs.skip != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: validation-slo-report

--- a/qmtl/services/worldservice/risk_hub.py
+++ b/qmtl/services/worldservice/risk_hub.py
@@ -197,14 +197,18 @@ class RiskSignalHub:
             raise ValueError("snapshot is expired")
 
         deduped = await self._enforce_version_idempotency(snapshot)
+        if self._repository is not None and not deduped:
+            try:
+                await self._repository.upsert(snapshot.world_id, snapshot.to_dict())  # type: ignore[union-attr]
+            except Exception:
+                retry_deduped = await self._enforce_version_idempotency(snapshot)
+                if not retry_deduped:
+                    self._logger.exception("Failed to persist risk snapshot for %s", snapshot.world_id)
+                    raise
+                deduped = True
+
         deduped = self._cache_snapshot(snapshot) or deduped
         await self._cache_latest(snapshot)
-        if self._repository is None:
-            return deduped
-        try:
-            await self._repository.upsert(snapshot.world_id, snapshot.to_dict())  # type: ignore[union-attr]
-        except Exception:
-            self._logger.exception("Failed to persist risk snapshot for %s", snapshot.world_id)
         return deduped
 
     async def latest_snapshot(self, world_id: str) -> Optional[PortfolioSnapshot]:

--- a/tests/qmtl/services/worldservice/test_risk_hub_validations.py
+++ b/tests/qmtl/services/worldservice/test_risk_hub_validations.py
@@ -87,3 +87,65 @@ def test_snapshot_round_trip_preserves_inline_realized_returns():
     snapshot = PortfolioSnapshot.from_payload(payload)
     encoded = snapshot.to_dict()
     assert encoded.get("realized_returns") == payload["realized_returns"]
+
+
+class _RacingConflictRepo:
+    def __init__(self) -> None:
+        self.insert_attempted = False
+
+    async def get(self, world_id: str, version: str):
+        if not self.insert_attempted:
+            return None
+        return {
+            "world_id": world_id,
+            "as_of": "2025-01-01T00:00:00Z",
+            "version": version,
+            "hash": "other-hash",
+            "weights": {"a": 1.0},
+        }
+
+    async def upsert(self, world_id: str, payload: dict):
+        self.insert_attempted = True
+        raise RuntimeError("unique constraint failed")
+
+
+class _BrokenRepo:
+    async def get(self, world_id: str, version: str):
+        return None
+
+    async def upsert(self, world_id: str, payload: dict):
+        raise RuntimeError("db unavailable")
+
+
+@pytest.mark.asyncio
+async def test_repository_race_conflict_is_raised_instead_of_silently_acked():
+    hub = RiskSignalHub()
+    hub.bind_repository(_RacingConflictRepo())
+    snap = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"a": 1.0},
+    )
+
+    with pytest.raises(RiskSnapshotConflictError):
+        await hub.upsert_snapshot(snap)
+
+    assert hub._snapshots == {}
+
+
+@pytest.mark.asyncio
+async def test_repository_failure_is_not_cached_locally_when_persist_fails():
+    hub = RiskSignalHub()
+    hub.bind_repository(_BrokenRepo())
+    snap = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"a": 1.0},
+    )
+
+    with pytest.raises(RuntimeError, match="db unavailable"):
+        await hub.upsert_snapshot(snap)
+
+    assert hub._snapshots == {}

--- a/tests/qmtl/services/worldservice/test_worldservice_api.py
+++ b/tests/qmtl/services/worldservice/test_worldservice_api.py
@@ -59,6 +59,26 @@ class _PersistentStoreStub:
         return None
 
 
+class _RacingRiskSnapshotRepo:
+    def __init__(self) -> None:
+        self.insert_attempted = False
+
+    async def get(self, world_id: str, version: str) -> dict[str, Any] | None:
+        if not self.insert_attempted:
+            return None
+        return {
+            "world_id": world_id,
+            "as_of": "2025-01-01T00:00:00Z",
+            "version": version,
+            "hash": "other-hash",
+            "weights": {"s1": 1.0},
+        }
+
+    async def upsert(self, world_id: str, payload: dict[str, Any]) -> None:
+        self.insert_attempted = True
+        raise RuntimeError("unique constraint failed")
+
+
 class DummyBus(ControlBusProducer):
     def __init__(self) -> None:
         self.events: list[tuple[str, str, dict]] = []
@@ -1947,6 +1967,29 @@ async def test_risk_hub_persists_snapshots_with_persistent_storage(tmp_path, fak
         assert latest["realized_returns"] == {"s1": [0.01, -0.005]}
     finally:
         await storage_inspect.close()
+
+
+@pytest.mark.asyncio
+async def test_risk_hub_conflict_does_not_ack_or_publish_event():
+    bus = DummyBus()
+    risk_hub = RiskSignalHub()
+    risk_hub.bind_repository(_RacingRiskSnapshotRepo())
+    app = create_app(storage=Storage(), bus=bus, risk_hub=risk_hub)
+    async with app.router.lifespan_context(app):
+        async with httpx.ASGITransport(app=app) as asgi:
+            async with httpx.AsyncClient(transport=asgi, base_url="http://test") as client:
+                resp = await client.post(
+                    "/risk-hub/worlds/race-hub/snapshots",
+                    json={
+                        "as_of": "2025-01-01T00:00:00Z",
+                        "version": "v1",
+                        "weights": {"s1": 1.0},
+                    },
+                    headers={"X-Actor": "risk", "X-Stage": "paper"},
+                )
+                assert resp.status_code == 409
+
+    assert not any(evt[0] == "risk_snapshot_updated" for evt in bus.events)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary:
- run baseline policy snapshots from the baseline checkout instead of head scripts
- gate scheduled/report workflows on missing worldservice secrets so downstream steps do not run
- stop risk-hub snapshot writes from acking or caching failed persistence attempts

Validation:
- bash scripts/run_ci_local.sh

Fixes #2078