### PR TITLE
Tighten world-isolation runtime storage scope

### DIFF
--- a/docs/en/operations/README.md
+++ b/docs/en/operations/README.md
@@ -47,6 +47,7 @@ Guidelines for running and maintaining QMTL in production.
 - [Rebalancing Execution Adapter](rebalancing_execution.md): order-conversion and execution boundary after plan/apply.
 - [World Validation Governance](world_validation_governance.md): override and re-review procedure.
 - [ControlBus/Queue Standards](controlbus_queue_standards.md): topic, consumer-group, and retry/DLQ rules.
+- [World Isolation Runtime Scope](world_isolation_runtime_scope.md): RBAC/write-scope separation and backtest/dry-run path namespace checks.
 
 ## Release and Change Management
 

--- a/docs/en/operations/world_isolation_runtime_scope.md
+++ b/docs/en/operations/world_isolation_runtime_scope.md
@@ -1,0 +1,43 @@
+# World Isolation Runtime Scope
+
+The remaining world-isolation gap is operational rather than architectural: align who is allowed to write with how local writable paths are scoped. This runbook does not redefine the core contracts; it captures the RBAC, write-scope, and namespace checks operators must verify in real deployments and backtest environments.
+
+Related normative documents:
+
+- [Architecture & World ID Flow](../architecture/architecture.md)
+- [WorldService](../architecture/worldservice.md)
+- [Configuration Reference](../reference/configuration.md)
+
+## 1. Authority and write ownership
+
+- WorldService remains the authority for world-scoped RBAC and write audit. `apply`, `activation PUT`, and world-state mutation stay behind WorldService operator permissions only.
+- Gateway is a proxy/bridge, not the source of truth for write-scope. Local Gateway or SDK settings must not bypass the WorldService boundary.
+- `live`/`shadow` must not be used as writable local cache/artifact domains. As defined by the existing contract, cross-domain reuse remains limited to read-only consumption of immutable feature artifacts.
+
+## 2. Local storage policy for backtest/dryrun
+
+- Any local writable path used by `backtest`/`dryrun` must be namespaced by both `world_id` and `execution_domain`.
+- When the runtime uses default or relative paths, it must avoid reusing long-lived shared directories and instead route writes under the ephemeral root (`$TMPDIR/qmtl/...`).
+- When operators provide an explicit absolute path, the effective write target must still be separated under `world=<id>/execution_domain=<domain>`.
+- This policy applies to:
+  - `seamless.artifact_dir`
+  - `cache.feature_artifact_dir`
+  - `cache.tagquery_cache_path`
+
+## 3. Queue / cache / artifact namespace checklist
+
+- Queue topics: production topics must stay in the `{world_id}.{execution_domain}.<topic>` form.
+  - Regression guard: `tests/qmtl/services/dagmanager/test_topic_namespace.py`
+- Feature artifact write-scope: keep `cache.feature_artifact_write_domains` restricted to `backtest`/`dryrun`, while `live`/`shadow` remain read-only consumers.
+  - Regression guard: `tests/qmtl/runtime/sdk/test_feature_artifact_plane.py`
+- TagQuery local cache: in backtest/dry-run, use world/domain-scoped paths and push default/relative locations into the ephemeral root.
+  - Regression guard: `tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py`
+- Seamless artifact manifests: producer provenance must retain `world_id`, `execution_domain`, and `strategy_id`.
+  - Regression guard: `tests/qmtl/runtime/sdk/test_artifact_registrar.py`
+
+## 4. Minimum pre-approval audit
+
+- Confirm world write APIs exist only behind the WorldService RBAC boundary.
+- Confirm local backtest/dry-run runs write cache/artifact data under `world=<id>/execution_domain=<domain>`.
+- When operations rely on relative paths or home-directory defaults, confirm the actual write target is downgraded into the ephemeral root.
+- Run the queue-namespace, feature-artifact write-domain, and manifest-provenance regression tests together before approval.

