### PR TITLE
Fix review follow-ups and restore CI parity

### DIFF
--- a/qmtl/runtime/sdk/snapshot.py
+++ b/qmtl/runtime/sdk/snapshot.py
@@ -24,8 +24,6 @@ from . import metrics as sdk_metrics
 
 if TYPE_CHECKING:
     import fsspec as _fsspec
-    import pyarrow as _pyarrow
-    import pyarrow.parquet as _pyarrow_parquet
 
 logger = logging.getLogger(__name__)
 
@@ -76,8 +74,8 @@ class FileSystemLike(Protocol):
 
 
 class ArrowContext(NamedTuple):
-    pa: "_pyarrow"
-    parquet: "_pyarrow_parquet"
+    pa: Any
+    parquet: Any
 
 
 def _get_arrow_context() -> ArrowContext | None:
@@ -85,8 +83,8 @@ def _get_arrow_context() -> ArrowContext | None:
 
 # Optional pyarrow context (exported for tests expecting module-level access)
 _arrow_ctx = _get_arrow_context()
-pa: "_pyarrow | None" = _arrow_ctx.pa if _arrow_ctx else None
-pq: "_pyarrow_parquet | None" = _arrow_ctx.parquet if _arrow_ctx else None
+pa: Any | None = _arrow_ctx.pa if _arrow_ctx else None
+pq: Any | None = _arrow_ctx.parquet if _arrow_ctx else None
 
 
 def _import_fsspec() -> "_fsspec | None":

--- a/qmtl/services/worldservice/activation.py
+++ b/qmtl/services/worldservice/activation.py
@@ -245,15 +245,21 @@ class ActivationEventPublisher:
             },
         )
         deduped = await self.risk_hub.upsert_snapshot(snap)
-        if deduped:
+        dispatch_required = (not deduped) or self.risk_hub.snapshot_dispatch_pending(world_id, snap.version)
+        if not dispatch_required:
             return
         if self.core_loop_hub is not None:
-            await self.core_loop_hub.handle_risk_snapshot_update(world_id, snap.to_dict())
+            outcome = await self.core_loop_hub.handle_risk_snapshot_update(world_id, snap.to_dict())
+            if outcome.completed:
+                self.risk_hub.mark_snapshot_dispatch_completed(world_id, snap.version)
         elif self.bus:
             try:
                 await self.bus.publish_risk_snapshot_updated(world_id, snap.to_dict())
+                self.risk_hub.mark_snapshot_dispatch_completed(world_id, snap.version)
             except Exception:
                 pass
+        else:
+            self.risk_hub.mark_snapshot_dispatch_completed(world_id, snap.version)
 
 
 __all__ = ["ActivationEventPublisher"]

--- a/qmtl/services/worldservice/core_loop_hub.py
+++ b/qmtl/services/worldservice/core_loop_hub.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import math
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
 from qmtl.runtime.sdk.world_validation_metrics import build_v1_evaluation_metrics
@@ -11,6 +12,16 @@ from qmtl.runtime.sdk.world_validation_metrics import build_v1_evaluation_metric
 from .controlbus_producer import ControlBusProducer
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RiskSnapshotDispatchOutcome:
+    bus_published: bool | None = None
+    validation_scheduled: bool | None = None
+
+    @property
+    def completed(self) -> bool:
+        return self.bus_published is not False and self.validation_scheduled is not False
 
 
 def deep_merge_mappings(base: Mapping[str, Any], overlay: Mapping[str, Any]) -> dict[str, Any]:
@@ -304,23 +315,38 @@ class CoreLoopHub:
     ) -> None:
         self._schedule_extended_validation = schedule_extended_validation
 
-    async def handle_risk_snapshot_update(self, world_id: str, snapshot: Mapping[str, Any]) -> None:
+    async def handle_risk_snapshot_update(
+        self,
+        world_id: str,
+        snapshot: Mapping[str, Any],
+    ) -> RiskSnapshotDispatchOutcome:
+        bus_published: bool | None = None
         if self._bus is not None:
             try:
                 await self._bus.publish_risk_snapshot_updated(world_id, dict(snapshot))
