### PR TITLE
Fix risk hub baseline and dispatch follow-ups

### DIFF
--- a/qmtl/services/worldservice/core_loop_hub.py
+++ b/qmtl/services/worldservice/core_loop_hub.py
@@ -149,11 +149,15 @@ def baseline_from_covariance(
             return None
     if w_sum <= 0:
         return None
-    norm_weights = {
-        str(k): float(v) / w_sum
-        for k, v in weights.items()
-        if isinstance(v, (int, float)) and not isinstance(v, bool)
-    }
+    norm_weights: dict[str, float] = {}
+    for key, value in weights.items():
+        try:
+            coerced = float(value)
+        except Exception:
+            return None
+        if not math.isfinite(coerced):
+            return None
+        norm_weights[str(key)] = coerced / w_sum
     variance = 0.0
     sids = list(norm_weights.keys())
     for a in sids:
@@ -196,11 +200,15 @@ def incremental_var_es_from_covariance(
     scaled_existing: dict[str, float] = {}
     if alpha < 1.0:
         for sid, weight in weights.items():
-            if not isinstance(weight, (int, float)) or isinstance(weight, bool):
+            try:
+                coerced = float(weight)
+            except Exception:
+                return None
+            if not math.isfinite(coerced):
+                return None
+            if coerced == 0:
                 continue
-            if weight == 0:
-                continue
-            scaled = float(weight) * (1.0 - alpha)
+            scaled = coerced * (1.0 - alpha)
             if scaled != 0:
                 scaled_existing[str(sid)] = scaled
 

--- a/qmtl/services/worldservice/risk_hub.py
+++ b/qmtl/services/worldservice/risk_hub.py
@@ -131,7 +131,7 @@ class RiskSignalHub:
         ttl_sec_max: int = 86400,
     ) -> None:
         self._snapshots: Dict[str, List[PortfolioSnapshot]] = {}
-        self._pending_dispatches: Dict[str, set[str]] = {}
+        self._pending_dispatches: Dict[str, Dict[str, datetime]] = {}
         self._repository = repository
         self._max_cached = max_cached
         self._cache = cache
@@ -162,13 +162,14 @@ class RiskSignalHub:
         self._blob_store = store
 
     def snapshot_dispatch_pending(self, world_id: str, version: str) -> bool:
-        return version in self._pending_dispatches.get(world_id, set())
+        self._prune_pending_dispatches(world_id)
+        return version in self._pending_dispatches.get(world_id, {})
 
     def mark_snapshot_dispatch_completed(self, world_id: str, version: str) -> None:
         pending = self._pending_dispatches.get(world_id)
         if pending is None:
             return
-        pending.discard(version)
+        pending.pop(version, None)
         if not pending:
             self._pending_dispatches.pop(world_id, None)
 
@@ -223,7 +224,7 @@ class RiskSignalHub:
 
         deduped = self._cache_snapshot(snapshot) or deduped
         if not deduped:
-            self._pending_dispatches.setdefault(snapshot.world_id, set()).add(snapshot.version)
+            self._mark_snapshot_dispatch_pending(snapshot)
         await self._cache_latest(snapshot)
         return deduped
 
@@ -316,6 +317,7 @@ class RiskSignalHub:
         if self._max_cached is not None and len(entries) > self._max_cached:
             entries = entries[-self._max_cached :]
         self._snapshots[snapshot.world_id] = entries
+        self._prune_pending_dispatches(snapshot.world_id)
         return False
 
     def _cached_version_deduped(self, snapshot: PortfolioSnapshot) -> bool:
@@ -328,6 +330,47 @@ class RiskSignalHub:
         raise RiskSnapshotConflictError(
             f"snapshot version collision for world_id={snapshot.world_id} version={snapshot.version}"
         )
+
+    def _mark_snapshot_dispatch_pending(self, snapshot: PortfolioSnapshot) -> None:
+        self._prune_pending_dispatches(snapshot.world_id)
+        ttl_seconds = max(
+            1,
+            int(snapshot.ttl_sec or self._cache_ttl or self._ttl_sec_default),
+        )
+        created_at = self._parse_iso(snapshot.created_at) or datetime.now(timezone.utc)
+        deadline = created_at + timedelta(seconds=ttl_seconds)
+        pending = self._pending_dispatches.setdefault(snapshot.world_id, {})
+        pending[snapshot.version] = deadline
+        if self._max_cached is not None and len(pending) > self._max_cached:
+            items = list(pending.items())[-self._max_cached :]
+            self._pending_dispatches[snapshot.world_id] = dict(items)
+
+    def _prune_pending_dispatches(self, world_id: str | None = None) -> None:
+        worlds = [world_id] if world_id is not None else list(self._pending_dispatches.keys())
+        now = datetime.now(timezone.utc)
+        for current_world in worlds:
+            pending = self._pending_dispatches.get(current_world)
+            if not pending:
+                self._pending_dispatches.pop(current_world, None)
+                continue
+            cached_versions = {
+                snap.version
+                for snap in self._snapshots.get(current_world, [])
+                if not self._expired(snap)
+            }
+            keep: dict[str, datetime] = {}
+            for version, deadline in pending.items():
+                if deadline <= now:
+                    continue
+                if cached_versions and version not in cached_versions:
+                    continue
+                keep[version] = deadline
+            if self._max_cached is not None and len(keep) > self._max_cached:
+                keep = dict(list(keep.items())[-self._max_cached :])
+            if keep:
+                self._pending_dispatches[current_world] = keep
+            else:
+                self._pending_dispatches.pop(current_world, None)
 
     def _validate_snapshot(self, snapshot: PortfolioSnapshot) -> None:
         if not snapshot.world_id:

--- a/tests/qmtl/services/worldservice/test_core_loop_hub.py
+++ b/tests/qmtl/services/worldservice/test_core_loop_hub.py
@@ -6,6 +6,7 @@ import httpx
 
 from qmtl.services.worldservice.core_loop_hub import (
     CoreLoopHub,
+    baseline_from_covariance,
     deep_merge_mappings,
     derive_metrics_from_risk_snapshot,
 )
@@ -66,6 +67,17 @@ def test_deep_merge_mappings_merges_nested_metrics() -> None:
         "returns": {"sharpe": 1.0, "max_drawdown": 0.2},
         "diagnostics": {"source": "runs", "live_returns_source": "risk_hub"},
     }