--- a/docs/en/reference/configuration.md
+++ b/docs/en/reference/configuration.md
@@ -108,6 +108,8 @@ Sample configurations for common environments live under
 | `conformance_preset` | string | `"strict-blocking"` | — | No |
 | `presets_file` | string or null | `null` | — | No |
 
+Processes running with `execution_domain=backtest` or `dryrun` scope `seamless.artifact_dir` under the active world/domain. When the runtime uses a default or relative path, the effective write target moves under the ephemeral root (`$TMPDIR/qmtl/seamless_artifacts/...`).
+
 ### Connectors
 
 | Key | Type | Default | Environment variable | Required |
@@ -150,6 +152,8 @@ Sample configurations for common environments live under
 | `snapshot_url` | string or null | `null` | `QMTL_SNAPSHOT_URL` | No |
 | `snapshot_strict_runtime` | boolean | `False` | `QMTL_SNAPSHOT_STRICT_RUNTIME` | No |
 | `snapshot_format` | string | `"json"` | `QMTL_SNAPSHOT_FORMAT` | No |
+
+Processes running with `execution_domain=backtest` or `dryrun` scope `cache.feature_artifact_dir` and `cache.tagquery_cache_path` under `world=<id>/execution_domain=<domain>`. Default and relative paths are relocated under `$TMPDIR/qmtl/...`; explicit absolute paths keep the configured root but still append the world/domain segments.
 
 ### Runtime
 

--- a/docs/ko/operations/README.md
+++ b/docs/ko/operations/README.md
@@ -47,6 +47,7 @@ last_modified: 2026-04-03
 - [리밸런싱 실행 어댑터](rebalancing_execution.md): plan/apply 이후 주문 변환과 실행 경계.
 - [World Validation 거버넌스](world_validation_governance.md): override와 재검토 절차.
 - [ControlBus/큐 운영 표준](controlbus_queue_standards.md): 토픽, consumer group, retry/DLQ 기준.
+- [World Isolation Runtime Scope](world_isolation_runtime_scope.md): RBAC/write-scope 분리와 backtest/dryrun 경로 네임스페이스 점검.
 
 ## 배포와 변경 관리
 

