### PR TITLE
Add local account PnL diagnostics helper

### DIFF
--- a/docs/en/reference/api/portfolio.md
+++ b/docs/en/reference/api/portfolio.md
@@ -3,7 +3,7 @@ title: "Portfolio & Position API"
 tags:
   - sdk
   - portfolio
-last_modified: 2025-09-08
+last_modified: 2026-04-24
 ---
 
 {{ nav_links() }}
@@ -45,3 +45,30 @@ Portfolio
 
 These helpers return signed quantities and can be combined with existing order
 generation routines.
+
+## Local PnL Diagnostics
+
+For fast local strategy iteration, callers can opt into
+`qmtl.runtime.sdk.diagnostics.summarize_account_pnl`. The helper accepts local
+fills plus optional mark prices and returns account-level `ending_cash`,
+`equity`, `realized_pnl`, `unrealized_pnl`, `fees`, `total_pnl`, and open
+position summaries.
+
+```python
+from qmtl.runtime.sdk.diagnostics import AccountFill, summarize_account_pnl
+
+summary = summarize_account_pnl(
+    [
+        AccountFill("AAPL", 10, 100.0, commission=1.0),
+        AccountFill("AAPL", -4, 110.0, commission=0.5),
+    ],
+    marks={"AAPL": 120.0},
+    starting_cash=1_000.0,
+)
+
+assert summary.total_pnl == 158.5
+```
+
+This surface is an opt-in local iteration aid. It does not change
+`Runner.submit(..., world=...)`, Gateway/WorldService, or the portfolio/risk
+hub authority model.

--- a/docs/ko/reference/api/portfolio.md
+++ b/docs/ko/reference/api/portfolio.md
@@ -3,7 +3,7 @@ title: "포트폴리오 & 포지션 API"
 tags:
   - sdk
   - portfolio
-last_modified: 2025-09-08
+last_modified: 2026-04-24
 ---
 
 {{ nav_links() }}
@@ -41,5 +41,26 @@ Portfolio
 : ``symbol`` 의 목표 비중을 달성하도록 리밸런싱합니다.
 
 이 헬퍼는 부호가 있는 수량을 반환하며 기존 주문 생성 루틴과 결합해 사용할 수 있습니다.
+
+## 로컬 PnL 진단 헬퍼
+
+빠른 전략 반복 검증에서는 `qmtl.runtime.sdk.diagnostics.summarize_account_pnl` 을 선택적으로 사용할 수 있습니다. 이 헬퍼는 로컬 fill 목록과 선택적 mark 가격을 받아 계정 단위 `ending_cash`, `equity`, `realized_pnl`, `unrealized_pnl`, `fees`, `total_pnl`, open position 요약을 반환합니다.
+
+```python
+from qmtl.runtime.sdk.diagnostics import AccountFill, summarize_account_pnl
+
+summary = summarize_account_pnl(
+    [
+        AccountFill("AAPL", 10, 100.0, commission=1.0),
+        AccountFill("AAPL", -4, 110.0, commission=0.5),
+    ],
+    marks={"AAPL": 120.0},
+    starting_cash=1_000.0,
+)
+
+assert summary.total_pnl == 158.5
+```
+
+이 표면은 로컬 iteration용 opt-in 진단 도구입니다. `Runner.submit(..., world=...)`, Gateway/WorldService, portfolio/risk hub의 권위 모델을 변경하지 않습니다.
 
 {{ nav_links() }}

--- a/qmtl/runtime/sdk/diagnostics/__init__.py
+++ b/qmtl/runtime/sdk/diagnostics/__init__.py
@@ -1,0 +1,10 @@
+"""Optional diagnostics helpers for local SDK iteration."""
+
+from .account_pnl import AccountFill, AccountPnlPosition, AccountPnlSummary, summarize_account_pnl
+
+__all__ = [
+    "AccountFill",
+    "AccountPnlPosition",
+    "AccountPnlSummary",
+    "summarize_account_pnl",
+]

