### PR TITLE
Refactor extended validation worker seams

### DIFF
--- a/qmtl/services/worldservice/extended_validation_worker.py
+++ b/qmtl/services/worldservice/extended_validation_worker.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import inspect
 import logging
-import math
 from collections.abc import Iterable, Mapping
 from typing import Any
 
 from qmtl.services.worldservice.policy_engine import Policy, evaluate_extended_layers
 
+from .core_loop_hub import (
+    baseline_from_covariance,
+    candidate_weight_from_snapshot,
+    extract_returns_from_realized,
+    extract_stress_for_strategy,
+    incremental_var_es_from_covariance,
+)
 from .live_metrics_risk import (
     risk_hub_snapshot_lag_seconds,
     risk_hub_snapshot_missing_total,
@@ -56,69 +62,105 @@ class ExtendedValidationWorker:
             return 0
 
         runs = await self.store.list_evaluation_runs(world_id=world_id)
+        filtered = self._filter_runs(
+            runs,
+            stage=stage,
+            strategy_id=strategy_id,
+            run_id=run_id,
+        )
+        if not filtered:
+            return 0
+
+        hub_payload = await self._latest_hub_snapshot(world_id)
+        self._enrich_runs_from_hub_payload(filtered, hub_payload, policy_payload=policy_payload)
+        hub_weights, hub_covariance, baseline_from_hub, candidate_weight = self._risk_hub_portfolio_context(
+            hub_payload
+        )
+
+        for run in filtered:
+            await self._augment_run_with_portfolio_metrics(
+                world_id,
+                run,
+                hub_weights=hub_weights,
+                hub_covariance=hub_covariance,
+                baseline_from_hub=baseline_from_hub,
+                candidate_weight=candidate_weight,
+            )
+
+        extended = evaluate_extended_layers(filtered, policy, stage=stage)
+        if not extended:
+            return 0
+
+        updated = 0
+        for run in filtered:
+            updated += await self._persist_extended_results(world_id, run, extended)
+        return updated
+
+    @staticmethod
+    def _filter_runs(
+        runs: list[dict[str, Any]],
+        *,
+        stage: str | None,
+        strategy_id: str | None,
+        run_id: str | None,
+    ) -> list[dict[str, Any]]:
         stage_normalized = (stage or "").lower()
         filtered = [
             run
             for run in runs
-            if not stage_normalized
-            or str(run.get("stage", "")).lower() == stage_normalized
+            if not stage_normalized or str(run.get("stage", "")).lower() == stage_normalized
         ]
         if strategy_id:
             filtered = [run for run in filtered if str(run.get("strategy_id") or "") == str(strategy_id)]
         if run_id:
             filtered = [run for run in filtered if str(run.get("run_id") or "") == str(run_id)]
-        if not filtered:
-            return 0
+        return filtered
 
-        # Enrich runs with realized/live returns from risk hub snapshots when available.
-        hub_payload = await self._latest_hub_snapshot(world_id)
-        realized_payload = (
-            hub_payload.get("realized_returns") if isinstance(hub_payload, Mapping) else None
-        )
-        if realized_payload is not None:
-            for run in filtered:
-                sid = str(run.get("strategy_id") or "")
-                if not sid:
-                    continue
-                metrics = run.get("metrics") if isinstance(run.get("metrics"), Mapping) else {}
-                metrics = dict(metrics or {})
-                diagnostics = (
-                    metrics.get("diagnostics")
-                    if isinstance(metrics.get("diagnostics"), Mapping)
-                    else {}
-                )
-                diagnostics = dict(diagnostics or {})
-                if diagnostics.get("live_returns") is None:
-                    live_returns = self._extract_live_returns(realized_payload, sid)
-                    if live_returns:
-                        diagnostics["live_returns"] = live_returns
-                        metrics["diagnostics"] = diagnostics
-                        run["metrics"] = metrics
+    def _enrich_runs_from_hub_payload(
+        self,
+        runs: list[dict[str, Any]],
+        hub_payload: Mapping[str, Any] | None,
+        *,
+        policy_payload: Any | None,
+    ) -> None:
+        realized_payload = hub_payload.get("realized_returns") if isinstance(hub_payload, Mapping) else None
+        stress_payload = hub_payload.get("stress") if isinstance(hub_payload, Mapping) else None
 
-        stress_payload = (
-            hub_payload.get("stress") if isinstance(hub_payload, Mapping) else None
-        )
-        if stress_payload is not None:
-            for run in filtered:
-                sid = str(run.get("strategy_id") or "")
-                if not sid:
-                    continue
-                metrics = run.get("metrics") if isinstance(run.get("metrics"), Mapping) else {}
-                metrics = dict(metrics or {})
-                if metrics.get("stress") is None:
-                    stress_for_sid = self._extract_stress_for_strategy(stress_payload, sid)
-                    if stress_for_sid:
-                        metrics["stress"] = stress_for_sid
-                        run["metrics"] = metrics
+        for run in runs:
+            sid = str(run.get("strategy_id") or "")
+            if not sid:
+                continue
 
-        # Ensure derived live metrics are present before rule evaluation.
-        for run in filtered:
-            raw_metrics = run.get("metrics") if isinstance(run.get("metrics"), Mapping) else None
-            if raw_metrics is not None:
-                derived = augment_live_metrics(raw_metrics, windows=self.windows)
+            metrics = run.get("metrics") if isinstance(run.get("metrics"), Mapping) else {}
+            metrics = dict(metrics or {})
+
+            diagnostics = metrics.get("diagnostics") if isinstance(metrics.get("diagnostics"), Mapping) else {}
+            diagnostics = dict(diagnostics or {})
+            if diagnostics.get("live_returns") is None and realized_payload is not None:
+                live_returns = extract_returns_from_realized(realized_payload, strategy_id=sid)
+                if live_returns:
+                    diagnostics["live_returns"] = live_returns
+                    metrics["diagnostics"] = diagnostics
+
+            if metrics.get("stress") is None and stress_payload is not None:
+                stress_for_sid = extract_stress_for_strategy(stress_payload, strategy_id=sid)
+                if stress_for_sid:
+                    metrics["stress"] = stress_for_sid
+
+            if metrics:
+                derived = augment_live_metrics(metrics, windows=self.windows)
                 derived = augment_stress_metrics(derived, policy_payload=policy_payload)
                 run["metrics"] = derived
 
+    @staticmethod
+    def _risk_hub_portfolio_context(
+        hub_payload: Mapping[str, Any] | None,
+    ) -> tuple[
+        dict[str, Any] | None,
+        dict[str, Any] | None,
+        dict[str, float | int | None],
+        float,
+    ]:
         hub_weights = (
             dict(hub_payload.get("weights") or {})
             if isinstance(hub_payload, Mapping) and isinstance(hub_payload.get("weights"), Mapping)
@@ -130,118 +172,122 @@ class ExtendedValidationWorker:
             else None
         )
         baseline_from_hub = (
-            self._baseline_from_covariance(hub_weights, hub_covariance)
+            baseline_from_covariance(weights=hub_weights, covariance=hub_covariance) or {}
             if hub_weights is not None and hub_covariance is not None
             else {}
         )
-        candidate_weight = self._candidate_weight_from_snapshot(
-            hub_payload, active_count=len(hub_weights) if hub_weights else 0
+        candidate_weight = candidate_weight_from_snapshot(hub_payload or {})
+        if candidate_weight is None:
+            candidate_weight = 1.0 / float(max(len(hub_weights or {}), 0) + 1)
+        return hub_weights, hub_covariance, baseline_from_hub, candidate_weight
+
+    async def _augment_run_with_portfolio_metrics(
+        self,
+        world_id: str,
+        run: dict[str, Any],
+        *,
+        hub_weights: dict[str, Any] | None,
+        hub_covariance: dict[str, Any] | None,
+        baseline_from_hub: Mapping[str, Any],
+        candidate_weight: float,
+    ) -> None:
+        strategy_id = run.get("strategy_id")
+        if not strategy_id:
+            return
+        sid = str(strategy_id)
+        raw_metrics = run.get("metrics") if isinstance(run.get("metrics"), Mapping) else {}
+        metrics: dict[str, Any] = dict(raw_metrics or {})
+
+        baseline = baseline_from_hub or await self._portfolio_baseline(world_id, exclude_strategy_id=sid)
+        incremental = (
+            incremental_var_es_from_covariance(
+                weights=hub_weights,
+                covariance=hub_covariance,
+                candidate_id=sid,
+                candidate_weight=candidate_weight,
+                baseline=baseline_from_hub,
+            )
+            if hub_weights is not None
+            and hub_covariance is not None
+            and baseline_from_hub.get("var_99") is not None
+            and baseline_from_hub.get("es_99") is not None
+            else None
         )
+        if incremental is not None:
+            risk_block = metrics.get("risk") if isinstance(metrics.get("risk"), Mapping) else {}
+            risk_block = dict(risk_block or {})
+            risk_block["incremental_var_99"] = incremental["incremental_var_99"]
+            risk_block["incremental_es_99"] = incremental["incremental_es_99"]
+            metrics["risk"] = risk_block
 
-        for run in filtered:
-            strategy_id = run.get("strategy_id")
-            if not strategy_id:
-                continue
-            sid = str(strategy_id)
-            raw_metrics = run.get("metrics") if isinstance(run.get("metrics"), Mapping) else {}
-            metrics: dict[str, Any] = dict(raw_metrics or {})
+            diagnostics = metrics.get("diagnostics") if isinstance(metrics.get("diagnostics"), Mapping) else {}
+            diagnostics = dict(diagnostics or {})
+            extra = diagnostics.get("extra_metrics")
+            extra = dict(extra) if isinstance(extra, Mapping) else {}
+            extra.setdefault("portfolio_candidate_weight", incremental["candidate_weight"])
+            diagnostics["extra_metrics"] = extra
+            metrics["diagnostics"] = diagnostics
 
-            baseline = baseline_from_hub or await self._portfolio_baseline(world_id, exclude_strategy_id=sid)
-            incremental = (
-                self._incremental_var_es_from_covariance(
-                    weights=hub_weights,
-                    covariance=hub_covariance,
-                    candidate_id=sid,
-                    candidate_weight=candidate_weight,
-                    baseline=baseline_from_hub,
-                )
-                if hub_weights is not None
-                and hub_covariance is not None
-                and baseline_from_hub.get("var_99") is not None
-                and baseline_from_hub.get("es_99") is not None
-                else None
-            )
-            if incremental is not None:
-                risk_block = metrics.get("risk") if isinstance(metrics.get("risk"), Mapping) else {}
-                risk_block = dict(risk_block or {})
-                risk_block["incremental_var_99"] = incremental["incremental_var_99"]
-                risk_block["incremental_es_99"] = incremental["incremental_es_99"]
-                metrics["risk"] = risk_block
+        metrics = augment_portfolio_metrics(
+            metrics,
+            baseline_sharpe=baseline.get("sharpe") if isinstance(baseline, Mapping) else None,
+            baseline_var_99=baseline.get("var_99") if isinstance(baseline, Mapping) else None,
+            baseline_es_99=baseline.get("es_99") if isinstance(baseline, Mapping) else None,
+        )
+        run["metrics"] = metrics
 
-                diagnostics = (
-                    metrics.get("diagnostics")
-                    if isinstance(metrics.get("diagnostics"), Mapping)
-                    else {}
-                )
-                diagnostics = dict(diagnostics or {})
-                extra = diagnostics.get("extra_metrics")
-                extra = dict(extra) if isinstance(extra, Mapping) else {}
-                extra.setdefault("portfolio_candidate_weight", incremental["candidate_weight"])
-                diagnostics["extra_metrics"] = extra
-                metrics["diagnostics"] = diagnostics
-
-            metrics = augment_portfolio_metrics(
-                metrics,
-                baseline_sharpe=baseline.get("sharpe") if isinstance(baseline, Mapping) else None,
-                baseline_var_99=baseline.get("var_99") if isinstance(baseline, Mapping) else None,
-                baseline_es_99=baseline.get("es_99") if isinstance(baseline, Mapping) else None,
-            )
-            run["metrics"] = metrics
-
-        extended = evaluate_extended_layers(filtered, policy, stage=stage)
-        if not extended:
+    async def _persist_extended_results(
+        self,
+        world_id: str,
+        run: dict[str, Any],
+        extended: dict[str, dict[str, Any]],
+    ) -> int:
+        strategy_id = run.get("strategy_id")
+        if not strategy_id:
+            return 0
+        strategy_id = str(strategy_id)
+        if strategy_id not in extended:
             return 0
 
-        updated = 0
-        for run in filtered:
-            strategy_id = run.get("strategy_id")
-            if not strategy_id:
-                continue
-            strategy_id = str(strategy_id)
-            if strategy_id not in extended:
-                continue
+        validation = dict(run.get("validation") or {})
+        history = validation.get("extended_history")
+        history_list = list(history) if isinstance(history, list) else []
+        results = validation.get("results") if isinstance(validation.get("results"), Mapping) else {}
+        merged_results = dict(results)
+        for name, result in extended[strategy_id].items():
+            merged_results[name] = result.model_dump()
+        validation["results"] = merged_results
+        prev_revision = validation.get("extended_revision")
+        try:
+            revision = int(prev_revision) + 1 if prev_revision is not None else 1
+        except Exception:
+            revision = 1
 
-            validation = dict(run.get("validation") or {})
-            history = validation.get("extended_history")
-            history_list = list(history) if isinstance(history, list) else []
-            results = validation.get("results") if isinstance(validation.get("results"), Mapping) else {}
-            merged_results = dict(results)
-            for name, result in extended[strategy_id].items():
-                merged_results[name] = result.model_dump()
-            validation["results"] = merged_results
-            prev_revision = validation.get("extended_revision")
-            try:
-                revision = int(prev_revision) + 1 if prev_revision is not None else 1
-            except Exception:
-                revision = 1
+        evaluated_at = iso_timestamp_now()
+        validation["extended_revision"] = revision
+        validation["extended_evaluated_at"] = evaluated_at
+        history_list.append(
+            {
+                "revision": revision,
+                "evaluated_at": evaluated_at,
+                "results": merged_results,
+            }
+        )
+        validation["extended_history"] = history_list
 
-            evaluated_at = iso_timestamp_now()
-            validation["extended_revision"] = revision
-            validation["extended_evaluated_at"] = evaluated_at
-            history_list.append(
-                {
-                    "revision": revision,
-                    "evaluated_at": evaluated_at,
-                    "results": merged_results,
-                }
-            )
-            validation["extended_history"] = history_list
-
-            metrics = run.get("metrics") if isinstance(run.get("metrics"), Mapping) else {}
-            await self.store.record_evaluation_run(
-                world_id,
-                strategy_id,
-                str(run.get("run_id") or ""),
-                stage=str(run.get("stage") or ""),
-                risk_tier=str(run.get("risk_tier") or ""),
-                model_card_version=run.get("model_card_version"),
-                metrics=metrics,
-                validation=validation,
-                summary=run.get("summary"),
-            )
-
-            updated += 1
-        return updated
+        metrics = run.get("metrics") if isinstance(run.get("metrics"), Mapping) else {}
+        await self.store.record_evaluation_run(
+            world_id,
+            strategy_id,
+            str(run.get("run_id") or ""),
+            stage=str(run.get("stage") or ""),
+            risk_tier=str(run.get("risk_tier") or ""),
+            model_card_version=run.get("model_card_version"),
+            metrics=metrics,
+            validation=validation,
+            summary=run.get("summary"),
+        )
+        return 1
 
     async def _portfolio_baseline(
         self,
@@ -255,7 +301,7 @@ class ExtendedValidationWorker:
         if hub_snapshot:
             weights = hub_snapshot.get("weights") or {}
             cov = hub_snapshot.get("covariance") or {}
-            baseline = self._baseline_from_covariance(weights, cov)
+            baseline = baseline_from_covariance(weights=weights, covariance=cov)
             if baseline:
                 return baseline
 
@@ -413,186 +459,6 @@ class ExtendedValidationWorker:
         except Exception:
             return None
 
-
-    @staticmethod
-    def _coerce_float_series(source: Any) -> list[float] | None:
-        if isinstance(source, (list, tuple)):
-            try:
-                return [float(v) for v in source]
-            except Exception:
-                return None
-        return None
-
-    @classmethod
-    def _extract_live_returns(cls, realized: Any, strategy_id: str) -> list[float] | None:
-        """Best-effort extraction of per-strategy live returns from realized payloads."""
-
-        if realized is None:
-            return None
-        if isinstance(realized, Mapping):
-            for key in (strategy_id, str(strategy_id), "live_returns", "returns"):
-                if key in realized:
-                    series = cls._coerce_float_series(realized.get(key))
-                    if series is not None:
-                        return series
-            nested = realized.get("strategies")
-            if isinstance(nested, Mapping) and strategy_id in nested:
-                series = cls._coerce_float_series(nested.get(strategy_id))
-                if series is not None:
-                    return series
-        return cls._coerce_float_series(realized)
-
-    @classmethod
-    def _extract_stress_for_strategy(
-        cls, stress_payload: Any, strategy_id: str
-    ) -> dict[str, Any] | None:
-        """Best-effort extraction of per-strategy stress metrics from hub payloads.
-
-        Supports either per-strategy buckets:
-        {"s1": {"crash": {"max_drawdown": 0.2}}}
-        or a shared scenario map:
-        {"crash": {"max_drawdown": 0.3}}
-        """
-
-        if stress_payload is None:
-            return None
-        if isinstance(stress_payload, Mapping):
-            direct = stress_payload.get(strategy_id)
-            if isinstance(direct, Mapping):
-                return dict(direct)
-            nested = stress_payload.get("strategies")
-            if isinstance(nested, Mapping):
-                bucket = nested.get(strategy_id)
-                if isinstance(bucket, Mapping):
-                    return dict(bucket)
-            # Treat as shared scenario map if keys look like scenarios.
-            if any(isinstance(v, Mapping) for v in stress_payload.values()):
-                return dict(stress_payload)
-        return None
-
-
-    @staticmethod
-    def _lookup_covariance(covariance: Mapping[str, Any], a: str, b: str) -> float | None:
-        for sep in (",", ":"):
-            key = f"{a}{sep}{b}"
-            if key in covariance:
-                try:
-                    return float(covariance[key])
-                except Exception:
-                    return None
-            rev = f"{b}{sep}{a}"
-            if rev in covariance:
-                try:
-                    return float(covariance[rev])
-                except Exception:
-                    return None
-        return None
-
-    @staticmethod
-    def _candidate_weight_from_snapshot(snapshot: Any, *, active_count: int) -> float:
-        default = 1.0 / float(max(int(active_count), 0) + 1)
-        constraints = snapshot.get("constraints") if isinstance(snapshot, Mapping) else None
-        if isinstance(constraints, Mapping):
-            raw = None
-            if "candidate_weight" in constraints:
-                raw = constraints.get("candidate_weight")
-            elif "candidate_weight_default" in constraints:
-                raw = constraints.get("candidate_weight_default")
-            elif "candidate_weight_pct" in constraints:
-                raw = constraints.get("candidate_weight_pct")
-                try:
-                    raw = float(raw) / 100.0
-                except Exception:
-                    raw = None
-
-            if raw is not None:
-                try:
-                    value = float(raw)
-                except Exception:
-                    value = None
-                if value is not None and math.isfinite(value) and 0.0 < value <= 1.0:
-                    return value
-        return default
-
-    def _incremental_var_es_from_covariance(
-        self,
-        *,
-        weights: Mapping[str, float],
-        covariance: Mapping[str, Any],
-        candidate_id: str,
-        candidate_weight: float,
-        baseline: Mapping[str, Any],
-    ) -> dict[str, float] | None:
-        if candidate_id in weights:
-            return None
-        base_var = baseline.get("var_99")
-        base_es = baseline.get("es_99")
-        if not isinstance(base_var, (int, float)) or not isinstance(base_es, (int, float)):
-            return None
-        alpha = float(candidate_weight)
-        if not math.isfinite(alpha) or alpha <= 0.0:
-            return None
-        if alpha > 1.0:
-            alpha = 1.0
-
-        if self._lookup_covariance(covariance, candidate_id, candidate_id) is None:
-            return None
-
-        scaled_existing: dict[str, float] = {}
-        if alpha < 1.0:
-            for sid, weight in weights.items():
-                if not isinstance(weight, (int, float)):
-                    continue
-                if weight == 0:
-                    continue
-                scaled = float(weight) * (1.0 - alpha)
-                if scaled != 0:
-                    scaled_existing[str(sid)] = scaled
-
-        new_weights = dict(scaled_existing)
-        new_weights[candidate_id] = alpha
-        with_candidate = self._baseline_from_covariance(new_weights, covariance)
-        with_var = with_candidate.get("var_99")
-        with_es = with_candidate.get("es_99")
-        if not isinstance(with_var, (int, float)) or not isinstance(with_es, (int, float)):
-            return None
-        return {
-            "candidate_weight": alpha,
-            "incremental_var_99": float(with_var) - float(base_var),
-            "incremental_es_99": float(with_es) - float(base_es),
-        }
-
-    def _baseline_from_covariance(
-        self, weights: Mapping[str, float], covariance: Mapping[str, Any]
-    ) -> dict[str, float | int | None]:
-        """Compute baseline var/es from provided weights + covariance matrix."""
-
-        if not weights:
-            return {}
-        if not covariance:
-            return {}
-        w_sum = 0.0
-        for value in weights.values():
-            try:
-                w_sum += float(value)
-            except Exception:
-                return {}
-        if w_sum <= 0:
-            return {}
-        norm_weights = {str(k): float(v) / w_sum for k, v in weights.items()}
-        variance = 0.0
-        sids = list(norm_weights.keys())
-        for a in sids:
-            for b in sids:
-                cov_val = self._lookup_covariance(covariance, a, b)
-                if cov_val is None:
-                    continue
-                variance += norm_weights.get(a, 0.0) * norm_weights.get(b, 0.0) * float(cov_val)
-        if variance < 0:
-            return {}
-        z_var_99 = 2.33
-        var_99 = (variance ** 0.5) * z_var_99
-        return {"var_99": var_99, "es_99": var_99 * 1.2}
 
     @staticmethod
     def _extract_correlations(


### PR DESCRIPTION
## Summary
- reuse shared risk-snapshot/covariance helpers from `core_loop_hub.py` inside `extended_validation_worker`
- split `ExtendedValidationWorker.run()` into smaller helper seams for filtering, enrichment, portfolio augmentation, and persistence
- open follow-up issues for the remaining policy/submit orchestration hotspots

## Verification
- `uv run ruff check qmtl/services/worldservice/extended_validation_worker.py`
- `uv run -m pytest -q tests/qmtl/services/worldservice/test_extended_validation_worker.py tests/qmtl/services/worldservice/test_extended_validation_worker_cov_ref.py tests/qmtl/services/worldservice/test_world_service_services.py -q`
- `bash scripts/run_ci_local.sh`

Fixes #2077
Refs #2084
Refs #2085