--- a/docs/ko/operations/world_isolation_runtime_scope.md
+++ b/docs/ko/operations/world_isolation_runtime_scope.md
@@ -1,0 +1,43 @@
+# World Isolation Runtime Scope
+
+월드 격리 후속 작업에서 남아 있던 운영 갭은 "누가 쓰기를 허용받는가"와 "로컬 쓰기 경로가 어떤 스코프로 분리되는가"를 일치시키는 데 있다. 이 문서는 기존 아키텍처 계약을 다시 정의하지 않고, 운영자가 실제 배포/백테스트 환경에서 확인해야 할 RBAC·write-scope·경로 네임스페이스 점검 항목만 정리한다.
+
+관련 규범 문서:
+
+- [Architecture & World ID Flow](../architecture/architecture.md)
+- [WorldService](../architecture/worldservice.md)
+- [Configuration Reference](../reference/configuration.md)
+
+## 1. 권한과 쓰기 소유권
+
+- WorldService가 월드 범위 RBAC와 쓰기 감사의 권위이다. `apply`, `activation PUT`, 월드 상태 변경은 WorldService operator 권한으로만 허용한다.
+- Gateway는 프록시/브리지 역할만 수행한다. Gateway 또는 SDK 로컬 설정으로 write-scope 를 우회해선 안 된다.
+- `live`/`shadow` 는 mutable runtime state 를 공유하거나 새 로컬 artifact/cache 를 기록하는 경로로 사용하지 않는다. cross-domain 재사용은 기존 계약대로 immutable feature artifact 의 read-only 소비에 한정한다.
+
+## 2. backtest/dryrun 로컬 저장소 정책
+
+- `backtest`/`dryrun` 에서 로컬 write 가 필요한 경로는 반드시 `world_id` 와 `execution_domain` 으로 namespaced 되어야 한다.
+- 기본값 또는 상대 경로를 사용할 때는 장기 공유 디렉터리를 재사용하지 않고 임시 루트(`$TMPDIR/qmtl/...`) 아래로 이동시켜야 한다.
+- 절대 경로를 명시적으로 설정한 경우에도 실제 쓰기 경로는 `world=<id>/execution_domain=<domain>` 하위로 분리해야 한다.
+- 적용 대상:
+  - `seamless.artifact_dir`
+  - `cache.feature_artifact_dir`
+  - `cache.tagquery_cache_path`
+
+## 3. 큐 / 캐시 / 아티팩트 네임스페이스 체크리스트
+
+- 큐 토픽: 프로덕션 토픽은 `{world_id}.{execution_domain}.<topic>` 형태를 유지해야 한다.
+  - 회귀 가드: `tests/qmtl/services/dagmanager/test_topic_namespace.py`
+- feature artifact write-scope: `cache.feature_artifact_write_domains` 로 `backtest`/`dryrun` 만 쓰기를 허용하고, `live`/`shadow` 는 read-only 소비로 유지한다.
+  - 회귀 가드: `tests/qmtl/runtime/sdk/test_feature_artifact_plane.py`
+- TagQuery 로컬 캐시: 백테스트/드라이런에서 world/domain 분리 경로를 사용하고, 상대/기본 경로는 임시 루트로 내려가야 한다.
+  - 회귀 가드: `tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py`
+- Seamless artifact manifest: producer provenance 에 `world_id`, `execution_domain`, `strategy_id` 가 남아야 한다.
+  - 회귀 가드: `tests/qmtl/runtime/sdk/test_artifact_registrar.py`
+
+## 4. 운영 승인 전 최소 점검
+
+- 월드 쓰기 API 가 WorldService RBAC 경계 뒤에만 있는지 확인한다.
+- 로컬 backtest/dryrun 실행에서 생성된 cache/artifact 경로가 `world=<id>/execution_domain=<domain>` 로 분리되는지 확인한다.
+- 운영 설정이 상대 경로나 홈 디렉터리 기본값에 의존할 때, 실제 write target 이 임시 루트로 강등되는지 확인한다.
+- queue namespace, feature artifact write-domain, manifest provenance 회귀 테스트를 함께 통과시킨다.

--- a/docs/ko/reference/configuration.md
+++ b/docs/ko/reference/configuration.md
@@ -102,6 +102,8 @@ qmtl config validate --target schema --config path/to/qmtl.yml
 | `conformance_preset` | 문자열 | `"strict-blocking"` | — | 아니오 |
 | `presets_file` | 문자열 또는 null | `null` | — | 아니오 |
 
+`execution_domain` 이 `backtest` 또는 `dryrun` 인 프로세스는 `seamless.artifact_dir` 을 world/domain 하위로 분리해 쓴다. 기본값이나 상대 경로를 사용할 경우 실제 write target 은 임시 루트(`$TMPDIR/qmtl/seamless_artifacts/...`) 로 이동한다.
+
 ### Connectors
 
 | Key | 타입 | 기본값 | 환경 변수 | 필수 |
@@ -142,6 +144,8 @@ qmtl config validate --target schema --config path/to/qmtl.yml
 | `snapshot_url` | 문자열 또는 null | `null` | `QMTL_SNAPSHOT_URL` | 아니오 |
 | `snapshot_strict_runtime` | boolean | `False` | `QMTL_SNAPSHOT_STRICT_RUNTIME` | 아니오 |
 | `snapshot_format` | 문자열 | `"json"` | `QMTL_SNAPSHOT_FORMAT` | 아니오 |
