### PR TITLE
Refactor policy evaluation helper boundaries

### DIFF
--- a/qmtl/services/worldservice/policy_engine.py
+++ b/qmtl/services/worldservice/policy_engine.py
@@ -448,37 +448,42 @@ def recommended_stage(profile: str | None, stage: str | None) -> str | None:
     return None
 
 
+def _resolve_profile_candidate(
+    candidate: str | None,
+    normalized_profiles: Mapping[str, str],
+) -> str | None:
+    normalized = _normalize_key(candidate)
+    if normalized and normalized in normalized_profiles:
+        return normalized_profiles[normalized]
+    return None
+
+
+def _mapped_profiles_for_stage(policy: Policy, stage: str | None) -> list[str]:
+    normalized_stage = _normalize_key(stage)
+    if not normalized_stage:
+        return []
+    mapping = {_normalize_key(k) or "": v for k, v in policy.default_profile_by_stage.items()}
+    candidates: list[str] = []
+    for key in (normalized_stage, f"{normalized_stage}_only"):
+        mapped = mapping.get(key)
+        if mapped:
+            candidates.append(mapped)
+    if stage:
+        candidates.append(stage)
+    return candidates
+
+
 def _choose_profile(policy: Policy, stage: str | None, profile: str | None) -> str | None:
     if not policy.validation_profiles:
         return None
-
     profiles = policy.validation_profiles
     normalized_profiles: Dict[str, str] = {_normalize_key(name) or "": name for name in profiles}
 
-    def resolve(candidate: str | None) -> str | None:
-        normalized = _normalize_key(candidate)
-        if normalized and normalized in normalized_profiles:
-            return normalized_profiles[normalized]
-        return None
-
-    selected = resolve(profile)
-    if selected:
-        return selected
-
-    normalized_stage = _normalize_key(stage)
-    if normalized_stage:
-        mapping = {_normalize_key(k) or "": v for k, v in policy.default_profile_by_stage.items()}
-        for key in (normalized_stage, f"{normalized_stage}_only"):
-            mapped = mapping.get(key)
-            selected = resolve(mapped)
-            if selected:
-                return selected
-        selected = resolve(stage)
-        if selected:
-            return selected
-
-    for mapped in policy.default_profile_by_stage.values():
-        selected = resolve(mapped)
+    candidates: list[str | None] = [profile]
+    candidates.extend(_mapped_profiles_for_stage(policy, stage))
+    candidates.extend(policy.default_profile_by_stage.values())
+    for candidate in candidates:
+        selected = _resolve_profile_candidate(candidate, normalized_profiles)
         if selected:
             return selected
 
@@ -486,7 +491,6 @@ def _choose_profile(policy: Policy, stage: str | None, profile: str | None) -> s
         return normalized_profiles["backtest"]
     if "paper" in normalized_profiles:
         return normalized_profiles["paper"]
-
     return next(iter(profiles.keys()))
 
 
@@ -616,6 +620,167 @@ def _stub_rule_result(
     )
 
 
