### PR TITLE
Reduce performance audit test overhead

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "grpcio",
     "PyYAML",
     "psutil",
+    "opentelemetry-api",
     "opentelemetry-sdk",
     "opentelemetry-exporter-otlp-proto-http",
     "opentelemetry-instrumentation-fastapi",
@@ -151,11 +152,23 @@ extend_exclude = [
   "qmtl/foundation/proto/.*_pb2.*\\.py$",
 ]
 
+[tool.deptry.package_module_name_map]
+grpcio = "grpc"
+opentelemetry-api = "opentelemetry"
+PyYAML = "yaml"
+
 [tool.deptry.per_rule_ignores]
 # These imports are lazy optional integrations and should not force hard runtime deps.
 DEP001 = [
   "aiokafka",
   "ccxtpro",
+  "confluent_kafka",
+  "fsspec",
+  "neo4j",
+  "orjson",
+  "pyoperon",
+]
+DEP003 = [
   "confluent_kafka",
   "fsspec",
   "neo4j",

--- a/qmtl/services/gateway/dagmanager_client.py
+++ b/qmtl/services/gateway/dagmanager_client.py
@@ -58,7 +58,9 @@ class DiffStreamClient:
     def __init__(self, stub: dagmanager_pb2_grpc.DiffServiceStub) -> None:
         self._stub = stub
 
-    async def collect(self, request: dagmanager_pb2.DiffRequest) -> dagmanager_pb2.DiffChunk:
+    async def collect(
+        self, request: dagmanager_pb2.DiffRequest
+    ) -> dagmanager_pb2.DiffChunk:
         queue_map: dict[str, str] = {}
         sentinel_id = ""
         version = ""
@@ -172,9 +174,7 @@ class DagManagerClient:
         deadline = asyncio.get_running_loop().time() + timeout
         while True:
             try:
-                reply = await self._health_stub.Status(
-                    dagmanager_pb2.StatusRequest()
-                )
+                reply = await self._health_stub.Status(dagmanager_pb2.StatusRequest())
                 if reply.neo4j == "ok" and reply.state == "running":
                     return
             except Exception:
@@ -199,6 +199,7 @@ class DagManagerClient:
 
     async def status(self) -> bool:
         """Return ``True`` if the remote DAG Manager reports healthy status."""
+
         @self._breaker
         async def _call() -> bool:
             self._ensure_channel()
@@ -287,6 +288,8 @@ class DagManagerClient:
             try:
                 result = await collector.collect(request)
                 return namespace.apply(result)
+            except ValueError:
+                raise
             except Exception:
                 if attempt == retries - 1:
                     raise

--- a/tests/qmtl/interfaces/cli/test_cli_help.py
+++ b/tests/qmtl/interfaces/cli/test_cli_help.py
@@ -1,15 +1,33 @@
 """CLI help tests for the v2 command surface."""
 
-import subprocess
-import sys
+from dataclasses import dataclass
+from io import StringIO
+from contextlib import redirect_stderr, redirect_stdout
+
+from qmtl.interfaces.cli.v2 import main as qmtl_main
 
 
-def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
-    cmd = [sys.executable, "-m", "qmtl", *args]
-    return subprocess.run(cmd, capture_output=True, text=True)
+@dataclass(frozen=True)
+class CliResult:
+    returncode: int
+    stdout: str
+    stderr: str
 
 
-def _output(result: subprocess.CompletedProcess[str]) -> str:
+def _run_cli(*args: str) -> CliResult:
+    stdout = StringIO()
+    stderr = StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        try:
+            returncode = qmtl_main(list(args))
+        except SystemExit as exc:
+            returncode = int(exc.code or 0)
+    return CliResult(
+        returncode=returncode, stdout=stdout.getvalue(), stderr=stderr.getvalue()
+    )
+
+
+def _output(result: CliResult) -> str:
     """Return stdout if present, otherwise stderr."""
     return result.stdout or result.stderr
 

--- a/tests/qmtl/services/gateway/test_diff.py
+++ b/tests/qmtl/services/gateway/test_diff.py
@@ -106,8 +106,10 @@ async def test_diff_retries(monkeypatch):
     monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", lambda c: None)
     monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", lambda c: None)
     monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
+
     async def _nowait(self, timeout: float = 5.0) -> None:
         return None
+
     monkeypatch.setattr(DagManagerClient, "_wait_for_service", _nowait)
 
     client = DagManagerClient("127.0.0.1:1")
@@ -196,6 +198,13 @@ async def test_diff_crc_mismatch(monkeypatch):
     monkeypatch.setattr(dagmanager_pb2_grpc, "TagQueryStub", lambda c: None)
     monkeypatch.setattr(dagmanager_pb2_grpc, "HealthCheckStub", lambda c: None)
     monkeypatch.setattr(grpc.aio, "insecure_channel", lambda target: DummyChannel())
+
+    async def fail_wait(self, timeout: float = 5.0) -> None:
+        raise AssertionError(
+            "CRC validation failures should not wait for service health"
+        )
+
+    monkeypatch.setattr(DagManagerClient, "_wait_for_service", fail_wait)
 
     client = DagManagerClient("127.0.0.1:1")
     result = await client.diff("sid", "{}")

--- a/tests/qmtl/services/gateway/test_gateway_cli.py
+++ b/tests/qmtl/services/gateway/test_gateway_cli.py
@@ -1,12 +1,35 @@
 import asyncio
-import subprocess
 import sys
+from dataclasses import dataclass
+from io import StringIO
+from contextlib import redirect_stderr, redirect_stdout
 
 import pytest
 
 from qmtl.foundation.config import DeploymentProfile
+from qmtl.interfaces.cli.v2 import main as qmtl_main
 from qmtl.services.gateway.config import GatewayConfig
 from qmtl.utils.i18n import set_language
+
+
+@dataclass(frozen=True)
+class CliResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run_qmtl_cli(*args: str) -> CliResult:
+    stdout = StringIO()
+    stderr = StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        try:
+            returncode = qmtl_main(list(args))
+        except SystemExit as exc:
+            returncode = int(exc.code or 0)
+    return CliResult(
+        returncode=returncode, stdout=stdout.getvalue(), stderr=stderr.getvalue()
+    )
 
 
 # v2 CLI: flat structure, admin commands are accessed via --help-admin
@@ -25,9 +48,11 @@ from qmtl.utils.i18n import set_language
     ],
 )
 def test_cli_subcommand_help(args, expected):