+
+`execution_domain` 이 `backtest` 또는 `dryrun` 인 프로세스는 `cache.feature_artifact_dir` 과 `cache.tagquery_cache_path` 를 `world=<id>/execution_domain=<domain>` 하위로 분리한다. 기본값이나 상대 경로는 임시 루트(`$TMPDIR/qmtl/...`) 로 내려가고, 절대 경로를 명시해도 world/domain 세그먼트는 유지된다.
 
 ### Runtime
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - WS Load & Endurance: operations/ws_load_testing.md
       - Evaluation Store: operations/evaluation_store.md
       - ControlBus/Queue Standards: operations/controlbus_queue_standards.md
+      - World Isolation Runtime Scope: operations/world_isolation_runtime_scope.md
       - World Activation Runbook: operations/activation.md
       - Determinism Runbook: operations/determinism.md
       - Rebalancing Execution: operations/rebalancing_execution.md

--- a/qmtl/runtime/sdk/artifacts/registrar.py
+++ b/qmtl/runtime/sdk/artifacts/registrar.py
@@ -21,6 +21,7 @@ from qmtl.runtime.io.artifact import (
 from qmtl.runtime.sdk.configuration import get_seamless_config
 
 from .. import configuration
+from ..storage_scope import resolve_runtime_scope, scoped_directory_path
 
 
 def _resolve_strategy_id() -> str | None:
@@ -50,6 +51,7 @@ class ProducerContext:
     node_id: str
     interval: int
     world_id: str
+    execution_domain: str | None = None
     strategy_id: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
@@ -58,6 +60,8 @@ class ProducerContext:
             "interval": int(self.interval),
             "world_id": self.world_id,
         }
+        if self.execution_domain:
+            payload["execution_domain"] = self.execution_domain
         if self.strategy_id:
             payload["strategy_id"] = self.strategy_id
         return payload
@@ -124,7 +128,11 @@ class FileSystemArtifactRegistrar(_IOArtifactRegistrar):
         if not bool(cfg.artifacts_enabled):
             return None
 
-        base = cfg.artifact_dir or ".qmtl_seamless_artifacts"
+        base = scoped_directory_path(
+            cfg.artifact_dir or ".qmtl_seamless_artifacts",
+            storage_kind="seamless_artifacts",
+            default_path="~/.qmtl_seamless_artifacts",
+        )
         return cls(base)
 
     # ------------------------------------------------------------------
@@ -214,10 +222,13 @@ class FileSystemArtifactRegistrar(_IOArtifactRegistrar):
                 "warnings": list(manifest["conformance"].get("warnings", [])),
             }
 
+        raw_world = os.getenv("WORLD_ID", "default")
+        _, scope_domain = resolve_runtime_scope()
         producer = ProducerContext(
             node_id=str(manifest.get("node_id", "unknown")),
             interval=int(manifest.get("interval", 0)),
-            world_id=os.getenv("WORLD_ID", "default"),
+            world_id=raw_world,
+            execution_domain=scope_domain if scope_domain else None,
             strategy_id=_resolve_strategy_id(),
         )
         producer_payload = producer.as_dict()

--- a/qmtl/runtime/sdk/feature_store/plane.py
+++ b/qmtl/runtime/sdk/feature_store/plane.py
@@ -13,6 +13,7 @@ from qmtl.foundation.common.compute_key import DEFAULT_EXECUTION_DOMAIN
 from qmtl.foundation.config import CacheConfig as _CacheConfig
 
 from .. import configuration
+from ..storage_scope import scoped_directory_path
 from .base import FeatureArtifactKey, FeatureStoreBackend
 from .filesystem import FileSystemFeatureStore
 
@@ -33,7 +34,11 @@ def _from_cache_config(cfg: _CacheConfig) -> "FeatureArtifactPlane | None":
     if not enabled:
         return None
 
-    base = cfg.feature_artifact_dir
+    base = scoped_directory_path(
+        cfg.feature_artifact_dir,
+        storage_kind="feature_artifacts",
+        default_path=".qmtl_feature_artifacts",
+    )
     max_versions: Any = cfg.feature_artifact_versions
     write_domains = list(cfg.feature_artifact_write_domains)
 