+def _as_number(value: Any, *, absolute: bool = False) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float)):
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            return None
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        return None
+    return abs(numeric) if absolute else numeric
+
+
+def _evaluate_optional_upper_bound(
+    *,
+    value: float | None,
+    threshold: float | None,
+    missing_reason: str,
+    fail_reason: str,
+    detail_key: str,
+    details: Dict[str, Any],
+) -> tuple[Literal["warn", "fail"], str] | None:
+    if threshold is None:
+        return None
+    details[detail_key] = threshold
+    if value is None:
+        return "warn", missing_reason
+    if value > threshold:
+        return "fail", fail_reason
+    return None
+
+
+def _evaluate_optional_lower_bound(
+    *,
+    value: float | None,
+    threshold: float | None,
+    missing_reason: str,
+    fail_reason: str,
+    detail_key: str,
+    details: Dict[str, Any],
+) -> tuple[Literal["warn", "fail"], str] | None:
+    if threshold is None:
+        return None
+    details[detail_key] = threshold
+    if value is None:
+        return "warn", missing_reason
+    if value < threshold:
+        return "fail", fail_reason
+    return None
+
+
+def _apply_rule_event(
+    status: str,
+    reasons: list[str],
+    event: tuple[Literal["warn", "fail"], str] | None,
+) -> str:
+    if event is None:
+        return status
+    level, reason = event
+    reasons.append(reason)
+    if level == "fail":
+        return "fail"
+    if status == "pass":
+        return "warn"
+    return status
+
+
+def _primary_reason(fail_reasons: list[str], warn_reasons: list[str], default_reason: str) -> str:
+    if fail_reasons:
+        return fail_reasons[0]
+    if warn_reasons:
+        return warn_reasons[0]
+    return default_reason
+
+
+def _metric_series(metrics: Mapping[str, Mapping[str, Any]], key: str) -> list[float]:
+    series: list[float] = []
+    for values in metrics.values():
+        number = _as_number(values.get(key))
+        if number is not None:
+            series.append(number)
+    return series
+
+
+def _cohort_topk_selected(
+    metrics: Mapping[str, Mapping[str, Any]],
+    top_k: int | None,
+    sharpe_values: Sequence[float],
+) -> set[str]:
+    if not top_k or not sharpe_values:
+        return set()
+    ranked = sorted(metrics.items(), key=lambda item: item[1].get("sharpe", float("-inf")), reverse=True)
+    return {sid for sid, _ in ranked[:top_k]}
+
+
+def _evaluate_cohort_strategy(
+    sid: str,
+    vals: Mapping[str, Any],
+    *,
+    cfg: CohortRuleConfig,
+    median_sharpe: float | None,
+    median_dsr: float | None,
+    topk_selected: set[str],
+    severity: str,
+    owner: str,
+) -> RuleResult:
+    reasons: list[str] = []
+    status = "pass"
+    details: Dict[str, Any] = {
+        "median_sharpe": median_sharpe,
+        "median_dsr": median_dsr,
+        "top_k": cfg.top_k,
+        "selected_in_top_k": sid in topk_selected if topk_selected else None,
+        "sharpe": vals.get("sharpe"),
+        "deflated_sharpe_ratio": vals.get("deflated_sharpe_ratio"),
+    }
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_lower_bound(
+            value=median_sharpe,
+            threshold=cfg.sharpe_median_min,
+            missing_reason="median_sharpe_missing",
+            fail_reason="cohort_median_sharpe_below_min",
+            detail_key="sharpe_median_min",
+            details=details,
+        ),
+    )
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_lower_bound(
+            value=median_dsr,
+            threshold=cfg.dsr_median_min,
+            missing_reason="median_dsr_missing",
+            fail_reason="cohort_median_dsr_below_min",
+            detail_key="dsr_median_min",
+            details=details,
+        ),
+    )
+
+    if cfg.top_k:
+        topk_event = ("warn", "top_k_unavailable") if not topk_selected else None
+        if topk_selected and sid not in topk_selected:
+            topk_event = ("fail", "cohort_top_k_exceeded")
+        status = _apply_rule_event(status, reasons, topk_event)
+
+    reason_code = reasons[0] if reasons else "cohort_ok"
+    reason = ", ".join(reasons) if reasons else "Cohort criteria satisfied"
+    return RuleResult(
+        status=status,
+        severity=severity,
+        owner=owner,
+        reason_code=reason_code,
+        reason=reason,
+        tags=["cohort"],
+        details=details,
+    )
+
+
 def evaluate_cohort_rules(
     metrics: Mapping[str, Mapping[str, Any]],
     policy: Policy,
@@ -627,69 +792,89 @@ def evaluate_cohort_rules(
     if cfg is None:
         return {}
     severity, owner = _resolve_meta_defaults(cfg, default_severity="soft", default_owner="risk")
-    sharpe_values = [v.get("sharpe") for v in metrics.values() if isinstance(v.get("sharpe"), (int, float))]
-    dsr_values = [v.get("deflated_sharpe_ratio") for v in metrics.values() if isinstance(v.get("deflated_sharpe_ratio"), (int, float))]
-
+    sharpe_values = _metric_series(metrics, "sharpe")
+    dsr_values = _metric_series(metrics, "deflated_sharpe_ratio")
     median_sharpe = statistics.median(sharpe_values) if sharpe_values else None
     median_dsr = statistics.median(dsr_values) if dsr_values else None
+    topk_selected = _cohort_topk_selected(metrics, cfg.top_k, sharpe_values)
 
-    topk_selected: set[str] = set()
-    if cfg.top_k and sharpe_values:
-        ranked = sorted(metrics.items(), key=lambda item: item[1].get("sharpe", float("-inf")), reverse=True)
-        topk_selected = {sid for sid, _ in ranked[: cfg.top_k]}
-
-    results: Dict[str, RuleResult] = {}
-    for sid, vals in metrics.items():
-        reasons: list[str] = []
-        tags = ["cohort"]
-        status = "pass"
-        details: Dict[str, Any] = {
-            "median_sharpe": median_sharpe,
-            "median_dsr": median_dsr,
-            "top_k": cfg.top_k,
-            "selected_in_top_k": sid in topk_selected if topk_selected else None,
-            "sharpe": vals.get("sharpe"),
-            "deflated_sharpe_ratio": vals.get("deflated_sharpe_ratio"),
-        }
-
-        if cfg.sharpe_median_min is not None:
-            if median_sharpe is None:
-                status = "warn"
-                reasons.append("median_sharpe_missing")
-            elif median_sharpe < cfg.sharpe_median_min:
-                status = "fail"
-                reasons.append("cohort_median_sharpe_below_min")
-                details["sharpe_median_min"] = cfg.sharpe_median_min
-
-        if cfg.dsr_median_min is not None:
-            if median_dsr is None:
-                status = "warn"
-                reasons.append("median_dsr_missing")
-            elif median_dsr < cfg.dsr_median_min:
-                status = "fail"
-                reasons.append("cohort_median_dsr_below_min")
-                details["dsr_median_min"] = cfg.dsr_median_min
-
-        if cfg.top_k:
-            if not topk_selected:
-                status = "warn"
-                reasons.append("top_k_unavailable")
-            elif sid not in topk_selected:
-                status = "fail"
-                reasons.append("cohort_top_k_exceeded")
-
-        reason_code = reasons[0] if reasons else "cohort_ok"
-        reason = ", ".join(reasons) if reasons else "Cohort criteria satisfied"
-        results[sid] = RuleResult(
-            status=status,
+    return {
+        sid: _evaluate_cohort_strategy(
+            sid,
+            vals,
+            cfg=cfg,
+            median_sharpe=median_sharpe,
+            median_dsr=median_dsr,
+            topk_selected=topk_selected,
             severity=severity,
             owner=owner,
-            reason_code=reason_code,
-            reason=reason,
-            tags=tags,
-            details=details,
         )
-    return results
+        for sid, vals in metrics.items()
+    }
+
+
+def _evaluate_portfolio_strategy(
+    vals: Mapping[str, Any],
+    *,
+    cfg: PortfolioRuleConfig,
+    severity: str,
+    owner: str,
+) -> RuleResult:
+    reasons: list[str] = []
+    status = "pass"
+    details: Dict[str, Any] = {
+        "max_incremental_var_99": vals.get("incremental_var_99"),
+        "max_incremental_es_99": vals.get("incremental_es_99"),
+        "portfolio_sharpe_uplift": vals.get("portfolio_sharpe_uplift"),
+    }
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_upper_bound(
+            value=_as_number(vals.get("incremental_var_99")),
+            threshold=cfg.max_incremental_var_99,
+            missing_reason="incremental_var_missing",
+            fail_reason="incremental_var_exceeds_max",
+            detail_key="incremental_var_99_max",
+            details=details,
+        ),
+    )
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_upper_bound(
+            value=_as_number(vals.get("incremental_es_99")),
+            threshold=cfg.max_incremental_es_99,
+            missing_reason="incremental_es_missing",
+            fail_reason="incremental_es_exceeds_max",
+            detail_key="incremental_es_99_max",
+            details=details,
+        ),
+    )
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_lower_bound(
+            value=_as_number(vals.get("portfolio_sharpe_uplift")),
+            threshold=cfg.min_portfolio_sharpe_uplift,
+            missing_reason="portfolio_sharpe_uplift_missing",
+            fail_reason="portfolio_sharpe_uplift_below_min",
+            detail_key="min_portfolio_sharpe_uplift",
+            details=details,
+        ),
+    )
+
+    reason_code = reasons[0] if reasons else "portfolio_ok"
+    reason = ", ".join(reasons) if reasons else "Portfolio constraints satisfied"
+    return RuleResult(
+        status=status,
+        severity=severity,
+        owner=owner,
+        reason_code=reason_code,
+        reason=reason,
+        tags=["portfolio"],
+        details=details,
+    )
 
 
 def evaluate_portfolio_rules(
@@ -703,58 +888,7 @@ def evaluate_portfolio_rules(
     if cfg is None:
         return {}
     severity, owner = _resolve_meta_defaults(cfg, default_severity="soft", default_owner="risk")
-    results: Dict[str, RuleResult] = {}
-    for sid, vals in metrics.items():
-        reasons: list[str] = []
-        status = "pass"
-        details: Dict[str, Any] = {
-            "max_incremental_var_99": vals.get("incremental_var_99"),
-            "max_incremental_es_99": vals.get("incremental_es_99"),
-            "portfolio_sharpe_uplift": vals.get("portfolio_sharpe_uplift"),
-        }
-
-        if cfg.max_incremental_var_99 is not None:
-            value = vals.get("incremental_var_99")
-            if value is None:
-                status = "warn"
-                reasons.append("incremental_var_missing")
-            elif value > cfg.max_incremental_var_99:
-                status = "fail"
-                reasons.append("incremental_var_exceeds_max")
-                details["incremental_var_99_max"] = cfg.max_incremental_var_99
-
-        if cfg.max_incremental_es_99 is not None:
-            value = vals.get("incremental_es_99")
-            if value is None:
-                status = "warn"
-                reasons.append("incremental_es_missing")
-            elif value > cfg.max_incremental_es_99:
-                status = "fail"
-                reasons.append("incremental_es_exceeds_max")
-                details["incremental_es_99_max"] = cfg.max_incremental_es_99
-
-        if cfg.min_portfolio_sharpe_uplift is not None:
-            value = vals.get("portfolio_sharpe_uplift")
-            if value is None:
-                status = "warn"
-                reasons.append("portfolio_sharpe_uplift_missing")
-            elif value < cfg.min_portfolio_sharpe_uplift:
-                status = "fail"
-                reasons.append("portfolio_sharpe_uplift_below_min")
-                details["min_portfolio_sharpe_uplift"] = cfg.min_portfolio_sharpe_uplift
-
-        reason_code = reasons[0] if reasons else "portfolio_ok"
-        reason = ", ".join(reasons) if reasons else "Portfolio constraints satisfied"
-        results[sid] = RuleResult(
-            status=status,
-            severity=severity,
-            owner=owner,
-            reason_code=reason_code,
-            reason=reason,
-            tags=["portfolio"],
-            details=details,
-        )
-    return results
+    return {sid: _evaluate_portfolio_strategy(vals, cfg=cfg, severity=severity, owner=owner) for sid, vals in metrics.items()}
 
 
 def evaluate_benchmark_rules(
@@ -806,6 +940,68 @@ def evaluate_benchmark_rules(
     return results
 
 
+def _stress_metric_value(
+    vals: Mapping[str, Any],
+    *,
+    metric_prefix: str,
+    primary_key: str,
+    fallback_key: str | None = None,
+) -> float | None:
+    raw_value = vals.get(f"{metric_prefix}{primary_key}")
+    if raw_value is None and fallback_key:
+        raw_value = vals.get(f"{metric_prefix}{fallback_key}")
+    return _as_number(raw_value, absolute=True)
+
+
+def _evaluate_stress_scenario(
+    name: str,
+    thresholds: Mapping[str, Any],
+    vals: Mapping[str, Any],
+    details: Dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    fail_reasons: list[str] = []
+    warn_reasons: list[str] = []
+    metric_prefix = f"stress.{name}."
+    dd_value = _stress_metric_value(vals, metric_prefix=metric_prefix, primary_key="max_drawdown", fallback_key="dd_max")
+    es_value = _stress_metric_value(vals, metric_prefix=metric_prefix, primary_key="es_99")
+    var_value = _stress_metric_value(vals, metric_prefix=metric_prefix, primary_key="var_99")
+
+    checks = [
+        _evaluate_optional_upper_bound(
+            value=dd_value,
+            threshold=thresholds.get("dd_max"),
+            missing_reason=f"{name}_dd_missing",
+            fail_reason=f"{name}_dd_exceeds_max",
+            detail_key=f"{name}_dd_max",
+            details=details,
+        ),
+        _evaluate_optional_upper_bound(
+            value=es_value,
+            threshold=thresholds.get("es_99"),
+            missing_reason=f"{name}_es_missing",
+            fail_reason=f"{name}_es_exceeds_max",
+            detail_key=f"{name}_es_99_max",
+            details=details,
+        ),
+        _evaluate_optional_upper_bound(
+            value=var_value,
+            threshold=thresholds.get("var_99"),
+            missing_reason=f"{name}_var_missing",
+            fail_reason=f"{name}_var_exceeds_max",
+            detail_key=f"{name}_var_99_max",
+            details=details,
+        ),
+    ]
+    for event in checks:
+        if event is None:
+            continue
+        if event[0] == "fail":
+            fail_reasons.append(event[1])
+        else:
+            warn_reasons.append(event[1])
+    return fail_reasons, warn_reasons
+
+
 def evaluate_stress_rules(
     metrics: Mapping[str, Mapping[str, Any]],
     policy: Policy,
@@ -825,53 +1021,12 @@ def evaluate_stress_rules(
         details: Dict[str, Any] = {"scenarios": list(scenarios.keys()), "stage": stage}
 
         for name, thresholds in scenarios.items():
-            dd_max = thresholds.get("dd_max")
-            es_99_max = thresholds.get("es_99")
-            var_99_max = thresholds.get("var_99")
-            metric_prefix = f"stress.{name}."
-            dd = vals.get(f"{metric_prefix}max_drawdown")
-            if dd is None:
-                dd = vals.get(f"{metric_prefix}dd_max")
-            es = vals.get(f"{metric_prefix}es_99")
-            var = vals.get(f"{metric_prefix}var_99")
-
-            dd_value: float | None = None
-            if isinstance(dd, (int, float)) and not isinstance(dd, bool):
-                dd_value = abs(float(dd))
-            es_value: float | None = None
-            if isinstance(es, (int, float)) and not isinstance(es, bool):
-                es_value = abs(float(es))
-            var_value: float | None = None
-            if isinstance(var, (int, float)) and not isinstance(var, bool):
-                var_value = abs(float(var))
-
-            if dd_max is not None:
-                if dd_value is None:
-                    warn_reasons.append(f"{name}_dd_missing")
-                elif dd_value > float(dd_max):
-                    fail_reasons.append(f"{name}_dd_exceeds_max")
-                    details[f"{name}_dd_max"] = dd_max
-            if es_99_max is not None:
-                if es_value is None:
-                    warn_reasons.append(f"{name}_es_missing")
-                elif es_value > float(es_99_max):
-                    fail_reasons.append(f"{name}_es_exceeds_max")
-                    details[f"{name}_es_99_max"] = es_99_max
-            if var_99_max is not None:
-                if var_value is None:
-                    warn_reasons.append(f"{name}_var_missing")
-                elif var_value > float(var_99_max):
-                    fail_reasons.append(f"{name}_var_exceeds_max")
-                    details[f"{name}_var_99_max"] = var_99_max
+            scenario_failures, scenario_warnings = _evaluate_stress_scenario(name, thresholds, vals, details)
+            fail_reasons.extend(scenario_failures)
+            warn_reasons.extend(scenario_warnings)
 
         status = "fail" if fail_reasons else "warn" if warn_reasons else "pass"
-        reason_code = (
-            fail_reasons[0]
-            if fail_reasons
-            else warn_reasons[0]
-            if warn_reasons
-            else "stress_ok"
-        )
+        reason_code = _primary_reason(fail_reasons, warn_reasons, "stress_ok")
         combined = fail_reasons + warn_reasons
         reason = ", ".join(combined) if combined else "Stress scenarios satisfied"
         results[sid] = RuleResult(
@@ -886,6 +1041,109 @@ def evaluate_stress_rules(
     return results
 
 
+def _paper_shadow_allowed_for_stage(cfg: PaperShadowConsistencyConfig, stage: str | None) -> bool:
+    stage_norm = _normalize_key(stage) or ""
+    allowed_raw = cfg.stages or ["paper", "shadow"]
+    allowed = {_normalize_key(s) or "" for s in allowed_raw}
+    return not stage_norm or stage_norm in allowed
+
+
+def _paper_shadow_details(vals: Mapping[str, Any], stage: str | None) -> Dict[str, Any]:
+    sharpe_ratio = vals.get("paper_vs_backtest_sharpe_ratio")
+    dd_ratio = vals.get("paper_vs_backtest_dd_ratio")
+    var_ratio = vals.get("paper_vs_backtest_var_p01_ratio")
+    es_ratio = vals.get("paper_vs_backtest_es_p01_ratio")
+    return {
+        "stage": stage,
+        "baseline_run_id": vals.get("paper_shadow_baseline_run_id"),
+        "backtest_sharpe": vals.get("backtest_sharpe"),
+        "backtest_max_drawdown": vals.get("backtest_max_drawdown"),
+        "backtest_var_p01": vals.get("backtest_var_p01"),
+        "backtest_es_p01": vals.get("backtest_es_p01"),
+        "paper_sharpe": vals.get("sharpe"),
+        "paper_max_drawdown": vals.get("max_drawdown"),
+        "paper_var_p01": vals.get("var_p01") or vals.get("returns.var_p01"),
+        "paper_es_p01": vals.get("es_p01") or vals.get("returns.es_p01"),
+        "paper_vs_backtest_sharpe_ratio": sharpe_ratio,
+        "paper_vs_backtest_dd_ratio": dd_ratio,
+        "paper_vs_backtest_var_p01_ratio": var_ratio,
+        "paper_vs_backtest_es_p01_ratio": es_ratio,
+    }
+
+
+def _evaluate_paper_shadow_strategy(
+    vals: Mapping[str, Any],
+    *,
+    cfg: PaperShadowConsistencyConfig,
+    stage: str | None,
+    severity: str,
+    owner: str,
+) -> RuleResult:
+    status = "pass"
+    reasons: list[str] = []
+    details = _paper_shadow_details(vals, stage)
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_lower_bound(
+            value=_as_number(details["paper_vs_backtest_sharpe_ratio"]),
+            threshold=cfg.min_sharpe_ratio,
+            missing_reason="paper_shadow_sharpe_ratio_missing",
+            fail_reason="paper_shadow_sharpe_ratio_below_min",
+            detail_key="min_sharpe_ratio",
+            details=details,
+        ),
+    )
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_upper_bound(
+            value=_as_number(details["paper_vs_backtest_dd_ratio"]),
+            threshold=cfg.max_drawdown_ratio,
+            missing_reason="paper_shadow_dd_ratio_missing",
+            fail_reason="paper_shadow_dd_ratio_exceeds_max",
+            detail_key="max_drawdown_ratio",
+            details=details,
+        ),
+    )
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_upper_bound(
+            value=_as_number(details["paper_vs_backtest_var_p01_ratio"]),
+            threshold=cfg.max_var_p01_ratio,
+            missing_reason="paper_shadow_var_ratio_missing",
+            fail_reason="paper_shadow_var_ratio_exceeds_max",
+            detail_key="max_var_p01_ratio",
+            details=details,
+        ),
+    )
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_upper_bound(
+            value=_as_number(details["paper_vs_backtest_es_p01_ratio"]),
+            threshold=cfg.max_es_p01_ratio,
+            missing_reason="paper_shadow_es_ratio_missing",
+            fail_reason="paper_shadow_es_ratio_exceeds_max",
+            detail_key="max_es_p01_ratio",
+            details=details,
+        ),
+    )
+
+    reason_code = reasons[0] if reasons else "paper_shadow_ok"
+    reason = ", ".join(reasons) if reasons else "Paper/shadow consistency satisfied"
+    return RuleResult(
+        status=status,
+        severity=severity,
+        owner=owner,
+        reason_code=reason_code,
+        reason=reason,
+        tags=["paper_shadow"],
+        details=details,
+    )
+
+
 def evaluate_paper_shadow_consistency(
     metrics: Mapping[str, Mapping[str, Any]],
     policy: Policy,
@@ -897,91 +1155,36 @@ def evaluate_paper_shadow_consistency(
     cfg = policy.paper_shadow_consistency
     if cfg is None:
         return {}
-
-    stage_norm = _normalize_key(stage) or ""
-    allowed_raw = cfg.stages or ["paper", "shadow"]
-    allowed = {_normalize_key(s) or "" for s in allowed_raw}
-    if stage_norm and stage_norm not in allowed:
+    if not _paper_shadow_allowed_for_stage(cfg, stage):
         return {}
 
     severity, owner = _resolve_meta_defaults(cfg, default_severity="soft", default_owner="ops")
-    results: Dict[str, RuleResult] = {}
-
-    for sid, vals in metrics.items():
-        status = "pass"
-        reasons: list[str] = []
-
-        sharpe_ratio = vals.get("paper_vs_backtest_sharpe_ratio")
-        dd_ratio = vals.get("paper_vs_backtest_dd_ratio")
-        var_ratio = vals.get("paper_vs_backtest_var_p01_ratio")
-        es_ratio = vals.get("paper_vs_backtest_es_p01_ratio")
-
-        details: Dict[str, Any] = {
-            "stage": stage,
-            "baseline_run_id": vals.get("paper_shadow_baseline_run_id"),
-            "backtest_sharpe": vals.get("backtest_sharpe"),
-            "backtest_max_drawdown": vals.get("backtest_max_drawdown"),
-            "backtest_var_p01": vals.get("backtest_var_p01"),
-            "backtest_es_p01": vals.get("backtest_es_p01"),
-            "paper_sharpe": vals.get("sharpe"),
-            "paper_max_drawdown": vals.get("max_drawdown"),
-            "paper_var_p01": vals.get("var_p01") or vals.get("returns.var_p01"),
-            "paper_es_p01": vals.get("es_p01") or vals.get("returns.es_p01"),
-            "paper_vs_backtest_sharpe_ratio": sharpe_ratio,
-            "paper_vs_backtest_dd_ratio": dd_ratio,
-            "paper_vs_backtest_var_p01_ratio": var_ratio,
-            "paper_vs_backtest_es_p01_ratio": es_ratio,
-        }
-
-        if cfg.min_sharpe_ratio is not None:
-            if sharpe_ratio is None:
-                status = "warn"
-                reasons.append("paper_shadow_sharpe_ratio_missing")
-            elif sharpe_ratio < cfg.min_sharpe_ratio:
-                status = "fail"
-                reasons.append("paper_shadow_sharpe_ratio_below_min")
-                details["min_sharpe_ratio"] = cfg.min_sharpe_ratio
-
-        if cfg.max_drawdown_ratio is not None:
-            if dd_ratio is None:
-                status = "warn"
-                reasons.append("paper_shadow_dd_ratio_missing")
-            elif dd_ratio > cfg.max_drawdown_ratio:
-                status = "fail"
-                reasons.append("paper_shadow_dd_ratio_exceeds_max")
-                details["max_drawdown_ratio"] = cfg.max_drawdown_ratio
-
-        if cfg.max_var_p01_ratio is not None:
-            if var_ratio is None:
-                status = "warn"
-                reasons.append("paper_shadow_var_ratio_missing")
-            elif var_ratio > cfg.max_var_p01_ratio:
-                status = "fail"
-                reasons.append("paper_shadow_var_ratio_exceeds_max")
-                details["max_var_p01_ratio"] = cfg.max_var_p01_ratio
-
-        if cfg.max_es_p01_ratio is not None:
-            if es_ratio is None:
-                status = "warn"
-                reasons.append("paper_shadow_es_ratio_missing")
-            elif es_ratio > cfg.max_es_p01_ratio:
-                status = "fail"
-                reasons.append("paper_shadow_es_ratio_exceeds_max")
-                details["max_es_p01_ratio"] = cfg.max_es_p01_ratio
-
-        reason_code = reasons[0] if reasons else "paper_shadow_ok"
-        reason = ", ".join(reasons) if reasons else "Paper/shadow consistency satisfied"
-        results[sid] = RuleResult(
-            status=status,
+    return {
+        sid: _evaluate_paper_shadow_strategy(
+            vals,
+            cfg=cfg,
+            stage=stage,
             severity=severity,
             owner=owner,
-            reason_code=reason_code,
-            reason=reason,
-            tags=["paper_shadow"],
-            details=details,
         )
+        for sid, vals in metrics.items()
+    }
 
-    return results
+
+def _live_metric_values(
+    metrics: Mapping[str, Mapping[str, Any]],
+    primary_key: str,
+    fallback_key: str | None = None,
+) -> list[float]:
+    values: list[float] = []
+    for strategy_metrics in metrics.values():
+        raw_value = strategy_metrics.get(primary_key)
+        if raw_value is None and fallback_key:
+            raw_value = strategy_metrics.get(fallback_key)
+        numeric = _as_number(raw_value)
+        if numeric is not None:
+            values.append(numeric)
+    return values
 
 
 def evaluate_live_monitoring(
@@ -1000,20 +1203,9 @@ def evaluate_live_monitoring(
     decay_threshold = cfg.decay_threshold
     lookback = cfg.lookback_days
 
-    # Aggregate across strategies; use average realized Sharpe/DD if present
-    sharpe_values: list[float] = []
-    dd_values: list[float] = []
-    decay_values: list[float] = []
-    for vals in metrics.values():
-        sharpe_live = vals.get("live_sharpe") or vals.get("realized_sharpe")
-        dd_live = vals.get("live_max_drawdown") or vals.get("realized_max_drawdown")
-        decay = vals.get("live_vs_backtest_sharpe_ratio")
-        if isinstance(sharpe_live, (int, float)):
-            sharpe_values.append(float(sharpe_live))
-        if isinstance(dd_live, (int, float)):
-            dd_values.append(float(dd_live))
-        if isinstance(decay, (int, float)):
-            decay_values.append(float(decay))
+    sharpe_values = _live_metric_values(metrics, "live_sharpe", "realized_sharpe")
+    dd_values = _live_metric_values(metrics, "live_max_drawdown", "realized_max_drawdown")
+    decay_values = _live_metric_values(metrics, "live_vs_backtest_sharpe_ratio")
 
     reasons: list[str] = []
     status = "pass"
@@ -1024,32 +1216,42 @@ def evaluate_live_monitoring(
         "lookback_days": lookback,
     }
 
-    if sharpe_min is not None:
-        if not sharpe_values:
-            status = "warn"
-            reasons.append("live_sharpe_missing")
-        elif details["sharpe_mean"] < sharpe_min:
-            status = "fail"
-            reasons.append("live_sharpe_below_min")
-            details["sharpe_min"] = sharpe_min
-
-    if dd_max is not None:
-        if not dd_values:
-            status = "warn"
-            reasons.append("live_dd_missing")
-        elif details["dd_mean"] > dd_max:
-            status = "fail"
-            reasons.append("live_dd_exceeds_max")
-            details["dd_max"] = dd_max
-
-    if decay_threshold is not None:
-        if not decay_values:
-            status = "warn"
-            reasons.append("live_decay_missing")
-        elif details["decay_mean"] < decay_threshold:
-            status = "fail"
-            reasons.append("live_decay_below_threshold")
-            details["decay_threshold"] = decay_threshold
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_lower_bound(
+            value=details["sharpe_mean"],
+            threshold=sharpe_min,
+            missing_reason="live_sharpe_missing",
+            fail_reason="live_sharpe_below_min",
+            detail_key="sharpe_min",
+            details=details,
+        ),
+    )
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_upper_bound(
+            value=details["dd_mean"],
+            threshold=dd_max,
+            missing_reason="live_dd_missing",
+            fail_reason="live_dd_exceeds_max",
+            detail_key="dd_max",
+            details=details,
+        ),
+    )
+    status = _apply_rule_event(
+        status,
+        reasons,
+        _evaluate_optional_lower_bound(
+            value=details["decay_mean"],
+            threshold=decay_threshold,
+            missing_reason="live_decay_missing",
+            fail_reason="live_decay_below_threshold",
+            detail_key="decay_threshold",
+            details=details,
+        ),
+    )
 
     reason_code = reasons[0] if reasons else "live_monitoring_ok"
     reason = ", ".join(reasons) if reasons else "Live monitoring within thresholds"
@@ -1076,16 +1278,16 @@ class _PolicySelectionPreparation:
 
 @dataclass
 class _RuleAssemblyProfileConfig:
-    sample_severity: str = "soft"
-    sample_owner: str = "quant"
-    performance_severity: str = "blocking"
-    performance_owner: str = "quant"
-    risk_severity: str = "blocking"
-    risk_owner: str = "risk"
-    robustness_severity: str = "soft"
-    robustness_owner: str = "quant"
-    robustness_dsr_min: float | None = None
-    robustness_cv_sharpe_gap_max: float | None = None
+    sample_severity: str
+    sample_owner: str
+    performance_severity: str
+    performance_owner: str
+    risk_severity: str
+    risk_owner: str
+    robustness_severity: str
+    robustness_owner: str
+    robustness_dsr_min: float | None
+    robustness_cv_sharpe_gap_max: float | None
 
 
 @dataclass
@@ -1110,7 +1312,6 @@ def _prepare_policy_selection(
         resolved_policy.thresholds,
         missing_mode=validation_cfg.on_missing_metric,
     )
-
     candidates = threshold_passed
     topk_ranks: Dict[str, int] = {sid: idx for idx, sid in enumerate(candidates)}
     if resolved_policy.top_k:
@@ -1139,6 +1340,13 @@ def _prepare_policy_selection(
     )
 
 
+def _profile_attr(section: Any, attr: str, default: Any) -> Any:
+    if section is None:
+        return default
+    value = getattr(section, attr, None)
+    return default if value is None else value
+
+
 def _resolve_rule_assembly_profile_config(
     selected_profile_cfg: ValidationProfile | None,
 ) -> _RuleAssemblyProfileConfig:
@@ -1146,18 +1354,17 @@ def _resolve_rule_assembly_profile_config(
     performance_cfg = selected_profile_cfg.performance if selected_profile_cfg else None
     risk_cfg = selected_profile_cfg.risk if selected_profile_cfg else None
     robustness_cfg = selected_profile_cfg.robustness if selected_profile_cfg else None
-
     return _RuleAssemblyProfileConfig(
-        sample_severity=(sample_cfg.severity if sample_cfg else None) or "soft",
-        sample_owner=(sample_cfg.owner if sample_cfg else None) or "quant",
-        performance_severity=(performance_cfg.severity if performance_cfg else None) or "blocking",
-        performance_owner=(performance_cfg.owner if performance_cfg else None) or "quant",
-        risk_severity=(risk_cfg.severity if risk_cfg else None) or "blocking",
-        risk_owner=(risk_cfg.owner if risk_cfg else None) or "risk",
-        robustness_severity=(robustness_cfg.severity if robustness_cfg else None) or "soft",
-        robustness_owner=(robustness_cfg.owner if robustness_cfg else None) or "quant",
-        robustness_dsr_min=robustness_cfg.dsr_min if robustness_cfg else None,
-        robustness_cv_sharpe_gap_max=robustness_cfg.cv_sharpe_gap_max if robustness_cfg else None,
+        sample_severity=_profile_attr(sample_cfg, "severity", "soft"),
+        sample_owner=_profile_attr(sample_cfg, "owner", "quant"),
+        performance_severity=_profile_attr(performance_cfg, "severity", "blocking"),
+        performance_owner=_profile_attr(performance_cfg, "owner", "quant"),
+        risk_severity=_profile_attr(risk_cfg, "severity", "blocking"),
+        risk_owner=_profile_attr(risk_cfg, "owner", "risk"),
+        robustness_severity=_profile_attr(robustness_cfg, "severity", "soft"),
+        robustness_owner=_profile_attr(robustness_cfg, "owner", "quant"),
+        robustness_dsr_min=_profile_attr(robustness_cfg, "dsr_min", None),
+        robustness_cv_sharpe_gap_max=_profile_attr(robustness_cfg, "cv_sharpe_gap_max", None),
     )
 
 
@@ -1432,44 +1639,56 @@ def _evaluate_thresholds_with_details(
         for rule in thresholds.values():
             val = values.get(rule.metric)
             if val is None:
-                if missing_mode_normalized != "ignore":
-                    entry = {
-                        "metric": rule.metric,
-                        "reason": "missing_metric",
-                        "mode": missing_mode_normalized,
-                        "blocking": missing_mode_normalized == "fail",
-                    }
+                entry = _missing_metric_failure(rule.metric, missing_mode_normalized)
+                if entry:
                     strategy_failures.append(entry)
-                    if entry["blocking"]:
-                        blocking_failure = True
+                    blocking_failure = blocking_failure or bool(entry.get("blocking"))
                 continue
-            if rule.min is not None and val < rule.min:
-                strategy_failures.append(
-                    {
-                        "metric": rule.metric,
-                        "reason": "below_min",
-                        "min": rule.min,
-                        "value": val,
-                        "blocking": True,
-                    }
-                )
-                blocking_failure = True
-            if rule.max is not None and val > rule.max:
-                strategy_failures.append(
-                    {
-                        "metric": rule.metric,
-                        "reason": "above_max",
-                        "max": rule.max,
-                        "value": val,
-                        "blocking": True,
-                    }
-                )
+            violations = _threshold_value_violations(rule, val)
+            if violations:
+                strategy_failures.extend(violations)
                 blocking_failure = True
         if strategy_failures:
             failures[sid] = strategy_failures
         if not blocking_failure:
             passed.append(sid)
     return passed, failures
+
+
+def _missing_metric_failure(metric: str, mode: str) -> Dict[str, Any] | None:
+    if mode == "ignore":
+        return None
+    return {
+        "metric": metric,
+        "reason": "missing_metric",
+        "mode": mode,
+        "blocking": mode == "fail",
+    }
+
+
+def _threshold_value_violations(rule: ThresholdRule, value: float) -> list[Dict[str, Any]]:
+    violations: list[Dict[str, Any]] = []
+    if rule.min is not None and value < rule.min:
+        violations.append(
+            {
+                "metric": rule.metric,
+                "reason": "below_min",
+                "min": rule.min,
+                "value": value,
+                "blocking": True,
+            }
+        )
+    if rule.max is not None and value > rule.max:
+        violations.append(
+            {
+                "metric": rule.metric,
+                "reason": "above_max",
+                "max": rule.max,
+                "value": value,
+                "blocking": True,
+            }
+        )
+    return violations
 
 
 def _apply_topk_with_details(
@@ -1532,6 +1751,251 @@ def _apply_hysteresis_with_details(
     return result, blocked
 
 
+def _data_currency_outcome(
+    metrics: Mapping[str, float],
+    missing: Sequence[str],
+    mode: str,
+    default_severity: str,
+) -> tuple[str, str, str, str]:
+    if not metrics:
+        severity = "info" if mode == "ignore" else default_severity
+        status = "fail" if mode == "fail" else "warn"
+        return status, severity, "metrics_missing", "No metrics provided for strategy"
+    if missing:
+        if mode == "fail":
+            return "fail", default_severity, "missing_metric", f"Missing metrics: {', '.join(sorted(missing))}"
+        if mode == "warn":
+            return "warn", default_severity, "missing_metric", f"Missing metrics: {', '.join(sorted(missing))}"
+        return "warn", "info", "missing_metric_ignored", f"Missing metrics: {', '.join(sorted(missing))}"
+    return "pass", default_severity, "data_currency_ok", "Required metrics present"
+
+
+_SAMPLE_METRIC_KEYS = {
+    "n_trades_total",
+    "n_trades_per_year",
+    "num_trades",
+    "effective_history_years",
+    "sample_days",
+}
+
+
+def _sample_metrics_view(metrics: Mapping[str, float]) -> Dict[str, float]:
+    return {key: value for key, value in metrics.items() if key in _SAMPLE_METRIC_KEYS}
+
+
+def _sample_threshold_failures(
+    sample_metrics: Mapping[str, float],
+    thresholds: Sequence[ThresholdRule],
+) -> list[Dict[str, Any]]:
+    if not thresholds:
+        return []
+    _, failures = _evaluate_thresholds_with_details({"_": sample_metrics}, {t.metric: t for t in thresholds})
+    return failures.get("_", [])
+
+
+def _build_sample_result(
+    sample_metrics: Mapping[str, float],
+    failures: Sequence[Dict[str, Any]],
+    severity: str,
+    owner: str,
+    tags: Sequence[str],
+) -> RuleResult:
+    if failures:
+        reason = f"Sample thresholds failed: {', '.join(item['metric'] for item in failures)}"
+        return RuleResult(
+            status="fail",
+            severity=severity,
+            owner=owner,
+            reason_code="sample_thresholds_failed",
+            reason=reason,
+            tags=list(tags),
+            details={"violations": list(failures)},
+        )
+    has_depth = any(value is not None and value > 0 for value in sample_metrics.values())
+    if has_depth:
+        return RuleResult(
+            status="pass",
+            severity=severity,
+            owner=owner,
+            reason_code="sample_ok",
+            reason="Sample depth present",
+            tags=list(tags),
+            details={"sample_metrics": dict(sample_metrics)},
+        )
+    return RuleResult(
+        status="warn",
+        severity=severity,
+        owner=owner,
+        reason_code="sample_metrics_missing",
+        reason="No sample metrics found",
+        tags=list(tags),
+        details={"sample_metrics": dict(sample_metrics)},
+    )
+
+
+def _performance_failures_for_strategy(
+    sid: str,
+    threshold_failures: Mapping[str, List[Dict[str, Any]]],
+) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]]]:
+    failures = list(threshold_failures.get(sid, []))
+    blocking = [failure for failure in failures if failure.get("blocking", True)]
+    return failures, blocking
+
+
+def _performance_missing_result(
+    failures: Sequence[Dict[str, Any]],
+    on_missing_metric: str,
+    *,
+    severity: str,
+    owner: str,
+    tags: Sequence[str],
+) -> RuleResult | None:
+    missing_entries = [failure for failure in failures if failure.get("reason") == "missing_metric"]
+    if not missing_entries:
+        return None
+    mode = (on_missing_metric or "fail").lower()
+    status = "warn" if mode != "fail" else "fail"
+    missing_metrics = [item.get("metric") for item in missing_entries]
+    reason = f"Missing metrics: {', '.join(missing_metrics)}"
+    return RuleResult(
+        status=status,
+        severity=severity,
+        owner=owner,
+        reason_code="performance_metrics_missing",
+        reason=reason,
+        tags=list(tags),
+        details={
+            "violations": list(failures),
+            "policy_on_missing_metric": mode,
+        },
+    )
+
+
+def _performance_rank_result(
+    sid: str,
+    top_k: TopKRule | None,
+    topk_selected: set[str],
+    topk_ranks: Mapping[str, int],
+    *,
+    severity: str,
+    owner: str,
+    tags: Sequence[str],
+) -> RuleResult | None:
+    if not top_k or sid in topk_selected:
+        return None
+    rank = topk_ranks.get(sid)
+    reason = f"Rank {rank + 1} outside top_k={top_k.k}" if rank is not None else f"Not selected by top_k={top_k.k}"
+    return RuleResult(
+        status="fail",
+        severity=severity,
+        owner=owner,
+        reason_code="performance_rank_outside_top_k",
+        reason=reason,
+        tags=list(set(tags) | {"top_k"}),
+        details={"rank": rank, "top_k": top_k.k},
+    )
+
+
+def _risk_correlation_failure(
+    sid: str,
+    rule: CorrelationRule | None,
+    violations: Mapping[str, List[Tuple[str, float]]],
+    *,
+    severity: str,
+    owner: str,
+    tags: Sequence[str],
+) -> RuleResult | None:
+    if not rule or sid not in violations:
+        return None
+    blocked = [{"strategy_id": other, "correlation": corr} for other, corr in violations[sid]]
+    return RuleResult(
+        status="fail",
+        severity=severity,
+        owner=owner,
+        reason_code="correlation_constraint_failed",
+        reason=f"Correlation exceeds max {rule.max}",
+        tags=list(tags),
+        details={"blocked_by": blocked},
+    )
+
+
+def _risk_hysteresis_failure(
+    sid: str,
+    metrics: Mapping[str, float],
+    context: RuleContext,
+    rule: HysteresisRule | None,
+    blocked: Mapping[str, str],
+    *,
+    severity: str,
+    owner: str,
+    tags: Sequence[str],
+) -> RuleResult | None:
+    if not rule or sid not in blocked:
+        return None
+    mode = blocked.get(sid)
+    reason_code = "hysteresis_exit" if mode == "exit" else "hysteresis_not_entered"
+    reason = (
+        f"{rule.metric} below exit {rule.exit} for previously active strategy"
+        if mode == "exit"
+        else f"{rule.metric} below enter {rule.enter}"
+    )
+    return RuleResult(
+        status="fail",
+        severity=severity,
+        owner=owner,
+        reason_code=reason_code,
+        reason=reason,
+        tags=list(tags),
+        details={
+            "metric": rule.metric,
+            "previously_active": sid in set(context.previous_active or []),
+            "mode": mode,
+            "value": metrics.get(rule.metric),
+        },
+    )
+
+
+def _robustness_base_details(metrics: Mapping[str, float]) -> Dict[str, Any]:
+    return {
+        "deflated_sharpe_ratio": metrics.get("deflated_sharpe_ratio"),
+        "sharpe_first_half": metrics.get("sharpe_first_half"),
+        "sharpe_second_half": metrics.get("sharpe_second_half"),
+        "cv_sharpe_mean": metrics.get("cv_sharpe_mean"),
+        "cv_sharpe_std": metrics.get("cv_sharpe_std"),
+    }
+
+
+def _robustness_dsr_event(
+    dsr: float | None,
+    dsr_min: float | None,
+    details: Dict[str, Any],
+) -> tuple[str, str] | None:
+    if dsr_min is None:
+        return None
+    if dsr is None:
+        return "warn", "dsr_missing"
+    if dsr < dsr_min:
+        details["dsr_min"] = dsr_min
+        return "fail", "dsr_below_min"
+    return None
+
+
+def _robustness_gap_event(
+    sharpe_first: float | None,
+    sharpe_second: float | None,
+    max_gap: float | None,
+    details: Dict[str, Any],
+) -> tuple[str, str] | None:
+    if max_gap is None or sharpe_first is None or sharpe_second is None:
+        return None
+    gap = abs(sharpe_first - sharpe_second)
+    details["sharpe_gap"] = gap
+    if gap > max_gap:
+        details["cv_sharpe_gap_max"] = max_gap
+        return "fail", "cv_sharpe_gap_exceeds_max"
+    return None
+
+
 @dataclass
 class DataCurrencyRule:
     required_metrics: Sequence[str] | None = None
@@ -1542,33 +2006,15 @@ class DataCurrencyRule:
     tags: Sequence[str] = ("data_currency",)
 
     def evaluate(self, metrics: Mapping[str, float], context: RuleContext) -> RuleResult:
-        missing: List[str] = []
         required = list(self.required_metrics or [])
-        if required:
-            missing = [metric for metric in required if metric not in metrics]
-        status = "pass"
-        reason_code = "data_currency_ok"
-        reason = "Required metrics present"
-        severity = self.severity
+        missing = [metric for metric in required if metric not in metrics]
         mode = (self.on_missing_metric or "fail").lower()
-        if not metrics:
-            status = "fail" if mode == "fail" else "warn"
-            if mode == "ignore":
-                severity = "info"
-            reason_code = "metrics_missing"
-            reason = "No metrics provided for strategy"
-        elif missing:
-            if mode == "fail":
-                status = "fail"
-                reason_code = "missing_metric"
-            elif mode == "warn":
-                status = "warn"
-                reason_code = "missing_metric"
-            else:
-                status = "warn"
-                severity = "info"
-                reason_code = "missing_metric_ignored"
-            reason = f"Missing metrics: {', '.join(sorted(missing))}"
+        status, severity, reason_code, reason = _data_currency_outcome(
+            metrics,
+            missing,
+            mode,
+            self.severity,
+        )
         details = {
             "missing_metrics": missing,
             "available_metrics": sorted(metrics.keys()),
@@ -1594,46 +2040,9 @@ class SampleRule:
     tags: Sequence[str] = ("sample",)
 
     def evaluate(self, metrics: Mapping[str, float], context: RuleContext) -> RuleResult:
-        sample_metrics = {
-            key: value
-            for key, value in metrics.items()
-            if key in {"n_trades_total", "n_trades_per_year", "num_trades", "effective_history_years", "sample_days"}
-        }
-        if self.thresholds:
-            _, failures = _evaluate_thresholds_with_details({"_": sample_metrics}, {t.metric: t for t in self.thresholds})
-            if failures:
-                detail = failures.get("_", [])
-                reason = f"Sample thresholds failed: {', '.join(item['metric'] for item in detail)}"
-                return RuleResult(
-                    status="fail",
-                    severity=self.severity,
-                    owner=self.owner,
-                    reason_code="sample_thresholds_failed",
-                    reason=reason,
-                    tags=list(self.tags),
-                    details={"violations": detail},
-                )
-
-        if sample_metrics and any(value is not None and value > 0 for value in sample_metrics.values()):
-            return RuleResult(
-                status="pass",
-                severity=self.severity,
-                owner=self.owner,
-                reason_code="sample_ok",
-                reason="Sample depth present",
-                tags=list(self.tags),
-                details={"sample_metrics": sample_metrics},
-            )
-
-        return RuleResult(
-            status="warn",
-            severity=self.severity,
-            owner=self.owner,
-            reason_code="sample_metrics_missing",
-            reason="No sample metrics found",
-            tags=list(self.tags),
-            details={"sample_metrics": sample_metrics},
-        )
+        sample_metrics = _sample_metrics_view(metrics)
+        failures = _sample_threshold_failures(sample_metrics, self.thresholds)
+        return _build_sample_result(sample_metrics, failures, self.severity, self.owner, self.tags)
 
 
 @dataclass
@@ -1651,8 +2060,7 @@ class PerformanceRule:
 
     def evaluate(self, metrics: Mapping[str, float], context: RuleContext) -> RuleResult:
         sid = context.strategy_id
-        failures = self.threshold_failures.get(sid, [])
-        blocking_failures = [f for f in failures if f.get("blocking", True)]
+        failures, blocking_failures = _performance_failures_for_strategy(sid, self.threshold_failures)
         if blocking_failures:
             reason = self._format_failure_reason(blocking_failures[0])
             return RuleResult(
@@ -1665,43 +2073,26 @@ class PerformanceRule:
                 details={"violations": blocking_failures},
             )
 
-        missing_entries = [
-            f for f in failures if f.get("reason") == "missing_metric"
-        ]
-        if missing_entries:
-            mode = (self.on_missing_metric or "fail").lower()
-            status = "warn" if mode != "fail" else "fail"
-            missing_metrics = [item.get("metric") for item in missing_entries]
-            reason = f"Missing metrics: {', '.join(missing_metrics)}"
-            return RuleResult(
-                status=status,
-                severity=self.severity,
-                owner=self.owner,
-                reason_code="performance_metrics_missing",
-                reason=reason,
-                tags=list(self.tags),
-                details={
-                    "violations": failures,
-                    "policy_on_missing_metric": mode,
-                },
-            )
-
-        if self.top_k and sid not in self.topk_selected:
-            rank = self.topk_ranks.get(sid)
-            reason = (
-                f"Rank {rank + 1} outside top_k={self.top_k.k}"
-                if rank is not None
-                else f"Not selected by top_k={self.top_k.k}"
-            )
-            return RuleResult(
-                status="fail",
-                severity=self.severity,
-                owner=self.owner,
-                reason_code="performance_rank_outside_top_k",
-                reason=reason,
-                tags=list(set(self.tags) | {"top_k"}),
-                details={"rank": rank, "top_k": self.top_k.k},
-            )
+        missing_result = _performance_missing_result(
+            failures,
+            self.on_missing_metric,
+            severity=self.severity,
+            owner=self.owner,
+            tags=self.tags,
+        )
+        if missing_result:
+            return missing_result
+        rank_result = _performance_rank_result(
+            sid,
+            self.top_k,
+            self.topk_selected,
+            self.topk_ranks,
+            severity=self.severity,
+            owner=self.owner,
+            tags=self.tags,
+        )
+        if rank_result:
+            return rank_result
 
         return RuleResult(
             status="pass",
@@ -1742,44 +2133,28 @@ class RiskConstraintRule:
 
     def evaluate(self, metrics: Mapping[str, float], context: RuleContext) -> RuleResult:
         sid = context.strategy_id
-        if self.correlation_rule and sid in self.correlation_violations:
-            blocked = [
-                {"strategy_id": other, "correlation": corr}
-                for other, corr in self.correlation_violations[sid]
-            ]
-            return RuleResult(
-                status="fail",
-                severity=self.severity,
-                owner=self.owner,
-                reason_code="correlation_constraint_failed",
-                reason=f"Correlation exceeds max {self.correlation_rule.max}",
-                tags=list(self.tags),
-                details={"blocked_by": blocked},
-            )
-
-        if self.hysteresis_rule and sid in self.hysteresis_blocked:
-            mode = self.hysteresis_blocked.get(sid)
-            reason_code = "hysteresis_exit" if mode == "exit" else "hysteresis_not_entered"
-            reason = (
-                f"{self.hysteresis_rule.metric} below exit {self.hysteresis_rule.exit} "
-                f"for previously active strategy"
-                if mode == "exit"
-                else f"{self.hysteresis_rule.metric} below enter {self.hysteresis_rule.enter}"
-            )
-            return RuleResult(
-                status="fail",
-                severity=self.severity,
-                owner=self.owner,
-                reason_code=reason_code,
-                reason=reason,
-                tags=list(self.tags),
-                details={
-                    "metric": self.hysteresis_rule.metric,
-                    "previously_active": sid in set(context.previous_active or []),
-                    "mode": mode,
-                    "value": metrics.get(self.hysteresis_rule.metric),
-                },
-            )
+        correlation_result = _risk_correlation_failure(
+            sid,
+            self.correlation_rule,
+            self.correlation_violations,
+            severity=self.severity,
+            owner=self.owner,
+            tags=self.tags,
+        )
+        if correlation_result:
+            return correlation_result
+        hysteresis_result = _risk_hysteresis_failure(
+            sid,
+            metrics,
+            context,
+            self.hysteresis_rule,
+            self.hysteresis_blocked,
+            severity=self.severity,
+            owner=self.owner,
+            tags=self.tags,
+        )
+        if hysteresis_result:
+            return hysteresis_result
 
         if not self.correlation_rule and not self.hysteresis_rule:
             return RuleResult(
@@ -1815,41 +2190,28 @@ class RobustnessRule:
     tags: Sequence[str] = ("robustness",)
 
     def evaluate(self, metrics: Mapping[str, float], context: RuleContext) -> RuleResult:
-        dsr = metrics.get("deflated_sharpe_ratio")
-        sharpe_first = metrics.get("sharpe_first_half")
-        sharpe_second = metrics.get("sharpe_second_half")
-        cv_sharpe_mean = metrics.get("cv_sharpe_mean")
-        cv_sharpe_std = metrics.get("cv_sharpe_std")
-
         reasons: list[str] = []
         status = "pass"
-        details: Dict[str, Any] = {
-            "deflated_sharpe_ratio": dsr,
-            "sharpe_first_half": sharpe_first,
-            "sharpe_second_half": sharpe_second,
-            "cv_sharpe_mean": cv_sharpe_mean,
-            "cv_sharpe_std": cv_sharpe_std,
-        }
-
-        # Check DSR threshold
-        if self.dsr_min is not None:
-            if dsr is None:
-                status = "warn"
-                reasons.append("dsr_missing")
-            elif dsr < self.dsr_min:
-                status = "fail"
-                reasons.append("dsr_below_min")
-                details["dsr_min"] = self.dsr_min
-
-        # Check CV sharpe gap (train/test consistency)
-        if self.cv_sharpe_gap_max is not None:
-            if sharpe_first is not None and sharpe_second is not None:
-                gap = abs(sharpe_first - sharpe_second)
-                details["sharpe_gap"] = gap
-                if gap > self.cv_sharpe_gap_max:
-                    status = "fail" if status != "fail" else status
-                    reasons.append("cv_sharpe_gap_exceeds_max")
-                    details["cv_sharpe_gap_max"] = self.cv_sharpe_gap_max
+        details = _robustness_base_details(metrics)
+        status = _apply_rule_event(
+            status,
+            reasons,
+            _robustness_dsr_event(
+                _as_number(details["deflated_sharpe_ratio"]),
+                self.dsr_min,
+                details,
+            ),
+        )
+        status = _apply_rule_event(
+            status,
+            reasons,
+            _robustness_gap_event(
+                _as_number(details["sharpe_first_half"]),
+                _as_number(details["sharpe_second_half"]),
+                self.cv_sharpe_gap_max,
+                details,
+            ),
+        )
 
         reason_code = reasons[0] if reasons else "robustness_ok"
         reason = ", ".join(reasons) if reasons else "Robustness checks passed"

--- a/qmtl/services/worldservice/policy_engine.py
+++ b/qmtl/services/worldservice/policy_engine.py
@@ -1064,6 +1064,226 @@ def evaluate_live_monitoring(
     )
 
 
+@dataclass
+class _PolicySelectionPreparation:
+    selected_ids: List[str]
+    threshold_failures: Dict[str, List[Dict[str, Any]]]
+    topk_selected: set[str]
+    topk_ranks: Dict[str, int]
+    correlation_violations: Dict[str, List[Tuple[str, float]]]
+    hysteresis_blocked: Dict[str, str]
+
+
+@dataclass
+class _RuleAssemblyProfileConfig:
+    sample_severity: str = "soft"
+    sample_owner: str = "quant"
+    performance_severity: str = "blocking"
+    performance_owner: str = "quant"
+    risk_severity: str = "blocking"
+    risk_owner: str = "risk"
+    robustness_severity: str = "soft"
+    robustness_owner: str = "quant"
+    robustness_dsr_min: float | None = None
+    robustness_cv_sharpe_gap_max: float | None = None
+
+
+@dataclass
+class _CrossStrategyLayerEvaluation:
+    cohort_results: Dict[str, RuleResult]
+    portfolio_results: Dict[str, RuleResult]
+    benchmark_results: Dict[str, RuleResult]
+    stress_results: Dict[str, RuleResult]
+    paper_shadow_results: Dict[str, RuleResult]
+    live_result: RuleResult | None
+
+
+def _prepare_policy_selection(
+    normalized: Dict[str, Dict[str, float]],
+    resolved_policy: Policy,
+    validation_cfg: ValidationConfig,
+    prev_active: Iterable[str] | None,
+    correlations: Dict[Tuple[str, str], float] | None,
+) -> _PolicySelectionPreparation:
+    threshold_passed, threshold_failures = _evaluate_thresholds_with_details(
+        normalized,
+        resolved_policy.thresholds,
+        missing_mode=validation_cfg.on_missing_metric,
+    )
+
+    candidates = threshold_passed
+    topk_ranks: Dict[str, int] = {sid: idx for idx, sid in enumerate(candidates)}
+    if resolved_policy.top_k:
+        candidates, topk_ranks = _apply_topk_with_details(normalized, candidates, resolved_policy.top_k)
+    topk_selected = set(candidates)
+
+    correlation_violations: Dict[str, List[Tuple[str, float]]] = {}
+    if resolved_policy.correlation:
+        candidates, correlation_violations = _apply_correlation_with_details(
+            correlations, candidates, resolved_policy.correlation
+        )
+
+    hysteresis_blocked: Dict[str, str] = {}
+    if resolved_policy.hysteresis:
+        candidates, hysteresis_blocked = _apply_hysteresis_with_details(
+            normalized, candidates, prev_active, resolved_policy.hysteresis
+        )
+
+    return _PolicySelectionPreparation(
+        selected_ids=list(candidates),
+        threshold_failures=threshold_failures,
+        topk_selected=topk_selected,
+        topk_ranks=topk_ranks,
+        correlation_violations=correlation_violations,
+        hysteresis_blocked=hysteresis_blocked,
+    )
+
+
+def _resolve_rule_assembly_profile_config(
+    selected_profile_cfg: ValidationProfile | None,
+) -> _RuleAssemblyProfileConfig:
+    sample_cfg = selected_profile_cfg.sample if selected_profile_cfg else None
+    performance_cfg = selected_profile_cfg.performance if selected_profile_cfg else None
+    risk_cfg = selected_profile_cfg.risk if selected_profile_cfg else None
+    robustness_cfg = selected_profile_cfg.robustness if selected_profile_cfg else None
+
+    return _RuleAssemblyProfileConfig(
+        sample_severity=(sample_cfg.severity if sample_cfg else None) or "soft",
+        sample_owner=(sample_cfg.owner if sample_cfg else None) or "quant",
+        performance_severity=(performance_cfg.severity if performance_cfg else None) or "blocking",
+        performance_owner=(performance_cfg.owner if performance_cfg else None) or "quant",
+        risk_severity=(risk_cfg.severity if risk_cfg else None) or "blocking",
+        risk_owner=(risk_cfg.owner if risk_cfg else None) or "risk",
+        robustness_severity=(robustness_cfg.severity if robustness_cfg else None) or "soft",
+        robustness_owner=(robustness_cfg.owner if robustness_cfg else None) or "quant",
+        robustness_dsr_min=robustness_cfg.dsr_min if robustness_cfg else None,
+        robustness_cv_sharpe_gap_max=robustness_cfg.cv_sharpe_gap_max if robustness_cfg else None,
+    )
+
+
+def _assemble_policy_rules(
+    resolved_policy: Policy,
+    validation_cfg: ValidationConfig,
+    selection: _PolicySelectionPreparation,
+    selected_profile_cfg: ValidationProfile | None,
+) -> List[ValidationRule]:
+    grouped_thresholds = _group_thresholds(resolved_policy.thresholds)
+    profile_cfg = _resolve_rule_assembly_profile_config(selected_profile_cfg)
+    return [
+        DataCurrencyRule(
+            required_metrics=[t.metric for t in grouped_thresholds["data_currency"]],
+            on_missing_metric=validation_cfg.on_missing_metric,
+        ),
+        SampleRule(
+            thresholds=grouped_thresholds["sample"],
+            severity=profile_cfg.sample_severity,
+            owner=profile_cfg.sample_owner,
+        ),
+        PerformanceRule(
+            thresholds=grouped_thresholds["performance"] or list(resolved_policy.thresholds.values()),
+            threshold_failures=selection.threshold_failures,
+            top_k=resolved_policy.top_k,
+            topk_selected=selection.topk_selected,
+            topk_ranks=selection.topk_ranks,
+            on_missing_metric=validation_cfg.on_missing_metric,
+            severity=profile_cfg.performance_severity,
+            owner=profile_cfg.performance_owner,
+        ),
+        RiskConstraintRule(
+            correlation_rule=resolved_policy.correlation,
+            hysteresis_rule=resolved_policy.hysteresis,
+            correlation_violations=selection.correlation_violations,
+            hysteresis_blocked=selection.hysteresis_blocked,
+            severity=profile_cfg.risk_severity,
+            owner=profile_cfg.risk_owner,
+        ),
+        RobustnessRule(
+            dsr_min=profile_cfg.robustness_dsr_min,
+            cv_sharpe_gap_max=profile_cfg.robustness_cv_sharpe_gap_max,
+            severity=profile_cfg.robustness_severity,
+            owner=profile_cfg.robustness_owner,
+        ),
+    ]
+
+
+def _evaluate_rule_results(
+    normalized: Dict[str, Dict[str, float]],
+    rules: Sequence[ValidationRule],
+    validation_cfg: ValidationConfig,
+    prev_active: Iterable[str] | None,
+    correlations: Dict[Tuple[str, str], float] | None,
+) -> Dict[str, Dict[str, RuleResult]]:
+    rule_results: Dict[str, Dict[str, RuleResult]] = {}
+    previous = set(prev_active or [])
+    for strategy_id, strategy_metrics in normalized.items():
+        context = RuleContext(
+            strategy_id=strategy_id,
+            previous_active=previous,
+            correlations=correlations,
+        )
+        per_rule: Dict[str, RuleResult] = {}
+        for rule in rules:
+            try:
+                per_rule[rule.name] = rule.evaluate(strategy_metrics, context)
+            except Exception as exc:  # pragma: no cover - defensive fail-closed
+                status = "fail" if validation_cfg.on_error == "fail" else "warn"
+                tags = getattr(rule, "tags", (rule.name,))
+                per_rule[rule.name] = RuleResult(
+                    status=status,
+                    severity=getattr(rule, "severity", "blocking"),
+                    owner=getattr(rule, "owner", "quant"),
+                    reason_code="rule_error",
+                    reason=str(exc),
+                    tags=list(tags),
+                    details={"error": repr(exc)},
+                )
+        rule_results[strategy_id] = per_rule
+    return rule_results
+
+
+def _evaluate_cross_strategy_layers(
+    metrics: Mapping[str, Mapping[str, float]],
+    policy: Policy,
+    *,
+    stage: str | None = None,
+) -> _CrossStrategyLayerEvaluation:
+    return _CrossStrategyLayerEvaluation(
+        cohort_results=evaluate_cohort_rules(metrics, policy, stage=stage),
+        portfolio_results=evaluate_portfolio_rules(metrics, policy, stage=stage),
+        benchmark_results=evaluate_benchmark_rules(metrics, policy, stage=stage),
+        stress_results=evaluate_stress_rules(metrics, policy, stage=stage),
+        paper_shadow_results=evaluate_paper_shadow_consistency(metrics, policy, stage=stage),
+        live_result=evaluate_live_monitoring(metrics, policy, stage=stage),
+    )
+
+
+def _merge_cross_strategy_layers(
+    base_results: Dict[str, Dict[str, RuleResult]],
+    strategy_ids: Iterable[str],
+    cross_layers: _CrossStrategyLayerEvaluation,
+    *,
+    include_empty: bool = False,
+) -> Dict[str, Dict[str, RuleResult]]:
+    merged = base_results
+    for sid in strategy_ids:
+        per_rule = merged.setdefault(sid, {})
+        if sid in cross_layers.cohort_results:
+            per_rule["cohort"] = cross_layers.cohort_results[sid]
+        if sid in cross_layers.portfolio_results:
+            per_rule["portfolio"] = cross_layers.portfolio_results[sid]
+        if sid in cross_layers.benchmark_results:
+            per_rule["benchmark"] = cross_layers.benchmark_results[sid]
+        if sid in cross_layers.stress_results:
+            per_rule["stress"] = cross_layers.stress_results[sid]
+        if sid in cross_layers.paper_shadow_results:
+            per_rule["paper_shadow_consistency"] = cross_layers.paper_shadow_results[sid]
+        if cross_layers.live_result:
+            per_rule["live_monitoring"] = cross_layers.live_result
+        if not per_rule and not include_empty:
+            merged.pop(sid, None)
+    return merged
+
+
 def evaluate_policy(
     metrics: Mapping[str, Mapping[str, Any]],
     policy: Policy,
@@ -1090,142 +1310,36 @@ def evaluate_policy(
     )
     validation_cfg = resolved_policy.validation or ValidationConfig()
     normalized = _normalize_metrics(metrics)
-    threshold_passed, threshold_failures = _evaluate_thresholds_with_details(
-        normalized,
-        resolved_policy.thresholds,
-        missing_mode=validation_cfg.on_missing_metric,
+    selection = _prepare_policy_selection(
+        normalized=normalized,
+        resolved_policy=resolved_policy,
+        validation_cfg=validation_cfg,
+        prev_active=prev_active,
+        correlations=correlations,
     )
-
-    candidates = threshold_passed
-    topk_ranks: Dict[str, int] = {sid: idx for idx, sid in enumerate(candidates)}
-    if resolved_policy.top_k:
-        candidates, topk_ranks = _apply_topk_with_details(normalized, candidates, resolved_policy.top_k)
-    topk_selected = set(candidates)
-
-    correlation_violations: Dict[str, List[Tuple[str, float]]] = {}
-    if resolved_policy.correlation:
-        candidates, correlation_violations = _apply_correlation_with_details(
-            correlations, candidates, resolved_policy.correlation
-        )
-
-    hysteresis_blocked: Dict[str, str] = {}
-    if resolved_policy.hysteresis:
-        candidates, hysteresis_blocked = _apply_hysteresis_with_details(
-            normalized, candidates, prev_active, resolved_policy.hysteresis
-        )
-
-    selected_ids = list(candidates)
-
-    grouped_thresholds = _group_thresholds(resolved_policy.thresholds)
-    sample_severity = (selected_profile_cfg.sample.severity if selected_profile_cfg and selected_profile_cfg.sample else None) or "soft"
-    sample_owner = (selected_profile_cfg.sample.owner if selected_profile_cfg and selected_profile_cfg.sample else None) or "quant"
-    performance_severity = (
-        selected_profile_cfg.performance.severity if selected_profile_cfg and selected_profile_cfg.performance else None
-    ) or "blocking"
-    performance_owner = (
-        selected_profile_cfg.performance.owner if selected_profile_cfg and selected_profile_cfg.performance else None
-    ) or "quant"
-    risk_severity = (selected_profile_cfg.risk.severity if selected_profile_cfg and selected_profile_cfg.risk else None) or "blocking"
-    risk_owner = (selected_profile_cfg.risk.owner if selected_profile_cfg and selected_profile_cfg.risk else None) or "risk"
-    robustness_severity = (
-        selected_profile_cfg.robustness.severity if selected_profile_cfg and selected_profile_cfg.robustness else None
-    ) or "soft"
-    robustness_owner = (
-        selected_profile_cfg.robustness.owner if selected_profile_cfg and selected_profile_cfg.robustness else None
-    ) or "quant"
-    robustness_dsr_min = (
-        selected_profile_cfg.robustness.dsr_min if selected_profile_cfg and selected_profile_cfg.robustness else None
+    rules = _assemble_policy_rules(
+        resolved_policy=resolved_policy,
+        validation_cfg=validation_cfg,
+        selection=selection,
+        selected_profile_cfg=selected_profile_cfg,
     )
-    robustness_cv_sharpe_gap_max = (
-        selected_profile_cfg.robustness.cv_sharpe_gap_max if selected_profile_cfg and selected_profile_cfg.robustness else None
+    rule_results = _evaluate_rule_results(
+        normalized=normalized,
+        rules=rules,
+        validation_cfg=validation_cfg,
+        prev_active=prev_active,
+        correlations=correlations,
     )
-
-    rules: List[ValidationRule] = [
-        DataCurrencyRule(
-            required_metrics=[t.metric for t in grouped_thresholds["data_currency"]],
-            on_missing_metric=validation_cfg.on_missing_metric,
-        ),
-        SampleRule(
-            thresholds=grouped_thresholds["sample"],
-            severity=sample_severity,
-            owner=sample_owner,
-        ),
-        PerformanceRule(
-            thresholds=grouped_thresholds["performance"] or list(resolved_policy.thresholds.values()),
-            threshold_failures=threshold_failures,
-            top_k=resolved_policy.top_k,
-            topk_selected=topk_selected,
-            topk_ranks=topk_ranks,
-            on_missing_metric=validation_cfg.on_missing_metric,
-            severity=performance_severity,
-            owner=performance_owner,
-        ),
-        RiskConstraintRule(
-            correlation_rule=resolved_policy.correlation,
-            hysteresis_rule=resolved_policy.hysteresis,
-            correlation_violations=correlation_violations,
-            hysteresis_blocked=hysteresis_blocked,
-            severity=risk_severity,
-            owner=risk_owner,
-        ),
-        RobustnessRule(
-            dsr_min=robustness_dsr_min,
-            cv_sharpe_gap_max=robustness_cv_sharpe_gap_max,
-            severity=robustness_severity,
-            owner=robustness_owner,
-        ),
-    ]
-
-    rule_results: Dict[str, Dict[str, RuleResult]] = {}
-    previous = set(prev_active or [])
-    for strategy_id, strategy_metrics in normalized.items():
-        context = RuleContext(
-            strategy_id=strategy_id,
-            previous_active=previous,
-            correlations=correlations,
-        )
-        per_rule: Dict[str, RuleResult] = {}
-        for rule in rules:
-            try:
-                per_rule[rule.name] = rule.evaluate(strategy_metrics, context)
-            except Exception as exc:  # pragma: no cover - defensive fail-closed
-                status = "fail" if validation_cfg.on_error == "fail" else "warn"
-                tags = getattr(rule, "tags", (rule.name,))
-                per_rule[rule.name] = RuleResult(
-                    status=status,
-                    severity=getattr(rule, "severity", "blocking"),
-                    owner=getattr(rule, "owner", "quant"),
-                    reason_code="rule_error",
-                    reason=str(exc),
-                    tags=list(tags),
-                    details={"error": repr(exc)},
-                )
-        rule_results[strategy_id] = per_rule
-
-    cohort_results = evaluate_cohort_rules(normalized, policy, stage=stage)
-    portfolio_results = evaluate_portfolio_rules(normalized, policy, stage=stage)
-    benchmark_results = evaluate_benchmark_rules(normalized, policy, stage=stage)
-    stress_results = evaluate_stress_rules(normalized, policy, stage=stage)
-    paper_shadow_results = evaluate_paper_shadow_consistency(normalized, policy, stage=stage)
-    live_result = evaluate_live_monitoring(normalized, policy, stage=stage)
-
-    for sid in normalized.keys():
-        per_rule = rule_results.setdefault(sid, {})
-        if sid in cohort_results:
-            per_rule["cohort"] = cohort_results[sid]
-        if sid in portfolio_results:
-            per_rule["portfolio"] = portfolio_results[sid]
-        if sid in benchmark_results:
-            per_rule["benchmark"] = benchmark_results[sid]
-        if sid in stress_results:
-            per_rule["stress"] = stress_results[sid]
-        if sid in paper_shadow_results:
-            per_rule["paper_shadow_consistency"] = paper_shadow_results[sid]
-        if live_result:
-            per_rule["live_monitoring"] = live_result
+    cross_layers = _evaluate_cross_strategy_layers(normalized, policy, stage=stage)
+    rule_results = _merge_cross_strategy_layers(
+        base_results=rule_results,
+        strategy_ids=normalized.keys(),
+        cross_layers=cross_layers,
+        include_empty=True,
+    )
 
     return PolicyEvaluationResult(
-        selected_ids=selected_ids,
+        selected_ids=selection.selected_ids,
         rule_results=rule_results,
         profile=selected_profile,
         ruleset_hash=_ruleset_hash(resolved_policy, profile=selected_profile),
@@ -1254,31 +1368,12 @@ def evaluate_extended_layers(
         if isinstance(raw_metrics, Mapping):
             metrics_map[str(sid)] = _flatten_evaluation_metrics(raw_metrics)
 
-    cohort_results = evaluate_cohort_rules(metrics_map, policy, stage=stage)
-    portfolio_results = evaluate_portfolio_rules(metrics_map, policy, stage=stage)
-    benchmark_results = evaluate_benchmark_rules(metrics_map, policy, stage=stage)
-    stress_results = evaluate_stress_rules(metrics_map, policy, stage=stage)
-    paper_shadow_results = evaluate_paper_shadow_consistency(metrics_map, policy, stage=stage)
-    live_result = evaluate_live_monitoring(metrics_map, policy, stage=stage)
-
-    merged: Dict[str, Dict[str, RuleResult]] = {}
-    for sid in metrics_map.keys():
-        per_rule: Dict[str, RuleResult] = {}
-        if sid in cohort_results:
-            per_rule["cohort"] = cohort_results[sid]
-        if sid in portfolio_results:
-            per_rule["portfolio"] = portfolio_results[sid]
-        if sid in benchmark_results:
-            per_rule["benchmark"] = benchmark_results[sid]
-        if sid in stress_results:
-            per_rule["stress"] = stress_results[sid]
-        if sid in paper_shadow_results:
-            per_rule["paper_shadow_consistency"] = paper_shadow_results[sid]
-        if live_result:
-            per_rule["live_monitoring"] = live_result
-        if per_rule:
-            merged[sid] = per_rule
-    return merged
+    cross_layers = _evaluate_cross_strategy_layers(metrics_map, policy, stage=stage)
+    return _merge_cross_strategy_layers(
+        base_results={},
+        strategy_ids=metrics_map.keys(),
+        cross_layers=cross_layers,
+    )
 
 
 def _group_thresholds(thresholds: Mapping[str, ThresholdRule]) -> Dict[str, List[ThresholdRule]]:

--- a/tests/qmtl/services/worldservice/test_policy_engine.py
+++ b/tests/qmtl/services/worldservice/test_policy_engine.py
@@ -135,6 +135,59 @@ def test_hysteresis_preserves_active_entries_on_exit_threshold():
     assert result.rule_results["s1"]["risk_constraint"].reason_code == "risk_constraints_ok"
 
 
+def test_prepare_policy_selection_keeps_topk_snapshot_before_risk_filters():
+    policy = Policy(
+        thresholds={"sharpe": ThresholdRule(metric="sharpe", min=0.0)},
+        top_k=TopKRule(metric="sharpe", k=2),
+        correlation=CorrelationRule(max=0.5),
+        hysteresis=HysteresisRule(metric="score", enter=0.6, exit=0.4),
+    )
+    normalized = {
+        "s1": {"sharpe": 1.0, "score": 0.8},
+        "s2": {"sharpe": 0.9, "score": 0.8},
+        "s3": {"sharpe": 0.7, "score": 0.8},
+    }
+    correlations = {("s1", "s2"): 0.9}
+
+    selection = pe._prepare_policy_selection(
+        normalized=normalized,
+        resolved_policy=policy,
+        validation_cfg=ValidationConfig(),
+        prev_active=None,
+        correlations=correlations,
+    )
+
+    assert selection.topk_selected == {"s1", "s2"}
+    assert selection.selected_ids == ["s1"]
+    assert selection.correlation_violations["s2"] == [("s1", 0.9)]
+
+
+def test_merge_cross_strategy_layers_include_empty_flag():
+    cross_layers = pe._CrossStrategyLayerEvaluation(
+        cohort_results={},
+        portfolio_results={},
+        benchmark_results={},
+        stress_results={},
+        paper_shadow_results={},
+        live_result=None,
+    )
+
+    merged_default = pe._merge_cross_strategy_layers(
+        base_results={},
+        strategy_ids=["s1"],
+        cross_layers=cross_layers,
+    )
+    merged_include_empty = pe._merge_cross_strategy_layers(
+        base_results={},
+        strategy_ids=["s1"],
+        cross_layers=cross_layers,
+        include_empty=True,
+    )
+
+    assert merged_default == {}
+    assert merged_include_empty == {"s1": {}}
+
+
 def test_parse_policy_from_yaml_payload():
     raw = """
     thresholds:


### PR DESCRIPTION
## Summary
- split policy-engine selection prep, rule assembly, and cross-strategy aggregation into dedicated helper boundaries
- further reduce  complexity so the changed-file Radon gate passes while preserving current policy contracts
- keep  behavior stable and extend regression coverage around ordering-sensitive selection behavior

## Verification
- 
==> Ruff lint (repo-safe subset)
All checks passed!

==> Dependency hygiene (deptry)

==> Docs link check
Docs link/path check passed

==> Radon diff (CC/MI)

qmtl/services/worldservice/policy_engine.py - C (0.00)
Radon MI warnings (C-or-worse) in changed files:
qmtl/services/worldservice/policy_engine.py - C (0.00)

==> Type check (mypy)
qmtl/examples/templates/layers/monitoring/metrics.py:19: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
qmtl/services/gateway/tests/test_strategy_history_metadata.py:74: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
qmtl/runtime/sdk/materialize_job.py:184: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
qmtl/runtime/sdk/submit.py:1424: error: Returning Any from function declared to
return "SubmitResult"  [no-any-return]
        return build_submit_result_from_validation(
        ^
qmtl/examples/dags/example_strategy/__init__.py:41: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Found 1 error in 1 file (checked 643 source files)

Fixes #2084
Refs #2077