+                bus_published = True
             except Exception:  # pragma: no cover - best-effort logging
+                bus_published = False
                 logger.exception("Failed to publish risk snapshot to ControlBus")
+        validation_scheduled: bool | None = None
         if self._schedule_extended_validation is not None:
             try:
                 maybe = self._schedule_extended_validation(world_id)
                 if inspect.isawaitable(maybe):
                     await maybe
+                validation_scheduled = True
             except Exception:  # pragma: no cover - best-effort logging
+                validation_scheduled = False
                 logger.exception("Failed to schedule extended validation from risk hub update")
+        return RiskSnapshotDispatchOutcome(
+            bus_published=bus_published,
+            validation_scheduled=validation_scheduled,
+        )
 
 
 __all__ = [
     "CoreLoopHub",
+    "RiskSnapshotDispatchOutcome",
     "deep_merge_mappings",
     "derive_metrics_from_risk_snapshot",
 ]

--- a/qmtl/services/worldservice/risk_hub.py
+++ b/qmtl/services/worldservice/risk_hub.py
@@ -131,6 +131,7 @@ class RiskSignalHub:
         ttl_sec_max: int = 86400,
     ) -> None:
         self._snapshots: Dict[str, List[PortfolioSnapshot]] = {}
+        self._pending_dispatches: Dict[str, set[str]] = {}
         self._repository = repository
         self._max_cached = max_cached
         self._cache = cache
@@ -159,6 +160,17 @@ class RiskSignalHub:
     def bind_blob_store(self, store: BlobStore | None) -> None:
         """Attach a blob store to offload large payloads (covariance/returns/stress)."""
         self._blob_store = store