--- a/qmtl/runtime/sdk/storage_scope.py
+++ b/qmtl/runtime/sdk/storage_scope.py
@@ -1,0 +1,106 @@
+"""Helpers for world/execution-domain scoped local storage paths."""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from pathlib import Path
+
+from qmtl.foundation.common.compute_key import DEFAULT_EXECUTION_DOMAIN
+
+from .configuration import get_connectors_config
+
+EPHEMERAL_EXECUTION_DOMAINS = frozenset({"backtest", "dryrun"})
+
+
+def _sanitize_scope_component(value: str | None, *, fallback: str) -> str:
+    text = str(value or "").strip().lower()
+    if not text:
+        return fallback
+    normalized = re.sub(r"[^a-z0-9._-]+", "-", text).strip("-.")
+    return normalized or fallback
+
+
+def resolve_runtime_scope(
+    *,
+    world_id: str | None = None,
+    execution_domain: str | None = None,
+) -> tuple[str, str]:
+    """Return normalized world/domain scope used for local storage."""
+
+    raw_world = world_id or os.getenv("WORLD_ID") or "default"
+    raw_domain = execution_domain
+    if raw_domain is None:
+        try:
+            raw_domain = get_connectors_config().execution_domain
+        except Exception:  # pragma: no cover - defensive
+            raw_domain = None
+    raw_domain = raw_domain or os.getenv("QMTL_EXECUTION_DOMAIN") or DEFAULT_EXECUTION_DOMAIN
+    return (
+        _sanitize_scope_component(raw_world, fallback="default"),
+        _sanitize_scope_component(raw_domain, fallback=DEFAULT_EXECUTION_DOMAIN),
+    )
+
+
+def _is_default_or_relative(raw_path: str | os.PathLike[str], default_path: str | None) -> bool:
+    expanded = Path(raw_path).expanduser()
+    if not expanded.is_absolute():
+        return True
+    if default_path is None:
+        return False
+    return expanded == Path(default_path).expanduser()
+
+
+def scoped_directory_path(
+    raw_path: str | os.PathLike[str],
+    *,
+    storage_kind: str,
+    default_path: str | None = None,
+    world_id: str | None = None,
+    execution_domain: str | None = None,
+) -> Path:
+    """Return a directory path scoped for local writes when needed."""
+
+    base = Path(raw_path).expanduser()
+    scope_world, scope_domain = resolve_runtime_scope(
+        world_id=world_id,
+        execution_domain=execution_domain,
+    )
+    if scope_domain not in EPHEMERAL_EXECUTION_DOMAINS:
+        return base
+    root = base
+    if _is_default_or_relative(raw_path, default_path):
+        root = Path(tempfile.gettempdir()) / "qmtl" / storage_kind
+    return root / f"world={scope_world}" / f"execution_domain={scope_domain}"
+
+
+def scoped_file_path(
+    raw_path: str | os.PathLike[str],
+    *,
+    storage_kind: str,
+    default_path: str | None = None,
+    world_id: str | None = None,
+    execution_domain: str | None = None,
+) -> Path:
+    """Return a file path scoped for local writes when needed."""
+
+    base = Path(raw_path).expanduser()
+    scope_world, scope_domain = resolve_runtime_scope(
+        world_id=world_id,
+        execution_domain=execution_domain,
+    )
+    if scope_domain not in EPHEMERAL_EXECUTION_DOMAINS:
+        return base
+    root = base.parent
+    if _is_default_or_relative(raw_path, default_path):
+        root = Path(tempfile.gettempdir()) / "qmtl" / storage_kind
+    return root / f"world={scope_world}" / f"execution_domain={scope_domain}" / base.name
+
+
+__all__ = [
+    "EPHEMERAL_EXECUTION_DOMAINS",
+    "resolve_runtime_scope",
+    "scoped_directory_path",
+    "scoped_file_path",
+]