-    result = subprocess.run([sys.executable, "-m", "qmtl", *args], capture_output=True, text=True)
+    result = run_qmtl_cli(*args)
     assert result.returncode == 0, f"Failed with stderr: {result.stderr}"
-    assert expected in result.stdout, f"Expected '{expected}' not found in: {result.stdout}"
+    assert expected in result.stdout, (
+        f"Expected '{expected}' not found in: {result.stdout}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -40,9 +65,7 @@ def test_cli_subcommand_help(args, expected):
     ],
 )
 def test_removed_top_level_aliases_show_top_level_usage(cmd):
-    result = subprocess.run(
-        [sys.executable, "-m", "qmtl", cmd, "--help"], capture_output=True, text=True
-    )
+    result = run_qmtl_cli(cmd, "--help")
     # v2 CLI: legacy commands return error with migration message
     assert result.returncode != 0
     assert "has been removed" in result.stderr or "Unknown command" in result.stderr
@@ -107,7 +130,9 @@ def test_gateway_cli_config_file(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "create_app", fake_create_app)
     monkeypatch.setattr(cli, "set_topic_namespace_enabled", fake_set_namespace)
 
-    fake_uvicorn = SimpleNamespace(run=lambda app, host, port: captured.update({"host": host, "port": port}))
+    fake_uvicorn = SimpleNamespace(
+        run=lambda app, host, port: captured.update({"host": host, "port": port})
+    )
     monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
     monkeypatch.chdir(tmp_path)
 
@@ -306,7 +331,9 @@ def test_gateway_cli_redis_backend(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli.redis, "from_url", fake_from_url)
     monkeypatch.setattr(cli, "create_app", fake_create_app)
-    monkeypatch.setitem(sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None))
+    monkeypatch.setitem(
+        sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None)
+    )
     monkeypatch.chdir(tmp_path)
 
     cli.main([])
@@ -409,7 +436,9 @@ def test_gateway_cli_no_sentinel_flag(monkeypatch, tmp_path):
         return SimpleNamespace(state=SimpleNamespace(database=None))
 
     monkeypatch.setattr(cli, "create_app", fake_create_app)
-    monkeypatch.setitem(sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None))
+    monkeypatch.setitem(
+        sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None)
+    )
     monkeypatch.chdir(tmp_path)
 
     cli.main(["--no-sentinel"])
@@ -441,7 +470,9 @@ def test_gateway_cli_allow_live_flag(monkeypatch, tmp_path):
         return SimpleNamespace(state=SimpleNamespace(database=None))
 
     monkeypatch.setattr(cli, "create_app", fake_create_app)
-    monkeypatch.setitem(sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None))
+    monkeypatch.setitem(
+        sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None)
+    )
     monkeypatch.chdir(tmp_path)
 
     cli.main(["--allow-live"])
@@ -483,7 +514,9 @@ def test_gateway_cli_db_connect_failure(monkeypatch, tmp_path):
         logged["msg"] = msg
 
     monkeypatch.setattr(cli, "create_app", fake_create_app)
-    monkeypatch.setitem(sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None))
+    monkeypatch.setitem(
+        sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None)
+    )
     monkeypatch.setattr(cli.logging, "exception", fake_exception)
     monkeypatch.chdir(tmp_path)
 
@@ -527,7 +560,9 @@ def test_gateway_cli_db_close_failure(monkeypatch, tmp_path):
         logged["msg"] = msg
 
     monkeypatch.setattr(cli, "create_app", fake_create_app)
-    monkeypatch.setitem(sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None))
+    monkeypatch.setitem(
+        sys.modules, "uvicorn", SimpleNamespace(run=lambda *a, **k: None)
+    )
     monkeypatch.setattr(cli.logging, "exception", fake_exception)
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
Summary:
- avoid retry/health-wait loops for deterministic DAG diff CRC validation failures
- run repeated CLI help assertions in-process instead of spawning python -m qmtl each time
- align deptry metadata with direct imports and lazy optional integrations

Validation:
- UV_PYTHON=3.11 bash scripts/run_ci_local.sh