--- a/qmtl/runtime/sdk/diagnostics/account_pnl.py
+++ b/qmtl/runtime/sdk/diagnostics/account_pnl.py
@@ -1,0 +1,279 @@
+"""Account-level PnL summaries for local strategy iteration.
+
+This module is intentionally independent from Runner, Gateway, WorldService,
+and the risk hub. It provides an opt-in helper for fast local validation loops
+that already have fill-like records and optional mark prices.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class AccountFill:
+    """A normalized local fill.
+
+    ``quantity`` is signed: positive quantities buy/increase long exposure and
+    negative quantities sell/increase short exposure.
+    """
+
+    symbol: str
+    quantity: float
+    price: float
+    commission: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class AccountPnlPosition:
+    """Open position included in an account-level PnL summary."""
+
+    symbol: str
+    quantity: float
+    avg_cost: float
+    mark_price: float
+
+    @property
+    def market_value(self) -> float:
+        """Signed mark-to-market value for the position."""
+
+        return self.quantity * self.mark_price
+
+    @property
+    def unrealized_pnl(self) -> float:
+        """Price PnL for the open position, before future exit fees."""
+
+        return (self.mark_price - self.avg_cost) * self.quantity
+
+
+@dataclass(frozen=True, slots=True)
+class AccountPnlSummary:
+    """Account-level PnL summary for local validation loops."""
+
+    starting_cash: float
+    ending_cash: float
+    equity: float
+    realized_pnl: float
+    unrealized_pnl: float
+    fees: float
+    total_pnl: float
+    positions: Mapping[str, AccountPnlPosition]
+
+
+@dataclass(slots=True)
+class _OpenPosition:
+    quantity: float
+    avg_cost: float
+    last_price: float
+
+
+def summarize_account_pnl(
+    fills: Iterable[AccountFill | Mapping[str, Any] | Any],
+    *,
+    marks: Mapping[str, float] | None = None,
+    starting_cash: float = 0.0,
+) -> AccountPnlSummary:
+    """Summarize account-level PnL from local fills and optional marks.
+
+    Accepted fill shapes:
+    - :class:`AccountFill`, with signed ``quantity``.
+    - Mapping/object with ``symbol``, ``quantity``, and ``price``.
+    - Mapping/object with execution-model style ``side``, ``quantity``, and
+      ``fill_price``.
+
+    ``realized_pnl`` and ``unrealized_pnl`` are price PnL before fees. ``fees``
+    captures paid commissions, and ``total_pnl`` is net of fees.
+    """
+
+    marks = marks or {}
+    cash = float(starting_cash)
+    realized_pnl = 0.0
+    fees = 0.0
+    positions: dict[str, _OpenPosition] = {}
+
+    for raw_fill in fills:
+        fill = _normalize_fill(raw_fill)
+        cash -= fill.quantity * fill.price + fill.commission
+        fees += fill.commission
+        realized_pnl += _apply_position_fill(positions, fill)
+
+    open_positions = _mark_positions(positions, marks)
+    unrealized_pnl = sum(position.unrealized_pnl for position in open_positions.values())
+    equity = cash + sum(position.market_value for position in open_positions.values())
+    total_pnl = equity - float(starting_cash)
+
+    return AccountPnlSummary(
+        starting_cash=float(starting_cash),
+        ending_cash=cash,
+        equity=equity,
+        realized_pnl=realized_pnl,
+        unrealized_pnl=unrealized_pnl,
+        fees=fees,
+        total_pnl=total_pnl,
+        positions=open_positions,
+    )
+
+
+def _apply_position_fill(positions: dict[str, _OpenPosition], fill: AccountFill) -> float:
+    current = positions.get(fill.symbol)
+    if current is None:
+        positions[fill.symbol] = _OpenPosition(
+            quantity=fill.quantity,
+            avg_cost=fill.price,
+            last_price=fill.price,
+        )
+        return 0.0
+
+    current.last_price = fill.price
+    same_direction = current.quantity * fill.quantity > 0
+    if same_direction:
+        total_quantity = current.quantity + fill.quantity
+        total_cost = current.avg_cost * abs(current.quantity) + fill.price * abs(fill.quantity)
+        current.quantity = total_quantity
+        current.avg_cost = total_cost / abs(total_quantity)
+        return 0.0
+
+    closed_quantity = min(abs(current.quantity), abs(fill.quantity))
+    realized_pnl = closed_quantity * (fill.price - current.avg_cost) * _sign(current.quantity)
+    new_quantity = current.quantity + fill.quantity
+
+    if new_quantity == 0:
+        del positions[fill.symbol]
+    elif current.quantity * new_quantity < 0:
+        current.quantity = new_quantity
+        current.avg_cost = fill.price
+    else:
+        current.quantity = new_quantity
+
+    return realized_pnl
+
+
+def _mark_positions(
+    positions: Mapping[str, _OpenPosition],
+    marks: Mapping[str, float],
+) -> dict[str, AccountPnlPosition]:
+    marked: dict[str, AccountPnlPosition] = {}
+    for symbol, position in positions.items():
+        mark_price = _positive_float(marks.get(symbol, position.last_price), f"marks[{symbol!r}]")
+        marked[symbol] = AccountPnlPosition(
+            symbol=symbol,
+            quantity=position.quantity,
+            avg_cost=position.avg_cost,
+            mark_price=mark_price,
+        )
+    return marked
+
+
+def _normalize_fill(raw_fill: AccountFill | Mapping[str, Any] | Any) -> AccountFill:
+    if isinstance(raw_fill, AccountFill):
+        fill = raw_fill
+    else:
+        symbol = str(_read_field(raw_fill, "symbol"))
+        quantity = _non_zero_float(_read_field(raw_fill, "quantity"), "quantity")
+        price = _positive_float(_read_price(raw_fill), "price")
+        side = _read_optional_field(raw_fill, "side")
+        signed_quantity = _signed_quantity(quantity, side)
+        commission = _non_negative_float(
+            _read_optional_field(raw_fill, "commission", "fee", default=0.0),
+            "commission",
+        )
+        fill = AccountFill(symbol=symbol, quantity=signed_quantity, price=price, commission=commission)
+
+    if not fill.symbol:
+        raise ValueError("symbol must be non-empty")
+    if fill.quantity == 0:
+        raise ValueError("quantity must be non-zero")
+    _positive_float(fill.price, "price")
+    _non_negative_float(fill.commission, "commission")
+    return fill
+
+
+def _read_price(raw_fill: Mapping[str, Any] | Any) -> Any:
+    return _read_optional_field(raw_fill, "price", "fill_price", default=_MISSING)
+
+
+def _read_field(raw: Mapping[str, Any] | Any, name: str) -> Any:
+    value = _read_optional_field(raw, name, default=_MISSING)
+    if value is _MISSING:
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def _read_optional_field(
+    raw: Mapping[str, Any] | Any,
+    *names: str,
+    default: Any = None,
+) -> Any:
+    if isinstance(raw, Mapping):
+        for name in names:
+            if name in raw:
+                return raw[name]
+        return default
+
+    for name in names:
+        if hasattr(raw, name):
+            return getattr(raw, name)
+    return default
+
+
+def _signed_quantity(quantity: float, side: Any) -> float:
+    if side is None:
+        return quantity
+
+    side_value = getattr(side, "value", side)
+    side_name = str(side_value).lower()
+    if side_name == "buy":
+        return abs(quantity)
+    if side_name == "sell":
+        return -abs(quantity)
+    raise ValueError("side must be 'buy' or 'sell'")
+
+
+def _positive_float(value: Any, name: str) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive number") from exc
+    if parsed <= 0:
+        raise ValueError(f"{name} must be a positive number")
+    return parsed
+
+
+def _non_negative_float(value: Any, name: str) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be non-negative") from exc
+    if parsed < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return parsed
+
+
+def _non_zero_float(value: Any, name: str) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be non-zero") from exc
+    if parsed == 0:
+        raise ValueError(f"{name} must be non-zero")
+    return parsed
+
+
+def _sign(value: float) -> int:
+    return 1 if value > 0 else -1
+
+
+class _Missing:
+    pass
+
+
+_MISSING = _Missing()
+
+
+__all__ = [
+    "AccountFill",
+    "AccountPnlPosition",
+    "AccountPnlSummary",
+    "summarize_account_pnl",
+]

--- a/tests/qmtl/runtime/sdk/test_account_pnl_diagnostics.py
+++ b/tests/qmtl/runtime/sdk/test_account_pnl_diagnostics.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from qmtl.runtime.sdk.diagnostics import AccountFill, summarize_account_pnl
+from qmtl.runtime.sdk.execution_modeling import ExecutionFill, OrderSide
+
+
+def test_summarize_account_pnl_realized_unrealized_and_fees() -> None:
+    summary = summarize_account_pnl(
+        [
+            AccountFill("AAPL", 10, 100.0, commission=1.0),
+            AccountFill("AAPL", -4, 110.0, commission=0.5),
+        ],
+        marks={"AAPL": 120.0},
+        starting_cash=1_000.0,
+    )
+
+    assert summary.ending_cash == pytest.approx(438.5)
+    assert summary.realized_pnl == pytest.approx(40.0)
+    assert summary.unrealized_pnl == pytest.approx(120.0)
+    assert summary.fees == pytest.approx(1.5)
+    assert summary.equity == pytest.approx(1_158.5)
+    assert summary.total_pnl == pytest.approx(158.5)
+
+    position = summary.positions["AAPL"]
+    assert position.quantity == pytest.approx(6.0)
+    assert position.avg_cost == pytest.approx(100.0)
+    assert position.mark_price == pytest.approx(120.0)
+
+
+def test_summarize_account_pnl_accepts_execution_fill_shape() -> None:
+    fills = [
+        ExecutionFill(
+            order_id="buy-1",
+            symbol="MSFT",
+            side=OrderSide.BUY,
+            quantity=2.0,
+            requested_price=50.0,
+            fill_price=51.0,
+            fill_time=1,
+            commission=0.25,
+            slippage=1.0,
+            market_impact=0.0,
+        ),
+        {
+            "symbol": "MSFT",
+            "side": "sell",
+            "quantity": 1.0,
+            "fill_price": 60.0,
+            "fee": 0.10,
+        },
+    ]
+
+    summary = summarize_account_pnl(fills, marks={"MSFT": 55.0})
+
+    assert summary.realized_pnl == pytest.approx(9.0)
+    assert summary.unrealized_pnl == pytest.approx(4.0)
+    assert summary.fees == pytest.approx(0.35)
+    assert summary.total_pnl == pytest.approx(12.65)
+
+
+def test_summarize_account_pnl_handles_short_positions_and_flips() -> None:
+    summary = summarize_account_pnl(
+        [
+            {"symbol": "BTC", "quantity": -3.0, "price": 100.0},
+            {"symbol": "BTC", "quantity": 5.0, "price": 90.0},
+        ],
+        marks={"BTC": 95.0},
+    )
+
+    assert summary.realized_pnl == pytest.approx(30.0)
+    assert summary.unrealized_pnl == pytest.approx(10.0)
+    assert summary.total_pnl == pytest.approx(40.0)
+    assert summary.positions["BTC"].quantity == pytest.approx(2.0)
+    assert summary.positions["BTC"].avg_cost == pytest.approx(90.0)
+
+
+def test_summarize_account_pnl_uses_last_fill_price_when_mark_missing() -> None:
+    summary = summarize_account_pnl([AccountFill("ETH", 2.0, 10.0)])
+
+    assert summary.unrealized_pnl == pytest.approx(0.0)
+    assert summary.equity == pytest.approx(0.0)
+    assert summary.positions["ETH"].mark_price == pytest.approx(10.0)
+
+
+def test_summarize_account_pnl_rejects_invalid_fill_values() -> None:
+    with pytest.raises(ValueError, match="quantity"):
+        summarize_account_pnl([{"symbol": "AAPL", "quantity": 0, "price": 100.0}])
+
+    with pytest.raises(ValueError, match="price"):
+        summarize_account_pnl([{"symbol": "AAPL", "quantity": 1, "price": 0.0}])
+
+    with pytest.raises(ValueError, match="commission"):
+        summarize_account_pnl([AccountFill("AAPL", 1, 100.0, commission=-1.0)])


### PR DESCRIPTION
Summary:
- Add opt-in qmtl.runtime.sdk.diagnostics account PnL helper for local strategy iteration.
- Support AccountFill, mapping fills, and execution-model fill objects with long, short, flip, fee, and mark handling.
- Document the helper in Korean and English portfolio API references.

Validation:
- uv run -m pytest -q tests/qmtl/runtime/sdk/test_account_pnl_diagnostics.py
- uv run -m pytest -q tests/qmtl/runtime/sdk/test_account_pnl_diagnostics.py tests/qmtl/runtime/sdk/test_portfolio.py tests/qmtl/runtime/sdk/test_portfolio_api.py
- uv run ruff check qmtl/runtime/sdk/diagnostics tests/qmtl/runtime/sdk/test_account_pnl_diagnostics.py
- uv run mkdocs build
- bash scripts/run_ci_local.sh

Fixes #2079
Refs #2100