### PR TITLE
Fix tagquery cache scoping for explicit world_id

### DIFF
--- a/qmtl/runtime/sdk/tagquery_manager.py
+++ b/qmtl/runtime/sdk/tagquery_manager.py
@@ -70,6 +70,7 @@ class TagQueryManager:
             cache_path,
             storage_kind="tagquery_cache",
             default_path=".qmtl_tagmap.json",
+            world_id=self.world_id,
         )
 
     # ------------------------------------------------------------------

--- a/tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py
+++ b/tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py
@@ -77,3 +77,33 @@ def test_backtest_default_cache_path_uses_ephemeral_namespace(monkeypatch):
         / "execution_domain=dryrun"
         / ".qmtl_tagmap.json"
     )
+
+
+def test_explicit_world_id_scopes_cache_path_even_without_env(monkeypatch):
+    monkeypatch.delenv("WORLD_ID", raising=False)
+    cfg = UnifiedConfig(
+        cache=CacheConfig(tagquery_cache_path=".qmtl_tagmap.json"),
+        connectors=ConnectorsConfig(execution_domain="backtest"),
+        present_sections=frozenset({"cache", "connectors"}),
+    )
+
+    with runtime_config_override(cfg):
+        manager_a = TagQueryManager(world_id="alpha world")
+        manager_b = TagQueryManager(world_id="beta world")
+
+    assert manager_a.cache_path == (
+        Path(tempfile.gettempdir())
+        / "qmtl"
+        / "tagquery_cache"
+        / "world=alpha-world"
+        / "execution_domain=backtest"
+        / ".qmtl_tagmap.json"
+    )
+    assert manager_b.cache_path == (
+        Path(tempfile.gettempdir())
+        / "qmtl"
+        / "tagquery_cache"
+        / "world=beta-world"
+        / "execution_domain=backtest"
+        / ".qmtl_tagmap.json"
+    )


### PR DESCRIPTION
## Summary
- pass the explicit TagQueryManager world_id into tagquery cache path scoping
- keep backtest and dryrun cache files isolated per world instead of falling back to WORLD_ID/default
- add regression coverage for explicit world-specific cache paths

## Verification
- uv run -m pytest -q tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py
- uv run ruff check qmtl/runtime/sdk/tagquery_manager.py tests/qmtl/runtime/sdk/tagquery/test_cache_parity.py
- bash scripts/run_ci_local.sh