+
+    def snapshot_dispatch_pending(self, world_id: str, version: str) -> bool:
+        return version in self._pending_dispatches.get(world_id, set())
+
+    def mark_snapshot_dispatch_completed(self, world_id: str, version: str) -> None:
+        pending = self._pending_dispatches.get(world_id)
+        if pending is None:
+            return
+        pending.discard(version)
+        if not pending:
+            self._pending_dispatches.pop(world_id, None)
 
     async def resolve_blob_ref(self, ref: str) -> Any | None:
         """Resolve a blob-store reference into an in-memory payload.
@@ -196,8 +208,10 @@ class RiskSignalHub:
         if self._expired(snapshot):
             raise ValueError("snapshot is expired")
 
-        deduped = await self._enforce_version_idempotency(snapshot)
-        if self._repository is not None and not deduped:
+        local_deduped = self._cached_version_deduped(snapshot)
+        repo_deduped = await self._enforce_version_idempotency(snapshot)
+        deduped = local_deduped or repo_deduped
+        if self._repository is not None and not repo_deduped:
             try:
                 await self._repository.upsert(snapshot.world_id, snapshot.to_dict())  # type: ignore[union-attr]
             except Exception:
@@ -208,6 +222,8 @@ class RiskSignalHub:
                 deduped = True
 
         deduped = self._cache_snapshot(snapshot) or deduped
+        if not deduped:
+            self._pending_dispatches.setdefault(snapshot.world_id, set()).add(snapshot.version)
         await self._cache_latest(snapshot)
         return deduped
 
@@ -301,6 +317,17 @@ class RiskSignalHub:
             entries = entries[-self._max_cached :]
         self._snapshots[snapshot.world_id] = entries
         return False
+
+    def _cached_version_deduped(self, snapshot: PortfolioSnapshot) -> bool:
+        entries = self._snapshots.get(snapshot.world_id, [])
+        existing = next((s for s in entries if s.version == snapshot.version), None)
+        if existing is None:
+            return False
+        if (existing.hash or "") == (snapshot.hash or ""):
+            return True
+        raise RiskSnapshotConflictError(
+            f"snapshot version collision for world_id={snapshot.world_id} version={snapshot.version}"
+        )
 
     def _validate_snapshot(self, snapshot: PortfolioSnapshot) -> None:
         if not snapshot.world_id:

--- a/qmtl/services/worldservice/routers/risk_hub.py
+++ b/qmtl/services/worldservice/routers/risk_hub.py
@@ -55,6 +55,41 @@ async def _expand_snapshot_payload(
     return payload
 
 
+async def _dispatch_snapshot_update(
+    *,
+    world_id: str,
+    snapshot: Dict[str, Any],
+    core_loop_hub: CoreLoopHub | None,
+    bus: ControlBusProducer | None,
+    schedule_extended_validation: Callable[[str], Awaitable[Any]] | Callable[[str], Any] | None,
+) -> bool:
+    if core_loop_hub is not None:
+        outcome = await core_loop_hub.handle_risk_snapshot_update(world_id, snapshot)
+        return outcome.completed
+
+    bus_published: bool | None = None
+    if bus is not None:
+        try:
+            await bus.publish_risk_snapshot_updated(world_id, snapshot)
+            bus_published = True
+        except Exception:  # pragma: no cover - best-effort
+            bus_published = False
+            logger.exception("Failed to publish risk snapshot to ControlBus")
+
+    validation_scheduled: bool | None = None
+    if schedule_extended_validation is not None:
+        try:
+            maybe = schedule_extended_validation(world_id)
+            if inspect.isawaitable(maybe):
+                await maybe
+            validation_scheduled = True
+        except Exception:  # pragma: no cover - best-effort
+            validation_scheduled = False
+            logger.exception("Failed to schedule extended validation from risk hub update")
+
+    return bus_published is not False and validation_scheduled is not False
+
+
 def create_risk_hub_router(
     hub: RiskSignalHub,
     *,
@@ -116,22 +151,17 @@ def create_risk_hub_router(
             ws_metrics.record_risk_snapshot_dedupe(world_id, stage=stage_label)
         else:
             ws_metrics.record_risk_snapshot_processed(world_id, stage=stage_label)
-        if not deduped:
-            if core_loop_hub is not None:
-                await core_loop_hub.handle_risk_snapshot_update(world_id, snapshot.to_dict())
-            else:
-                if bus is not None:
-                    try:
-                        await bus.publish_risk_snapshot_updated(world_id, snapshot.to_dict())
-                    except Exception:  # pragma: no cover - best-effort
-                        logger.exception("Failed to publish risk snapshot to ControlBus")
-                if schedule_extended_validation is not None:
-                    try:
-                        maybe = schedule_extended_validation(world_id)
-                        if inspect.isawaitable(maybe):
-                            await maybe
-                    except Exception:  # pragma: no cover - best-effort
-                        logger.exception("Failed to schedule extended validation from risk hub update")
+        dispatch_required = (not deduped) or hub.snapshot_dispatch_pending(world_id, snapshot.version)
+        if dispatch_required:
+            dispatch_completed = await _dispatch_snapshot_update(
+                world_id=world_id,
+                snapshot=snapshot.to_dict(),
+                core_loop_hub=core_loop_hub,
+                bus=bus,
+                schedule_extended_validation=schedule_extended_validation,
+            )
+            if dispatch_completed:
+                hub.mark_snapshot_dispatch_completed(world_id, snapshot.version)
         return snapshot.to_dict()
 
     @router.get("/worlds/{world_id}/snapshots/lookup")

--- a/tests/qmtl/runtime/sdk/test_seamless_provider.py
+++ b/tests/qmtl/runtime/sdk/test_seamless_provider.py
@@ -1544,7 +1544,10 @@ async def test_backfill_retry_applies_jitter_ratio(monkeypatch) -> None:
     assert jitter_calls[0][0] == pytest.approx(0.0)
     assert jitter_calls[0][1] == pytest.approx(base_delay * 0.25)
     assert sleep_durations, "expected retry backoff sleep"
-    assert sleep_durations[0] == pytest.approx(base_delay, rel=0.05)
+    assert any(
+        duration == pytest.approx(base_delay, rel=0.05)
+        for duration in sleep_durations
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/qmtl/services/worldservice/test_activation_publisher.py
+++ b/tests/qmtl/services/worldservice/test_activation_publisher.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import copy
 import json
+from types import SimpleNamespace
 from typing import Any, Dict
 
 import pytest
 
 from qmtl.foundation.common.hashutils import hash_bytes
 from qmtl.services.worldservice.activation import ActivationEventPublisher
+from qmtl.services.worldservice.core_loop_hub import CoreLoopHub
+from qmtl.services.worldservice.risk_hub import RiskSignalHub
 from qmtl.services.worldservice.run_state import ApplyRunState
 
 
@@ -42,10 +45,18 @@ class _StubStore:
     async def get_activation(self, world_id: str) -> Dict[str, Any]:
         return copy.deepcopy(self.full_state)
 
+    async def get_decisions(self, world_id: str) -> list[Dict[str, Any]]:
+        state = self.full_state.get("state", {})
+        return [{"strategy_id": strategy_id} for strategy_id in state.keys()]
+
+    async def snapshot_activation(self, world_id: str) -> Any:
+        return SimpleNamespace(state=copy.deepcopy(self.full_state.get("state", {})))
+
 
 class _StubBus:
     def __init__(self) -> None:
         self.activation_updates: list[Dict[str, Any]] = []
+        self.risk_snapshot_updates: list[Dict[str, Any]] = []
 
     async def publish_activation_update(
         self,
@@ -71,6 +82,14 @@ class _StubBus:
                 "version": version,
                 "requires_ack": requires_ack,
                 "sequence": sequence,
+            }
+        )
+
+    async def publish_risk_snapshot_updated(self, world_id: str, payload: Dict[str, Any]) -> None:
+        self.risk_snapshot_updates.append(
+            {
+                "world_id": world_id,
+                "payload": copy.deepcopy(payload),
             }
         )
 
@@ -174,3 +193,40 @@ async def test_freeze_and_unfreeze_sequence_ack_flow() -> None:
         "phase": "unfreeze",
     }
 
+
+@pytest.mark.asyncio
+async def test_publish_snapshot_retries_pending_dispatch_after_transient_bus_failure() -> None:
+    class _FlakyRiskBus(_StubBus):
+        def __init__(self) -> None:
+            super().__init__()
+            self.snapshot_attempts = 0
+
+        async def publish_risk_snapshot_updated(self, world_id: str, payload: Dict[str, Any]) -> None:
+            self.snapshot_attempts += 1
+            if self.snapshot_attempts == 1:
+                raise RuntimeError("transient bus failure")
+            await super().publish_risk_snapshot_updated(world_id, payload)
+
+    store = _StubStore(
+        initial_state={
+            "state": {
+                "alpha": {
+                    "long": {"weight": 1.0, "effective_mode": "live", "active": True}
+                }
+            }
+        }
+    )
+    bus = _FlakyRiskBus()
+    publisher = ActivationEventPublisher(
+        store,
+        bus,
+        risk_hub=RiskSignalHub(),
+        core_loop_hub=CoreLoopHub(bus=bus),
+    )
+
+    await publisher._publish_snapshot("world-3", version_hint="v1")
+    await publisher._publish_snapshot("world-3", version_hint="v1")
+    await publisher._publish_snapshot("world-3", version_hint="v1")
+
+    assert bus.snapshot_attempts == 2
+    assert len(bus.risk_snapshot_updates) == 1

--- a/tests/qmtl/services/worldservice/test_core_loop_hub.py
+++ b/tests/qmtl/services/worldservice/test_core_loop_hub.py
@@ -125,3 +125,51 @@ async def test_risk_hub_router_dedupes_without_retriggering_core_loop_hub() -> N
     assert second.status_code == 200
     assert len(events) == 1
     assert scheduled == ["w1"]
+
+
+@pytest.mark.asyncio
+async def test_risk_hub_router_retries_pending_dispatch_after_transient_bus_failure() -> None:
+    events: list[tuple[str, str, dict[str, object]]] = []
+
+    class _FlakyBus:
+        def __init__(self) -> None:
+            self.attempts = 0
+
+        async def publish_risk_snapshot_updated(self, world_id: str, payload: dict[str, object]) -> None:
+            self.attempts += 1
+            if self.attempts == 1:
+                raise RuntimeError("transient bus failure")
+            events.append(("risk_snapshot_updated", world_id, payload))
+
+    bus = _FlakyBus()
+    app = FastAPI()
+    app.include_router(
+        create_risk_hub_router(
+            RiskSignalHub(),
+            core_loop_hub=CoreLoopHub(bus=bus),
+        )
+    )
+
+    payload = {
+        "as_of": "2025-01-01T00:00:00Z",
+        "version": "v1",
+        "weights": {"s1": 1.0},
+    }
+    headers = {"X-Actor": "risk", "X-Stage": "paper"}
+
+    async with httpx.ASGITransport(app=app) as asgi:
+        async with httpx.AsyncClient(transport=asgi, base_url="http://test") as client:
+            first = await client.post("/risk-hub/worlds/w1/snapshots", json=payload, headers=headers)
+            second = await client.post("/risk-hub/worlds/w1/snapshots", json=payload, headers=headers)
+            third = await client.post("/risk-hub/worlds/w1/snapshots", json=payload, headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 200
+    assert bus.attempts == 2
+    assert len(events) == 1
+    _, event_world_id, event_payload = events[0]
+    assert event_world_id == "w1"
+    assert event_payload["world_id"] == "w1"
+    assert event_payload["version"] == payload["version"]
+    assert event_payload["weights"] == payload["weights"]

--- a/tests/qmtl/services/worldservice/test_risk_hub_validations.py
+++ b/tests/qmtl/services/worldservice/test_risk_hub_validations.py
@@ -117,6 +117,17 @@ class _BrokenRepo:
         raise RuntimeError("db unavailable")
 
 
+class _RecordingRepo:
+    def __init__(self) -> None:
+        self.upsert_calls = 0
+
+    async def get(self, world_id: str, version: str):
+        return None
+
+    async def upsert(self, world_id: str, payload: dict):
+        self.upsert_calls += 1
+
+
 @pytest.mark.asyncio
 async def test_repository_race_conflict_is_raised_instead_of_silently_acked():
     hub = RiskSignalHub()
@@ -149,3 +160,29 @@ async def test_repository_failure_is_not_cached_locally_when_persist_fails():
         await hub.upsert_snapshot(snap)
 
     assert hub._snapshots == {}
+
+
+@pytest.mark.asyncio
+async def test_in_memory_conflict_blocks_repository_write_before_persist() -> None:
+    hub = RiskSignalHub()
+    repo = _RecordingRepo()
+    original = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"a": 1.0},
+    )
+    await hub.upsert_snapshot(original)
+    hub.bind_repository(repo)
+
+    conflicting = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"a": 0.9, "b": 0.1},
+    )
+
+    with pytest.raises(RiskSnapshotConflictError):
+        await hub.upsert_snapshot(conflicting)
+
+    assert repo.upsert_calls == 0


### PR DESCRIPTION
## Summary
- address the merged PR review gaps around risk snapshot conflict ordering and deduped dispatch retries
- keep pending risk snapshot dispatches retryable across router and activation paths after transient downstream failures
- fix the `snapshot.py` mypy regression and make the jitter retry test assert the intended backoff without relying on the first global `asyncio.sleep`

## Verification
- `uv run --with mypy -m mypy`
- `uv run -m pytest -q tests/qmtl/services/worldservice/test_risk_hub_validations.py tests/qmtl/services/worldservice/test_core_loop_hub.py tests/qmtl/services/worldservice/test_activation_publisher.py tests/qmtl/runtime/sdk/test_snapshot_imports.py -q`
- `uv run -m pytest -q tests/qmtl/runtime/sdk/test_seamless_provider.py::test_backfill_retry_applies_jitter_ratio -q`
- `bash scripts/run_ci_local.sh`

Refs #2082
Refs #2083
Refs #2086