+
+
+def test_baseline_from_covariance_preserves_float_coercion_for_bool_weights() -> None:
+    baseline = baseline_from_covariance(
+        weights={"s1": True},
+        covariance={"s1,s1": 0.04},
+    )
+
+    assert baseline is not None
+    assert baseline["var_99"] == pytest.approx((0.04 ** 0.5) * 2.33)
+    assert baseline["es_99"] == pytest.approx(((0.04 ** 0.5) * 2.33) * 1.2)
 
 
 @pytest.mark.asyncio

--- a/tests/qmtl/services/worldservice/test_risk_hub_validations.py
+++ b/tests/qmtl/services/worldservice/test_risk_hub_validations.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from qmtl.services.worldservice.risk_hub import (
@@ -186,3 +188,39 @@ async def test_in_memory_conflict_blocks_repository_write_before_persist() -> No
         await hub.upsert_snapshot(conflicting)
 
     assert repo.upsert_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_pending_dispatch_versions_are_pruned_when_snapshot_cache_evicts_them() -> None:
+    hub = RiskSignalHub(max_cached=1)
+
+    first = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:00:00Z",
+        version="v1",
+        weights={"a": 1.0},
+    )
+    second = PortfolioSnapshot(
+        world_id="w",
+        as_of="2025-01-01T00:01:00Z",
+        version="v2",
+        weights={"a": 1.0},
+    )
+
+    await hub.upsert_snapshot(first)
+    assert hub.snapshot_dispatch_pending("w", "v1") is True
+
+    await hub.upsert_snapshot(second)
+
+    assert hub.snapshot_dispatch_pending("w", "v1") is False
+    assert hub.snapshot_dispatch_pending("w", "v2") is True
+
+
+def test_pending_dispatch_versions_are_pruned_when_deadline_expires() -> None:
+    hub = RiskSignalHub()
+    hub._pending_dispatches = {  # type: ignore[assignment]
+        "w": {"v1": datetime.now(timezone.utc) - timedelta(seconds=1)}
+    }
+
+    assert hub.snapshot_dispatch_pending("w", "v1") is False
+    assert "w" not in hub._pending_dispatches


### PR DESCRIPTION
## Summary
- preserve float-coercion semantics in `baseline_from_covariance()` and incremental covariance calculations so accepted risk snapshot weights do not collapse downstream baselines
- prune pending dispatch state by TTL and cache retention so transient dispatch failures do not leave unbounded stale versions behind
- add regression tests for bool-weight baseline coercion and pending dispatch pruning

## Verification
- `uv run -m pytest -q tests/qmtl/services/worldservice/test_core_loop_hub.py tests/qmtl/services/worldservice/test_risk_hub_validations.py -q`
- `uv run ruff check qmtl/services/worldservice/core_loop_hub.py qmtl/services/worldservice/risk_hub.py tests/qmtl/services/worldservice/test_core_loop_hub.py tests/qmtl/services/worldservice/test_risk_hub_validations.py`
- `uv run --with mypy -m mypy qmtl/services/worldservice/core_loop_hub.py qmtl/services/worldservice/risk_hub.py`
- `bash scripts/run_ci_local.sh`

Refs #2087