--- a/qmtl/runtime/sdk/tagquery_manager.py
+++ b/qmtl/runtime/sdk/tagquery_manager.py
@@ -5,7 +5,6 @@ import json
 import os
 import tempfile
 import zlib
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Tuple
 
 import httpx
@@ -21,6 +20,7 @@ from qmtl.runtime.sdk._normalizers import extract_message_payload
 
 from . import configuration, runtime
 from . import metrics as sdk_metrics
+from .storage_scope import scoped_file_path
 from .ws_client import WebSocketClient
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -66,7 +66,11 @@ class TagQueryManager:
             cache_path = (
                 cfg.cache.tagquery_cache_path if cfg is not None else ".qmtl_tagmap.json"
             )
-        self.cache_path = Path(cache_path)
+        self.cache_path = scoped_file_path(
+            cache_path,
+            storage_kind="tagquery_cache",
+            default_path=".qmtl_tagmap.json",
+        )
 
     # ------------------------------------------------------------------
     @staticmethod

--- a/tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py
+++ b/tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py
@@ -1,10 +1,14 @@
 import asyncio
 import json
+import tempfile
+from pathlib import Path
 
 import httpx
 import pytest
 
+from qmtl.foundation.config import CacheConfig, ConnectorsConfig, UnifiedConfig
 from qmtl.runtime.sdk import TagQueryNode
+from qmtl.runtime.sdk.configuration import runtime_config_override
 from qmtl.runtime.sdk.tagquery_manager import TagQueryManager
 
 
@@ -52,3 +56,24 @@ def test_offline_cache_parity(tmp_path, monkeypatch):
         assert node_off.upstreams == node_live.upstreams
 
     asyncio.run(run_case())
+
+
+def test_backtest_default_cache_path_uses_ephemeral_namespace(monkeypatch):
+    monkeypatch.setenv("WORLD_ID", "Paper World")
+    cfg = UnifiedConfig(
+        cache=CacheConfig(tagquery_cache_path=".qmtl_tagmap.json"),
+        connectors=ConnectorsConfig(execution_domain="dryrun"),
+        present_sections=frozenset({"cache", "connectors"}),
+    )
+
+    with runtime_config_override(cfg):
+        manager = TagQueryManager()
+
+    assert manager.cache_path == (
+        Path(tempfile.gettempdir())
+        / "qmtl"
+        / "tagquery_cache"
+        / "world=paper-world"
+        / "execution_domain=dryrun"
+        / ".qmtl_tagmap.json"
+    )

--- a/tests/qmtl/runtime/sdk/test_artifact_registrar.py
+++ b/tests/qmtl/runtime/sdk/test_artifact_registrar.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from qmtl.foundation.config import SeamlessConfig, UnifiedConfig
+from qmtl.foundation.config import ConnectorsConfig, SeamlessConfig, UnifiedConfig
 from qmtl.runtime.io.artifact import ArtifactRegistrar as IOArtifactRegistrar
 from qmtl.runtime.sdk.artifacts import FileSystemArtifactRegistrar
 from qmtl.runtime.sdk.configuration import runtime_config_override
@@ -29,6 +29,28 @@ def test_from_config_enabled_with_flag_and_dir(tmp_path) -> None:
 
         assert isinstance(registrar, FileSystemArtifactRegistrar)
         assert registrar.base_dir == Path(tmp_path)
+
+
+def test_from_config_namespaces_backtest_artifacts(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WORLD_ID", "Sandbox World")
+    cfg = UnifiedConfig(
+        seamless=SeamlessConfig(
+            artifacts_enabled=True,
+            artifact_dir=str(tmp_path / "artifacts"),
+        ),
+        connectors=ConnectorsConfig(execution_domain="dryrun"),
+    )
+
+    with runtime_config_override(cfg):
+        registrar = FileSystemArtifactRegistrar.from_runtime_config()
+
+    assert isinstance(registrar, FileSystemArtifactRegistrar)
+    assert registrar.base_dir == (
+        tmp_path
+        / "artifacts"
+        / "world=sandbox-world"
+        / "execution_domain=dryrun"
+    )
 
 @pytest.mark.asyncio
 async def test_filesystem_registrar_applies_partition_template(tmp_path) -> None:
@@ -126,3 +148,33 @@ async def test_io_registrar_includes_provenance_metadata() -> None:
     assert manifest["producer"]["node_id"] == "custom-node"
     assert manifest["producer"]["interval"] == 60
     assert manifest["publication_watermark"].endswith("Z")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_registrar_manifest_includes_execution_domain(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("WORLD_ID", "backtest-world")
+    monkeypatch.setenv("QMTL_EXECUTION_DOMAIN", "backtest")
+    frame = pl.DataFrame(
+        {
+            "ts": [0, 60, 120],
+            "open": [1.0, 1.1, 1.2],
+            "high": [1.0, 1.2, 1.3],
+            "low": [0.9, 1.0, 1.1],
+            "close": [1.0, 1.1, 1.2],
+            "volume": [5, 6, 7],
+        }
+    )
+
+    registrar = FileSystemArtifactRegistrar(tmp_path)
+    publication = await registrar.publish(
+        frame,
+        node_id="custom-node",
+        interval=60,
+    )
+
+    assert publication is not None
+    manifest = json.loads(Path(publication.manifest_uri).read_text())
+    assert manifest["producer"]["world_id"] == "backtest-world"
+    assert manifest["producer"]["execution_domain"] == "backtest"

--- a/tests/qmtl/runtime/sdk/test_feature_artifact_plane.py
+++ b/tests/qmtl/runtime/sdk/test_feature_artifact_plane.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from qmtl.foundation.config import CacheConfig, UnifiedConfig
+from qmtl.foundation.config import CacheConfig, ConnectorsConfig, UnifiedConfig
 from qmtl.runtime.sdk import ProcessingNode, Strategy, StreamInput, configuration
 from qmtl.runtime.sdk.feature_store import FeatureArtifactPlane, FileSystemFeatureStore
 from qmtl.runtime.sdk.runner import Runner
@@ -179,3 +179,29 @@ def test_live_domain_does_not_write_feature_artifacts(artifact_plane):
 
     assert result["value"] == 30
     assert artifact_plane.count(strategy.factor, instrument="BTC") == initial_count
+
+
+def test_from_config_scopes_backtest_feature_artifact_dir(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("WORLD_ID", "Replay Lab")
+    cfg = UnifiedConfig(
+        cache=CacheConfig(
+            feature_artifacts_enabled=True,
+            feature_artifact_dir=str(tmp_path / "plane"),
+        ),
+        connectors=ConnectorsConfig(execution_domain="backtest"),
+        present_sections=frozenset({"cache", "connectors"}),
+    )
+
+    with configuration.runtime_config_override(cfg):
+        plane = FeatureArtifactPlane.from_config()
+
+    assert plane is not None
+    assert isinstance(plane.backend, FileSystemFeatureStore)
+    assert plane.backend.base_dir == (
+        tmp_path
+        / "plane"
+        / "world=replay-lab"
+        / "execution_domain=backtest"
+    )


### PR DESCRIPTION
## Summary
- scope local backtest and dryrun cache/artifact writes under `world=<id>/execution_domain=<domain>`
- move default and relative backtest/dryrun paths under the ephemeral runtime root while preserving existing world and execution-domain contracts
- document the remaining world-isolation runtime checklist and add regression coverage for scoped feature artifacts, tagquery cache paths, and seamless manifest provenance

## Verification
- `bash scripts/run_ci_local.sh`

Fixes #2081
Refs #1258
